### PR TITLE
Use pytest as the test runner

### DIFF
--- a/.agents/skills/eeglab-gui-visual-parity/SKILL.md
+++ b/.agents/skills/eeglab-gui-visual-parity/SKILL.md
@@ -20,7 +20,7 @@ git rev-parse --show-toplevel
 Use the uv-managed project environment by default:
 
 ```bash
-uv run python -m unittest tests.test_visual_parity
+uv run pytest tests/test_visual_parity.py
 ```
 
 For repeated capture runs after the environment is synced, skip dependency

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -100,7 +100,7 @@ beginning work. Your tests will be minimal and refrain from using mocks.
 * You never use mocks when testing.
 * You keep tests simple and minimal. You do not test obvious behavior like "object has an attr".
 * You run `./pre-commit.py --fix` and resolve all reported issues before uploading.
-* You will test using `uv run python -m unittest discover -s tests` before uploading.
+* You will test using `uv run pytest` before uploading.
 * You will ensure _all_ tests pass.
 
 ## Uploading

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -60,7 +60,7 @@ issue link.
 Run these before pushing. Do not skip any step.
 
 1. `./pre-commit.py --fix` — resolve all issues. Do not substitute `uv run pre-commit ...`.
-2. `uv run python -m unittest discover -s tests` — relevant test directories.
+2. `uv run pytest` — relevant test files or directories.
 
 After pushing, monitor CI: `gh pr view <number> --json statusCheckRollup`.
 Fix failures before considering the PR complete.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,7 +69,7 @@ jobs:
             --model claude-opus-4-7
             --max-turns 250
             --allowedTools "Bash(git:*),Bash(./pre-commit.py:*),Bash(uv:*),Bash(gh:*),Bash(python:*)"
-            --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./pre-commit.py --fix and fix any issues. 2) Run uv run python -m unittest discover -s tests on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
+            --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./pre-commit.py --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
 
   triage:
       if: |
@@ -207,7 +207,7 @@ jobs:
             2. Fetch inline PR review comments: `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`
             3. Apply ALL actionable changes from the review comments to the code.
             4. Run ./pre-commit.py --fix
-            5. Run uv run python -m unittest discover -s tests on affected tests
+            5. Run uv run pytest on affected tests
             6. Commit and push changes to the PR branch
             7. Post a comment summarizing what was changed, prefixed with "🤖 Autofix:"
           claude_args: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
         uses: matlab-actions/run-command@v2
         with:
           command: |
-            [status, cmdout] = system('uv run --no-sync python -m unittest discover -s tests');
+            [status, cmdout] = system('uv run --no-sync pytest tests');
             disp(cmdout);
             if status ~= 0
                 error('Python tests failed');
@@ -150,7 +150,7 @@ jobs:
       - name: Run Python tests
         if: steps.matlab-availability.outputs.available != 'true'
         run: |
-          uv run --no-sync python -m unittest discover -s tests
+          uv run --no-sync pytest tests
 
       - name: Display installed packages
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,12 +81,14 @@ Primary references:
 
 ## Testing
 
-- Current CI uses `unittest`, not pytest markers. Do not assume `pytest -m "not slow"` works here.
+- Pytest is the default test runner. Existing tests may still use `unittest.TestCase`; do not rewrite them unless the touched test benefits from pytest fixtures or parametrization.
+- Registered markers include `slow`, `matlab`, `octave`, `gui`, `visual`, and `parity`.
 - Always fix tests you break.
 - Run the narrowest relevant tests first, then broaden as risk requires:
-  - Single file: `uv run python -m unittest tests.test_pop_select`
-  - Full suite: `uv run python -m unittest discover -s tests`
-  - No MATLAB locally: `EEGPREP_SKIP_MATLAB=1 uv run python -m unittest discover -s tests`
+  - Single file: `uv run pytest tests/test_pop_select.py`
+  - Marker subset: `uv run pytest -m "not slow"`
+  - Full suite: `uv run pytest tests`
+  - No MATLAB locally: `EEGPREP_SKIP_MATLAB=1 uv run pytest tests`
 - Some parity tests require MATLAB Engine or Octave via `src/eegprep/functions/adminfunc/eeglabcompat.py`; preserve skip behavior instead of weakening assertions.
 - Prefer integration-style tests that validate externally observable behavior on EEG dicts, BIDS outputs, files, or MATLAB parity results.
 - Search existing test files before creating new ones. Extend the closest existing test first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Primary references:
 
 - Pytest is the default test runner. Existing tests may still use `unittest.TestCase`; do not rewrite them unless the touched test benefits from pytest fixtures or parametrization.
 - Registered markers include `slow`, `matlab`, `octave`, `gui`, `visual`, and `parity`.
+- Legacy `unittest` tests are categorized by path/name in `tests/conftest.py`; update that map when adding obvious slow, MATLAB, GUI, visual, or parity coverage.
 - Always fix tests you break.
 - Run the narrowest relevant tests first, then broaden as risk requires:
   - Single file: `uv run pytest tests/test_pop_select.py`

--- a/README.md
+++ b/README.md
@@ -151,11 +151,17 @@ engine.eval("disp('hello world');", nargout=0)
 
 Use tests/matlab/main_compare.m
 
-This project uses `unittest`. You can run tests from the project root via the command:
+This project uses `pytest` as the test runner. Existing tests may still use
+`unittest.TestCase`, and pytest runs them normally. Run tests from the project
+root with:
 ```
-uv run python -m unittest discover -s tests
+uv run pytest tests
 ```
-...or use the unittest integration in your IDE (e.g., PyCharm, VS Code, or Cursor).
+
+For quick local iteration, exclude slow tests with:
+```
+uv run pytest -m "not slow"
+```
 
 ## Core maintainers
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -100,19 +100,19 @@ Run the full test suite:
 
 .. code-block:: bash
 
-    uv run python -m unittest discover -s tests
+    uv run pytest tests
 
 Run tests for a specific module:
 
 .. code-block:: bash
 
-    uv run python -m unittest tests.test_clean_artifacts
+    uv run pytest tests/test_clean_artifacts.py
 
 Run tests with verbose output:
 
 .. code-block:: bash
 
-    uv run python -m unittest -v tests.test_clean_artifacts
+    uv run pytest -v tests/test_clean_artifacts.py
 
 Writing Tests
 -------------
@@ -227,7 +227,7 @@ Before Submitting
 
 .. code-block:: bash
 
-    uv run python -m unittest discover -s tests
+    uv run pytest tests
 
 3. Check code style:
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -84,19 +84,25 @@ Tests are located in the ``tests/`` directory. Run all tests:
 
 .. code-block:: bash
 
-    uv run python -m unittest discover -s tests
+    uv run pytest tests
 
 Run specific test file:
 
 .. code-block:: bash
 
-    uv run python -m unittest tests.test_clean_artifacts
+    uv run pytest tests/test_clean_artifacts.py
 
 Run specific test function:
 
 .. code-block:: bash
 
-    uv run python -m unittest tests.test_clean_artifacts.TestClassName.test_method_name
+    uv run pytest tests/test_clean_artifacts.py::TestClassName::test_method_name
+
+Run a marker subset:
+
+.. code-block:: bash
+
+    uv run pytest -m "not slow"
 
 Continuous Integration
 ----------------------
@@ -357,7 +363,7 @@ Test Failures
 .. code-block:: bash
 
     uv sync --group dev
-    uv run python -m unittest discover -s tests
+    uv run pytest tests
 
 Documentation Build Errors
 ---------------------------

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -104,6 +104,10 @@ Run a marker subset:
 
     uv run pytest -m "not slow"
 
+Markers include ``slow``, ``matlab``, ``octave``, ``gui``, ``visual``, and
+``parity``. Legacy ``unittest`` tests are categorized during collection in
+``tests/conftest.py`` so marker expressions work without rewriting the tests.
+
 Continuous Integration
 ----------------------
 

--- a/docs/source/user_guide/visual_parity.rst
+++ b/docs/source/user_guide/visual_parity.rst
@@ -132,7 +132,7 @@ Compare the exported EEGLAB menu JSON with an EEGPREP menu model:
 
 .. code-block:: bash
 
-   python tools/visual_parity/menu_inventory.py \
+   uv run --no-sync python tools/visual_parity/menu_inventory.py \
        --reference .visual-parity/eeglab_menus.json \
        --candidate .visual-parity/eegprep_menus.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ all = [
 
 [dependency-groups]
 dev = [
+  "pytest>=8.0",
   "pyyaml>=6.0",
   "tomli>=2.0; python_version < '3.11'",
 ]
@@ -95,6 +96,22 @@ constraint-dependencies = [
 ]
 required-environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = [
+  "-ra",
+  "--strict-config",
+  "--strict-markers",
+]
+markers = [
+  "slow: tests that are too slow for quick local iteration",
+  "matlab: tests that require MATLAB or MATLAB Engine",
+  "octave: tests that require Octave",
+  "gui: tests that exercise GUI behavior",
+  "visual: visual parity capture or comparison tests",
+  "parity: numerical or behavioral parity tests against EEGLAB/MATLAB",
 ]
 
 [tool.setuptools]

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -201,7 +201,7 @@ def check_prerequisites():
 
     # Remind about tests
     print_info("Remember to run tests before releasing!")
-    print_info("  uv run python -m unittest discover -s tests")
+    print_info("  uv run pytest tests")
 
 
 def get_new_version(current_version):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,114 @@
+"""Pytest collection markers for legacy unittest-style tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+SLOW_NODEID_PARTS = (
+    "tests/test_eeg_amica.py::",
+    "tests/test_runamica.py::TestRunamicaIntegration::",
+)
+
+VISUAL_FILE_SUFFIXES = (
+    "tests/test_visual_parity.py",
+)
+
+GUI_FILE_SUFFIXES = (
+    "tests/test_gui_pop_adjustevents.py",
+)
+GUI_NODEID_PARTS = (
+    "::test_gui_",
+)
+
+MATLAB_FILE_SUFFIXES = (
+    "tests/test_ICL_feature_extractor_parity.py",
+    "tests/test_bids_preproc.py",
+    "tests/test_clean_rawdata.py",
+    "tests/test_eeg_compare.py",
+    "tests/test_eeg_eeg2mne.py",
+    "tests/test_eeg_eegrej.py",
+    "tests/test_eeg_lat2point.py",
+    "tests/test_eeg_mne2eeg_epochs.py",
+    "tests/test_eeg_point2lat.py",
+    "tests/test_eeg_rpsd_parity.py",
+    "tests/test_eegfindboundaries.py",
+    "tests/test_iclabel.py",
+    "tests/test_iclabel_features.py",
+    "tests/test_parity_rng.py",
+    "tests/test_pinv.py",
+    "tests/test_pipeline.py",
+    "tests/test_pop_epoch.py",
+    "tests/test_pop_loadset_h5.py",
+    "tests/test_pop_resample.py",
+    "tests/test_pop_rmbase.py",
+)
+
+MATLAB_NODEID_PARTS = (
+    "tests/test_ICL_feature_extractor.py::TestICLFeatureExtractorParity::",
+    "tests/test_eeg_autocorr.py::TestEegAutocorr::test_parity_",
+    "tests/test_eeg_autocorr_fftw.py::TestEegAutocorrFftw::test_parity_",
+    "tests/test_eeg_autocorr_welch.py::TestEegAutocorrWelch::test_parity_",
+    "tests/test_eeg_interp.py::TestComputeGParity::",
+    "tests/test_eeg_interp.py::TestEegInterpParity::",
+    "tests/test_eeg_interp.py::TestSphericalSplineParity::",
+    "tests/test_eeg_picard.py::TestEegPicard::",
+    "tests/test_eegrej.py::TestEEGRej::test_compare_to_eeglab",
+    "tests/test_eeglabcompat.py::TestCleanDrifts::",
+    "tests/test_eeglabcompat.py::TestEegChecksetMatlab::",
+    "tests/test_eeglabcompat.py::TestEeglabCompatIntegration::",
+    "tests/test_eeglabcompat.py::TestGetEeglab::",
+    "tests/test_eeglabcompat.py::TestPopEegfiltnew::",
+    "tests/test_epoch.py::TestEpochParity::",
+    "tests/test_matlab_path.py::TestMatlabPath::test_get_eeglab_mat",
+    "tests/test_matlab_path.py::TestMatlabPath::test_python_matlab_engine",
+    "tests/test_matlab_path.py::TestMatlabPath::test_start_matlab_engine",
+    "tests/test_pop_reref.py::TestPopReref::test_parity_",
+    "tests/test_pop_select.py::TestPopSelectParity::",
+    "tests/test_runica.py::TestRunicaParity::",
+    "tests/test_topoplot.py::TestTopoplotParity::",
+)
+
+OCTAVE_NODEID_PARTS = (
+    "tests/test_matlab_path.py::TestMatlabPath::test_get_eeglab_oct",
+)
+
+
+def _path_has_suffix(path: str, suffixes: tuple[str, ...]) -> bool:
+    return any(path == suffix or path.endswith(f"/{suffix}") for suffix in suffixes)
+
+
+def _nodeid_has_part(nodeid: str, parts: tuple[str, ...]) -> bool:
+    return any(part in nodeid for part in parts)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    del config
+
+    for item in items:
+        nodeid = item.nodeid
+        lower_nodeid = nodeid.lower()
+        path = item.path.as_posix()
+
+        if _nodeid_has_part(nodeid, SLOW_NODEID_PARTS):
+            item.add_marker(pytest.mark.slow)
+
+        if _path_has_suffix(path, VISUAL_FILE_SUFFIXES):
+            item.add_marker(pytest.mark.visual)
+
+        if _path_has_suffix(path, GUI_FILE_SUFFIXES) or _nodeid_has_part(
+            lower_nodeid, GUI_NODEID_PARTS
+        ):
+            item.add_marker(pytest.mark.gui)
+
+        if "parity" in lower_nodeid:
+            item.add_marker(pytest.mark.parity)
+
+        requires_matlab = _path_has_suffix(path, MATLAB_FILE_SUFFIXES) or _nodeid_has_part(
+            nodeid, MATLAB_NODEID_PARTS
+        )
+        if requires_matlab:
+            item.add_marker(pytest.mark.matlab)
+
+        if _nodeid_has_part(nodeid, OCTAVE_NODEID_PARTS):
+            item.add_marker(pytest.mark.octave)

--- a/uv.lock
+++ b/uv.lock
@@ -736,6 +736,7 @@ torch = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -783,6 +784,7 @@ provides-extras = ["torch", "eeglabio", "gui", "docs", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
@@ -1055,6 +1057,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2407,6 +2418,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pooch"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2652,6 +2672,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/35/f06b1b641d7600ec46374c16cd37c66fa4a22870326b4eb073a95471035f/pyside6_essentials-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4854cb0a1b061e7a576d8fb7bb7cf9f49540d558b1acb7df0742a7afefe61e4e", size = 77380821, upload-time = "2026-03-23T12:43:24.649Z" },
     { url = "https://files.pythonhosted.org/packages/ff/37/ba95c6262836d2b286b4e05a9d16a5e870995d5d2503ac6adc6312208049/pyside6_essentials-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:3b3362882ad9389357a80504e600180006a957731fec05786fced7b038461fdf", size = 75793322, upload-time = "2026-03-23T12:43:35.575Z" },
     { url = "https://files.pythonhosted.org/packages/53/27/d17f25e45820e633a70e6109b35991eda09a5e8000c2a306f0ab7538d48c/pyside6_essentials-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:81ca603dbf21bc39f89bb42db215c25ebe0c879a1a4c387625c321d2730ec187", size = 56337457, upload-time = "2026-03-23T12:43:43.573Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add pytest to the uv dev dependency group and register repo markers: `slow`, `matlab`, `octave`, `gui`, `visual`, and `parity`.
- Switch CI and agent workflow test commands from `python -m unittest discover` to `uv run pytest` while keeping existing `unittest.TestCase` tests intact.
- Update README, contributor/development docs, AGENTS.md, and agent skills with pytest commands, including `uv run pytest -m "not slow"` for quick local iteration.

## Validation
- `uv lock --check`
- `uv sync --group dev`
- `uv run --no-sync pytest tests/test_runamica.py::TestFindAmicaBinary -q`
- `EEGPREP_SKIP_MATLAB=1 timeout 180 uv run --no-sync pytest --collect-only tests -q`
- `uv run --no-sync pytest -m "not slow" --collect-only tests/test_runamica.py -q`
- `./pre-commit.py <changed files>`

Stacked on #50 so the diff stays limited to the pytest runner migration.