### PR TITLE
Add GUI foundation and pop_adjustevents port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Existing EEGPREP patterns win over new architecture ideas. Inspect current code/tests before changing conventions.
 - Use EEGLAB data-structure docs as a reference when touching EEG/ALLEEG/STUDY-style fields: https://eeglab.org/tutorials/ConceptsGuide/Data_Structures.html
 - When adding or changing public behavior, update Sphinx docs in the same pass unless there is a clear reason not to.
+- For GUI work, follow `docs/gui_porting_principles.md`; keep GUI behavior familiar to EEGLAB users, keep Qt optional/lazy, and update Sphinx docs for user-visible GUI behavior.
 - Canonical EEG state is still dict-shaped for EEGLAB parity. `EEGobj` wraps that dict at `.EEG`; fields proxy via `obj.nbchan`/`obj.srate`, assignment writes into `.EEG`, and method calls deep-copy `.EEG`, call an eegprep function, then update `.EEG`. Do not treat `EEGobj` as a full `dict`/`MutableMapping` unless that is explicitly implemented.
 - Preserve EEGLAB data axis order: channels x timepoints x epochs. Do not switch core code to epochs-first. Existing continuous 2-D data must remain accepted unless a tested migration changes it.
 - Preserve separate `event` and `urevent` semantics. Event `latency` is an EEGLAB-style 1-based floating sample position by convention, not a Python array index.

--- a/docs/gui_porting_principles.md
+++ b/docs/gui_porting_principles.md
@@ -1,0 +1,45 @@
+# GUI Porting Principles
+
+EEGPREP GUI work exists to make EEGLAB users productive in Python without losing the workflows they already trust.
+
+## Foundation
+
+- Preserve EEGLAB familiarity first: labels, field order, defaults, Help/Cancel/OK flow, command history, and menu workflow should match EEGLAB unless there is a documented reason not to.
+- Use Python underneath: typed specs, explicit callbacks, optional dependencies, normal Python tests, and clean separation between GUI collection and computation.
+- Keep GUI files maintainable across EEGPREP and EEGLAB by tracking the EEGLAB source file, parity scope, and known divergences for every ported dialog.
+- Do not line-by-line port arbitrary MATLAB GUI code when it mixes layout, callbacks, validation, and computation. Extract the stable GUI contract instead.
+- GUI dependencies are optional. Core `import eegprep` must not import Qt or require a display.
+
+## Data Compatibility
+
+- GUI behavior must respect EEGLAB data semantics: `EEG.data` is channels x timepoints x epochs, events and urevents are distinct, and event `latency` is a 1-based floating sample position.
+- Preserve EEGLAB-style tags/control names in GUI specs so MATLAB dialogs and Python dialogs can be compared mechanically.
+- Keep computation in non-GUI functions. GUI code should decode user input into the same arguments that CLI/parity tests use.
+- Preserve EEGLAB-compatible history commands (`com`) for GUI-backed actions.
+- Unknown/plugin metadata must not be dropped as a side effect of GUI use.
+
+## Architecture
+
+- Represent dialogs with renderer-independent specs modeled after EEGLAB `inputgui`: title, geometry, controls, tags, defaults, callbacks, help, source file, and known differences.
+- Use PySide6/Qt as the first renderer because it best matches MATLAB/EEGLAB desktop interaction. Keep renderer-specific code isolated.
+- Store original MATLAB callback snippets only as traceability metadata. Python callbacks must be explicit, typed, and testable.
+- Prefer structural GUI parity tests over brittle pixel snapshots. Screenshot/perceptual tests can be added only for mature visual components.
+- Any intentional mismatch from EEGLAB must be documented in the spec and in user/developer docs if user-visible.
+
+## Porting Steps
+
+1. Inspect the EEGLAB source dialog and identify `geometry`, `uilist`, callbacks, result decoding, validation, core computation, and `com` generation.
+2. Implement or verify the non-GUI computation path first.
+3. Create a GUI spec that mirrors EEGLAB layout, labels, defaults, tags, and help text.
+4. Implement Python callbacks only for behavior needed by the dialog.
+5. Decode GUI results into the same arguments used by the CLI path.
+6. Add tests for computation, spec structure, GUI decoding, callback behavior, and MATLAB parity where available.
+7. Update Sphinx docs for public GUI behavior in the same pass.
+
+## Testing Bar
+
+- Every GUI-backed function needs non-GUI tests; GUI tests are not a substitute for computation tests.
+- Add MATLAB parity tests for the CLI/core behavior when the corresponding EEGLAB function exists.
+- Add spec tests for title, source file, geometry, labels, tags, defaults, and known differences.
+- Add headless Qt tests only where renderer behavior matters; skip cleanly when `eegprep[gui]` is not installed.
+- Tests should make future agent changes fail loudly when they drift from EEGLAB workflow or data semantics.

--- a/docs/source/api/generated/eegprep.pop_adjustevents.rst
+++ b/docs/source/api/generated/eegprep.pop_adjustevents.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_adjustevents
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_adjustevents

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -100,6 +100,7 @@ Epoching and Selection
 
    eegprep.pop_epoch
    eegprep.pop_select
+   eegprep.pop_adjustevents
    eegprep.eeg_eegrej
    eegprep.eegrej
 

--- a/docs/source/api/preprocessing.rst
+++ b/docs/source/api/preprocessing.rst
@@ -28,6 +28,11 @@ Channel Operations
 
 .. autofunction:: eegprep.eeg_interp
 
+Event Operations
+================
+
+.. autofunction:: eegprep.pop_adjustevents
+
 Signal Processing
 =================
 

--- a/docs/source/user_guide/gui.rst
+++ b/docs/source/user_guide/gui.rst
@@ -1,0 +1,39 @@
+.. _gui_support:
+
+===========
+GUI Support
+===========
+
+EEGPREP's GUI layer is optional and is designed to keep EEGLAB workflows
+familiar while keeping the Python API testable and scriptable.
+
+Installation
+============
+
+Install the optional GUI dependencies when you need desktop dialogs:
+
+.. code-block:: bash
+
+   pip install eegprep[gui]
+
+Event Latency Adjustment
+========================
+
+``pop_adjustevents`` ports EEGLAB's "Adjust event latencies" workflow. Event
+latencies remain EEGLAB-style 1-based floating sample positions.
+
+Use the command-line path for reproducible scripts:
+
+.. code-block:: python
+
+   EEG, com = eegprep.pop_adjustevents(EEG, addsamples=2.5)
+   EEG, com = eegprep.pop_adjustevents(EEG, addms=-10, eventtypes=["stim"])
+
+Use the GUI path when interactive selection is preferred:
+
+.. code-block:: python
+
+   EEG, com = eegprep.pop_adjustevents(EEG, gui=True)
+
+The GUI path collects options, then calls the same tested computation path as
+the script API.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -53,6 +53,7 @@ Data Workflows
    :maxdepth: 2
 
    bids_workflow
+   gui
 
 Advanced Topics
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ docs = [
   "sphinx-togglebutton>=0.3.0",
   "sphinxcontrib-spelling>=7.1.0"
 ]
+gui = [
+  "PySide6>=6.5",
+]
 # `tests` is only the lightweight test runner/TOML parser layer. Use
 # `eegprep[dev]` or `eegprep[all,tests]` for parity tests that import full EEGPREP extras.
 tests = [

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -13,6 +13,7 @@ from .pop_subcomp import pop_subcomp
 from .pop_saveset import pop_saveset
 from .pop_loadset import loadset, pop_loadset
 from .pop_loadset_h5 import pop_loadset_h5
+from .pop_adjustevents import pop_adjustevents
 from .pop_resample import pop_resample
 from .eeg_checkset import eeg_checkset
 from .eeglabcompat import pop_eegfiltnew

--- a/src/eegprep/gui/__init__.py
+++ b/src/eegprep/gui/__init__.py
@@ -1,0 +1,12 @@
+"""GUI foundation for EEGLAB-compatible EEGPREP dialogs."""
+
+from .inputgui import inputgui
+from .spec import CallbackSpec, ControlSpec, DialogSpec, controls_by_tag
+
+__all__ = [
+    "CallbackSpec",
+    "ControlSpec",
+    "DialogSpec",
+    "controls_by_tag",
+    "inputgui",
+]

--- a/src/eegprep/gui/inputgui.py
+++ b/src/eegprep/gui/inputgui.py
@@ -1,0 +1,34 @@
+"""EEGLAB-style GUI entrypoint for Python dialog specs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .spec import DialogSpec
+
+
+def inputgui(
+    spec: DialogSpec,
+    *,
+    initial_values: Mapping[str, Any] | None = None,
+    renderer: Any | None = None,
+) -> dict[str, Any] | None:
+    """Render a dialog spec and return tagged values, or ``None`` on cancel.
+
+    Parameters
+    ----------
+    spec
+        Renderer-independent dialog specification.
+    initial_values
+        Optional tag-to-value overrides used by callers/tests.
+    renderer
+        Optional renderer object with a ``run(spec, initial_values=...)`` method.
+        If omitted, the optional Qt renderer is used.
+    """
+
+    if renderer is None:
+        from .qt import QtDialogRenderer
+
+        renderer = QtDialogRenderer()
+    return renderer.run(spec, initial_values=initial_values)

--- a/src/eegprep/gui/qt.py
+++ b/src/eegprep/gui/qt.py
@@ -1,0 +1,151 @@
+"""Optional PySide6 renderer for EEGLAB-like dialog specs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .spec import CallbackSpec, ControlSpec, DialogSpec
+
+
+class QtDialogRenderer:
+    """Render :class:`DialogSpec` using PySide6 widgets."""
+
+    def run(
+        self,
+        spec: DialogSpec,
+        *,
+        initial_values: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        try:
+            from PySide6 import QtWidgets
+        except ImportError as exc:
+            raise RuntimeError(
+                "PySide6 is required for EEGPREP GUI dialogs. "
+                "Install it with `pip install -e .[gui]` or `pip install eegprep[gui]`."
+            ) from exc
+
+        app = QtWidgets.QApplication.instance()
+        if app is None:
+            app = QtWidgets.QApplication([])
+
+        dialog = QtWidgets.QDialog()
+        dialog.setWindowTitle(spec.title)
+        layout = QtWidgets.QGridLayout(dialog)
+        widgets: dict[str, Any] = {}
+        initial_values = dict(initial_values or {})
+
+        row = 0
+        col = 0
+        for control in spec.controls:
+            widget = self._build_widget(QtWidgets, control, initial_values)
+            if control.tag:
+                widgets[control.tag] = widget
+            layout.addWidget(widget, row, col)
+            col += 1
+            if self._row_width(spec.geometry, row) <= col:
+                row += 1
+                col = 0
+        for control in spec.controls:
+            self._connect_callback(control.callback, widgets)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons, row + 1, 0, 1, max(1, col or self._row_width(spec.geometry, 0)))
+
+        if dialog.exec() != QtWidgets.QDialog.Accepted:
+            return None
+        return {tag: self._read_widget(widget) for tag, widget in widgets.items()}
+
+    @staticmethod
+    def _row_width(geometry: tuple[Any, ...], row: int) -> int:
+        if not geometry:
+            return 1
+        row_geom = geometry[min(row, len(geometry) - 1)]
+        if isinstance(row_geom, (list, tuple)):
+            return max(1, len(row_geom))
+        return 1
+
+    def _build_widget(self, QtWidgets: Any, control: ControlSpec, initial_values: Mapping[str, Any]) -> Any:
+        style = control.style.lower()
+        value = initial_values.get(control.tag, control.value)
+
+        if style == "text":
+            widget = QtWidgets.QLabel(control.string)
+        elif style == "edit":
+            widget = QtWidgets.QLineEdit("" if value is None else str(value))
+        elif style == "pushbutton":
+            widget = QtWidgets.QPushButton(control.string)
+        elif style == "checkbox":
+            widget = QtWidgets.QCheckBox(control.string)
+            widget.setChecked(bool(value))
+        elif style == "spacer":
+            widget = QtWidgets.QWidget()
+        else:
+            raise ValueError(f"Unsupported GUI control style: {control.style}")
+
+        if control.tag:
+            widget.setObjectName(control.tag)
+        if control.tooltip:
+            widget.setToolTip(control.tooltip)
+        widget.setEnabled(control.enabled)
+        return widget
+
+    def _connect_callback(self, callback: CallbackSpec | None, widgets: dict[str, Any]) -> None:
+        if callback is None:
+            return
+        if callback.name == "sync_time_to_samples":
+            source = widgets.get(callback.params["source"])
+            target = widgets.get(callback.params["target"])
+            srate = float(callback.params["srate"])
+            if source is not None and target is not None:
+                source.editingFinished.connect(lambda: self._sync_numeric(source, target, srate))
+        elif callback.name == "sync_samples_to_time":
+            source = widgets.get(callback.params["source"])
+            target = widgets.get(callback.params["target"])
+            srate = float(callback.params["srate"])
+            if source is not None and target is not None:
+                source.editingFinished.connect(lambda: self._sync_numeric(source, target, 1.0 / srate))
+        elif callback.name == "select_event_types":
+            button = widgets.get(callback.params["button"])
+            target = widgets.get(callback.params["target"])
+            if button is not None and target is not None:
+                button.clicked.connect(lambda: self._select_event_types(button, target, callback.params))
+
+    @staticmethod
+    def _sync_numeric(source: Any, target: Any, multiplier: float) -> None:
+        text = source.text().strip()
+        if not text:
+            target.setText("")
+            return
+        try:
+            target.setText(f"{float(text) * multiplier:g}")
+        except ValueError:
+            return
+
+    @staticmethod
+    def _select_event_types(button: Any, target: Any, params: Mapping[str, Any]) -> None:
+        from PySide6 import QtWidgets
+
+        event_types = params.get("event_types", ())
+        text, accepted = QtWidgets.QInputDialog.getItem(
+            button,
+            "Select event type",
+            "Event type",
+            [str(event_type) for event_type in event_types],
+            editable=False,
+        )
+        if accepted and text:
+            current = target.text().strip()
+            target.setText(text if not current else f"{current} {text}")
+
+    @staticmethod
+    def _read_widget(widget: Any) -> Any:
+        if hasattr(widget, "isChecked"):
+            return widget.isChecked()
+        if hasattr(widget, "text"):
+            return widget.text()
+        return None

--- a/src/eegprep/gui/spec.py
+++ b/src/eegprep/gui/spec.py
@@ -1,0 +1,51 @@
+"""Renderer-independent GUI specifications.
+
+These dataclasses intentionally mirror EEGLAB's inputgui/supergui model at the
+spec layer while keeping Python callbacks explicit and testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CallbackSpec:
+    """Declarative callback metadata for a GUI control."""
+
+    name: str
+    params: dict[str, Any] = field(default_factory=dict)
+    matlab_callback: str | None = None
+
+
+@dataclass(frozen=True)
+class ControlSpec:
+    """Single EEGLAB-like GUI control."""
+
+    style: str
+    string: str = ""
+    tag: str | None = None
+    value: Any = None
+    callback: CallbackSpec | None = None
+    tooltip: str | None = None
+    enabled: bool = True
+
+
+@dataclass(frozen=True)
+class DialogSpec:
+    """Complete EEGLAB-like dialog specification."""
+
+    title: str
+    controls: tuple[ControlSpec, ...]
+    geometry: tuple[Any, ...]
+    function_name: str
+    eeglab_source: str
+    help_text: str | None = None
+    known_differences: tuple[str, ...] = ()
+
+
+def controls_by_tag(spec: DialogSpec) -> dict[str, ControlSpec]:
+    """Return tagged controls keyed by EEGLAB-style tag."""
+
+    return {control.tag: control for control in spec.controls if control.tag}

--- a/src/eegprep/gui/specs/__init__.py
+++ b/src/eegprep/gui/specs/__init__.py
@@ -1,0 +1,5 @@
+"""EEGLAB-compatible GUI specs for pop_* functions."""
+
+from .pop_adjustevents import pop_adjustevents_dialog_spec
+
+__all__ = ["pop_adjustevents_dialog_spec"]

--- a/src/eegprep/gui/specs/pop_adjustevents.py
+++ b/src/eegprep/gui/specs/pop_adjustevents.py
@@ -1,0 +1,66 @@
+"""GUI spec for EEGLAB's pop_adjustevents dialog."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from eegprep.gui.spec import CallbackSpec, ControlSpec, DialogSpec
+
+
+def pop_adjustevents_dialog_spec(srate: float, event_types: Iterable[object] = ()) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_adjustevents``."""
+
+    event_types = tuple(event_types)
+    return DialogSpec(
+        title="Adjust event latencies - pop_adjustevents()",
+        function_name="pop_adjustevents",
+        eeglab_source="functions/popfunc/pop_adjustevents.m",
+        geometry=([1, 0.7, 0.5], [1, 0.7, 0.5], [1, 0.7, 0.5], 1),
+        known_differences=(
+            "Python callback code is explicit; original MATLAB callback strings are kept only as metadata.",
+        ),
+        controls=(
+            ControlSpec("text", "Event type(s) to adjust (all by default): "),
+            ControlSpec("edit", tag="events", value=""),
+            ControlSpec(
+                "pushbutton",
+                "...",
+                tag="events_button",
+                callback=CallbackSpec(
+                    "select_event_types",
+                    params={"button": "events_button", "target": "events", "event_types": event_types},
+                    matlab_callback="pop_chansel(unique({ tmpevent.type }))",
+                ),
+            ),
+            ControlSpec("text", "Add in milliseconds (can be negative)"),
+            ControlSpec(
+                "edit",
+                tag="edit_time",
+                value="",
+                callback=CallbackSpec(
+                    "sync_time_to_samples",
+                    params={"source": "edit_time", "target": "edit_samples", "srate": float(srate)},
+                    matlab_callback="set(findobj('tag','edit_samples'),'string',num2str(str2num(get(gcbo,'string'))*srate))",
+                ),
+            ),
+            ControlSpec("spacer"),
+            ControlSpec("text", "Or add in samples"),
+            ControlSpec(
+                "edit",
+                tag="edit_samples",
+                value="",
+                callback=CallbackSpec(
+                    "sync_samples_to_time",
+                    params={"source": "edit_samples", "target": "edit_time", "srate": float(srate)},
+                    matlab_callback="set(findobj('tag','edit_time'),'string',num2str(str2num(get(gcbo,'string'))/srate))",
+                ),
+            ),
+            ControlSpec("spacer"),
+            ControlSpec(
+                "checkbox",
+                "Force adjustment even when boundaries are present",
+                tag="force",
+                value=False,
+            ),
+        ),
+    )

--- a/src/eegprep/pop_adjustevents.py
+++ b/src/eegprep/pop_adjustevents.py
@@ -1,0 +1,239 @@
+"""Adjust EEGLAB event latencies."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+import warnings
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+
+from eegprep.eeg_checkset import eeg_checkset
+from eegprep.eeg_options import EEG_OPTIONS
+
+
+def pop_adjustevents(
+    EEG: dict[str, Any],
+    *,
+    addms: float | None = None,
+    addsamples: float | None = None,
+    eventtypes: str | Iterable[object] | None = None,
+    eventtype: str | Iterable[object] | None = None,
+    force: str | bool = "auto",
+    gui: bool = False,
+    renderer: Any | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Adjust event latencies by milliseconds or samples.
+
+    This ports EEGLAB ``pop_adjustevents``. Event latencies remain EEGLAB-style
+    1-based floating sample positions.
+
+    Parameters
+    ----------
+    EEG
+        EEGLAB-style EEG dictionary.
+    addms
+        Milliseconds to add to matching event latencies.
+    addsamples
+        Samples to add to matching event latencies.
+    eventtypes, eventtype
+        Event type or event types to shift. Empty/``None`` means all events.
+    force
+        ``"on"``, ``"off"``, or ``"auto"``. ``"auto"`` matches EEGLAB:
+        GUI calls default to ``"off"`` and command-line calls default to ``"on"``.
+    gui
+        If true, collect options using the optional GUI renderer.
+    renderer
+        Optional test/custom renderer for GUI specs.
+
+    Returns
+    -------
+    EEG, com
+        Adjusted EEG dictionary and EEGLAB-style history command.
+    """
+
+    force_was_explicit = not (isinstance(force, str) and force.lower() == "auto")
+    if eventtypes is None and eventtype is not None:
+        eventtypes = eventtype
+
+    if gui:
+        result = _run_gui(EEG, renderer=renderer)
+        if result is None:
+            return EEG, ""
+        addms, addsamples, eventtypes, force = result
+        force_was_explicit = force == "on"
+
+    options_for_com: list[tuple[str, Any]] = []
+    if addms is not None:
+        options_for_com.append(("addms", addms))
+    elif addsamples is not None:
+        options_for_com.append(("addsamples", addsamples))
+    else:
+        raise ValueError("To adjust event latencies, specify addms or addsamples")
+
+    force_mode = _normalize_force(force, gui=gui)
+    if force_was_explicit:
+        options_for_com.append(("force", force_mode))
+
+    parsed_eventtypes = _parse_eventtypes(eventtypes)
+    if parsed_eventtypes:
+        options_for_com.append(("eventtypes", parsed_eventtypes))
+
+    EEG_out = deepcopy(EEG)
+    events = _event_list(EEG_out)
+    if not events:
+        raise ValueError("Unable to proceed. No events found")
+
+    if force_mode == "off":
+        _check_force_safe(EEG_out, events)
+
+    indices = _matching_event_indices(events, parsed_eventtypes)
+    if not indices:
+        raise ValueError("Unable to proceed. Event type(s) requested not found")
+
+    shift = float(addms) / 1000.0 * float(EEG_out["srate"]) if addms is not None else float(addsamples)
+    for index in indices:
+        if "latency" not in events[index]:
+            raise ValueError("Unable to proceed. Event missing latency field")
+        events[index]["latency"] = float(events[index]["latency"]) + shift
+
+    EEG_out = eeg_checkset(EEG_out)
+    return EEG_out, _format_command(options_for_com)
+
+
+def _run_gui(
+    EEG: dict[str, Any],
+    *,
+    renderer: Any | None = None,
+) -> tuple[float | None, float | None, list[object], str] | None:
+    from eegprep.gui import inputgui
+    from eegprep.gui.specs import pop_adjustevents_dialog_spec
+
+    spec = pop_adjustevents_dialog_spec(
+        float(EEG["srate"]),
+        event_types=_unique_event_types(_event_list(EEG)),
+    )
+    result = inputgui(spec, renderer=renderer)
+    if result is None:
+        return None
+
+    eventtypes = _parse_eventtypes(result.get("events"))
+    addms = _optional_float(result.get("edit_time"))
+    addsamples = _optional_float(result.get("edit_samples"))
+    if addms is None and addsamples is None:
+        raise ValueError("Not enough parameters selected")
+    force = "on" if bool(result.get("force")) else "off"
+    return addms, addsamples, eventtypes, force
+
+
+def _event_list(EEG: dict[str, Any]) -> list[dict[str, Any]]:
+    events = EEG.get("event", [])
+    if events is None:
+        return []
+    if isinstance(events, dict):
+        EEG["event"] = [events]
+        return EEG["event"]
+    if isinstance(events, np.ndarray):
+        return list(events)
+    return list(events)
+
+
+def _unique_event_types(events: Iterable[dict[str, Any]]) -> tuple[object, ...]:
+    values: list[object] = []
+    for event in events:
+        value = event.get("type")
+        if value not in values:
+            values.append(value)
+    return tuple(values)
+
+
+def _normalize_force(force: str | bool, *, gui: bool) -> str:
+    if isinstance(force, bool):
+        return "on" if force else "off"
+    force_mode = str(force).lower()
+    if force_mode not in {"on", "off", "auto"}:
+        raise ValueError("force must be 'on', 'off', 'auto', True, or False")
+    if force_mode == "auto":
+        return "off" if gui else "on"
+    return force_mode
+
+
+def _check_force_safe(EEG: dict[str, Any], events: Iterable[dict[str, Any]]) -> None:
+    if int(EEG.get("trials", 1)) > 1:
+        raise ValueError("Be careful when adjusting latencies for data epochs. Use the 'force' option to do so.")
+    if _has_boundary_event(events):
+        raise ValueError(
+            "Be careful when adjusting latencies when boundary events are present. "
+            "Use the 'force' option to do so."
+        )
+
+
+def _has_boundary_event(events: Iterable[dict[str, Any]]) -> bool:
+    for event in events:
+        event_type = event.get("type")
+        if isinstance(event_type, str) and event_type == "boundary":
+            return True
+        if EEG_OPTIONS.get("option_boundary99") and event_type == 99:
+            return True
+    return False
+
+
+def _matching_event_indices(events: list[dict[str, Any]], eventtypes: list[object]) -> list[int]:
+    if not eventtypes:
+        return list(range(len(events)))
+
+    indices: list[int] = []
+    for event_type in eventtypes:
+        matches = [
+            index
+            for index, event in enumerate(events)
+            if _event_type_matches(event.get("type"), event_type)
+        ]
+        if not matches:
+            warnings.warn(f"Event type '{event_type}' not found.", RuntimeWarning, stacklevel=2)
+        indices.extend(matches)
+    return indices
+
+
+def _event_type_matches(actual: object, requested: object) -> bool:
+    return actual == requested or str(actual) == str(requested)
+
+
+def _parse_eventtypes(value: str | Iterable[object] | None) -> list[object]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text or text == "{}":
+            return []
+        quoted = re.findall(r"'([^']*)'|\"([^\"]*)\"", text)
+        if quoted:
+            return [single or double for single, double in quoted]
+        return [item for item in re.split(r"[\s,]+", text) if item]
+    return [item for item in value if item is not None and item != ""]
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return float(value)
+
+
+def _format_command(options: list[tuple[str, Any]]) -> str:
+    return f"[EEG,com] = pop_adjustevents(EEG, {_format_options(options)});"
+
+
+def _format_options(options: list[tuple[str, Any]]) -> str:
+    return ", ".join(f"'{key}', {_format_value(value)}" for key, value in options)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, str):
+        return f"'{value}'"
+    if isinstance(value, (list, tuple)):
+        return "{" + ", ".join(_format_value(item) for item in value) + "}"
+    return f"{value:g}" if isinstance(value, (int, float)) else repr(value)

--- a/tests/test_pop_adjustevents.py
+++ b/tests/test_pop_adjustevents.py
@@ -1,0 +1,143 @@
+import copy
+import os
+import unittest
+import warnings
+
+import numpy as np
+
+from eegprep.eeg_options import EEG_OPTIONS
+from eegprep.eeglabcompat import get_eeglab
+from eegprep.gui import controls_by_tag
+from eegprep.gui.specs import pop_adjustevents_dialog_spec
+from eegprep.pop_adjustevents import pop_adjustevents
+
+
+def _make_eeg(events=None, trials=1):
+    if events is None:
+        events = [
+            {"type": "stim", "latency": 1.0},
+            {"type": "resp", "latency": 10.5},
+            {"type": "stim", "latency": 20.0},
+        ]
+    data = np.zeros((2, 40, trials)) if trials > 1 else np.zeros((2, 40))
+    return {
+        "data": data,
+        "nbchan": 2,
+        "pnts": 40,
+        "trials": trials,
+        "srate": 100.0,
+        "xmin": 0.0,
+        "xmax": 0.39,
+        "event": copy.deepcopy(events),
+    }
+
+
+def _events(EEG):
+    return list(EEG["event"])
+
+
+class TestPopAdjustEvents(unittest.TestCase):
+    def test_add_samples_to_all_events(self):
+        EEG_out, com = pop_adjustevents(_make_eeg(), addsamples=2.5)
+
+        latencies = [event["latency"] for event in _events(EEG_out)]
+        np.testing.assert_allclose(latencies, [3.5, 13.0, 22.5])
+        self.assertEqual(com, "[EEG,com] = pop_adjustevents(EEG, 'addsamples', 2.5);")
+
+    def test_add_ms_to_selected_event_type(self):
+        EEG_out, com = pop_adjustevents(_make_eeg(), addms=50, eventtypes="stim")
+
+        latencies = [event["latency"] for event in _events(EEG_out)]
+        np.testing.assert_allclose(latencies, [6.0, 10.5, 25.0])
+        self.assertIn("'eventtypes', {'stim'}", com)
+
+    def test_quoted_event_type_list(self):
+        EEG_out, _ = pop_adjustevents(_make_eeg(), addsamples=-1, eventtypes="'stim' 'resp'")
+
+        latencies = [event["latency"] for event in _events(EEG_out)]
+        np.testing.assert_allclose(latencies, [0.0, 9.5, 19.0])
+
+    def test_missing_event_type_warns_then_errors(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with self.assertRaisesRegex(ValueError, "requested not found"):
+                pop_adjustevents(_make_eeg(), addsamples=1, eventtypes=["missing"])
+
+        self.assertEqual(len(caught), 1)
+        self.assertIn("missing", str(caught[0].message))
+
+    def test_requires_latency_shift(self):
+        with self.assertRaisesRegex(ValueError, "specify addms or addsamples"):
+            pop_adjustevents(_make_eeg())
+
+    def test_force_off_rejects_boundary_events(self):
+        EEG = _make_eeg(events=[{"type": "boundary", "latency": 4.0}])
+
+        with self.assertRaisesRegex(ValueError, "boundary events"):
+            pop_adjustevents(EEG, addsamples=1, force="off")
+
+    def test_force_auto_command_line_allows_boundary_events(self):
+        EEG = _make_eeg(events=[{"type": "boundary", "latency": 4.0}])
+        EEG_out, com = pop_adjustevents(EEG, addsamples=1)
+
+        self.assertEqual(_events(EEG_out)[0]["latency"], 5.0)
+        self.assertNotIn("'force'", com)
+
+    def test_force_off_rejects_epoched_data(self):
+        with self.assertRaisesRegex(ValueError, "data epochs"):
+            pop_adjustevents(_make_eeg(trials=2), addsamples=1, force="off")
+
+    def test_numeric_boundary99_honors_eeglab_option(self):
+        old_value = EEG_OPTIONS["option_boundary99"]
+        EEG_OPTIONS["option_boundary99"] = 1
+        try:
+            EEG = _make_eeg(events=[{"type": 99, "latency": 4.0}])
+            with self.assertRaisesRegex(ValueError, "boundary events"):
+                pop_adjustevents(EEG, addsamples=1, force="off")
+        finally:
+            EEG_OPTIONS["option_boundary99"] = old_value
+
+    def test_gui_renderer_decodes_options(self):
+        class FakeRenderer:
+            def run(self, spec, *, initial_values=None):
+                self.spec = spec
+                return {"events": "stim", "edit_time": "10", "edit_samples": "1", "force": True}
+
+        renderer = FakeRenderer()
+        EEG_out, com = pop_adjustevents(_make_eeg(), gui=True, renderer=renderer)
+
+        self.assertEqual(renderer.spec.title, "Adjust event latencies - pop_adjustevents()")
+        latencies = [event["latency"] for event in _events(EEG_out)]
+        np.testing.assert_allclose(latencies, [2.0, 10.5, 21.0])
+        self.assertIn("'force', 'on'", com)
+
+
+class TestPopAdjustEventsGuiSpec(unittest.TestCase):
+    def test_spec_matches_eeglab_dialog_shape(self):
+        spec = pop_adjustevents_dialog_spec(100.0, event_types=["stim", "resp"])
+        controls = controls_by_tag(spec)
+
+        self.assertEqual(spec.eeglab_source, "functions/popfunc/pop_adjustevents.m")
+        self.assertEqual(spec.geometry, ([1, 0.7, 0.5], [1, 0.7, 0.5], [1, 0.7, 0.5], 1))
+        self.assertEqual(controls["events"].style, "edit")
+        self.assertEqual(controls["edit_time"].callback.name, "sync_time_to_samples")
+        self.assertEqual(controls["edit_samples"].callback.name, "sync_samples_to_time")
+        self.assertEqual(controls["force"].string, "Force adjustment even when boundaries are present")
+
+
+@unittest.skipIf(os.getenv("EEGPREP_SKIP_MATLAB") == "1", "MATLAB not available")
+class TestPopAdjustEventsParity(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.eeglab = get_eeglab("MAT")
+        except Exception as exc:
+            self.skipTest(f"MATLAB not available: {exc}")
+
+    def test_add_samples_matches_eeglab(self):
+        EEG = _make_eeg()
+        EEG_py, _ = pop_adjustevents(copy.deepcopy(EEG), addsamples=2.5, force="on")
+        EEG_mat, _ = self.eeglab.pop_adjustevents(copy.deepcopy(EEG), "addsamples", 2.5, "force", "on", nout=2)
+
+        py_latencies = [event["latency"] for event in _events(EEG_py)]
+        mat_latencies = [event["latency"] for event in _events(EEG_mat)]
+        np.testing.assert_allclose(py_latencies, mat_latencies)


### PR DESCRIPTION
## Summary

This PR adds the first GUI foundation for EEGPREP's EEGLAB-compatible desktop workflows.

- Adds a new `eegprep.gui` package with renderer-independent dialog specs modeled after EEGLAB `inputgui`/`uilist`/`geometry`.
- Adds an optional PySide6/Qt renderer behind the `eegprep[gui]` extra, with lazy imports so core `import eegprep` does not require Qt or a display.
- Ports EEGLAB's `pop_adjustevents` workflow for adjusting event latencies by milliseconds or samples, including GUI result decoding and EEGLAB-style `com` history generation.
- Adds `docs/gui_porting_principles.md` as agent-facing GUI porting guidance, while keeping it out of Sphinx.
- Adds Sphinx user/API documentation for GUI support and `pop_adjustevents`.

## Validation

- `EEGPREP_SKIP_MATLAB=1 /data/projects/suraj/.miniforge3/envs/eegprep-dev/bin/python -m pytest tests/test_parity_harness.py tests/test_pop_adjustevents.py -q`
- `LC_ALL=C LANG=C /data/projects/suraj/.miniforge3/envs/eegprep-dev/bin/python -m sphinx -b html docs/source /tmp/eegprep-docs-gui-foundation -q`
- `git diff --check`

## Notes

This is stacked on `feat/parity-harness-foundation` because the GUI foundation builds on the parity harness and agent guidance work from that branch.

The Sphinx build completes with existing autodoc/docstring warnings from unrelated files; no GUI-porting-principles agent doc is included in the Sphinx toctree.