### PR TITLE
Add cart2topo coordinate conversion

### DIFF
--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -47,5 +47,6 @@ from .eeg_mne2eeg import eeg_mne2eeg
 from .eeg_mne2eeg_epochs import eeg_mne2eeg_epochs
 from .eeg_lat2point import eeg_lat2point
 from .eeg_point2lat import eeg_point2lat
+from .cart2topo import cart2topo
 from .eeg_options import EEG_OPTIONS
 from .eeg_checkset import eeg_checkset, strict_mode as eeg_checkset_strict_mode

--- a/src/eegprep/cart2topo.py
+++ b/src/eegprep/cart2topo.py
@@ -1,0 +1,63 @@
+"""Convert Cartesian channel coordinates to EEGLAB topoplot coordinates."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _coerce_xyz(x, y=None, z=None) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Normalize supported cart2topo input forms to flat x/y/z arrays."""
+    if y is None and z is None:
+        xyz = np.asarray(x, dtype=np.float64)
+        if xyz.size == 0:
+            return (
+                np.array([], dtype=np.float64),
+                np.array([], dtype=np.float64),
+                np.array([], dtype=np.float64),
+            )
+        if xyz.ndim == 1 and xyz.size == 3:
+            xyz = xyz.reshape(1, 3)
+        if xyz.ndim != 2 or xyz.shape[1] != 3:
+            raise ValueError("cart2topo: x must be an N x 3 coordinate array")
+        return xyz[:, 0], xyz[:, 1], xyz[:, 2]
+
+    if y is None or z is None:
+        raise ValueError("cart2topo: x, y, and z must all be provided")
+
+    x_arr = np.asarray(x, dtype=np.float64)
+    y_arr = np.asarray(y, dtype=np.float64)
+    z_arr = np.asarray(z, dtype=np.float64)
+    if x_arr.shape != y_arr.shape or x_arr.shape != z_arr.shape:
+        raise ValueError("cart2topo: x, y, and z must have matching shapes")
+    return x_arr.reshape(-1), y_arr.reshape(-1), z_arr.reshape(-1)
+
+
+def cart2topo(x, y=None, z=None) -> tuple[np.ndarray, np.ndarray]:
+    """Convert Cartesian coordinates to EEGLAB polar topoplot coordinates.
+
+    This follows current EEGLAB ``cart2topo`` behavior, which delegates to
+    ``convertlocs(..., 'cart2all')``: Cartesian coordinates are first converted
+    to MATLAB spherical coordinates, then to topoplot coordinates.
+
+    Parameters
+    ----------
+    x : array-like
+        Either an ``N x 3`` array of ``[X, Y, Z]`` coordinates, a single
+        ``[X, Y, Z]`` coordinate, or the X coordinate array when ``y`` and
+        ``z`` are also supplied.
+    y, z : array-like, optional
+        Y and Z coordinate arrays. Must have the same shape as ``x``.
+
+    Returns
+    -------
+    theta, radius : tuple[np.ndarray, np.ndarray]
+        EEGLAB topoplot angle in degrees and radius by topoplot convention.
+    """
+    x_arr, y_arr, z_arr = _coerce_xyz(x, y, z)
+    hypot_xy = np.hypot(x_arr, y_arr)
+    sph_theta = np.degrees(np.arctan2(y_arr, x_arr))
+    sph_phi = np.degrees(np.arctan2(z_arr, hypot_xy))
+
+    theta = -sph_theta
+    radius = 0.5 - sph_phi / 180.0
+    return theta.astype(np.float64, copy=False), radius.astype(np.float64, copy=False)

--- a/tests/test_cart2topo.py
+++ b/tests/test_cart2topo.py
@@ -1,0 +1,133 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import scipy.io
+
+from eegprep.cart2topo import cart2topo
+
+
+class TestCart2Topo(unittest.TestCase):
+    def test_cardinal_points(self):
+        xyz = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, -1.0],
+            ]
+        )
+        theta, radius = cart2topo(xyz)
+
+        np.testing.assert_allclose(theta, [0.0, -180.0, -90.0, 90.0, -0.0, -0.0], atol=1e-12)
+        np.testing.assert_allclose(radius, [0.5, 0.5, 0.5, 0.5, 0.0, 1.0], atol=1e-12)
+
+    def test_single_xyz_vector(self):
+        theta, radius = cart2topo([0.0, 1.0, 0.0])
+
+        self.assertEqual(theta.shape, (1,))
+        np.testing.assert_allclose(theta, [-90.0], atol=1e-12)
+        np.testing.assert_allclose(radius, [0.5], atol=1e-12)
+
+    def test_matrix_input(self):
+        theta, radius = cart2topo(np.array([[1.0, 1.0, 1.0], [1.0, -1.0, 0.0]]))
+
+        expected_theta = -np.degrees(np.arctan2([1.0, -1.0], [1.0, 1.0]))
+        expected_radius = 0.5 - np.degrees(np.arctan2([1.0, 0.0], [np.sqrt(2.0), np.sqrt(2.0)])) / 180
+        np.testing.assert_allclose(theta, expected_theta, atol=1e-12)
+        np.testing.assert_allclose(radius, expected_radius, atol=1e-12)
+
+    def test_separate_coordinate_vectors(self):
+        theta, radius = cart2topo([1.0, 0.0], [0.0, 1.0], [0.0, 0.0])
+
+        np.testing.assert_allclose(theta, [0.0, -90.0], atol=1e-12)
+        np.testing.assert_allclose(radius, [0.5, 0.5], atol=1e-12)
+
+    def test_empty_input_returns_empty_arrays(self):
+        theta, radius = cart2topo([])
+
+        self.assertEqual(theta.shape, (0,))
+        self.assertEqual(radius.shape, (0,))
+        self.assertEqual(theta.dtype, np.float64)
+        self.assertEqual(radius.dtype, np.float64)
+
+    def test_invalid_shapes_raise(self):
+        with self.assertRaisesRegex(ValueError, "N x 3"):
+            cart2topo(np.ones((2, 2)))
+        with self.assertRaisesRegex(ValueError, "all be provided"):
+            cart2topo([1.0], [2.0])
+        with self.assertRaisesRegex(ValueError, "matching shapes"):
+            cart2topo([1.0, 2.0], [1.0], [0.0, 0.0])
+
+    def test_nan_input_propagates(self):
+        theta, radius = cart2topo([[np.nan, 0.0, 1.0]])
+
+        self.assertTrue(np.isnan(theta[0]))
+        self.assertTrue(np.isnan(radius[0]))
+
+    def test_top_level_export(self):
+        from eegprep import cart2topo as exported_cart2topo
+
+        self.assertIs(exported_cart2topo, cart2topo)
+
+
+@unittest.skipIf(os.getenv("EEGPREP_SKIP_MATLAB") == "1", "MATLAB not available")
+class TestCart2TopoParity(unittest.TestCase):
+    def setUp(self):
+        try:
+            from eegprep.eeglabcompat import get_eeglab
+
+            self.eeglab = get_eeglab("MAT")
+        except Exception as exc:
+            self.skipTest(f"MATLAB not available: {exc}")
+
+    def _matlab_cart2topo(self, xyz):
+        input_file = tempfile.NamedTemporaryFile(suffix=".mat", delete=False)
+        output_file = tempfile.NamedTemporaryFile(suffix=".mat", delete=False)
+        input_file.close()
+        output_file.close()
+        try:
+            scipy.io.savemat(input_file.name, {"xyz": xyz})
+            self.eeglab.engine.eval(
+                (
+                    f"args = load('{input_file.name}'); "
+                    "[theta, radius] = cart2topo(args.xyz); "
+                    f"save('-mat', '{output_file.name}', 'theta', 'radius');"
+                ),
+                nargout=0,
+            )
+            out = scipy.io.loadmat(output_file.name)
+            theta = np.asarray(out["theta"], dtype=float).reshape(-1)
+            radius = np.asarray(out["radius"], dtype=float).reshape(-1)
+            return theta, radius
+        finally:
+            for filename in (input_file.name, output_file.name):
+                try:
+                    os.remove(filename)
+                except OSError:
+                    pass
+
+    def test_parity_with_eeglab_matrix_input(self):
+        xyz = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.3, -0.4, 0.5],
+                [0.3, -0.4, -0.5],
+            ],
+            dtype=float,
+        )
+
+        theta_py, radius_py = cart2topo(xyz)
+        theta_ml, radius_ml = self._matlab_cart2topo(xyz)
+        np.testing.assert_allclose(theta_py, theta_ml, atol=1e-12, rtol=0)
+        np.testing.assert_allclose(radius_py, radius_ml, atol=1e-12, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR ports EEGLAB's current `cart2topo` coordinate conversion behavior to Python in EEGPREP.

Changes:
- Adds `eegprep.cart2topo.cart2topo` for converting Cartesian channel coordinates to EEGLAB topoplot `theta`/`radius` coordinates.
- Supports both `N x 3` coordinate arrays and separate `x, y, z` coordinate vectors.
- Exports `cart2topo` from the top-level `eegprep` namespace for compatibility with existing EEGPREP function patterns.
- Adds unit coverage for cardinal points, shape handling, empty input, NaN propagation, and top-level export.
- Adds MATLAB parity coverage comparing both `theta` and `radius` against EEGLAB's `cart2topo`.

## Notes

Current EEGLAB `cart2topo.m` has deprecated documentation for GUI/squeeze/center options, but the active implementation rejects additional parameters and delegates to `convertlocs(..., 'cart2all')`. This Python port implements that active non-GUI behavior.

## Validation

- `python -m pytest tests/test_cart2topo.py -q` passed: `9 passed`
- `python -m pytest tests/test_topoplot.py tests/test_cart2topo.py -q` passed: `38 passed, 2 subtests passed`