### PR TITLE
Use CommonAverageReference consistently in bids_preproc reports

### DIFF
--- a/scripts/bids_preproc_accuracy_report.py
+++ b/scripts/bids_preproc_accuracy_report.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         11: 'Reinterpolate',
         12: 'Epoching',
         13: 'BaselineRemoval',
-        14: 'CommonAverageRef',
+        14: 'CommonAverageReference',
     }
 
     # Initialize results structure indexed by stage

--- a/scripts/bids_preproc_accuracy_report_new.py
+++ b/scripts/bids_preproc_accuracy_report_new.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         11: 'Reinterpolate',
         12: 'Epoching',
         13: 'BaselineRemoval',
-        14: 'CommonAverageRef',
+        14: 'CommonAverageReference',
     }
 
     # Initialize results structure indexed by stage

--- a/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 eeg_extensions = ('.vhdr', '.edf', '.bdf', '.set')
 
 # list of all possible processing stages, in the order in which they apply
-all_stages = ['Import', 'ChannelSelection', 'Resample', 'CleanArtifacts', 'ICA', 'ICLabel', 'ChannelInterp', 'Epoching', 'CommonAverageRef']
+all_stages = ['Import', 'ChannelSelection', 'Resample', 'CleanArtifacts', 'ICA', 'ICLabel', 'ChannelInterp', 'Epoching', 'CommonAverageReference']
 
 def _copy_misc_root_files(root: str, dst: str, exclude: List[str]) -> None:
     """Move miscellaneous description files from the study root to the target directory."""
@@ -540,7 +540,7 @@ def bids_preproc(
             need_final = False
 
         if CommonAverageReference:
-            StagesToGo += ['CommonAverageRef']
+            StagesToGo += ['CommonAverageReference']
             need_final = True
 
         if need_final:
@@ -949,7 +949,7 @@ def bids_preproc(
 
                 if CommonAverageReference:
                     EEG = pop_reref(EEG, [])
-                    StagesToGo.remove('CommonAverageRef')
+                    StagesToGo.remove('CommonAverageReference')
                     report["CommonAverageReference"] = {"Applied": True}
                     save_stage(EEG, 14, 'reref')
 


### PR DESCRIPTION
The success path wrote report key "CommonAverageReference" while the cascade-skip path wrote "CommonAverageRef" (from all_stages/StagesToGo), so the same stage appeared under two different keys depending on whether it ran or was skipped. Standardize on the long form (matching the existing kwarg) across all_stages, StagesToGo, and the two report writes; update the stage label in scripts/bids_preproc_accuracy_report*.py for consistency.