### PR TITLE
Add Ruff and ty CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,18 @@ jobs:
         run: |
           uv sync --python ${{ matrix.python-version }} --all-extras --group dev
 
+      - name: Run Ruff lint
+        run: |
+          uv run --no-sync ruff check .
+
+      - name: Run Ruff format check
+        run: |
+          uv run --no-sync ruff format --check .
+
+      - name: Run ty type check
+        run: |
+          uv run --no-sync ty check
+
       - name: Set up MATLAB
         if: steps.matlab-availability.outputs.available == 'true'
         uses: matlab-actions/setup-matlab@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,44 @@ jobs:
         run: |
           ./pre-commit.py --changed-from "origin/${{ github.base_ref }}"
 
+  lint:
+    name: Ruff and ty
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python 3.11
+        run: |
+          uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv sync --python 3.11 --all-extras --group dev
+
+      - name: Run Ruff lint
+        run: |
+          uv run --no-sync ruff check .
+
+      - name: Run Ruff format check
+        run: |
+          uv run --no-sync ruff format --check .
+
+      - name: Run ty type check
+        run: |
+          uv run --no-sync ty check
+
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -102,18 +137,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --python ${{ matrix.python-version }} --all-extras --group dev
-
-      - name: Run Ruff lint
-        run: |
-          uv run --no-sync ruff check .
-
-      - name: Run Ruff format check
-        run: |
-          uv run --no-sync ruff format --check .
-
-      - name: Run ty type check
-        run: |
-          uv run --no-sync ty check
 
       - name: Set up MATLAB
         if: steps.matlab-availability.outputs.available == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Primary references:
 - Use `./pre-commit.py --changed-from origin/develop` for PR-scope checks.
 - Use `./pre-commit.py --changed-from origin/develop --fix` to fix only files changed against the base branch.
 - Avoid `./pre-commit.py --all-files --fix` unless the user explicitly wants a repo-wide cleanup.
+- CI also runs `uv run --no-sync ruff check .`, `uv run --no-sync ruff format --check .`, and `uv run --no-sync ty check`; run these locally after broad formatting, import, or typing-sensitive changes.
 - Pre-commit is separate from unit tests; run both when code changes.
 
 ## Dependencies

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import os
 import sys
 from pathlib import Path
 
@@ -19,6 +18,7 @@ author = "EEGPrep contributors"
 # Import version from eegprep package
 try:
     import eegprep
+
     version = eegprep.__version__
     release = version
 except ImportError as e:
@@ -243,4 +243,3 @@ html_search_language = "en"
 html_search_options = {
     "type": "default",
 }
-

--- a/docs/source/examples/plot_artifact_removal.py
+++ b/docs/source/examples/plot_artifact_removal.py
@@ -32,9 +32,10 @@ References
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mne import create_info, EpochsArray
+from mne import create_info
 from mne.channels import make_standard_montage
 import sys
+
 sys.path.insert(0, '/Users/baristim/Projects/eegprep/src')
 
 import eegprep
@@ -56,10 +57,38 @@ duration = n_samples / sfreq
 
 # Create standard 10-20 channel names
 ch_names = [
-    'Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8',
-    'T7', 'C3', 'Cz', 'C4', 'T8', 'P7', 'P3', 'Pz',
-    'P4', 'P8', 'O1', 'Oz', 'O2', 'A1', 'A2', 'M1',
-    'M2', 'Fc1', 'Fc2', 'Cp1', 'Cp2', 'Fc5', 'Fc6', 'Cp5'
+    'Fp1',
+    'Fpz',
+    'Fp2',
+    'F7',
+    'F3',
+    'Fz',
+    'F4',
+    'F8',
+    'T7',
+    'C3',
+    'Cz',
+    'C4',
+    'T8',
+    'P7',
+    'P3',
+    'Pz',
+    'P4',
+    'P8',
+    'O1',
+    'Oz',
+    'O2',
+    'A1',
+    'A2',
+    'M1',
+    'M2',
+    'Fc1',
+    'Fc2',
+    'Cp1',
+    'Cp2',
+    'Fc5',
+    'Fc6',
+    'Cp5',
 ]
 
 # Create time vector
@@ -115,7 +144,7 @@ for i in range(n_channels):
     data[i, :] += drift * (0.1 + np.random.rand())
 print("  ✓ Added slow drift artifacts")
 
-print(f"\nData with artifacts created:")
+print("\nData with artifacts created:")
 print(f"  Shape: {data.shape}")
 print(f"  Range: [{np.min(data):.2f}, {np.max(data):.2f}] µV")
 print("=" * 70)
@@ -149,18 +178,20 @@ for i, ch_name in enumerate(ch_names):
             theta = (i / len(ch_names)) * 2 * np.pi
             phi = np.pi / 4
             pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
-    except:
+    except Exception:
         # Default: generate position on unit sphere
         theta = (i / len(ch_names)) * 2 * np.pi
         phi = np.pi / 4
         pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
 
-    chanlocs.append({
-        'labels': ch_name,
-        'X': float(pos[0]),
-        'Y': float(pos[1]),
-        'Z': float(pos[2]),
-    })
+    chanlocs.append(
+        {
+            'labels': ch_name,
+            'X': float(pos[0]),
+            'Y': float(pos[1]),
+            'Z': float(pos[2]),
+        }
+    )
 
 EEG_dict = {
     'data': data.copy(),
@@ -170,7 +201,7 @@ EEG_dict = {
     'xmin': 0,
     'xmax': (data.shape[1] - 1) / sfreq,
     'chanlocs': chanlocs,
-    'etc': {}
+    'etc': {},
 }
 
 result = eegprep.clean_artifacts(EEG_dict, ChannelCriterion='off', LineNoiseCriterion='off')
@@ -191,16 +222,10 @@ print("Description: Removes artifacts while preserving signal structure")
 print("Threshold controls aggressiveness (lower = more aggressive)")
 
 # Create EEG dict for ASR (reuse the one created earlier)
-cleaned_asr_20_result = eegprep.clean_asr(
-    EEG_dict.copy(),
-    cutoff=20
-)
+cleaned_asr_20_result = eegprep.clean_asr(EEG_dict.copy(), cutoff=20)
 cleaned_asr_20 = cleaned_asr_20_result['data']
 
-cleaned_asr_15_result = eegprep.clean_asr(
-    EEG_dict.copy(),
-    cutoff=15
-)
+cleaned_asr_15_result = eegprep.clean_asr(EEG_dict.copy(), cutoff=15)
 cleaned_asr_15 = cleaned_asr_15_result['data']
 
 print(f"ASR (threshold=20): Data range [{np.min(cleaned_asr_20):.2f}, {np.max(cleaned_asr_20):.2f}] µV")
@@ -217,9 +242,7 @@ print("=" * 70)
 print("Description: Removes channels with flat/dead signals")
 print("Good for: Detecting and handling non-functional channels")
 
-cleaned_flatlines_result = eegprep.clean_flatlines(
-    EEG_dict.copy()
-)
+cleaned_flatlines_result = eegprep.clean_flatlines(EEG_dict.copy())
 cleaned_flatlines = cleaned_flatlines_result['data']
 
 print(f"Result: Data range [{np.min(cleaned_flatlines):.2f}, {np.max(cleaned_flatlines):.2f}] µV")
@@ -239,61 +262,56 @@ time_window = slice(0, 3000)  # First 6 seconds
 ax = axes[0]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 150
-    ax.plot(t[time_window], data[ch_idx, time_window] + offset,
-            linewidth=1.5, label=ch_names[ch_idx])
+    ax.plot(t[time_window], data[ch_idx, time_window] + offset, linewidth=1.5, label=ch_names[ch_idx])
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('Original Data with Artifacts', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 ax.legend(loc='upper right', fontsize=10)
 
 # Plot 2: clean_artifacts
 ax = axes[1]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 150
-    ax.plot(t[time_window], cleaned_artifacts[ch_idx, time_window] + offset,
-            linewidth=1.5, label=ch_names[ch_idx])
+    ax.plot(t[time_window], cleaned_artifacts[ch_idx, time_window] + offset, linewidth=1.5, label=ch_names[ch_idx])
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After clean_artifacts', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 ax.legend(loc='upper right', fontsize=10)
 
 # Plot 3: clean_asr (threshold=20)
 ax = axes[2]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 150
-    ax.plot(t[time_window], cleaned_asr_20[ch_idx, time_window] + offset,
-            linewidth=1.5, label=ch_names[ch_idx])
+    ax.plot(t[time_window], cleaned_asr_20[ch_idx, time_window] + offset, linewidth=1.5, label=ch_names[ch_idx])
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After clean_asr (threshold=20)', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 ax.legend(loc='upper right', fontsize=10)
 
 # Plot 4: clean_asr (threshold=15)
 ax = axes[3]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 150
-    ax.plot(t[time_window], cleaned_asr_15[ch_idx, time_window] + offset,
-            linewidth=1.5, label=ch_names[ch_idx])
+    ax.plot(t[time_window], cleaned_asr_15[ch_idx, time_window] + offset, linewidth=1.5, label=ch_names[ch_idx])
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After clean_asr (threshold=15, more aggressive)', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 ax.legend(loc='upper right', fontsize=10)
 
 # Plot 5: clean_flatlines
 ax = axes[4]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 150
-    ax.plot(t[time_window], cleaned_flatlines[ch_idx, time_window] + offset,
-            linewidth=1.5, label=ch_names[ch_idx])
+    ax.plot(t[time_window], cleaned_flatlines[ch_idx, time_window] + offset, linewidth=1.5, label=ch_names[ch_idx])
 ax.set_xlabel('Time (s)', fontsize=11)
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After clean_flatlines', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 ax.legend(loc='upper right', fontsize=10)
 
 plt.tight_layout()
@@ -321,8 +339,7 @@ ax.grid(True, alpha=0.3, axis='y')
 # Add value labels on bars
 for bar in bars:
     height = bar.get_height()
-    ax.text(bar.get_x() + bar.get_width()/2., height,
-            f'{height:.0f}', ha='center', va='bottom', fontsize=9)
+    ax.text(bar.get_x() + bar.get_width() / 2.0, height, f'{height:.0f}', ha='center', va='bottom', fontsize=9)
 
 # Standard deviation comparison
 ax = axes[0, 1]
@@ -334,8 +351,7 @@ ax.tick_params(axis='x', rotation=45)
 ax.grid(True, alpha=0.3, axis='y')
 for bar in bars:
     height = bar.get_height()
-    ax.text(bar.get_x() + bar.get_width()/2., height,
-            f'{height:.1f}', ha='center', va='bottom', fontsize=9)
+    ax.text(bar.get_x() + bar.get_width() / 2.0, height, f'{height:.1f}', ha='center', va='bottom', fontsize=9)
 
 # Range comparison
 ax = axes[1, 0]
@@ -347,8 +363,7 @@ ax.tick_params(axis='x', rotation=45)
 ax.grid(True, alpha=0.3, axis='y')
 for bar in bars:
     height = bar.get_height()
-    ax.text(bar.get_x() + bar.get_width()/2., height,
-            f'{height:.0f}', ha='center', va='bottom', fontsize=9)
+    ax.text(bar.get_x() + bar.get_width() / 2.0, height, f'{height:.0f}', ha='center', va='bottom', fontsize=9)
 
 # Mean absolute value comparison
 ax = axes[1, 1]
@@ -360,8 +375,7 @@ ax.tick_params(axis='x', rotation=45)
 ax.grid(True, alpha=0.3, axis='y')
 for bar in bars:
     height = bar.get_height()
-    ax.text(bar.get_x() + bar.get_width()/2., height,
-            f'{height:.1f}', ha='center', va='bottom', fontsize=9)
+    ax.text(bar.get_x() + bar.get_width() / 2.0, height, f'{height:.1f}', ha='center', va='bottom', fontsize=9)
 
 plt.tight_layout()
 plt.show()
@@ -382,7 +396,7 @@ print("   - General-purpose artifact removal")
 print("   - Removes high-amplitude transient artifacts")
 print("   - Fast and computationally efficient")
 print("   - Good for eye blinks and muscle artifacts")
-var_reduction = (1 - np.var(cleaned_artifacts)/np.var(data))*100
+var_reduction = (1 - np.var(cleaned_artifacts) / np.var(data)) * 100
 print(f"   - Variance reduction: {var_reduction:.1f}%")
 print("\n   Best for: Quick preprocessing, real-time applications")
 
@@ -393,8 +407,8 @@ print("   - Removes artifacts while preserving signal structure")
 print("   - Threshold controls aggressiveness")
 print("   - More sophisticated than clean_artifacts")
 print("   - Preserves brain activity better")
-var_reduction_20 = (1 - np.var(cleaned_asr_20)/np.var(data))*100
-var_reduction_15 = (1 - np.var(cleaned_asr_15)/np.var(data))*100
+var_reduction_20 = (1 - np.var(cleaned_asr_20) / np.var(data)) * 100
+var_reduction_15 = (1 - np.var(cleaned_asr_15) / np.var(data)) * 100
 print(f"   - ASR(20) variance reduction: {var_reduction_20:.1f}%")
 print(f"   - ASR(15) variance reduction: {var_reduction_15:.1f}%")
 print("\n   Best for: Research applications, when signal preservation is critical")
@@ -405,7 +419,7 @@ print("   Characteristics:")
 print("   - Removes channels with no signal variation")
 print("   - Detects dead/non-functional channels")
 print("   - Complements other methods")
-var_reduction_flat = (1 - np.var(cleaned_flatlines)/np.var(data))*100
+var_reduction_flat = (1 - np.var(cleaned_flatlines) / np.var(data)) * 100
 print(f"   - Variance reduction: {var_reduction_flat:.1f}%")
 print("\n   Best for: Channel quality control, preprocessing pipeline")
 

--- a/docs/source/examples/plot_basic_preprocessing.py
+++ b/docs/source/examples/plot_basic_preprocessing.py
@@ -36,6 +36,7 @@ import matplotlib.pyplot as plt
 from mne import create_info, EpochsArray
 from mne.channels import make_standard_montage
 import sys
+
 sys.path.insert(0, '/Users/baristim/Projects/eegprep/src')
 
 import eegprep
@@ -58,10 +59,38 @@ duration = n_samples / sfreq
 
 # Create standard 10-20 channel names
 ch_names = [
-    'Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8',
-    'T7', 'C3', 'Cz', 'C4', 'T8', 'P7', 'P3', 'Pz',
-    'P4', 'P8', 'O1', 'Oz', 'O2', 'A1', 'A2', 'M1',
-    'M2', 'Fc1', 'Fc2', 'Cp1', 'Cp2', 'Fc5', 'Fc6', 'Cp5'
+    'Fp1',
+    'Fpz',
+    'Fp2',
+    'F7',
+    'F3',
+    'Fz',
+    'F4',
+    'F8',
+    'T7',
+    'C3',
+    'Cz',
+    'C4',
+    'T8',
+    'P7',
+    'P3',
+    'Pz',
+    'P4',
+    'P8',
+    'O1',
+    'Oz',
+    'O2',
+    'A1',
+    'A2',
+    'M1',
+    'M2',
+    'Fc1',
+    'Fc2',
+    'Cp1',
+    'Cp2',
+    'Fc5',
+    'Fc6',
+    'Cp5',
 ]
 
 # Initialize data array
@@ -139,18 +168,20 @@ for i, ch_name in enumerate(ch_names):
                 theta = (i / len(ch_names)) * 2 * np.pi
                 phi = np.pi / 4
                 pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
-    except:
+    except Exception:
         # Default: generate position on unit sphere
         theta = (i / len(ch_names)) * 2 * np.pi
         phi = np.pi / 4
         pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
 
-    chanlocs.append({
-        'labels': ch_name,
-        'X': float(pos[0]),
-        'Y': float(pos[1]),
-        'Z': float(pos[2]),
-    })
+    chanlocs.append(
+        {
+            'labels': ch_name,
+            'X': float(pos[0]),
+            'Y': float(pos[1]),
+            'Z': float(pos[2]),
+        }
+    )
 
 EEG_dict = {
     'data': raw_data,
@@ -160,7 +191,7 @@ EEG_dict = {
     'xmin': 0,
     'xmax': (raw_data.shape[1] - 1) / sfreq,
     'chanlocs': chanlocs,
-    'etc': {}
+    'etc': {},
 }
 
 # Apply artifact cleaning with default parameters
@@ -210,12 +241,9 @@ if len(bad_channels) > 0:
         'xmin': 0,
         'xmax': (cleaned_data.shape[1] - 1) / sfreq,
         'chanlocs': chanlocs,
-        'etc': {}
+        'etc': {},
     }
-    EEG_interp_result = eegprep.eeg_interp(
-        EEG_interp_dict,
-        bad_chans=bad_channels
-    )
+    EEG_interp_result = eegprep.eeg_interp(EEG_interp_dict, bad_chans=bad_channels)
     interpolated_data = EEG_interp_result['data']
     print(f"Interpolated data shape: {interpolated_data.shape}")
 else:
@@ -238,40 +266,42 @@ time_window = slice(0, 2000)  # First 4 seconds
 ax = axes[0]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 30  # Vertical offset for clarity
-    ax.plot(t[time_window], raw_data[ch_idx, time_window] + offset,
-            label=ch_names[ch_idx], linewidth=1.5)
+    ax.plot(t[time_window], raw_data[ch_idx, time_window] + offset, label=ch_names[ch_idx], linewidth=1.5)
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('Original EEG Data (with artifacts)', fontsize=12, fontweight='bold')
 ax.legend(loc='upper right', fontsize=9, ncol=2)
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 # Plot 2: After artifact cleaning
 ax = axes[1]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 30
-    ax.plot(t[time_window], cleaned_data[ch_idx, time_window] + offset,
-            label=ch_names[ch_idx], linewidth=1.5)
+    ax.plot(t[time_window], cleaned_data[ch_idx, time_window] + offset, label=ch_names[ch_idx], linewidth=1.5)
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After Artifact Cleaning', fontsize=12, fontweight='bold')
 ax.legend(loc='upper right', fontsize=9, ncol=2)
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 # Plot 3: After channel interpolation
 ax = axes[2]
 for i, ch_idx in enumerate(channels_to_plot):
     offset = i * 30
     color = 'orange' if ch_idx in bad_channels else 'steelblue'
-    ax.plot(t[time_window], interpolated_data[ch_idx, time_window] + offset,
-            label=ch_names[ch_idx], linewidth=1.5, color=color)
+    ax.plot(
+        t[time_window],
+        interpolated_data[ch_idx, time_window] + offset,
+        label=ch_names[ch_idx],
+        linewidth=1.5,
+        color=color,
+    )
 ax.set_xlabel('Time (s)', fontsize=11)
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
-ax.set_title('After Channel Interpolation (interpolated channels in orange)',
-             fontsize=12, fontweight='bold')
+ax.set_title('After Channel Interpolation (interpolated channels in orange)', fontsize=12, fontweight='bold')
 ax.legend(loc='upper right', fontsize=9, ncol=2)
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 plt.tight_layout()
 plt.show()
@@ -314,7 +344,7 @@ print(f"\n{'Variance Reduction':<20} {var_reduction_clean:>14.1f}% {var_reductio
 # Channel quality summary
 print(f"\n{'Total channels':<20} {n_channels}")
 print(f"{'Bad channels identified':<20} {len(bad_channels)}")
-print(f"{'Percentage bad':<20} {len(bad_channels)/n_channels*100:.1f}%")
+print(f"{'Percentage bad':<20} {len(bad_channels) / n_channels * 100:.1f}%")
 
 print("=" * 70)
 

--- a/docs/source/examples/plot_bids_pipeline.py
+++ b/docs/source/examples/plot_bids_pipeline.py
@@ -36,12 +36,12 @@ References
 # -----------------
 
 import numpy as np
-import matplotlib.pyplot as plt
 import tempfile
 import os
 import json
-from pathlib import Path
 import sys
+import shutil
+
 sys.path.insert(0, '/Users/baristim/Projects/eegprep/src')
 
 import eegprep
@@ -112,30 +112,14 @@ dataset_desc = {
     "BIDSVersion": "1.9.0",
     "DatasetType": "raw",
     "License": "CC0",
-    "Authors": [
-        {
-            "Name": "Example Author",
-            "Email": "author@example.com"
-        }
-    ],
+    "Authors": [{"Name": "Example Author", "Email": "author@example.com"}],
     "Acknowledgements": "Example dataset for eegprep documentation",
     "HowToAcknowledge": "Please cite this paper: Example et al. (2024)",
-    "Funding": [
-        {
-            "Funder": "Example Foundation",
-            "Grant": "EX-12345"
-        }
-    ],
+    "Funding": [{"Funder": "Example Foundation", "Grant": "EX-12345"}],
     "EthicsApprovals": [
-        {
-            "HipApproval": True,
-            "Committee": "Example IRB",
-            "CommitteeAbbreviation": "IRB",
-            "ExpireDate": "2025-12-31"
-        }
+        {"HipApproval": True, "Committee": "Example IRB", "CommitteeAbbreviation": "IRB", "ExpireDate": "2025-12-31"}
     ],
     "ReferencesAndLinks": [],
-    "DatasetType": "raw"
 }
 
 with open(os.path.join(bids_root, 'dataset_description.json'), 'w') as f:
@@ -165,10 +149,38 @@ for sub_id in ['01', '02']:
 
     # Create channel names
     ch_names = [
-        'Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8',
-        'T7', 'C3', 'Cz', 'C4', 'T8', 'P7', 'P3', 'Pz',
-        'P4', 'P8', 'O1', 'Oz', 'O2', 'A1', 'A2', 'M1',
-        'M2', 'Fc1', 'Fc2', 'Cp1', 'Cp2', 'Fc5', 'Fc6', 'Cp5'
+        'Fp1',
+        'Fpz',
+        'Fp2',
+        'F7',
+        'F3',
+        'Fz',
+        'F4',
+        'F8',
+        'T7',
+        'C3',
+        'Cz',
+        'C4',
+        'T8',
+        'P7',
+        'P3',
+        'Pz',
+        'P4',
+        'P8',
+        'O1',
+        'Oz',
+        'O2',
+        'A1',
+        'A2',
+        'M1',
+        'M2',
+        'Fc1',
+        'Fc2',
+        'Cp1',
+        'Cp2',
+        'Fc5',
+        'Fc6',
+        'Cp5',
     ]
 
     # Create synthetic data
@@ -194,7 +206,7 @@ for sub_id in ['01', '02']:
         "EEGReference": "average",
         "EEGGround": "Fpz",
         "RecordingDuration": n_samples / sfreq,
-        "RecordingType": "continuous"
+        "RecordingType": "continuous",
     }
 
     json_file = os.path.join(sub_dir, f'sub-{sub_id}_ses-01_task-rest_eeg.json')
@@ -219,7 +231,7 @@ for sub_id in ['01', '02']:
 
     print(f"  ✓ Created subject sub-{sub_id} data")
 
-print(f"\nBIDS dataset created successfully!")
+print("\nBIDS dataset created successfully!")
 print(f"Dataset location: {bids_root}")
 
 # %%
@@ -238,7 +250,7 @@ try:
     for f in eeg_files:
         print(f"  - {f}")
 except Exception as e:
-    print(f"Note: bids_list_eeg_files may require specific BIDS structure")
+    print("Note: bids_list_eeg_files may require specific BIDS structure")
     print(f"Error: {e}")
     # List files manually
     print("\nManually listing EEG files:")
@@ -314,7 +326,7 @@ preproc_params = {
     'asr_threshold': 20,
     'ica_method': 'picard',
     'iclabel_threshold': 0.5,
-    'verbose': False
+    'verbose': False,
 }
 
 print("\nPreprocessing Configuration:")
@@ -458,10 +470,8 @@ Key Points About BIDS Preprocessing with eegprep:
 print(summary)
 print("=" * 70)
 
-# Clean up temporary directory
-import shutil
 shutil.rmtree(bids_root)
-print(f"\nCleaned up temporary BIDS directory")
+print("\nCleaned up temporary BIDS directory")
 
 # %%
 # Key Takeaways

--- a/docs/source/examples/plot_channel_interpolation.py
+++ b/docs/source/examples/plot_channel_interpolation.py
@@ -42,9 +42,10 @@ References
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mne import create_info, EpochsArray
+from mne import create_info
 from mne.channels import make_standard_montage
 import sys
+
 sys.path.insert(0, '/Users/baristim/Projects/eegprep/src')
 
 import eegprep
@@ -66,10 +67,38 @@ duration = n_samples / sfreq
 
 # Create standard 10-20 channel names
 ch_names = [
-    'Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8',
-    'T7', 'C3', 'Cz', 'C4', 'T8', 'P7', 'P3', 'Pz',
-    'P4', 'P8', 'O1', 'Oz', 'O2', 'A1', 'A2', 'M1',
-    'M2', 'Fc1', 'Fc2', 'Cp1', 'Cp2', 'Fc5', 'Fc6', 'Cp5'
+    'Fp1',
+    'Fpz',
+    'Fp2',
+    'F7',
+    'F3',
+    'Fz',
+    'F4',
+    'F8',
+    'T7',
+    'C3',
+    'Cz',
+    'C4',
+    'T8',
+    'P7',
+    'P3',
+    'Pz',
+    'P4',
+    'P8',
+    'O1',
+    'Oz',
+    'O2',
+    'A1',
+    'A2',
+    'M1',
+    'M2',
+    'Fc1',
+    'Fc2',
+    'Cp1',
+    'Cp2',
+    'Fc5',
+    'Fc6',
+    'Cp5',
 ]
 
 # Create time vector
@@ -109,17 +138,17 @@ print(f"Bad channels to introduce: {bad_ch_names}")
 
 # Type 1: High noise channel (excessive noise)
 print(f"\n  Type 1: High noise channel ({ch_names[5]})")
-print(f"    - Adding 50 µV noise (vs. typical 2 µV)")
+print("    - Adding 50 µV noise (vs. typical 2 µV)")
 data[5, :] += np.random.randn(n_samples) * 50
 
 # Type 2: Flat/dead channel (no signal variation)
 print(f"\n  Type 2: Flat/dead channel ({ch_names[15]})")
-print(f"    - Replacing signal with minimal noise")
+print("    - Replacing signal with minimal noise")
 data[15, :] = np.random.randn(n_samples) * 0.1
 
 # Type 3: Noisy channel with artifacts
 print(f"\n  Type 3: Noisy channel with artifacts ({ch_names[25]})")
-print(f"    - Adding 30 µV noise + 50 Hz artifact")
+print("    - Adding 30 µV noise + 50 Hz artifact")
 data[25, :] += np.random.randn(n_samples) * 30
 data[25, 2000:2500] += 100 * np.sin(2 * np.pi * 50 * t[2000:2500])
 
@@ -246,18 +275,20 @@ for i, ch_name in enumerate(ch_names):
             theta = (i / len(ch_names)) * 2 * np.pi
             phi = np.pi / 4
             pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
-    except:
+    except Exception:
         # Default: generate position on unit sphere
         theta = (i / len(ch_names)) * 2 * np.pi
         phi = np.pi / 4
         pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
 
-    chanlocs.append({
-        'labels': ch_name,
-        'X': float(pos[0]),
-        'Y': float(pos[1]),
-        'Z': float(pos[2]),
-    })
+    chanlocs.append(
+        {
+            'labels': ch_name,
+            'X': float(pos[0]),
+            'Y': float(pos[1]),
+            'Z': float(pos[2]),
+        }
+    )
 
 EEG_dict = {
     'data': data.copy(),
@@ -267,17 +298,14 @@ EEG_dict = {
     'xmin': 0,
     'xmax': (data.shape[1] - 1) / sfreq,
     'chanlocs': chanlocs,
-    'etc': {}
+    'etc': {},
 }
 
 # Perform interpolation
-EEG_interp = eegprep.eeg_interp(
-    EEG_dict,
-    bad_chans=bad_channel_indices
-)
+EEG_interp = eegprep.eeg_interp(EEG_dict, bad_chans=bad_channel_indices)
 interpolated_data = EEG_interp['data']
 
-print(f"Interpolation complete!")
+print("Interpolation complete!")
 print(f"  Interpolated data shape: {interpolated_data.shape}")
 print(f"  Interpolated channels: {bad_ch_names}")
 
@@ -300,7 +328,7 @@ for i in range(n_channels):
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('Original Data (Bad Channels in Red)', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 # Plot 2: Interpolated data
 ax = axes[1]
@@ -311,7 +339,7 @@ for i in range(n_channels):
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('After Interpolation (Previously Bad Channels in Orange)', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 # Plot 3: Difference (interpolation effect)
 ax = axes[2]
@@ -324,7 +352,7 @@ ax.set_xlabel('Time (s)', fontsize=11)
 ax.set_ylabel('Amplitude (µV)', fontsize=11)
 ax.set_title('Interpolation Effect (Difference)', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3)
-ax.set_xlim([t[time_window.start], t[time_window.stop-1]])
+ax.set_xlim([t[time_window.start], t[time_window.stop - 1]])
 
 plt.tight_layout()
 plt.show()
@@ -411,11 +439,25 @@ if len(correlations) > 1:
         bad_bins = 1
 
     if good_corrs:
-        ax.hist(good_corrs, bins=good_bins, alpha=0.6, label='Good Channels', color='steelblue',
-                edgecolor='black', linewidth=1.5)
+        ax.hist(
+            good_corrs,
+            bins=good_bins,
+            alpha=0.6,
+            label='Good Channels',
+            color='steelblue',
+            edgecolor='black',
+            linewidth=1.5,
+        )
     if bad_corrs:
-        ax.hist(bad_corrs, bins=bad_bins, alpha=0.6, label='Bad Channels (Interpolated)', color='orange',
-                edgecolor='black', linewidth=1.5)
+        ax.hist(
+            bad_corrs,
+            bins=bad_bins,
+            alpha=0.6,
+            label='Bad Channels (Interpolated)',
+            color='orange',
+            edgecolor='black',
+            linewidth=1.5,
+        )
     ax.set_xlabel('Correlation Coefficient', fontsize=11)
     ax.set_ylabel('Number of Channels', fontsize=11)
     ax.set_title('Correlation Distribution: Original vs Interpolated Data', fontsize=12, fontweight='bold')
@@ -436,11 +478,11 @@ print("SUMMARY")
 print("=" * 70)
 print(f"Total channels: {n_channels}")
 print(f"Bad channels identified: {len(bad_channel_indices)}")
-print(f"Percentage of bad channels: {len(bad_channel_indices)/n_channels*100:.1f}%")
+print(f"Percentage of bad channels: {len(bad_channel_indices) / n_channels * 100:.1f}%")
 print(f"\nMean correlation (good channels): {np.mean(good_corrs):.4f}")
 print(f"Mean correlation (bad channels): {np.mean(bad_corrs):.4f}")
-print(f"\nInterpolation successfully recovered bad channels")
-print(f"Interpolated channels can be used for further analysis")
+print("\nInterpolation successfully recovered bad channels")
+print("Interpolated channels can be used for further analysis")
 print("=" * 70)
 
 print("\nRecommendations:")

--- a/docs/source/examples/plot_ica_and_iclabel.py
+++ b/docs/source/examples/plot_ica_and_iclabel.py
@@ -37,10 +37,11 @@ References
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mne import create_info, EpochsArray
+from mne import create_info
 from mne.channels import make_standard_montage
 from scipy import signal
 import sys
+
 sys.path.insert(0, '/Users/baristim/Projects/eegprep/src')
 
 import eegprep
@@ -62,10 +63,38 @@ duration = n_samples / sfreq
 
 # Create standard 10-20 channel names
 ch_names = [
-    'Fp1', 'Fpz', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8',
-    'T7', 'C3', 'Cz', 'C4', 'T8', 'P7', 'P3', 'Pz',
-    'P4', 'P8', 'O1', 'Oz', 'O2', 'A1', 'A2', 'M1',
-    'M2', 'Fc1', 'Fc2', 'Cp1', 'Cp2', 'Fc5', 'Fc6', 'Cp5'
+    'Fp1',
+    'Fpz',
+    'Fp2',
+    'F7',
+    'F3',
+    'Fz',
+    'F4',
+    'F8',
+    'T7',
+    'C3',
+    'Cz',
+    'C4',
+    'T8',
+    'P7',
+    'P3',
+    'Pz',
+    'P4',
+    'P8',
+    'O1',
+    'Oz',
+    'O2',
+    'A1',
+    'A2',
+    'M1',
+    'M2',
+    'Fc1',
+    'Fc2',
+    'Cp1',
+    'Cp2',
+    'Fc5',
+    'Fc6',
+    'Cp5',
 ]
 
 # Create time vector
@@ -122,7 +151,7 @@ print("  4. Line noise (50 Hz)")
 for i in range(n_channels):
     data[i, :] += 3 * np.sin(2 * np.pi * 50 * t)
 
-print(f"\nData created:")
+print("\nData created:")
 print(f"  Shape: {data.shape}")
 print(f"  Range: [{np.min(data):.2f}, {np.max(data):.2f}] µV")
 print("=" * 70)
@@ -153,18 +182,20 @@ for i, ch_name in enumerate(ch_names):
             theta = (i / len(ch_names)) * 2 * np.pi
             phi = np.pi / 4
             pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
-    except:
+    except Exception:
         # Default: generate position on unit sphere
         theta = (i / len(ch_names)) * 2 * np.pi
         phi = np.pi / 4
         pos = np.array([np.sin(phi) * np.cos(theta), np.sin(phi) * np.sin(theta), np.cos(phi)])
 
-    chanlocs.append({
-        'labels': ch_name,
-        'X': float(pos[0]),
-        'Y': float(pos[1]),
-        'Z': float(pos[2]),
-    })
+    chanlocs.append(
+        {
+            'labels': ch_name,
+            'X': float(pos[0]),
+            'Y': float(pos[1]),
+            'Z': float(pos[2]),
+        }
+    )
 
 EEG_dict = {
     'data': data.copy(),
@@ -174,14 +205,14 @@ EEG_dict = {
     'xmin': 0,
     'xmax': (data.shape[1] - 1) / sfreq,
     'chanlocs': chanlocs,
-    'etc': {}
+    'etc': {},
 }
 
 result = eegprep.clean_artifacts(EEG_dict, ChannelCriterion='off', LineNoiseCriterion='off')
 EEG_prep = result[0]  # clean_artifacts returns a tuple
 data_prep = EEG_prep['data']
 
-print(f"Data after preprocessing:")
+print("Data after preprocessing:")
 print(f"  Shape: {data_prep.shape}")
 print(f"  Range: [{np.min(data_prep):.2f}, {np.max(data_prep):.2f}] µV")
 
@@ -201,11 +232,7 @@ info.set_montage(montage, on_missing='ignore')
 
 # Perform ICA using eeg_picard
 try:
-    ica_result = eegprep.eeg_picard(
-        data_prep,
-        sfreq=sfreq,
-        verbose=False
-    )
+    ica_result = eegprep.eeg_picard(data_prep, sfreq=sfreq, verbose=False)
 
     # Extract ICA components and mixing matrix
     if isinstance(ica_result, dict):
@@ -217,7 +244,7 @@ try:
 
     if ica_components is not None:
         n_components = ica_components.shape[0]
-        print(f"ICA decomposition successful!")
+        print("ICA decomposition successful!")
         print(f"  Number of components: {n_components}")
         print(f"  Component shape: {ica_components.shape}")
     else:
@@ -255,17 +282,9 @@ try:
     iclabel_classes = np.argmax(iclabel_probs, axis=1)
 
     # Class names (ICLabel standard)
-    class_names = [
-        'Brain',
-        'Muscle',
-        'Eye',
-        'Heart',
-        'Line Noise',
-        'Channel Noise',
-        'Other'
-    ]
+    class_names = ['Brain', 'Muscle', 'Eye', 'Heart', 'Line Noise', 'Channel Noise', 'Other']
 
-    print(f"ICLabel classification complete!")
+    print("ICLabel classification complete!")
     print(f"  Number of components classified: {n_components}")
     print(f"  Number of classes: {n_classes}")
 
@@ -311,8 +330,7 @@ ax.grid(True, alpha=0.3, axis='y')
 for bar in bars:
     height = bar.get_height()
     if height > 0:
-        ax.text(bar.get_x() + bar.get_width()/2., height,
-                f'{int(height)}', ha='center', va='bottom', fontsize=10)
+        ax.text(bar.get_x() + bar.get_width() / 2.0, height, f'{int(height)}', ha='center', va='bottom', fontsize=10)
 
 # Component confidence distribution
 ax = axes[1]
@@ -323,8 +341,7 @@ ax.set_ylabel('Number of Components', fontsize=11)
 ax.set_title('Distribution of Classification Confidence', fontsize=12, fontweight='bold')
 ax.grid(True, alpha=0.3, axis='y')
 mean_conf = np.mean(confidences)
-ax.axvline(mean_conf, color='red', linestyle='--', linewidth=2,
-           label=f'Mean: {mean_conf:.3f}')
+ax.axvline(mean_conf, color='red', linestyle='--', linewidth=2, label=f'Mean: {mean_conf:.3f}')
 ax.legend(fontsize=10)
 
 plt.tight_layout()
@@ -354,11 +371,7 @@ for plot_idx, comp_idx in enumerate(component_indices):
     ax = axes[plot_idx]
 
     # Compute power spectral density using Welch's method
-    freqs, psd = signal.welch(
-        ica_components[comp_idx, :],
-        sfreq,
-        nperseg=min(1024, n_samples // 4)
-    )
+    freqs, psd = signal.welch(ica_components[comp_idx, :], sfreq, nperseg=min(1024, n_samples // 4))
 
     # Plot spectrum
     ax.semilogy(freqs, psd, linewidth=2, color='steelblue')
@@ -367,8 +380,7 @@ for plot_idx, comp_idx in enumerate(component_indices):
 
     pred_class = class_names[iclabel_classes[comp_idx]]
     confidence = iclabel_probs[comp_idx, iclabel_classes[comp_idx]]
-    ax.set_title(f'Component {comp_idx}: {pred_class} (conf: {confidence:.3f})',
-                 fontsize=11, fontweight='bold')
+    ax.set_title(f'Component {comp_idx}: {pred_class} (conf: {confidence:.3f})', fontsize=11, fontweight='bold')
 
     ax.set_xlim([0, 100])
     ax.grid(True, alpha=0.3, which='both')
@@ -398,7 +410,7 @@ for i in range(n_components):
         if confidence > rejection_threshold:
             components_to_reject.append(i)
 
-print(f"\nRejection Criteria:")
+print("\nRejection Criteria:")
 print(f"  Confidence threshold: {rejection_threshold}")
 print(f"  Artifact classes: {[class_names[c] for c in artifact_classes]}")
 
@@ -435,7 +447,7 @@ print(f"Line noise components: {np.sum(iclabel_classes == 4)}")
 print(f"Channel noise components: {np.sum(iclabel_classes == 5)}")
 print(f"Other components: {np.sum(iclabel_classes == 6)}")
 print(f"\nArtifact components: {len(components_to_reject)}")
-print(f"Percentage of artifacts: {len(components_to_reject)/n_components*100:.1f}%")
+print(f"Percentage of artifacts: {len(components_to_reject) / n_components * 100:.1f}%")
 print("=" * 70)
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,6 @@ no-matching-overload = "ignore"
 not-iterable = "ignore"
 not-subscriptable = "ignore"
 unsupported-operator = "ignore"
-unresolved-attribute = "ignore"
-call-non-callable = "ignore"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,11 +132,18 @@ select = ["E4", "E7", "E9", "F"]
 
 [tool.ty.environment]
 python-version = "3.10"
-root = ["./src"]
+root = ["."]
 
 [tool.ty.src]
-include = ["src/eegprep"]
+include = [
+  "src/eegprep",
+  "scripts",
+  "tools",
+]
 exclude = [
+  "scripts/mne_iclabel_script.py",
+  "scripts/test_flask.py",
+  "scripts/tmp_pipeline_for_ppt.py",
   "src/eegprep/eeglab/**",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ eegprep-console = "eegprep.functions.adminfunc.console:main"
 dev = [
   "pytest>=8.0",
   "pyyaml>=6.0",
+  "ruff>=0.15.14",
   "tomli>=2.0; python_version < '3.11'",
+  "ty>=0.0.39",
 ]
 release = [
   "build>=1.2",
@@ -106,6 +108,57 @@ constraint-dependencies = [
 required-environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+extend-exclude = [
+  "pre-commit.py",
+  "sample_notebooks/**",
+  "scripts/tmp_pipeline_for_ppt.py",
+  "src/eegprep/eeglab/**",
+]
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# These development scripts adjust sys.path before importing package modules.
+"tools/visual_parity/export_eegprep_menu_inventory.py" = ["E402"]
+"tests/matlab/*.py" = ["E402"]
+
+[tool.ty.environment]
+python-version = "3.10"
+root = ["./src"]
+
+[tool.ty.src]
+include = ["src/eegprep"]
+exclude = [
+  "src/eegprep/eeglab/**",
+]
+
+[tool.ty.terminal]
+output-format = "concise"
+
+[tool.ty.rules]
+# EEGPrep currently uses dynamic EEGLAB-style EEG dictionaries and optional GUI
+# modules extensively. Keep ty blocking on high-signal name/import/syntax
+# failures now, while avoiding CI noise from broad annotation migration work.
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+invalid-context-manager = "ignore"
+invalid-parameter-default = "ignore"
+invalid-return-type = "ignore"
+invalid-type-form = "ignore"
+no-matching-overload = "ignore"
+not-iterable = "ignore"
+not-subscriptable = "ignore"
+unsupported-operator = "ignore"
+unresolved-attribute = "ignore"
+call-non-callable = "ignore"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/bids_minimal_preproc.py
+++ b/scripts/bids_minimal_preproc.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import argparse
-import sys
 import logging
 
 logging.basicConfig(
@@ -20,24 +19,21 @@ logging.basicConfig(
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Minimal EEGPrep preprocessing: resample and highpass filter.')
-    parser.add_argument('--input', required=True,
-                        help='Path to the BIDS dataset root directory')
-    parser.add_argument('--output', default=None,
-                        help='Output directory (default: {input}/derivatives/eegprep)')
-    parser.add_argument('--srate', type=float, default=100.0,
-                        help='Target sampling rate in Hz (default: 100)')
-    parser.add_argument('--highpass', type=float, default=0.5,
-                        help='Highpass filter cutoff in Hz (default: 0.5)')
-    parser.add_argument('--subjects', nargs='*', default=None,
-                        help='Subject IDs or 0-based indices to process (default: all)')
-    parser.add_argument('--jobs', default='1CPU',
-                        help='Parallelism spec, e.g. "1CPU" or "4GB" (default: 1CPU)')
-    parser.add_argument('--desc', default='',
-                        help='desc- label for output files (default: none)')
-    parser.add_argument('--report-dir', default='code/reports',
-                        help='Directory for report files relative to output (default: code/reports)')
+    parser = argparse.ArgumentParser(description='Minimal EEGPrep preprocessing: resample and highpass filter.')
+    parser.add_argument('--input', required=True, help='Path to the BIDS dataset root directory')
+    parser.add_argument('--output', default=None, help='Output directory (default: {input}/derivatives/eegprep)')
+    parser.add_argument('--srate', type=float, default=100.0, help='Target sampling rate in Hz (default: 100)')
+    parser.add_argument('--highpass', type=float, default=0.5, help='Highpass filter cutoff in Hz (default: 0.5)')
+    parser.add_argument(
+        '--subjects', nargs='*', default=None, help='Subject IDs or 0-based indices to process (default: all)'
+    )
+    parser.add_argument('--jobs', default='1CPU', help='Parallelism spec, e.g. "1CPU" or "4GB" (default: 1CPU)')
+    parser.add_argument('--desc', default='', help='desc- label for output files (default: none)')
+    parser.add_argument(
+        '--report-dir',
+        default='code/reports',
+        help='Directory for report files relative to output (default: code/reports)',
+    )
     args = parser.parse_args()
 
     from eegprep import bids_preproc

--- a/scripts/bids_preproc_accuracy_report.py
+++ b/scripts/bids_preproc_accuracy_report.py
@@ -15,7 +15,14 @@ logger = logging.getLogger(__name__)
 curhost = socket.gethostname()
 
 # add your host to this list if you want to run things in parallel
-slow_tests_hosts_only = ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'sccn-delorme.ucsd.edu','jamming', 'DESKTOP-TGLFTPM']
+slow_tests_hosts_only = [
+    'ck-carbon',
+    'MacBook-Pro-10.local',
+    'MacBook-Pro-10.lan',
+    'sccn-delorme.ucsd.edu',
+    'jamming',
+    'DESKTOP-TGLFTPM',
+]
 
 # add your host to this list if you want to run things in parallel
 if curhost in ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'jamming', 'sccn-delorme.ucsd.edu']:
@@ -35,11 +42,11 @@ studies = [
     #     'subjects': ['001', '002'],
     #     'runs': [],
     # },
-   {
-       'studyname': 'ds002680',
-       'subjects': ['002'],  # first subject, has 2 sessions
-       'runs': [],  # needs to be >= 10 otherwise MATLAB-side filtering by run fails
-   }
+    {
+        'studyname': 'ds002680',
+        'subjects': ['002'],  # first subject, has 2 sessions
+        'runs': [],  # needs to be >= 10 otherwise MATLAB-side filtering by run fails
+    }
 ]
 
 if __name__ == '__main__':
@@ -55,15 +62,15 @@ if __name__ == '__main__':
     # run up to and including the given numeric stage
     # (1=import, 2=select channels, 3=resample, ... up to and including 14=CAR)
     StageNames = {
-        1:  'BIDS Import',
-        2:  'ChannelSelection',
-        3:  'Resampling',
-        4:  'FlatlineRemoval',
-        5:  'HighpassFilter',
-        6:  'BadChannelRemoval',
-        7:  'BurstRemoval (ASR)',
-        8:  'BadWindowRemoval',
-        9:  'PICARD',
+        1: 'BIDS Import',
+        2: 'ChannelSelection',
+        3: 'Resampling',
+        4: 'FlatlineRemoval',
+        5: 'HighpassFilter',
+        6: 'BadChannelRemoval',
+        7: 'BurstRemoval (ASR)',
+        8: 'BadWindowRemoval',
+        9: 'PICARD',
         10: 'ICLabel',
         11: 'Reinterpolate',
         12: 'Epoching',
@@ -90,8 +97,9 @@ if __name__ == '__main__':
         candidates = [studyname, studyname + '-download']
         retain = [d for d in os.listdir(root_path) if d in candidates]
         if len(retain) == 0:
-            raise ValueError(f"None of the candidate study folders {candidates} was "
-                             f"found in {root_path}. Cannot generate report.")
+            raise ValueError(
+                f"None of the candidate study folders {candidates} was found in {root_path}. Cannot generate report."
+            )
 
         study_path = os.path.join(root_path, retain[0])
 
@@ -102,12 +110,15 @@ if __name__ == '__main__':
                 study_path,
                 ReservePerJob=reservation,
                 # just the first few subjects of the main task
-                Subjects=subjects, Runs=runs,
+                Subjects=subjects,
+                Runs=runs,
                 # reuse results for for quicker re-runs
-                SkipIfPresent=True, UseHashes=True, MinimizeDiskUsage=False,
+                SkipIfPresent=True,
+                UseHashes=True,
+                MinimizeDiskUsage=False,
                 # parse events from BIDS, use value column
-                ApplyEvents=True, EventColumn='value', # <- needed for study ds3061 to match pop_importbids() in MATLAB
-
+                ApplyEvents=True,
+                EventColumn='value',  # <- needed for study ds3061 to match pop_importbids() in MATLAB
                 # determine arguments in accordance with to_stage
                 OnlyChannelsWithPosition=True if to_stage >= 2 else False,
                 OnlyModalities=() if to_stage >= 2 else (),
@@ -124,19 +135,17 @@ if __name__ == '__main__':
                 EpochEvents=[] if to_stage >= 12 else None,
                 EpochBaseline=[-0.2, 0] if to_stage >= 13 else None,
                 CommonAverageReference=to_stage >= 14,
-
                 # misc params
                 EpochLimits=[-0.2, 0.5],
                 # return results so we can compare things
-                ReturnData=True)
+                ReturnData=True,
+            )
 
             print(f"Running bids_pipeline() on {study_path} to stage {to_stage} ({StageNames[to_stage]})...")
             eeglab = get_eeglab('MATLAB')
             result_paths = eeglab.bids_pipeline(
-                study_path,
-                [f'sub-{s}' for s in subjects],
-                [f'{r}' for r in runs],
-                to_stage)
+                study_path, [f'sub-{s}' for s in subjects], [f'{r}' for r in runs], to_stage
+            )
 
             with eeg_checkset_strict_mode(False):
                 ALLEEG_mat = [pop_loadset(p.item()) for p in result_paths.flatten()]
@@ -172,9 +181,9 @@ if __name__ == '__main__':
             results[to_stage]['all'].extend(stage_errs)
 
     # Print summary table
-    print("\n\n" + "="*80)
+    print("\n\n" + "=" * 80)
     print("Summary of maximum absolute errors (in µV) between Python and MATLAB results:")
-    print("="*80)
+    print("=" * 80)
 
     # Build header
     header = ["Stage", "StageName", "MaxErr(all)"]
@@ -204,5 +213,5 @@ if __name__ == '__main__':
 
         print("\t".join(row))
 
-    print("="*80)
+    print("=" * 80)
     print("\nDone.")

--- a/scripts/bids_preproc_accuracy_report_new.py
+++ b/scripts/bids_preproc_accuracy_report_new.py
@@ -15,7 +15,14 @@ logger = logging.getLogger(__name__)
 curhost = socket.gethostname()
 
 # add your host to this list if you want to run things in parallel
-slow_tests_hosts_only = ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'sccn-delorme.ucsd.edu','jamming', 'DESKTOP-TGLFTPM']
+slow_tests_hosts_only = [
+    'ck-carbon',
+    'MacBook-Pro-10.local',
+    'MacBook-Pro-10.lan',
+    'sccn-delorme.ucsd.edu',
+    'jamming',
+    'DESKTOP-TGLFTPM',
+]
 
 # add your host to this list if you want to run things in parallel
 if curhost in ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'jamming', 'sccn-delorme.ucsd.edu']:
@@ -35,11 +42,11 @@ studies = [
     #     'subjects': ['001', '002'],
     #     'runs': [],
     # },
-   {
-       'studyname': 'ds002680',
-       'subjects': ['002'],  # first subject, has 2 sessions
-       'runs': [],  # needs to be >= 10 otherwise MATLAB-side filtering by run fails
-   }
+    {
+        'studyname': 'ds002680',
+        'subjects': ['002'],  # first subject, has 2 sessions
+        'runs': [],  # needs to be >= 10 otherwise MATLAB-side filtering by run fails
+    }
 ]
 
 if __name__ == '__main__':
@@ -55,15 +62,15 @@ if __name__ == '__main__':
     # run up to and including the given numeric stage
     # (1=import, 2=select channels, 3=resample, ... up to and including 14=CAR)
     StageNames = {
-        1:  'BIDS Import',
-        2:  'ChannelSelection',
-        3:  'Resampling',
-        4:  'FlatlineRemoval',
-        5:  'HighpassFilter',
-        6:  'BadChannelRemoval',
-        7:  'BurstRemoval (ASR)',
-        8:  'BadWindowRemoval',
-        9:  'PICARD',
+        1: 'BIDS Import',
+        2: 'ChannelSelection',
+        3: 'Resampling',
+        4: 'FlatlineRemoval',
+        5: 'HighpassFilter',
+        6: 'BadChannelRemoval',
+        7: 'BurstRemoval (ASR)',
+        8: 'BadWindowRemoval',
+        9: 'PICARD',
         10: 'ICLabel',
         11: 'Reinterpolate',
         12: 'Epoching',
@@ -90,8 +97,9 @@ if __name__ == '__main__':
         candidates = [studyname, studyname + '-download']
         retain = [d for d in os.listdir(root_path) if d in candidates]
         if len(retain) == 0:
-            raise ValueError(f"None of the candidate study folders {candidates} was "
-                             f"found in {root_path}. Cannot generate report.")
+            raise ValueError(
+                f"None of the candidate study folders {candidates} was found in {root_path}. Cannot generate report."
+            )
 
         study_path = os.path.join(root_path, retain[0])
 
@@ -102,12 +110,15 @@ if __name__ == '__main__':
                 study_path,
                 ReservePerJob=reservation,
                 # just the first few subjects of the main task
-                Subjects=subjects, Runs=runs,
+                Subjects=subjects,
+                Runs=runs,
                 # reuse results for for quicker re-runs
-                SkipIfPresent=True, UseHashes=True, MinimizeDiskUsage=False,
+                SkipIfPresent=True,
+                UseHashes=True,
+                MinimizeDiskUsage=False,
                 # parse events from BIDS, use value column
-                ApplyEvents=True, EventColumn='value', # <- needed for study ds3061 to match pop_importbids() in MATLAB
-
+                ApplyEvents=True,
+                EventColumn='value',  # <- needed for study ds3061 to match pop_importbids() in MATLAB
                 # determine arguments in accordance with to_stage
                 OnlyChannelsWithPosition=True if to_stage >= 2 else False,
                 OnlyModalities=() if to_stage >= 2 else (),
@@ -124,19 +135,17 @@ if __name__ == '__main__':
                 EpochEvents=[] if to_stage >= 12 else None,
                 EpochBaseline=[-0.2, 0] if to_stage >= 13 else None,
                 CommonAverageReference=to_stage >= 14,
-
                 # misc params
                 EpochLimits=[-0.2, 0.5],
                 # return results so we can compare things
-                ReturnData=True)
+                ReturnData=True,
+            )
 
             print(f"Running bids_pipeline() on {study_path} to stage {to_stage} ({StageNames[to_stage]})...")
             eeglab = get_eeglab('MATLAB')
             result_paths = eeglab.bids_pipeline(
-                study_path,
-                [f'sub-{s}' for s in subjects],
-                [f'{r}' for r in runs],
-                to_stage)
+                study_path, [f'sub-{s}' for s in subjects], [f'{r}' for r in runs], to_stage
+            )
 
             with eeg_checkset_strict_mode(False):
                 ALLEEG_mat = [pop_loadset(p.item()) for p in result_paths.flatten()]
@@ -172,9 +181,9 @@ if __name__ == '__main__':
             results[to_stage]['all'].extend(stage_errs)
 
     # Print summary table
-    print("\n\n" + "="*80)
+    print("\n\n" + "=" * 80)
     print("Summary of maximum absolute errors (in µV) between Python and MATLAB results:")
-    print("="*80)
+    print("=" * 80)
 
     # Build header
     header = ["Stage", "StageName", "MaxErr(all)"]
@@ -204,5 +213,5 @@ if __name__ == '__main__':
 
         print("\t".join(row))
 
-    print("="*80)
+    print("=" * 80)
     print("\nDone.")

--- a/scripts/build_derivative.py
+++ b/scripts/build_derivative.py
@@ -12,12 +12,10 @@ Usage:
 
 import argparse
 import os
-import re
 import shutil
 import subprocess
 import sys
 import tarfile
-import tempfile
 
 EEGPREP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 IMAGE_NAME = 'eegprep-minimal'
@@ -34,8 +32,7 @@ def run(cmd, **kwargs):
 
 
 def docker_is_running():
-    result = subprocess.run('docker info', shell=True,
-                            capture_output=True, timeout=10)
+    result = subprocess.run('docker info', shell=True, capture_output=True, timeout=10)
     return result.returncode == 0
 
 
@@ -48,8 +45,7 @@ def build_docker():
 def run_docker(bids_root, srate, highpass, extra_args=''):
     """Run the Docker container on the dataset."""
     print('\n=== Running preprocessing ===')
-    cmd = (f'docker run --rm -v {bids_root}:/data {IMAGE_NAME}'
-           f' --srate {srate} --highpass {highpass}')
+    cmd = f'docker run --rm -v {bids_root}:/data {IMAGE_NAME} --srate {srate} --highpass {highpass}'
     if extra_args:
         cmd += f' {extra_args}'
     run(cmd)
@@ -94,9 +90,9 @@ def save_pinned_requirements(dest):
     """Extract pinned requirements from the Docker image."""
     print('\n=== Saving pinned requirements ===')
     result = subprocess.run(
-        f'docker run --rm --entrypoint pip {IMAGE_NAME} freeze',
-        shell=True, capture_output=True, text=True)
-    lines = [l for l in result.stdout.splitlines() if not l.startswith('eegprep @')]
+        f'docker run --rm --entrypoint pip {IMAGE_NAME} freeze', shell=True, capture_output=True, text=True
+    )
+    lines = [line for line in result.stdout.splitlines() if not line.startswith('eegprep @')]
     with open(dest, 'w') as f:
         f.write('\n'.join(lines) + '\n')
     print(f'  {len(lines)} packages pinned to {dest}')
@@ -118,9 +114,7 @@ def copy_code_folder(bids_root, deriv_dir, srate, highpass):
     with open(src_dockerfile) as f:
         content = f.read()
     # Adjust paths: in code/ the script is at root level, not scripts/
-    content = content.replace(
-        'COPY scripts/bids_minimal_preproc.py',
-        'COPY bids_minimal_preproc.py')
+    content = content.replace('COPY scripts/bids_minimal_preproc.py', 'COPY bids_minimal_preproc.py')
     with open(dst_dockerfile, 'w') as f:
         f.write(content)
 
@@ -140,6 +134,7 @@ def copy_code_folder(bids_root, deriv_dir, srate, highpass):
     ds_url = ''
     if os.path.exists(ds_desc_path):
         import json
+
         with open(ds_desc_path) as f:
             desc = json.load(f)
         ds_name = desc.get('Name', ds_name)
@@ -273,8 +268,7 @@ def validate_bids(deriv_dir):
     """Run bids-validator if available."""
     print('\n=== Validating BIDS compliance ===')
     if shutil.which('bids-validator'):
-        result = subprocess.run(
-            f'bids-validator {deriv_dir}', shell=True, capture_output=True, text=True)
+        result = subprocess.run(f'bids-validator {deriv_dir}', shell=True, capture_output=True, text=True)
         print(result.stdout)
         if result.stderr:
             print(result.stderr)
@@ -286,19 +280,17 @@ def validate_bids(deriv_dir):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Build a BIDS derivative dataset with Docker.')
+    parser = argparse.ArgumentParser(description='Build a BIDS derivative dataset with Docker.')
     parser.add_argument('bids_root', help='Path to the BIDS dataset')
-    parser.add_argument('--srate', type=float, default=100.0,
-                        help='Target sampling rate (default: 100)')
-    parser.add_argument('--highpass', type=float, default=0.5,
-                        help='Highpass cutoff in Hz (default: 0.5)')
-    parser.add_argument('--skip-docker-build', action='store_true',
-                        help='Skip building the Docker image (reuse existing)')
-    parser.add_argument('--skip-processing', action='store_true',
-                        help='Skip running the pipeline (reuse existing output)')
-    parser.add_argument('--extra-args', default='',
-                        help='Extra args passed to the Docker container')
+    parser.add_argument('--srate', type=float, default=100.0, help='Target sampling rate (default: 100)')
+    parser.add_argument('--highpass', type=float, default=0.5, help='Highpass cutoff in Hz (default: 0.5)')
+    parser.add_argument(
+        '--skip-docker-build', action='store_true', help='Skip building the Docker image (reuse existing)'
+    )
+    parser.add_argument(
+        '--skip-processing', action='store_true', help='Skip running the pipeline (reuse existing output)'
+    )
+    parser.add_argument('--extra-args', default='', help='Extra args passed to the Docker container')
     args = parser.parse_args()
 
     bids_root = os.path.abspath(args.bids_root)
@@ -332,7 +324,7 @@ def main():
     # Validate
     validate_bids(deriv_dir)
 
-    print(f'\n=== Done ===')
+    print('\n=== Done ===')
     print(f'  Derivative: {deriv_dir}')
     print(f'  Code:       {os.path.join(deriv_dir, "code")}')
 

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -42,13 +42,16 @@ from importlib.util import find_spec
 # Use colorama for colored output (already a dependency)
 try:
     from colorama import init, Fore, Style
+
     init(autoreset=True)
 except ImportError:
     # Fallback if colorama not available
     class Fore:
         RED = GREEN = YELLOW = CYAN = BLUE = MAGENTA = ""
+
     class Style:
         BRIGHT = RESET_ALL = ""
+
 
 # Find project root (parent of scripts directory)
 SCRIPT_DIR = Path(__file__).parent
@@ -140,11 +143,7 @@ def set_package_name(new_name):
 
         # Replace the name field
         modified_content = re.sub(
-            r'^name\s*=\s*["\']([^"\']+)["\']',
-            f'name = "{new_name}"',
-            content,
-            count=1,
-            flags=re.MULTILINE
+            r'^name\s*=\s*["\']([^"\']+)["\']', f'name = "{new_name}"', content, count=1, flags=re.MULTILINE
         )
 
         with open(PYPROJECT_PATH, 'w') as f:
@@ -238,54 +237,50 @@ def update_version_files(old_version, new_version):
     print_step(3, f"Updating version from {old_version} to {new_version}")
 
     # Update pyproject.toml
-    print_info(f"Updating pyproject.toml...")
+    print_info("Updating pyproject.toml...")
     cmd = f"sed -i '' 's/version = \"{old_version}\"/version = \"{new_version}\"/' {PYPROJECT_PATH}"
     print(f"Running: {cmd}")
     try:
         subprocess.run(
             ["sed", "-i", "", f's/version = "{old_version}"/version = "{new_version}"/', str(PYPROJECT_PATH)],
             cwd=PROJECT_ROOT,
-            check=True
+            check=True,
         )
-        print_success(f"Updated pyproject.toml")
+        print_success("Updated pyproject.toml")
     except subprocess.CalledProcessError:
         # Fallback to Python method
         if not update_version_in_file(PYPROJECT_PATH, f'version = "{old_version}"', f'version = "{new_version}"'):
             return False
-        print_success(f"Updated pyproject.toml")
+        print_success("Updated pyproject.toml")
 
     # Update HPC wrapper
-    print_info(f"Updating HPC wrapper...")
+    print_info("Updating HPC wrapper...")
     cmd = f"sed -i '' 's/eegprep:{old_version}/eegprep:{new_version}/g' {MAIN_PATH}"
     print(f"Running: {cmd}")
     try:
         subprocess.run(
             ["sed", "-i", "", f's/eegprep:{old_version}/eegprep:{new_version}/g', str(MAIN_PATH)],
             cwd=PROJECT_ROOT,
-            check=True
+            check=True,
         )
-        print_success(f"Updated HPC wrapper")
+        print_success("Updated HPC wrapper")
     except subprocess.CalledProcessError:
         # Fallback to Python method
         if not update_version_in_file(MAIN_PATH, f'eegprep:{old_version}', f'eegprep:{new_version}'):
             return False
-        print_success(f"Updated HPC wrapper")
+        print_success("Updated HPC wrapper")
 
     return True
 
 
 def commit_version_changes(version):
     """Commit version changes."""
-    print_step(4, f"Committing version changes")
+    print_step(4, "Committing version changes")
 
     cmd = f"git add {PYPROJECT_PATH} {MAIN_PATH}"
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["git", "add", str(PYPROJECT_PATH), str(MAIN_PATH)],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["git", "add", str(PYPROJECT_PATH), str(MAIN_PATH)], cwd=PROJECT_ROOT, check=True)
         print_success("Staged version files")
     except subprocess.CalledProcessError as e:
         print_error(f"Failed to stage files: {e}")
@@ -295,11 +290,7 @@ def commit_version_changes(version):
     cmd = f'git commit -m "{commit_msg}"'
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["git", "commit", "-m", commit_msg],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["git", "commit", "-m", commit_msg], cwd=PROJECT_ROOT, check=True)
         print_success(f"Committed version changes: {commit_msg}")
         return True
     except subprocess.CalledProcessError as e:
@@ -329,7 +320,7 @@ def choose_release_type():
 def clean_dist():
     """Remove old dist directory."""
     if DIST_DIR.exists():
-        print_info(f"Removing old dist directory...")
+        print_info("Removing old dist directory...")
         shutil.rmtree(DIST_DIR)
         print_success("Old dist directory removed")
 
@@ -355,11 +346,7 @@ def build_package(package_name=None):
     cmd = f"{sys.executable} -m build"
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            [sys.executable, "-m", "build"],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run([sys.executable, "-m", "build"], cwd=PROJECT_ROOT, check=True)
         print_success("Package built successfully")
 
         # Show what was built
@@ -409,12 +396,7 @@ def upload_to_testpypi():
         env = None
 
     try:
-        subprocess.run(
-            cmd,
-            cwd=PROJECT_ROOT,
-            check=True,
-            env=env
-        )
+        subprocess.run(cmd, cwd=PROJECT_ROOT, check=True, env=env)
         print_success(f"Uploaded to TestPyPI successfully as '{TESTPYPI_PACKAGE_NAME}'")
         return True
     except subprocess.CalledProcessError as e:
@@ -444,12 +426,7 @@ def upload_to_pypi():
         env = None
 
     try:
-        subprocess.run(
-            [sys.executable, "-m", "twine", "upload", "dist/*"],
-            cwd=PROJECT_ROOT,
-            check=True,
-            env=env
-        )
+        subprocess.run([sys.executable, "-m", "twine", "upload", "dist/*"], cwd=PROJECT_ROOT, check=True, env=env)
         print_success("Uploaded to PyPI successfully")
         return True
     except subprocess.CalledProcessError as e:
@@ -465,11 +442,7 @@ def push_git_changes():
     cmd = "git push"
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["git", "push"],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["git", "push"], cwd=PROJECT_ROOT, check=True)
         print_success("Pushed git changes successfully")
         return True
     except subprocess.CalledProcessError as e:
@@ -489,11 +462,7 @@ def create_and_push_tag(version):
     cmd = f'git tag -a {tag_name} -m "Release version {version}"'
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["git", "tag", "-a", tag_name, "-m", f"Release version {version}"],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["git", "tag", "-a", tag_name, "-m", f"Release version {version}"], cwd=PROJECT_ROOT, check=True)
         print_success(f"Created git tag: {tag_name}")
     except subprocess.CalledProcessError as e:
         print_error(f"Failed to create tag: {e}")
@@ -503,11 +472,7 @@ def create_and_push_tag(version):
     cmd = f"git push origin {tag_name}"
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["git", "push", "origin", tag_name],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["git", "push", "origin", tag_name], cwd=PROJECT_ROOT, check=True)
         print_success(f"Pushed tag {tag_name} to origin")
         return True
     except subprocess.CalledProcessError as e:
@@ -519,16 +484,14 @@ def create_and_push_tag(version):
 
 def build_and_push_docker(version):
     """Build and push Docker image."""
-    print_step(9, f"Building and pushing Docker image")
+    print_step(9, "Building and pushing Docker image")
 
     # Build Docker image
     cmd = f"docker build -t eegprep:{version} -f DOCKERFILE ."
     print(f"Running: {cmd}")
     try:
         subprocess.run(
-            ["docker", "build", "-t", f"eegprep:{version}", "-f", "DOCKERFILE", "."],
-            cwd=PROJECT_ROOT,
-            check=True
+            ["docker", "build", "-t", f"eegprep:{version}", "-f", "DOCKERFILE", "."], cwd=PROJECT_ROOT, check=True
         )
         print_success(f"Built Docker image: eegprep:{version}")
     except subprocess.CalledProcessError as e:
@@ -540,9 +503,7 @@ def build_and_push_docker(version):
     print(f"Running: {cmd}")
     try:
         subprocess.run(
-            ["docker", "tag", f"eegprep:{version}", f"arnodelorme/eegprep:{version}"],
-            cwd=PROJECT_ROOT,
-            check=True
+            ["docker", "tag", f"eegprep:{version}", f"arnodelorme/eegprep:{version}"], cwd=PROJECT_ROOT, check=True
         )
         print_success(f"Tagged Docker image: arnodelorme/eegprep:{version}")
     except subprocess.CalledProcessError as e:
@@ -553,11 +514,7 @@ def build_and_push_docker(version):
     cmd = f"docker push arnodelorme/eegprep:{version}"
     print(f"Running: {cmd}")
     try:
-        subprocess.run(
-            ["docker", "push", f"arnodelorme/eegprep:{version}"],
-            cwd=PROJECT_ROOT,
-            check=True
-        )
+        subprocess.run(["docker", "push", f"arnodelorme/eegprep:{version}"], cwd=PROJECT_ROOT, check=True)
         print_success(f"Pushed Docker image: arnodelorme/eegprep:{version}")
         return True
     except subprocess.CalledProcessError as e:
@@ -573,10 +530,12 @@ def print_test_instructions(version, release_type):
     if release_type in ['test', 'both']:
         print(f"{Fore.MAGENTA}To test the TestPyPI release:{Style.RESET_ALL}")
         print(f"{Fore.YELLOW}  NOTE: The test package is named '{TESTPYPI_PACKAGE_NAME}' on TestPyPI{Style.RESET_ALL}")
-        print(f"  uv pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ {TESTPYPI_PACKAGE_NAME}=={version}")
+        print(
+            f"  uv pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ {TESTPYPI_PACKAGE_NAME}=={version}"
+        )
         print()
         print(f"{Fore.CYAN}  After installing, you can still import it as 'eegprep':{Style.RESET_ALL}")
-        print(f"  python -c 'import eegprep; print(eegprep.__version__)'")
+        print("  python -c 'import eegprep; print(eegprep.__version__)'")
         print()
 
     if release_type in ['prod', 'both']:
@@ -602,11 +561,7 @@ def main():
     print(f"Running: {cmd}")
     try:
         result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True
+            ["git", "status", "--porcelain"], cwd=PROJECT_ROOT, capture_output=True, text=True, check=True
         )
 
         if result.stdout.strip():

--- a/scripts/mne_epoch_conversion_example.py
+++ b/scripts/mne_epoch_conversion_example.py
@@ -2,15 +2,12 @@
 # Events are not handled correctly in this example but it works
 
 import mne
-from mne.datasets import sample
 import numpy as np
 from scipy.io import savemat
 
 # Load example data
 sample_data_folder = mne.datasets.sample.data_path()
-sample_data_raw_file = (
-    sample_data_folder / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
-)
+sample_data_raw_file = sample_data_folder / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
 raw = mne.io.read_raw_fif(sample_data_raw_file)
 events = mne.find_events(raw, stim_channel="STI 014")
 event_dict = {
@@ -37,94 +34,94 @@ data = epochs.get_data()  # Get the data from the epochs
 n_epochs, n_channels, n_times = data.shape
 
 # Create a dictionary to save as a MATLAB file
-    #          setname: 'EEG Data epochs'
-    #         filename: 'eeglab_data_epochs_ica.set'
-    #         filepath: '/System/Volumes/Data/data/matlab/eeglab/sample_data'
-    #          subject: ''
-    #            group: ''
-    #        condition: ''
-    #          session: []
-    #         comments: [9×769 char]
-    #           nbchan: 32
-    #           trials: 80
-    #             pnts: 384
-    #            srate: 128
-    #             xmin: -1
-    #             xmax: 1.9922
-    #            times: [-1000 -992.1875 -984.3750 -976.5625 -968.7500 -960.9375 -953.1250 -945.3125 -937.5000 -929.6875 -921.8750 -914.0625 -906.2500 -898.4375 -890.6250 -882.8125 -875 -867.1875 -859.3750 -851.5625 -843.7500 -835.9375 … ] (1×384 double)
-    #             data: [32×384×80 single]
-    #           icaact: [32×384×80 single]
-    #          icawinv: [32×32 double]
-    #        icasphere: [32×32 double]
-    #       icaweights: [32×32 double]
-    #      icachansind: [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]
-    #         chanlocs: [1×32 struct]
-    #       urchanlocs: [1×32 struct]
-    #         chaninfo: [1×1 struct]
-    #              ref: 'common'
-    #            event: [1×157 struct]
-    #          urevent: [1×154 struct]
-    # eventdescription: {[2×29 char]  [2×63 char]  [2×36 char]  ''  ''}
-    #            epoch: [1×80 struct]
-    # epochdescription: {}
-    #           reject: [1×1 struct]
-    #            stats: [1×1 struct]
-    #         specdata: []
-    #       specicaact: []
-    #       splinefile: []
-    #    icasplinefile: ''
-    #           dipfit: []
-    #          history: 'EEG = eeg_checkset( EEG );↵EEG = eeg_checkset( EEG );↵figure;pop_topoplot(EEG,0, 1, 'EEG Data epochs',[1 1] ,0, 'electrodes', 'on', 'masksurf', 'on');↵EEG = eeg_checkset( EEG );↵EEG.chanlocs=pop_chanedit(EEG.chanlocs,  'plotrad',0.5);↵EEG = pop_loadset( 'filename', 'eeglab_data_epochs_ica.set', 'filepath', '/data/common/matlab/eeglab/sample_data/');↵EEG=pop_chanedit(EEG,  'lookup', '/data/common/matlab/eeglab/plugins/dipfit2.0/standard_BESA/standard-10-5-cap385.elp');↵EEG = pop_saveset( EEG,  'savemode', 'resave');↵EEG=pop_chanedit(EEG,  'eval', 'pop_writelocs( chans, ''/data/common/matlab/eeglab/sample_data/eeglab_chan32_2.locs'',  ''filetype'', ''loc'', ''format'',{ ''channum'', ''theta'', ''radius'', ''labels''}, ''header'', ''off'', ''customheader'','''');', 'load',{ '/data/common/matlab/eeglab/sample_data/eeglab_chan32_2.locs', 'filetype', 'autodetect'}, 'lookup', '/data/common/matlab/eeglab/plugins/dipfit2.0/standard_BESA/standard-10-5-cap385.elp');↵EEG=pop_chanedit(EEG,  'settype',{ '1:32', 'EEG'}, 'changefield',{2, 'type', 'EOG'}, 'changefield',{6, 'type', 'EOG'});↵EEG = pop_loadset( 'filename', 'eeglab_data_epochs_ica.set', 'filepath', '/data/common/matlab/eeglab/sample_data/');↵EEG = pop_loadset('filename','eeglab_data_epochs_ica.set','filepath','/Users/arno/eeglab/sample_data/');↵EEG = eeg_checkset( EEG );↵EEG.etc.eeglabvers = '2024.2'; % this tracks which version of EEGLAB is being used, you may ignore it'
-    #            saved: 'yes'
-    #              etc: [1×1 struct]
-    #          datfile: 'eeglab_data_epochs_ica.fdt'
-    #              run: []
-    #              roi: []
+#          setname: 'EEG Data epochs'
+#         filename: 'eeglab_data_epochs_ica.set'
+#         filepath: '/System/Volumes/Data/data/matlab/eeglab/sample_data'
+#          subject: ''
+#            group: ''
+#        condition: ''
+#          session: []
+#         comments: [9×769 char]
+#           nbchan: 32
+#           trials: 80
+#             pnts: 384
+#            srate: 128
+#             xmin: -1
+#             xmax: 1.9922
+#            times: [-1000 -992.1875 -984.3750 -976.5625 -968.7500 -960.9375 -953.1250 -945.3125 -937.5000 -929.6875 -921.8750 -914.0625 -906.2500 -898.4375 -890.6250 -882.8125 -875 -867.1875 -859.3750 -851.5625 -843.7500 -835.9375 … ] (1×384 double)
+#             data: [32×384×80 single]
+#           icaact: [32×384×80 single]
+#          icawinv: [32×32 double]
+#        icasphere: [32×32 double]
+#       icaweights: [32×32 double]
+#      icachansind: [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]
+#         chanlocs: [1×32 struct]
+#       urchanlocs: [1×32 struct]
+#         chaninfo: [1×1 struct]
+#              ref: 'common'
+#            event: [1×157 struct]
+#          urevent: [1×154 struct]
+# eventdescription: {[2×29 char]  [2×63 char]  [2×36 char]  ''  ''}
+#            epoch: [1×80 struct]
+# epochdescription: {}
+#           reject: [1×1 struct]
+#            stats: [1×1 struct]
+#         specdata: []
+#       specicaact: []
+#       splinefile: []
+#    icasplinefile: ''
+#           dipfit: []
+#          history: 'EEG = eeg_checkset( EEG );↵EEG = eeg_checkset( EEG );↵figure;pop_topoplot(EEG,0, 1, 'EEG Data epochs',[1 1] ,0, 'electrodes', 'on', 'masksurf', 'on');↵EEG = eeg_checkset( EEG );↵EEG.chanlocs=pop_chanedit(EEG.chanlocs,  'plotrad',0.5);↵EEG = pop_loadset( 'filename', 'eeglab_data_epochs_ica.set', 'filepath', '/data/common/matlab/eeglab/sample_data/');↵EEG=pop_chanedit(EEG,  'lookup', '/data/common/matlab/eeglab/plugins/dipfit2.0/standard_BESA/standard-10-5-cap385.elp');↵EEG = pop_saveset( EEG,  'savemode', 'resave');↵EEG=pop_chanedit(EEG,  'eval', 'pop_writelocs( chans, ''/data/common/matlab/eeglab/sample_data/eeglab_chan32_2.locs'',  ''filetype'', ''loc'', ''format'',{ ''channum'', ''theta'', ''radius'', ''labels''}, ''header'', ''off'', ''customheader'','''');', 'load',{ '/data/common/matlab/eeglab/sample_data/eeglab_chan32_2.locs', 'filetype', 'autodetect'}, 'lookup', '/data/common/matlab/eeglab/plugins/dipfit2.0/standard_BESA/standard-10-5-cap385.elp');↵EEG=pop_chanedit(EEG,  'settype',{ '1:32', 'EEG'}, 'changefield',{2, 'type', 'EOG'}, 'changefield',{6, 'type', 'EOG'});↵EEG = pop_loadset( 'filename', 'eeglab_data_epochs_ica.set', 'filepath', '/data/common/matlab/eeglab/sample_data/');↵EEG = pop_loadset('filename','eeglab_data_epochs_ica.set','filepath','/Users/arno/eeglab/sample_data/');↵EEG = eeg_checkset( EEG );↵EEG.etc.eeglabvers = '2024.2'; % this tracks which version of EEGLAB is being used, you may ignore it'
+#            saved: 'yes'
+#              etc: [1×1 struct]
+#          datfile: 'eeglab_data_epochs_ica.fdt'
+#              run: []
+#              roi: []
 
 eeglab_dict = {
-    'setname'         : '',
-    'filename'        : '',
-    'filepath'        : '',
-    'subject'         : '',
-    'group'           : '',
-    'condition'       : '',
-    'session'         : np.array([]),
-    'comments'        : '',
-    'nbchan'          : n_channels,
-    'trials'          : n_epochs,
-    'pnts'            : n_times,
-    'srate'           : epochs.info['sfreq'],
-    'xmin'            : aud_epochs.tmin,
-    'xmax'            : aud_epochs.tmax,
-    'times'           : epochs.times,
-    'data'            : data,
-    'icaact'          : np.array([]),
-    'icawinv'         : np.array([]),
-    'icasphere'       : np.array([]),
-    'icaweights'      : np.array([]),
-    'icachansind'     : np.array([]),
-    'chanlocs'        : np.array([]),
-    'urchanlocs'      : np.array([]),
-    'chaninfo'        : np.array([]),
-    'ref'             : np.array([]),
-    'event'           : np.array([]),
-    'urevent'         : np.array([]),
+    'setname': '',
+    'filename': '',
+    'filepath': '',
+    'subject': '',
+    'group': '',
+    'condition': '',
+    'session': np.array([]),
+    'comments': '',
+    'nbchan': n_channels,
+    'trials': n_epochs,
+    'pnts': n_times,
+    'srate': epochs.info['sfreq'],
+    'xmin': aud_epochs.tmin,
+    'xmax': aud_epochs.tmax,
+    'times': epochs.times,
+    'data': data,
+    'icaact': np.array([]),
+    'icawinv': np.array([]),
+    'icasphere': np.array([]),
+    'icaweights': np.array([]),
+    'icachansind': np.array([]),
+    'chanlocs': np.array([]),
+    'urchanlocs': np.array([]),
+    'chaninfo': np.array([]),
+    'ref': np.array([]),
+    'event': np.array([]),
+    'urevent': np.array([]),
     'eventdescription': np.array([]),
-    'epoch'           : np.array([]),
+    'epoch': np.array([]),
     'epochdescription': np.array([]),
-    'reject'          : np.array([]),
-    'stats'           : np.array([]),
-    'specdata'        : np.array([]),
-    'specicaact'      : np.array([]),
-    'splinefile'      : np.array([]),
-    'icasplinefile'   : np.array([]),
-    'dipfit'          : np.array([]),
-    'history'         : np.array([]),
-    'saved'           : np.array([]),
-    'etc'             : np.array([]),
-    'datfile'         : np.array([]),
-    'run'             : np.array([]),
-    'roi'             : np.array([]),
+    'reject': np.array([]),
+    'stats': np.array([]),
+    'specdata': np.array([]),
+    'specicaact': np.array([]),
+    'splinefile': np.array([]),
+    'icasplinefile': np.array([]),
+    'dipfit': np.array([]),
+    'history': np.array([]),
+    'saved': np.array([]),
+    'etc': np.array([]),
+    'datfile': np.array([]),
+    'run': np.array([]),
+    'roi': np.array([]),
 }
 
 # create channel locations
@@ -132,20 +129,23 @@ ch_names = epochs.ch_names
 ch_locs = np.array([[i, 0, 0] for i in range(n_channels)])
 
 # Create the list of dictionaries with a string field
-d_list = [{
-    'labels': ch_name,
-    'theta': 0,
-    'radius': 0,
-    'X': ch_loc[0],
-    'Y': ch_loc[1],
-    'Z': ch_loc[2],
-    'sph_theta': 0,
-    'sph_phi': 0,
-    'sph_radius': 0,
-    'type': 'EEG',
-    'urchan': 0,
-    'ref': ''
-} for ch_name, ch_loc in zip(ch_names, ch_locs)]
+d_list = [
+    {
+        'labels': ch_name,
+        'theta': 0,
+        'radius': 0,
+        'X': ch_loc[0],
+        'Y': ch_loc[1],
+        'Z': ch_loc[2],
+        'sph_theta': 0,
+        'sph_phi': 0,
+        'sph_radius': 0,
+        'type': 'EEG',
+        'urchan': 0,
+        'ref': '',
+    }
+    for ch_name, ch_loc in zip(ch_names, ch_locs)
+]
 
 # Define the data type for the structured array, including a string field
 # dtype = np.dtype([
@@ -163,39 +163,44 @@ d_list = [{
 #     ('ref', np.str_),
 # ])
 
-dtype = np.dtype([
-    ('labels', 'U100'),      # String up to 100 characters
-    ('theta', np.float64),
-    ('radius', np.float64),
-    ('X', np.float64),
-    ('Y', np.float64),
-    ('Z', np.float64),
-    ('sph_theta', np.float64),
-    ('sph_phi', np.float64),
-    ('sph_radius', np.float64),
-    ('type', 'U10'),         # String up to 10 characters
-    ('urchan', np.int32),
-    ('ref', 'U100')          # String up to 100 characters
-])
+dtype = np.dtype(
+    [
+        ('labels', 'U100'),  # String up to 100 characters
+        ('theta', np.float64),
+        ('radius', np.float64),
+        ('X', np.float64),
+        ('Y', np.float64),
+        ('Z', np.float64),
+        ('sph_theta', np.float64),
+        ('sph_phi', np.float64),
+        ('sph_radius', np.float64),
+        ('type', 'U10'),  # String up to 10 characters
+        ('urchan', np.int32),
+        ('ref', 'U100'),  # String up to 100 characters
+    ]
+)
 
 # Convert the list of dictionaries to a structured NumPy array
-eeglab_dict['chanlocs'] = np.array([
-    (
-        item['labels'],
-        item['theta'],
-        item['radius'],
-        item['X'],
-        item['Y'],
-        item['Z'],
-        item['sph_theta'],
-        item['sph_phi'],
-        item['sph_radius'],
-        item['type'],
-        item['urchan'],
-        item['ref']
-    )
-    for item in d_list
-], dtype=dtype)
+eeglab_dict['chanlocs'] = np.array(
+    [
+        (
+            item['labels'],
+            item['theta'],
+            item['radius'],
+            item['X'],
+            item['Y'],
+            item['Z'],
+            item['sph_theta'],
+            item['sph_phi'],
+            item['sph_radius'],
+            item['type'],
+            item['urchan'],
+            item['ref'],
+        )
+        for item in d_list
+    ],
+    dtype=dtype,
+)
 
 # ch_dict = [{'labels': ch_name, 'X': ch_loc[0], 'Y': ch_loc[1], 'Z': ch_loc[2]} for ch_name, ch_loc in zip(ch_names, ch_locs)]
 # eeglab_dict['chanlocs'] = np.array(ch_dict)
@@ -206,4 +211,4 @@ eeglab_dict['chanlocs'] = np.array([
 # # Step 4: Save the EEGLAB dataset as a .mat file
 savemat('output_file.mat', eeglab_dict)
 
-#print("EEGLAB dataset saved successfully!")
+# print("EEGLAB dataset saved successfully!")

--- a/scripts/mne_iclabel_script.py
+++ b/scripts/mne_iclabel_script.py
@@ -9,7 +9,7 @@ eeglab_data_path = '/System/Volumes/Data/data/matlab/eeglab/sample_data/eeglab_d
 
 if 1:
     raw = mne.io.read_epochs_eeglab(eeglab_data_path)
-    raw.filter(1., 40., fir_design='firwin')
+    raw.filter(1.0, 40.0, fir_design='firwin')
 
     # Select the EEG channels
     picks = mne.pick_types(raw.info, meg=False, eeg=True, eog=False, exclude='bads')

--- a/scripts/test_bids_preproc_expanse.py
+++ b/scripts/test_bids_preproc_expanse.py
@@ -1,4 +1,5 @@
 """End-to-end test"""
+
 import sys
 from eegprep import bids_preproc
 import os
@@ -15,7 +16,7 @@ if __name__ == '__main__':
         root_path = '/'.join(path_parts[:-1]) if len(path_parts) > 1 else '/'
         bids_collection = [dataset_name]
     else:
-        bids_collection = ['ds003061'] #'ds002680'] # 'ds003061']
+        bids_collection = ['ds003061']  #'ds002680'] # 'ds003061']
         root_path = '../../../openneuro'
 
     print(f"Running bids_preproc() on {root_path}/{bids_collection[0]}...")
@@ -25,7 +26,7 @@ if __name__ == '__main__':
     outputdir = './bids_preproc_output'
     retain = [d for d in os.listdir(root_path) if d in bids_collection]
     if len(retain) != len(bids_collection):
-        self.skipTest(f"Skipping test_end2end because neither {bids_collection} exist in {root_path}")
+        raise SystemExit(f"Skipping end-to-end run because none of {bids_collection} exists in {root_path}")
 
     for bids_study in bids_collection:
         study_path = os.path.join(root_path, bids_study)
@@ -38,15 +39,17 @@ if __name__ == '__main__':
             outputdir=outputdir,
             ReservePerJob='1CPU',
             # just the first 2 subjects of the main task
-            subjects=[0,1],
+            subjects=[0, 1],
             runs=[1],
-            SkipIfPresent=True, # <- for quicker re-runs
+            SkipIfPresent=True,  # <- for quicker re-runs
             bidsevent=True,
             SamplingRate=128,
             WithInterp=True,
             EpochEvents=[],
             EpochLimits=[-0.2, 0.5],
             EpochBaseline=[None, 0],
-            WithICA=True, WithICLabel=True,
+            WithICA=True,
+            WithICLabel=True,
             MinimizeDiskUsage=False,
-            ReturnData=True)
+            ReturnData=True,
+        )

--- a/scripts/test_flask.py
+++ b/scripts/test_flask.py
@@ -1,11 +1,14 @@
 from flask import Flask, request, jsonify
+
 app = Flask(__name__)
+
 
 @app.route('/compute', methods=['POST'])
 def compute():
     data = request.json
     x = data['x']
     return jsonify(result=x**2)
+
 
 if __name__ == '__main__':
     app.run(port=5000)

--- a/src/eegprep/functions/__init__.py
+++ b/src/eegprep/functions/__init__.py
@@ -1,2 +1,1 @@
 """EEGLAB-style function modules."""
-

--- a/src/eegprep/functions/adminfunc/__init__.py
+++ b/src/eegprep/functions/adminfunc/__init__.py
@@ -1,2 +1,1 @@
 """EEGLAB-style administrative function modules."""
-

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -725,18 +725,19 @@ class _ConsoleCommandArgumentConverter(ast.NodeTransformer):
                 node.args[index + 1] = self._zero_base_channel_arg(node.args[index + 1])
 
     def _zero_base_channel_arg(self, node: ast.AST) -> ast.AST:
-        if isinstance(node, ast.List) and all(_is_numeric_ast_constant(item) for item in node.elts):
+        if isinstance(node, ast.List):
+            values = [_numeric_ast_constant_value(item) for item in node.elts]
+            if not all(value is not None for value in values):
+                return node
             self.changed = True
             return ast.List(
-                elts=[
-                    ast.Constant(value=int(float(item.value)) - 1)  # type: ignore[union-attr]
-                    for item in node.elts
-                ],
+                elts=[ast.Constant(value=int(float(value)) - 1) for value in values],
                 ctx=node.ctx,
             )
-        if _is_numeric_ast_constant(node):
+        value = _numeric_ast_constant_value(node)
+        if value is not None:
             self.changed = True
-            return ast.Constant(value=int(float(node.value)) - 1)  # type: ignore[union-attr]
+            return ast.Constant(value=int(float(value)) - 1)
         return node
 
     @staticmethod
@@ -871,8 +872,10 @@ def _resolve_eegprep_callable(name: str) -> Callable[..., Any] | None:
     return value if callable(value) else None
 
 
-def _is_numeric_ast_constant(node: ast.AST) -> bool:
-    return isinstance(node, ast.Constant) and isinstance(node.value, (int, float))
+def _numeric_ast_constant_value(node: ast.AST) -> int | float | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    return None
 
 
 def _make_shell_prompt_dynamic(shell: Any) -> None:

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -25,7 +25,9 @@ POP_RESULT_PREVIEW_LIMIT = 96
 ANSI_CLEAR_LINE = "\r\x1b[2K"
 _ACTIVE_TERMINAL_BUFFER = contextvars.ContextVar("_ACTIVE_TERMINAL_BUFFER", default=None)
 _MATLAB_MULTI_ASSIGN_PATTERN = re.compile(r"^\s*\[([A-Za-z_][A-Za-z0-9_]*(?:\s+[A-Za-z_][A-Za-z0-9_]*)+)\]\s*=")
-_TUPLE_ASSIGNMENT_TARGET_PATTERN = re.compile(r"(^|;\s*)\(([A-Za-z_][A-Za-z0-9_]*(?:,\s*[A-Za-z_][A-Za-z0-9_]*)+)\)\s*=")
+_TUPLE_ASSIGNMENT_TARGET_PATTERN = re.compile(
+    r"(^|;\s*)\(([A-Za-z_][A-Za-z0-9_]*(?:,\s*[A-Za-z_][A-Za-z0-9_]*)+)\)\s*="
+)
 _POP_INTERP_CHANNELS_PATTERN = re.compile(r"(pop_interp\s*\(\s*EEG\s*,\s*)\[([0-9,\s]+)\]")
 _PYTHON_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _CONSOLE_COMMAND_EXPORTS = {"pop_newset": pop_newset}
@@ -818,7 +820,11 @@ def _keywordize_option_pairs(
     index = 0
     while index + 1 < len(args):
         key = _option_pair_key(args[index])
-        if key is None or key in existing_keywords or not _can_pass_keyword(key, keyword_parameters, accepts_var_keywords):
+        if (
+            key is None
+            or key in existing_keywords
+            or not _can_pass_keyword(key, keyword_parameters, accepts_var_keywords)
+        ):
             break
         keywords.append(ast.keyword(arg=key, value=args[index + 1]))
         existing_keywords.add(key)
@@ -840,17 +846,17 @@ def _can_pass_keyword(key: str, keyword_parameters: set[str], accepts_var_keywor
 
 
 def _is_workspace_argument(parameter_name: str, arg: ast.expr) -> bool:
-    return parameter_name.upper() in WORKSPACE_NAMES and isinstance(arg, ast.Name) and arg.id.upper() == parameter_name.upper()
+    return (
+        parameter_name.upper() in WORKSPACE_NAMES
+        and isinstance(arg, ast.Name)
+        and arg.id.upper() == parameter_name.upper()
+    )
 
 
 def _console_call_name(node: ast.expr) -> str | None:
     if isinstance(node, ast.Name):
         return node.id
-    if (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "eegprep"
-    ):
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "eegprep":
         return node.attr
     return None
 

--- a/src/eegprep/functions/adminfunc/eeg_checkset.py
+++ b/src/eegprep/functions/adminfunc/eeg_checkset.py
@@ -18,10 +18,12 @@ option_scaleicarms = True
 # Context variable for strict mode (default True)
 _strict_mode_var = contextvars.ContextVar('strict_mode', default=True)
 
+
 class DummyException(Exception):
     """Exception that should never be raised, used to disable exception handling in strict mode."""
 
     pass
+
 
 @contextmanager
 def strict_mode(enabled: bool):
@@ -70,17 +72,16 @@ def _eventconsistency(EEG):
         return EEG
 
     # 1. Remove events with NaN latency
-    events = [e for e in events if not (
-        'latency' in e and isinstance(e.get('latency'), float) and np.isnan(e['latency'])
-    )]
+    events = [
+        e for e in events if not ('latency' in e and isinstance(e.get('latency'), float) and np.isnan(e['latency']))
+    ]
     if not events:
         EEG['event'] = np.asarray(events, dtype=object)
         return EEG
 
     # 2. First boundary event: if boundary with duration < 1 remove it;
     #    if latency in (0, 1), clamp to 0.5  (MATLAB lines 424-430)
-    if (events[0].get('type', '') == 'boundary'
-            and 'duration' in events[0]):
+    if events[0].get('type', '') == 'boundary' and 'duration' in events[0]:
         if events[0].get('duration', 0) < 1:
             events.pop(0)
         elif 0 < events[0].get('latency', 0) < 1:
@@ -94,9 +95,7 @@ def _eventconsistency(EEG):
     pnts = int(EEG.get('pnts', 0))
     trials = int(EEG.get('trials', 1))
     upper_bound = pnts * trials + 1
-    events = [e for e in events
-              if 'latency' not in e
-              or (e['latency'] >= 0.5 and e['latency'] <= upper_bound)]
+    events = [e for e in events if 'latency' not in e or (e['latency'] >= 0.5 and e['latency'] <= upper_bound)]
     if not events:
         EEG['event'] = np.asarray(events, dtype=object)
         return EEG
@@ -154,6 +153,7 @@ def _eventconsistency(EEG):
         ep = ep if isinstance(ep, (int, float)) else 0
         lat = lat if isinstance(lat, (int, float)) else 0
         return (ep, lat)
+
     events.sort(key=_sort_key)
 
     # 8. Clamp first event latency to >= 0.5  (MATLAB lines 600-604)
@@ -175,7 +175,6 @@ def eeg_checkset(EEG, *checks, load_data=True):
     # In strict mode (True), we catch DummyException (never raised) so exceptions propagate
     # In non-strict mode (False), we catch Exception and handle gracefully
     exception_type = DummyException if _strict_mode_var.get() else Exception
-
 
     # convert EEG['nbchan] to integer
     if 'nbchan' in EEG:
@@ -224,16 +223,22 @@ def eeg_checkset(EEG, *checks, load_data=True):
             file_name = EEG['filepath'] + os.sep + EEG['filename'].replace('.set', '.fdt')
             if not os.path.exists(file_name):
                 raise FileNotFoundError(f"Data file {file_name} not found")
-        EEG['data'] = np.fromfile(file_name, dtype='float32').reshape( EEG['pnts']*EEG['trials'], EEG['nbchan'])
+        EEG['data'] = np.fromfile(file_name, dtype='float32').reshape(EEG['pnts'] * EEG['trials'], EEG['nbchan'])
         EEG['data'] = EEG['data'].T.reshape(EEG['nbchan'], EEG['trials'], EEG['pnts']).transpose(0, 2, 1)
 
     # Scale ICA components to RMS microvolt (matches MATLAB's option_scaleicarms)
-    if (option_scaleicarms and
-        'icaweights' in EEG and 'icasphere' in EEG and 'icawinv' in EEG and
-        hasattr(EEG['icaweights'], 'size') and hasattr(EEG['icasphere'], 'size') and
-        hasattr(EEG['icawinv'], 'size') and
-        EEG['icaweights'].size > 0 and EEG['icasphere'].size > 0 and EEG['icawinv'].size > 0):
-
+    if (
+        option_scaleicarms
+        and 'icaweights' in EEG
+        and 'icasphere' in EEG
+        and 'icawinv' in EEG
+        and hasattr(EEG['icaweights'], 'size')
+        and hasattr(EEG['icasphere'], 'size')
+        and hasattr(EEG['icawinv'], 'size')
+        and EEG['icaweights'].size > 0
+        and EEG['icasphere'].size > 0
+        and EEG['icawinv'].size > 0
+    ):
         try:
             # Check if pinv(icaweights @ icasphere) ≈ icawinv
             with np.errstate(divide='ignore', over='ignore', invalid='ignore'):
@@ -263,21 +268,31 @@ def eeg_checkset(EEG, *checks, load_data=True):
             logger.error("Error scaling ICA components: " + str(e))
 
     # compute ICA activations
-    if ('icaweights' in EEG and 'icasphere' in EEG and
-        hasattr(EEG['icaweights'], 'size') and hasattr(EEG['icasphere'], 'size') and
-        EEG['icaweights'].size > 0 and EEG['icasphere'].size > 0):
-
+    if (
+        'icaweights' in EEG
+        and 'icasphere' in EEG
+        and hasattr(EEG['icaweights'], 'size')
+        and hasattr(EEG['icasphere'], 'size')
+        and EEG['icaweights'].size > 0
+        and EEG['icasphere'].size > 0
+    ):
         try:
             # Use icachansind to select only channels ICA was trained on (matches MATLAB eeg_checkset.m:1030)
-            if ('icachansind' in EEG and EEG['icachansind'] is not None and
-                hasattr(EEG['icachansind'], '__len__') and len(EEG['icachansind']) > 0):
+            if (
+                'icachansind' in EEG
+                and EEG['icachansind'] is not None
+                and hasattr(EEG['icachansind'], '__len__')
+                and len(EEG['icachansind']) > 0
+            ):
                 # Convert to numpy array if it's a list
                 icachansind = np.array(EEG['icachansind'], dtype=int)
                 # Validate indices are within bounds
                 n_channels = EEG['data'].shape[0]
                 if np.any(icachansind < 0) or np.any(icachansind >= n_channels):
-                    logger.warning(f"icachansind contains out-of-bounds indices (valid range: 0-{n_channels-1}). "
-                                 "Using all channels instead.")
+                    logger.warning(
+                        f"icachansind contains out-of-bounds indices (valid range: 0-{n_channels - 1}). "
+                        "Using all channels instead."
+                    )
                     ica_data = EEG['data']
                 else:
                     ica_data = EEG['data'][icachansind, :]
@@ -290,11 +305,15 @@ def eeg_checkset(EEG, *checks, load_data=True):
             actual_channels = ica_data.shape[0]  # Number of channels in ica_data
 
             if expected_channels != actual_channels:
-                logger.warning(f"ICA dimension mismatch: icaweights expects {expected_channels} channels "
-                             f"but ica_data has {actual_channels} channels. Skipping ICA activation computation.")
+                logger.warning(
+                    f"ICA dimension mismatch: icaweights expects {expected_channels} channels "
+                    f"but ica_data has {actual_channels} channels. Skipping ICA activation computation."
+                )
                 EEG['icaact'] = np.array([])
             else:
-                EEG['icaact'] = np.dot(np.dot(EEG['icaweights'], EEG['icasphere']), ica_data.reshape(ica_data.shape[0], -1))
+                EEG['icaact'] = np.dot(
+                    np.dot(EEG['icaweights'], EEG['icasphere']), ica_data.reshape(ica_data.shape[0], -1)
+                )
                 EEG['icaact'] = EEG['icaact'].astype(np.float32)
                 EEG['icaact'] = EEG['icaact'].reshape(EEG['icaweights'].shape[0], -1, int(EEG['trials']))
         except exception_type as e:
@@ -414,25 +433,25 @@ def eeg_checkset(EEG, *checks, load_data=True):
         'nbchan': int,
         'trials': int,
         'pnts': int,
-        'srate': (float,int),
+        'srate': (float, int),
         'xmin': float,
         'xmax': float,
         'times': np.ndarray,  # Expecting a float numpy array
-        'data': np.ndarray,   # Expecting a float numpy array
-        'icaact': np.ndarray, # Expecting a float numpy array
-        'icawinv': np.ndarray,# Expecting a float numpy array
-        'icasphere': np.ndarray, # Expecting a float numpy array
-        'icaweights': np.ndarray, # Expecting a float numpy array
-        'icachansind': np.ndarray, # Expecting an integer numpy array
-        'chanlocs': np.ndarray,    # Expecting numpy array of dictionaries
+        'data': np.ndarray,  # Expecting a float numpy array
+        'icaact': np.ndarray,  # Expecting a float numpy array
+        'icawinv': np.ndarray,  # Expecting a float numpy array
+        'icasphere': np.ndarray,  # Expecting a float numpy array
+        'icaweights': np.ndarray,  # Expecting a float numpy array
+        'icachansind': np.ndarray,  # Expecting an integer numpy array
+        'chanlocs': np.ndarray,  # Expecting numpy array of dictionaries
         'urchanlocs': np.ndarray,  # Expecting numpy array of dictionaries
         'chaninfo': dict,
         'ref': str,
-        'event': np.ndarray,       # Expecting numpy array of dictionaries
-        'urevent': np.ndarray,     # Expecting numpy array of dictionaries
-        'eventdescription': np.ndarray, # Expecting numpy array of strings
-        'epoch': np.ndarray,       # Expecting numpy array of dictionaries
-        'epochdescription': np.ndarray, # Expecting numpy array of strings
+        'event': np.ndarray,  # Expecting numpy array of dictionaries
+        'urevent': np.ndarray,  # Expecting numpy array of dictionaries
+        'eventdescription': np.ndarray,  # Expecting numpy array of strings
+        'epoch': np.ndarray,  # Expecting numpy array of dictionaries
+        'epochdescription': np.ndarray,  # Expecting numpy array of strings
         'reject': dict,
         'stats': dict,
         'specdata': dict,
@@ -454,13 +473,13 @@ def eeg_checkset(EEG, *checks, load_data=True):
             logger.debug(f"Field '{field}' is missing from the EEG dictionary, adding it.")
 
             # add default values
-            if expected_type == str:
+            if expected_type is str:
                 EEG[field] = ''
-            elif expected_type == int:
+            elif expected_type is int:
                 EEG[field] = np.array([], dtype=int)
-            elif expected_type == float:
+            elif expected_type is float:
                 EEG[field] = np.array([], dtype=float)
-            elif expected_type == dict:
+            elif expected_type is dict:
                 EEG[field] = {}
             elif expected_type == np.ndarray:
                 EEG[field] = np.array([])
@@ -473,18 +492,26 @@ def eeg_checkset(EEG, *checks, load_data=True):
         # Special cases for numpy arrays with specific content types
         if isinstance(expected_type, type) and expected_type == np.ndarray:
             if not isinstance(value, np.ndarray):
-                logger.warning(f"Field '{field}' is expected to be a numpy array but is of type {type(value).__name__}.")
+                logger.warning(
+                    f"Field '{field}' is expected to be a numpy array but is of type {type(value).__name__}."
+                )
                 continue
             # Further checks for numpy array content types
             if field in ['times', 'data', 'icaact', 'icawinv', 'icasphere', 'icaweights']:
                 if not np.issubdtype(value.dtype, np.floating):
-                    logger.warning(f"Field '{field}' is expected to be a numpy array of floats but has dtype {value.dtype}.")
+                    logger.warning(
+                        f"Field '{field}' is expected to be a numpy array of floats but has dtype {value.dtype}."
+                    )
             elif field in ['icachansind']:
                 if not np.issubdtype(value.dtype, np.integer):
-                    logger.warning(f"Field '{field}' is expected to be a numpy array of integers but has dtype {value.dtype}.")
+                    logger.warning(
+                        f"Field '{field}' is expected to be a numpy array of integers but has dtype {value.dtype}."
+                    )
             elif field in ['chanlocs', 'urchanlocs', 'event', 'urevent', 'epoch']:
                 if not all(isinstance(item, dict) for item in value):
-                    logger.warning(f"Field '{field}' is expected to be a numpy array of dictionaries but contains other types.")
+                    logger.warning(
+                        f"Field '{field}' is expected to be a numpy array of dictionaries but contains other types."
+                    )
             # elif field in ['eventdescription', 'epochdescription']:
             #     if not all(isinstance(item, str) for item in value):
             #         print(f"Field '{field}' is expected to be a numpy array of strings but contains other types.")
@@ -494,9 +521,12 @@ def eeg_checkset(EEG, *checks, load_data=True):
                 # check for empty Ndarray
                 if isinstance(value, np.ndarray) and value.size == 0:
                     continue
-                logger.warning(f"Field '{field}' is expected to be of type {expected_type} but is of type {type(value).__name__}.")
+                logger.warning(
+                    f"Field '{field}' is expected to be of type {expected_type} but is of type {type(value).__name__}."
+                )
 
     return EEG
+
 
 def test_eeg_checkset():
     from eegprep.functions.popfunc.pop_loadset import pop_loadset
@@ -505,6 +535,7 @@ def test_eeg_checkset():
     EEG = pop_loadset(eeglab_file_path)
     EEG = eeg_checkset(EEG)
     logger.info('Checkset done')
+
 
 if __name__ == '__main__':
     test_eeg_checkset()

--- a/src/eegprep/functions/adminfunc/eeg_options.py
+++ b/src/eegprep/functions/adminfunc/eeg_options.py
@@ -6,44 +6,46 @@ options in Python pipelines or serialize them to JSON/YAML.
 
 from dataclasses import dataclass, asdict
 
+
 @dataclass
 class EEGOptions:
     """Configuration options for EEG processing, mirroring MATLAB EEGLAB options."""
 
     # STUDY and file options
-    option_storedisk: int = 0           # keep at most one dataset in memory
-    option_savetwofiles: int = 0        # save header and data as two files
-    option_saveversion6: int = 1        # write files in Matlab v6.5 format
-    option_saveasstruct: int = 1        # save EEG fields as individual variables
-    option_parallel: int = 0            # use parallel toolbox when processing multiple datasets
+    option_storedisk: int = 0  # keep at most one dataset in memory
+    option_savetwofiles: int = 0  # save header and data as two files
+    option_saveversion6: int = 1  # write files in Matlab v6.5 format
+    option_saveasstruct: int = 1  # save EEG fields as individual variables
+    option_parallel: int = 0  # use parallel toolbox when processing multiple datasets
 
     # Memory options
-    option_single: int = 1              # use single precision in memory
-    option_memmapdata: int = 0          # use memory-mapped arrays
-    option_eegobject: int = 0           # use EEGLAB EEG object instead of struct
+    option_single: int = 1  # use single precision in memory
+    option_memmapdata: int = 0  # use memory-mapped arrays
+    option_eegobject: int = 0  # use EEGLAB EEG object instead of struct
 
     # ICA options
-    option_computeica: int = 1          # precompute ICA activations
-    option_scaleicarms: int = 1         # scale ICA components to RMS in microvolt
+    option_computeica: int = 1  # precompute ICA activations
+    option_scaleicarms: int = 1  # scale ICA components to RMS in microvolt
 
     # Folder options
-    option_rememberfolder: int = 1      # remember last dataset folder
+    option_rememberfolder: int = 1  # remember last dataset folder
 
     # Toolbox options
-    option_donotusetoolboxes: int = 0   # ignore optional MATLAB toolboxes
+    option_donotusetoolboxes: int = 0  # ignore optional MATLAB toolboxes
 
     # EEGLAB connectivity and support
-    option_showadvanced: int = 0        # show advanced options
-    option_boundary99: int = 0          # use type "-99" for boundary events (ERPLAB compatibility)
+    option_showadvanced: int = 0  # show advanced options
+    option_boundary99: int = 0  # use type "-99" for boundary events (ERPLAB compatibility)
     option_showpendingplugins: int = 0  # show plugins pending approval
-    option_allmenus: int = 0            # show all legacy menu items
-    option_htmlingraphics: int = 1      # allow HTML in graphics
-    option_checkversion: int = 1        # check for new EEGLAB versions at startup
-    option_cachesize: int = 500         # STUDY cache size in MB
+    option_allmenus: int = 0  # show all legacy menu items
+    option_htmlingraphics: int = 1  # allow HTML in graphics
+    option_checkversion: int = 1  # check for new EEGLAB versions at startup
+    option_cachesize: int = 500  # STUDY cache size in MB
 
     def to_dict(self):
         """Convert the options to a dictionary."""
         return asdict(self)
+
 
 # Default options instance mirroring the MATLAB file
 EEG_OPTIONS = EEGOptions()

--- a/src/eegprep/functions/adminfunc/eeglabcompat.py
+++ b/src/eegprep/functions/adminfunc/eeglabcompat.py
@@ -1,8 +1,5 @@
 """EEGLAB compatibility utilities."""
 
-# import sys
-# sys.path.insert(0, 'src/')
-
 import importlib
 import logging
 import os
@@ -191,18 +188,14 @@ class MatlabWrapper:
                 try:
                     # noinspection PyUnboundLocalVariable
                     if os.path.exists(temp_filename1):
-                        # os.remove(temp_filename1)
-                        pass
+                        os.remove(temp_filename1)
                     if os.path.exists(temp_filename2):
-                        # os.remove(temp_filename2)
-                        pass
+                        os.remove(temp_filename2)
                     # noinspection PyUnboundLocalVariable
                     if os.path.exists(result_filename):
-                        # os.remove(result_filename)
-                        pass
+                        os.remove(result_filename)
                     if os.path.exists(result_filename.replace('result.set', 'result.fdt')):
-                        # os.remove(fdt_file)
-                        pass
+                        os.remove(result_filename.replace('result.set', 'result.fdt'))
                 except OSError as e:
                     logger.warning(f"Error deleting temporary file(s) in temp dir {temp_dir}: {e}")
             # else:
@@ -247,6 +240,7 @@ def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = Tr
             engine.warning('off', 'backtrace')
         elif rt == 'mat':
             try:
+                # Use import_module so ty can run before MATLAB Engine is installed.
                 matlab_engine = importlib.import_module("matlab.engine")
             except ImportError:
                 raise ImportError("""\
@@ -374,6 +368,16 @@ def pop_eegfiltnew(EEG, locutoff=None, hicutoff=None, revfilt=False, plotfreqz=F
     )
 
 
+def _matlab_false_or_off(value: Any) -> bool:
+    if isinstance(value, str):
+        return value == 'off'
+    if value is False:
+        return True
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return value == 0
+    return False
+
+
 def clean_artifacts(
     EEG,
     ChannelCriterion=False,
@@ -415,22 +419,22 @@ def clean_artifacts(
     """
     eeglab = get_eeglab(auto_file_roundtrip=False)
 
-    if not ChannelCriterion or ChannelCriterion == 'off':
+    if _matlab_false_or_off(ChannelCriterion):
         ChannelCriterion = 'off'
 
-    if not LineNoiseCriterion or LineNoiseCriterion == 'off':
+    if _matlab_false_or_off(LineNoiseCriterion):
         LineNoiseCriterion = 'off'
 
-    if not FlatlineCriterion or FlatlineCriterion == 'off':
+    if _matlab_false_or_off(FlatlineCriterion):
         FlatlineCriterion = 'off'
 
-    if not BurstCriterion or BurstCriterion == 'off':
+    if _matlab_false_or_off(BurstCriterion):
         BurstCriterion = 'off'
 
-    if not Highpass or Highpass == 'off':
+    if _matlab_false_or_off(Highpass):
         Highpass = 'off'
 
-    if not BurstRejection or BurstRejection == 'off':
+    if _matlab_false_or_off(BurstRejection):
         BurstRejection = 'off'
     else:
         BurstRejection = 'on'

--- a/src/eegprep/functions/adminfunc/eeglabcompat.py
+++ b/src/eegprep/functions/adminfunc/eeglabcompat.py
@@ -3,17 +3,19 @@
 # import sys
 # sys.path.insert(0, 'src/')
 
-import tempfile
-from typing import *
-
-from ..popfunc.pop_loadset import pop_loadset
-from ..popfunc.pop_saveset import pop_saveset
+import importlib
 import logging
 import os
+import tempfile
 from pathlib import Path
+from typing import Any
+
 import numpy as np
-from eegprep.functions.adminfunc.pymat import py2mat
 import scipy.io
+
+from eegprep.functions.adminfunc.pymat import py2mat
+from ..popfunc.pop_loadset import pop_loadset
+from ..popfunc.pop_saveset import pop_saveset
 
 logger = logging.getLogger(__name__)
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -32,6 +34,7 @@ else:
     temp_dir = str(REPO_ROOT / 'temp')
     if not os.path.exists(temp_dir):
         os.makedirs(temp_dir, exist_ok=True)
+
 
 class MatlabWrapper:
     """MATLAB engine wrapper that round-trips calls involving the EEGLAB data structure through files."""
@@ -80,6 +83,7 @@ class MatlabWrapper:
         callable
             Wrapper function.
         """
+
         def wrapper(*args, **kwargs):
             # arg list
             new_args = list(args)
@@ -115,19 +119,23 @@ class MatlabWrapper:
             for i, arg in enumerate(new_args):
                 if isinstance(arg, list) and all(isinstance(x, (int, float, np.integer, np.floating)) for x in arg):
                     new_args[i] = np.array(arg, dtype=np.float64)
-                elif isinstance(arg, np.ndarray) and all(isinstance(x, (int, float, np.integer, np.floating)) for x in np.ravel(arg)):
+                elif isinstance(arg, np.ndarray) and all(
+                    isinstance(x, (int, float, np.integer, np.floating)) for x in np.ravel(arg)
+                ):
                     new_args[i] = np.array(arg, dtype=np.float64)
                 elif isinstance(arg, (int, float, np.integer, np.floating)):
                     new_args[i] = np.array(arg, dtype=np.float64)
                 elif isinstance(arg, str):
                     new_args[i] = arg
                 else:
-                    new_args[i] = py2mat(arg) # it is unclear if the flatten function of pop_saveset is better here
+                    new_args[i] = py2mat(arg)  # it is unclear if the flatten function of pop_saveset is better here
 
             try:
                 # temporary files
-                temp_filename1 = tempfile.mktemp(dir=temp_dir, suffix='.set')
-                temp_filename2 = tempfile.mktemp(dir=temp_dir, suffix='.mat')
+                with tempfile.NamedTemporaryFile(dir=temp_dir, suffix='.set', delete=False) as temp_file1:
+                    temp_filename1 = temp_file1.name
+                with tempfile.NamedTemporaryFile(dir=temp_dir, suffix='.mat', delete=False) as temp_file2:
+                    temp_filename2 = temp_file2.name
                 result_filename = temp_filename1 + '.result.set'
                 print(f"temp_filename1: {temp_filename1}")
                 print(f"temp_filename2: {temp_filename2}")
@@ -136,9 +144,13 @@ class MatlabWrapper:
                 # save all parameters in the temp_filename which is a .mat file
                 if len(new_args) > 0:
                     if len(new_args) > 1:
-                        scipy.io.savemat(temp_filename2, {'args': np.array(new_args, dtype=object)}) # object required for passing as cell array
+                        scipy.io.savemat(
+                            temp_filename2, {'args': np.array(new_args, dtype=object)}
+                        )  # object required for passing as cell array
                     else:
-                        scipy.io.savemat(temp_filename2, {'args': new_args[0]}) # [0] because other increase dim of array by 1
+                        scipy.io.savemat(
+                            temp_filename2, {'args': new_args[0]}
+                        )  # [0] because other increase dim of array by 1
                     self.engine.eval(f"args = load('{temp_filename2}');", nargout=0)
                 else:
                     self.engine.eval("args.args = {};", nargout=0)
@@ -179,17 +191,17 @@ class MatlabWrapper:
                 try:
                     # noinspection PyUnboundLocalVariable
                     if os.path.exists(temp_filename1):
-                        #os.remove(temp_filename1)
+                        # os.remove(temp_filename1)
                         pass
                     if os.path.exists(temp_filename2):
-                        #os.remove(temp_filename2)
+                        # os.remove(temp_filename2)
                         pass
                     # noinspection PyUnboundLocalVariable
                     if os.path.exists(result_filename):
-                        #os.remove(result_filename)
+                        # os.remove(result_filename)
                         pass
-                    if os.path.exists(fdt_file := result_filename.replace('result.set', 'result.fdt')):
-                        #os.remove(fdt_file)
+                    if os.path.exists(result_filename.replace('result.set', 'result.fdt')):
+                        # os.remove(fdt_file)
                         pass
                 except OSError as e:
                     logger.warning(f"Error deleting temporary file(s) in temp dir {temp_dir}: {e}")
@@ -198,6 +210,7 @@ class MatlabWrapper:
             #     return getattr(self.engine, name)(*args)
 
         return wrapper
+
 
 # noinspection PyDefaultArgument
 def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = True, _cache={}):
@@ -227,13 +240,14 @@ def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = Tr
         # not yet loaded, do so now
         if rt == 'oct':
             from oct2py import Oct2Py, get_log
+
             engine = Oct2Py(logger=get_log())
             engine.logger = get_log("new_log")
             engine.logger.setLevel(logging.WARNING)
             engine.warning('off', 'backtrace')
         elif rt == 'mat':
             try:
-                import matlab.engine
+                matlab_engine = importlib.import_module("matlab.engine")
             except ImportError:
                 raise ImportError("""\
                     The MATLAB runtime has not been installed into your Python environment.
@@ -244,7 +258,7 @@ def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = Tr
                     This will insert a wrapper package in the python environment that forwards
                     calls to the MATLAB runtime.
                     """)
-            engine = matlab.engine.start_matlab()
+            engine = matlab_engine.start_matlab()
             # engine.cd(path2eeglab)
             # engine.eval('eeglab nogui;', nargout=0) # starting EEGLAB is too slow
         else:
@@ -272,8 +286,8 @@ def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = Tr
         engine.cd(path2eeglab + '/plugins/clean_rawdata/private')  # to grant access to util funcs for unit testing
 
         # path2eeglab = 'eeglab' # init >10 seconds
-        #res = eeglab.version()
-        #print('Running EEGLAB commands in compatibility mode with Octave ' + res)
+        # res = eeglab.version()
+        # print('Running EEGLAB commands in compatibility mode with Octave ' + res)
 
         if rt == 'oct':
             engine.logger.setLevel(logging.INFO)
@@ -322,7 +336,7 @@ def clean_drifts(EEG, Transition, Attenuation, eeglab=None):
 #     return EEG3
 
 
-def pop_eegfiltnew(EEG, locutoff=None,hicutoff=None,revfilt=False,plotfreqz=False):
+def pop_eegfiltnew(EEG, locutoff=None, hicutoff=None, revfilt=False, plotfreqz=False):
     """Filter EEG data using EEGLAB's pop_eegfiltnew.
 
     Parameters
@@ -355,10 +369,22 @@ def pop_eegfiltnew(EEG, locutoff=None,hicutoff=None,revfilt=False,plotfreqz=Fals
 
     # Use wrapper which handles EEG struct conversion via file roundtrip
     eeglab = get_eeglab(auto_file_roundtrip=True)
-    return eeglab.pop_eegfiltnew(EEG, 'locutoff', locutoff, 'hicutoff', hicutoff,
-                                  'revfilt', revfilt, 'plotfreqz', plotfreqz)
+    return eeglab.pop_eegfiltnew(
+        EEG, 'locutoff', locutoff, 'hicutoff', hicutoff, 'revfilt', revfilt, 'plotfreqz', plotfreqz
+    )
 
-def clean_artifacts( EEG, ChannelCriterion=False, LineNoiseCriterion=False, FlatlineCriterion=False, BurstCriterion=False, BurstRejection=False, WindowCriterion=0, Highpass=[0.25, 0.75], WindowCriterionTolerances=[float('-inf'), 8]):
+
+def clean_artifacts(
+    EEG,
+    ChannelCriterion=False,
+    LineNoiseCriterion=False,
+    FlatlineCriterion=False,
+    BurstCriterion=False,
+    BurstRejection=False,
+    WindowCriterion=0,
+    Highpass=[0.25, 0.75],
+    WindowCriterionTolerances=[float('-inf'), 8],
+):
     """Clean artifacts from EEG data using EEGLAB's clean_artifacts.
 
     Parameters
@@ -389,44 +415,55 @@ def clean_artifacts( EEG, ChannelCriterion=False, LineNoiseCriterion=False, Flat
     """
     eeglab = get_eeglab(auto_file_roundtrip=False)
 
-    if ChannelCriterion == False or ChannelCriterion == 'off':
-        ChannelCriterion='off'
+    if not ChannelCriterion or ChannelCriterion == 'off':
+        ChannelCriterion = 'off'
 
-    if LineNoiseCriterion == False or LineNoiseCriterion == 'off':
-        LineNoiseCriterion='off'
+    if not LineNoiseCriterion or LineNoiseCriterion == 'off':
+        LineNoiseCriterion = 'off'
 
-    if FlatlineCriterion == False or FlatlineCriterion == 'off':
-        FlatlineCriterion='off'
+    if not FlatlineCriterion or FlatlineCriterion == 'off':
+        FlatlineCriterion = 'off'
 
-    if BurstCriterion == False or BurstCriterion == 'off':
-        BurstCriterion='off'
+    if not BurstCriterion or BurstCriterion == 'off':
+        BurstCriterion = 'off'
 
-    if Highpass == False or Highpass == 'off':
-        Highpass='off'
+    if not Highpass or Highpass == 'off':
+        Highpass = 'off'
 
-    if BurstRejection == False or BurstRejection == 'off':
-        BurstRejection='off'
+    if not BurstRejection or BurstRejection == 'off':
+        BurstRejection = 'off'
     else:
-        BurstRejection='on'
+        BurstRejection = 'on'
 
-
-    pop_saveset(EEG, './tmp.set') # 0.8 seconds
-    EEG2 = eeglab.pop_loadset('./tmp.set') # 2 seconds
-    EEG3 = eeglab.clean_artifacts(EEG2, 'ChannelCriterion', ChannelCriterion, \
-        'LineNoiseCriterion', LineNoiseCriterion, \
-        'FlatlineCriterion', FlatlineCriterion, \
-        'BurstCriterion', BurstCriterion,  \
-        'BurstRejection', BurstRejection,  \
-        'WindowCriterion', WindowCriterion, \
-        'Highpass',Highpass, \
-        'WindowCriterionTolerances', WindowCriterionTolerances)
-    eeglab.pop_saveset(EEG3, './tmp2.set') # 2.4 seconds
-    EEG4 = pop_loadset('./tmp2.set') # 0.2 seconds
+    pop_saveset(EEG, './tmp.set')  # 0.8 seconds
+    EEG2 = eeglab.pop_loadset('./tmp.set')  # 2 seconds
+    EEG3 = eeglab.clean_artifacts(
+        EEG2,
+        'ChannelCriterion',
+        ChannelCriterion,
+        'LineNoiseCriterion',
+        LineNoiseCriterion,
+        'FlatlineCriterion',
+        FlatlineCriterion,
+        'BurstCriterion',
+        BurstCriterion,
+        'BurstRejection',
+        BurstRejection,
+        'WindowCriterion',
+        WindowCriterion,
+        'Highpass',
+        Highpass,
+        'WindowCriterionTolerances',
+        WindowCriterionTolerances,
+    )
+    eeglab.pop_saveset(EEG3, './tmp2.set')  # 2.4 seconds
+    EEG4 = pop_loadset('./tmp2.set')  # 0.2 seconds
 
     # delete temporary files
     os.remove('./tmp.set')
     os.remove('./tmp2.set')
     return EEG4
+
 
 # sys.exit()
 def test_eeglab_compat():
@@ -434,8 +471,18 @@ def test_eeglab_compat():
     eeglab_file_path = '/System/Volumes/Data/data/matlab/eeglab/sample_data/eeglab_data_epochs_ica.set'
 
     EEG = pop_loadset(eeglab_file_path)
-    EEG = pop_eegfiltnew(EEG, locutoff=5,hicutoff=25,revfilt=True,plotfreqz=False)
-    EEG = clean_artifacts(EEG, FlatlineCriterion=5,ChannelCriterion=0.87, LineNoiseCriterion=4,Highpass=False,BurstCriterion= 20, WindowCriterion=0.25, BurstRejection=False, WindowCriterionTolerances=[float('-inf'), 7])
+    EEG = pop_eegfiltnew(EEG, locutoff=5, hicutoff=25, revfilt=True, plotfreqz=False)
+    EEG = clean_artifacts(
+        EEG,
+        FlatlineCriterion=5,
+        ChannelCriterion=0.87,
+        LineNoiseCriterion=4,
+        Highpass=False,
+        BurstCriterion=20,
+        WindowCriterion=0.25,
+        BurstRejection=False,
+        WindowCriterionTolerances=[float('-inf'), 7],
+    )
 
     # EEG = eeglab.pop_loadset(eeglab_file_path)
     # TMPEEG = eeglab.pop_eegfiltnew(EEG, 'locutoff',5,'hicutoff',25,'revfilt',1,'plotfreqz',0)

--- a/src/eegprep/functions/adminfunc/git.py
+++ b/src/eegprep/functions/adminfunc/git.py
@@ -7,7 +7,7 @@ import os
 __all__ = ['get_git_commit_id']
 
 
-def get_git_commit_id(repo_path: str = None, shorten: int = 8) -> str | None:
+def get_git_commit_id(repo_path: str | None = None, shorten: int = 8) -> str | None:
     """Get the current commit ID (hash) of a Git repository.
 
     Args:
@@ -35,20 +35,13 @@ def get_git_commit_id(repo_path: str = None, shorten: int = 8) -> str | None:
             cwd=repo_path,  # Run command in the specified directory
             capture_output=True,  # Capture stdout and stderr
             text=True,  # Decode output as text
-            check=True  # Raise CalledProcessError if command fails
+            check=True,  # Raise CalledProcessError if command fails
         )
-
 
         # 2. Check for dirty status using the porcelain format
         # This command outputs nothing if the working tree is clean.
         status_cmd = ['git', 'status', '--porcelain']
-        status_result = subprocess.run(
-            status_cmd,
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=True
-        )
+        status_result = subprocess.run(status_cmd, cwd=repo_path, capture_output=True, text=True, check=True)
 
         # The output is the commit hash, with a trailing newline
         hash = commit_result.stdout.strip()

--- a/src/eegprep/functions/adminfunc/logs.py
+++ b/src/eegprep/functions/adminfunc/logs.py
@@ -7,6 +7,7 @@ import warnings
 # Try importing colorama, handle if missing
 try:
     import colorama
+
     _COLORAMA_AVAILABLE = True
     # Initialize colorama for Windows compatibility
     colorama.init()
@@ -47,8 +48,7 @@ class ColoredWarningFormatter(logging.Formatter):
                 logging.CRITICAL: logging.Formatter(self.log_format_error, datefmt=datefmt, style=style),
             }
         else:
-            self.formats = {} # No special formats if no colorama
-
+            self.formats = {}  # No special formats if no colorama
 
     def format(self, record):
         """Format the record with color if applicable."""
@@ -83,18 +83,16 @@ def setup_logging(level=logging.INFO, only_if_unset=True):
         If True (default), configuration is skipped if the
         root logger already has handlers configured.
     """
-    root_logger = logging.getLogger() # Get the root logger
+    root_logger = logging.getLogger()  # Get the root logger
 
     # Check if handlers already exist and if we should skip configuration
     if only_if_unset and root_logger.hasHandlers():
-        logging.getLogger(__name__).debug(
-            "Root logger already has handlers, skipping setup_logging."
-        )
-        return # Skip configuration
+        logging.getLogger(__name__).debug("Root logger already has handlers, skipping setup_logging.")
+        return  # Skip configuration
 
     # --- Proceed with configuration ---
     # Set level *after* checking handlers, so we don't change level if skipping.
-    root_logger.setLevel(level) # Set the minimum level for the logger itself
+    root_logger.setLevel(level)  # Set the minimum level for the logger itself
 
     # Configure console handler
     console_handler = logging.StreamHandler(sys.stderr)
@@ -104,19 +102,17 @@ def setup_logging(level=logging.INFO, only_if_unset=True):
         formatter = ColoredWarningFormatter()
         console_handler.setFormatter(formatter)
     elif not _COLORAMA_AVAILABLE:
-         warnings.warn(
-             "Optional dependency 'colorama' not found. Log colors will be disabled. "
-             "Install with: pip install colorama",
-             ImportWarning
-         )
-         # Fallback to standard formatter if colorama is missing
-         formatter = logging.Formatter(ColoredWarningFormatter.log_format)
-         console_handler.setFormatter(formatter)
+        warnings.warn(
+            "Optional dependency 'colorama' not found. Log colors will be disabled. Install with: pip install colorama",
+            ImportWarning,
+        )
+        # Fallback to standard formatter if colorama is missing
+        formatter = logging.Formatter(ColoredWarningFormatter.log_format)
+        console_handler.setFormatter(formatter)
     else:
         # Use standard formatter if not a TTY (e.g., redirecting to a file)
         formatter = logging.Formatter(ColoredWarningFormatter.log_format)
         console_handler.setFormatter(formatter)
-
 
     # Set the level for the handler (controls what messages the handler *outputs*)
     console_handler.setLevel(level)

--- a/src/eegprep/functions/adminfunc/pymat.py
+++ b/src/eegprep/functions/adminfunc/pymat.py
@@ -1,7 +1,5 @@
 """Python-MATLAB data conversion utilities."""
 
-from typing import *
-
 import numpy as np
 import scipy.io
 
@@ -9,7 +7,8 @@ import scipy.io
 # recarray -> struct array
 
 default_empty = np.array([])
-#default_empty = None
+# default_empty = None
+
 
 # convert list of arbitrary dicts to struct array
 def py2mat(dicts):
@@ -99,7 +98,7 @@ def py2mat(dicts):
             elif isinstance(processed_v, (int, np.integer)):
                 if k not in key_types:
                     key_types[k] = int
-                elif key_types[k] != int and key_types[k] != object:
+                elif key_types[k] is not int and key_types[k] is not object:
                     key_types[k] = object
             elif isinstance(processed_v, (float, np.floating)):
                 if k not in key_types:
@@ -109,7 +108,7 @@ def py2mat(dicts):
             elif isinstance(processed_v, bool):
                 if k not in key_types:
                     key_types[k] = bool
-                elif key_types[k] != bool and key_types[k] != object:
+                elif key_types[k] is not bool and key_types[k] is not object:
                     key_types[k] = object
             elif isinstance(processed_v, np.ndarray):
                 # For arrays (including nested struct arrays), use object type
@@ -148,13 +147,13 @@ def py2mat(dicts):
                 if key_types[k] == 'U':
                     # For string fields, use empty string instead of None
                     struct_array[i][k] = ''
-                elif key_types[k] == int:
+                elif key_types[k] is int:
                     # For int fields, use 0
                     struct_array[i][k] = 0
-                elif key_types[k] == float:
+                elif key_types[k] is float:
                     # For float fields, use NaN
                     struct_array[i][k] = np.nan
-                elif key_types[k] == bool:
+                elif key_types[k] is bool:
                     # For bool fields, use False
                     struct_array[i][k] = False
                 else:
@@ -165,6 +164,7 @@ def py2mat(dicts):
 
     return struct_array
 
+
 # def mat2py(mat_dict):
 #     # convert all struct arrays to lists of dicts recursively
 #     for k, v in mat_dict.items():
@@ -173,6 +173,7 @@ def py2mat(dicts):
 #         elif isinstance(v, dict):
 #             mat_dict[k] = mat2py(v)
 #     return mat_dict
+
 
 def mat2py(obj):
     """Convert MATLAB data structures to Python equivalents.
@@ -258,7 +259,7 @@ def mat2py(obj):
                 if not attr_name.startswith('_') and not callable(getattr(obj, attr_name)):
                     attr_value = getattr(obj, attr_name)
                     dict_obj[attr_name] = mat2py(attr_value)
-            except:
+            except Exception:
                 # Skip attributes that can't be accessed or cause errors
                 continue
         return dict_obj if dict_obj else obj
@@ -266,21 +267,18 @@ def mat2py(obj):
         # Fallback: return the object as-is if no conversion rule applies
         return obj
 
+
 def test_py2mat():
     """Test the py2mat and mat2py conversion functions with various data structures."""
     import scipy.io
 
     # Test basic functionality
     print("=== Basic Test ===")
-    dicts = [
-        {'a': 'adsaf1', 'b': 2.0},
-        {'a': 'adsaf', 'b': 4.0},
-        {'a': 'adsaf33', 'b': 7.0}
-    ]
+    dicts = [{'a': 'adsaf1', 'b': 2.0}, {'a': 'adsaf', 'b': 4.0}, {'a': 'adsaf33', 'b': 7.0}]
     struct_array = py2mat(dicts)
     print("Original: ", dicts)
 
-    dicts2 = mat2py(struct_array)
+    mat2py(struct_array)
     scipy.io.savemat('test1.mat', {'struct_array': struct_array})
     struct_array2 = scipy.io.loadmat('test1.mat')
     struct_array2 = struct_array2['struct_array'][0]
@@ -290,18 +288,8 @@ def test_py2mat():
     # Test nested dictionaries
     print("\n=== Nested Dictionary Test ===")
     nested_dicts = [
-        {
-            'name': 'item1',
-            'value': 10.5,
-            'config': {'enabled': True, 'threshold': 0.8},
-            'tags': ['tag1', 'tag2']
-        },
-        {
-            'name': 'item2',
-            'value': 20.3,
-            'config': {'enabled': False, 'threshold': 0.9},
-            'tags': ['tag3']
-        }
+        {'name': 'item1', 'value': 10.5, 'config': {'enabled': True, 'threshold': 0.8}, 'tags': ['tag1', 'tag2']},
+        {'name': 'item2', 'value': 20.3, 'config': {'enabled': False, 'threshold': 0.9}, 'tags': ['tag3']},
     ]
     nested_struct = py2mat(nested_dicts)
     print("Original: ", nested_dicts)
@@ -318,27 +306,21 @@ def test_py2mat():
     # Test list of dictionaries as values
     print("\n=== List of Dictionaries Test ===")
     list_dict_data = [
-        {
-            'id': 1,
-            'measurements': [
-                {'sensor': 'A', 'reading': 1.2},
-                {'sensor': 'B', 'reading': 2.3}
-            ]
-        },
+        {'id': 1, 'measurements': [{'sensor': 'A', 'reading': 1.2}, {'sensor': 'B', 'reading': 2.3}]},
         {
             'id': 2,
             'measurements': [
                 {'sensor': 'A', 'reading': 3.4},
                 {'sensor': 'B', 'reading': 4.5},
-                {'sensor': 'C', 'reading': 5.6}
-            ]
-        }
+                {'sensor': 'C', 'reading': 5.6},
+            ],
+        },
     ]
     list_dict_struct = py2mat(list_dict_data)
     scipy.io.savemat('test3.mat', {'list_dict_struct': list_dict_struct})
     list_dict_struct2 = scipy.io.loadmat('test3.mat')
     list_dict_struct2 = list_dict_struct2['list_dict_struct'][0]
-    list_dict_data3   = mat2py(list_dict_struct2)
+    list_dict_data3 = mat2py(list_dict_struct2)
     print("Original: ", list_dict_data)
     print("Converted: ", list_dict_data3)
 
@@ -353,27 +335,19 @@ def test_py2mat():
     print("Original: ", single_dict)
     print("Converted: ", single_dict2)
 
-
     # Test numpy array of dictionaries
     print("\n=== NumPy Array of Dictionaries Test ===")
-    dict_array = np.array([
-        {'name': 'sensor1', 'value': 1.1},
-        {'name': 'sensor2', 'value': 2.2},
-        {'name': 'sensor3', 'value': 3.3}
-    ], dtype=object)
+    dict_array = np.array(
+        [{'name': 'sensor1', 'value': 1.1}, {'name': 'sensor2', 'value': 2.2}, {'name': 'sensor3', 'value': 3.3}],
+        dtype=object,
+    )
 
     array_dict_data = [
-        {
-            'id': 'device1',
-            'sensors': dict_array
-        },
+        {'id': 'device1', 'sensors': dict_array},
         {
             'id': 'device2',
-            'sensors': np.array([
-                {'name': 'sensorA', 'value': 4.4},
-                {'name': 'sensorB', 'value': 5.5}
-            ], dtype=object)
-        }
+            'sensors': np.array([{'name': 'sensorA', 'value': 4.4}, {'name': 'sensorB', 'value': 5.5}], dtype=object),
+        },
     ]
 
     array_dict_struct = py2mat(array_dict_data)
@@ -382,7 +356,7 @@ def test_py2mat():
     array_dict_struct2 = array_dict_struct2['array_dict_struct'][0]
     array_dict_data2 = mat2py(array_dict_struct2)
     print("Original: ", array_dict_data)
-    print("Converted: ", array_dict_data2) # Numpy array gets converted to a list of dicts
+    print("Converted: ", array_dict_data2)  # Numpy array gets converted to a list of dicts
 
     params = [np.vstack([np.arange(1, 21), np.arange(101, 121)]), [[5, 8]], 10.0, [{'latency': 5.0}, {'latency': 10.0}]]
     params_struct = py2mat(params)
@@ -396,7 +370,8 @@ def test_py2mat():
     # EEGLAB dataset
     eeglab_file_path = '/System/Volumes/Data/data/matlab/eeglab/sample_data/eeglab_data_epochs_ica.set'
     from eegprep.functions.popfunc.pop_loadset import pop_loadset
-    EEG_LOADSET = pop_loadset(eeglab_file_path)
+
+    pop_loadset(eeglab_file_path)
 
     # pop_loadset wihtout index adjustment
     EEG_LOADMAT = scipy.io.loadmat(eeglab_file_path)
@@ -413,8 +388,11 @@ def test_py2mat():
 
     # Limitations
     print("\n=== Limitations ===")
-    print("- Conversion back: py2mat then mat2py does not always work for nested structures (works when the file is saved as a .mat file)")
+    print(
+        "- Conversion back: py2mat then mat2py does not always work for nested structures (works when the file is saved as a .mat file)"
+    )
     print("- Numpy arrays of dicts are converted to lists of dicts (an intented feature)")
+
 
 if __name__ == "__main__":
     test_py2mat()

--- a/src/eegprep/functions/eegobj/__init__.py
+++ b/src/eegprep/functions/eegobj/__init__.py
@@ -2,3 +2,4 @@
 
 from .eegobj import EEGobj
 
+__all__ = ["EEGobj"]

--- a/src/eegprep/functions/eegobj/eegobj.py
+++ b/src/eegprep/functions/eegobj/eegobj.py
@@ -4,6 +4,7 @@ import copy
 import importlib
 import os
 import types
+from typing import Any
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 
@@ -18,6 +19,11 @@ _EEGPREP_FUNCTION_MODULE_PREFIXES = (
     "eegprep.plugins.EEG_BIDS",
     "eegprep.plugins.firfilt",
 )
+
+
+def _tolist_if_available(value: Any) -> Any:
+    tolist = getattr(value, 'tolist', None)
+    return tolist() if callable(tolist) else value
 
 
 class EEGobj:
@@ -194,9 +200,7 @@ class EEGobj:
             evcnt = 0
         ev_types = {}
         try:
-            iterable_ev = ev
-            if hasattr(ev, 'tolist'):
-                iterable_ev = ev.tolist()
+            iterable_ev = _tolist_if_available(ev)
             if isinstance(iterable_ev, (list, tuple)):
                 for e in iterable_ev:
                     if isinstance(e, dict) and 'type' in e:
@@ -214,9 +218,7 @@ class EEGobj:
         # Channel type summary (if available)
         ch_types = {}
         try:
-            iterable_cl = clocs
-            if hasattr(clocs, 'tolist'):
-                iterable_cl = clocs.tolist()
+            iterable_cl = _tolist_if_available(clocs)
             for ch in iterable_cl if isinstance(iterable_cl, (list, tuple)) else []:
                 if isinstance(ch, dict) and 'type' in ch:
                     t = ch['type']

--- a/src/eegprep/functions/eegobj/eegobj.py
+++ b/src/eegprep/functions/eegobj/eegobj.py
@@ -6,7 +6,6 @@ import os
 import types
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
-from eegprep.functions.popfunc.pop_select import pop_select  # ensure availability via globals
 
 _EEGPREP_FUNCTION_MODULE_PREFIXES = (
     "eegprep.functions.popfunc",
@@ -51,6 +50,7 @@ class EEGobj:
             # Try public package exports before probing EEGLAB-style modules.
             try:
                 import eegprep as eegpkg
+
                 cand = getattr(eegpkg, n, None)
                 if callable(cand):
                     return cand
@@ -120,6 +120,7 @@ class EEGobj:
 
         def wrapper(*args, **kwargs):
             return self._call_eegprep(name, *args, **kwargs)
+
         return wrapper
 
     def __setattr__(self, name, value):
@@ -216,7 +217,7 @@ class EEGobj:
             iterable_cl = clocs
             if hasattr(clocs, 'tolist'):
                 iterable_cl = clocs.tolist()
-            for ch in (iterable_cl if isinstance(iterable_cl, (list, tuple)) else []):
+            for ch in iterable_cl if isinstance(iterable_cl, (list, tuple)) else []:
                 if isinstance(ch, dict) and 'type' in ch:
                     t = ch['type']
                     if isinstance(t, bytes):

--- a/src/eegprep/functions/guifunc/eeglab_menu.py
+++ b/src/eegprep/functions/guifunc/eeglab_menu.py
@@ -44,7 +44,9 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
                         tag="import data",
                         userdata=ON_NO_STUDY,
                         children=[
-                            menu_item("(for more use menu File > Manage EEGPrep extensions)", userdata=OFF, enabled=False),
+                            menu_item(
+                                "(for more use menu File > Manage EEGPrep extensions)", userdata=OFF, enabled=False
+                            ),
                             menu_item("From ASCII/float file or MATLAB array", action="pop_importdata", separator=True),
                             menu_item("From Biosemi BDF file (BIOSIG toolbox)", action="pop_biosig", separator=True),
                             menu_item("From EDF/EDF+/GDF files (BIOSIG toolbox)", action="pop_biosig"),
@@ -144,7 +146,9 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
         tag="tools",
         userdata=ON_DATA_STUDY,
         children=[
-            menu_item('(Expand tool choices via "File > Preferences")', userdata=OFF, enabled=False, visibility="default"),
+            menu_item(
+                '(Expand tool choices via "File > Preferences")', userdata=OFF, enabled=False, visibility="default"
+            ),
             menu_item("Change sampling rate", action="pop_resample", userdata=ON_DATA_STUDY, separator=True),
             menu_item(
                 "Filter the data",
@@ -171,11 +175,18 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
                     menu_item("Reject by probability", action="pop_jointprob:data", userdata=ON_EPOCH),
                     menu_item("Reject by kurtosis", action="pop_rejkurt:data", userdata=ON_EPOCH),
                     menu_item("Reject by spectra", action="pop_rejspec:data", userdata=ON_EPOCH),
-                    menu_item("Export marks to ICA reject", action="eeg_rejsuperpose:data_to_ica", userdata=ON_EPOCH, separator=True),
+                    menu_item(
+                        "Export marks to ICA reject",
+                        action="eeg_rejsuperpose:data_to_ica",
+                        userdata=ON_EPOCH,
+                        separator=True,
+                    ),
                     menu_item("Reject marked epochs", action="pop_rejepoch:data", userdata=ON_EPOCH, separator=True),
                 ],
             ),
-            menu_item("Inspect/label components by map", action="pop_selectcomps", userdata=ON_DATA, visibility="default"),
+            menu_item(
+                "Inspect/label components by map", action="pop_selectcomps", userdata=ON_DATA, visibility="default"
+            ),
             menu_item(
                 "Reject data using ICA",
                 userdata=ON_DATA,
@@ -189,7 +200,12 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
                     menu_item("Reject by probability", action="pop_jointprob:ica", userdata=ON_EPOCH),
                     menu_item("Reject by kurtosis", action="pop_rejkurt:ica", userdata=ON_EPOCH),
                     menu_item("Reject by spectra", action="pop_rejspec:ica", userdata=ON_EPOCH),
-                    menu_item("Export marks to data reject", action="eeg_rejsuperpose:ica_to_data", userdata=ON_EPOCH, separator=True),
+                    menu_item(
+                        "Export marks to data reject",
+                        action="eeg_rejsuperpose:ica_to_data",
+                        userdata=ON_EPOCH,
+                        separator=True,
+                    ),
                     menu_item("Reject marked epochs", action="pop_rejepoch:ica", userdata=ON_EPOCH, separator=True),
                 ],
             ),
@@ -234,7 +250,9 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
             ),
             menu_item("Sum/Compare ERPs", action="pop_comperp:channels", userdata=ON_EPOCH, visibility="allmenus"),
             menu_item("Channel time-frequency", action="pop_newtimef:channels", visibility="default"),
-            menu_item("Component activations (scroll)", action="pop_eegplot:components", userdata=ON_DATA, separator=True),
+            menu_item(
+                "Component activations (scroll)", action="pop_eegplot:components", userdata=ON_DATA, separator=True
+            ),
             menu_item("Component spectra and maps", action="pop_spectopo:components", userdata=ON_DATA_NO_ROI),
             menu_item(
                 "Component maps",
@@ -255,7 +273,12 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
                     menu_item("In rectangular array", action="pop_plotdata:components", userdata=ON_EPOCH),
                 ],
             ),
-            menu_item("Sum/Compare comp. ERPs", action="pop_comperp:components", userdata=ON_EPOCH_NO_ROI, visibility="allmenus"),
+            menu_item(
+                "Sum/Compare comp. ERPs",
+                action="pop_comperp:components",
+                userdata=ON_EPOCH_NO_ROI,
+                visibility="allmenus",
+            ),
             menu_item(
                 "Data statistics",
                 userdata=ON_DATA,
@@ -292,7 +315,9 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
             menu_item("Select/Edit study design(s)", action="pop_studydesign", userdata=ON_STUDY),
             menu_item("Precompute channel measures", action="pop_precomp:channels", userdata=ON_STUDY, separator=True),
             menu_item("Plot channel measures", action="pop_chanplot", userdata=ON_STUDY),
-            menu_item("Precompute component measures", action="pop_precomp:components", userdata=ON_STUDY, separator=True),
+            menu_item(
+                "Precompute component measures", action="pop_precomp:components", userdata=ON_STUDY, separator=True
+            ),
             menu_item(
                 "PCA clustering (original)",
                 userdata=ON_STUDY_NO_ROI,

--- a/src/eegprep/functions/guifunc/main_window.py
+++ b/src/eegprep/functions/guifunc/main_window.py
@@ -14,7 +14,7 @@ from eegprep.functions.guifunc.eeglab_menu import eeglab_menus
 from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.menu_placeholders import is_placeholder_action
 from eegprep.functions.guifunc.menu_spec import MenuItemSpec, menu_enabled
-from eegprep.functions.guifunc.session import EEGPrepSession, has_eeg_data
+from eegprep.functions.guifunc.session import EEGPrepSession
 
 try:  # pragma: no cover - optional GUI dependency
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -239,9 +239,15 @@ class EEGPrepMainWindow:
             for index, label, _selected in summaries
         ]
         if len(summaries) > 1:
-            items.append(MenuItemSpec("Select multiple datasets", action="select_multiple_datasets", userdata="study:on", separator=True))
+            items.append(
+                MenuItemSpec(
+                    "Select multiple datasets", action="select_multiple_datasets", userdata="study:on", separator=True
+                )
+            )
         if self.session.CURRENTSTUDY == 1 and self.session.STUDY:
-            items.append(MenuItemSpec("Select the study set", action="select_study_set", userdata="study:on", separator=True))
+            items.append(
+                MenuItemSpec("Select the study set", action="select_study_set", userdata="study:on", separator=True)
+            )
         return tuple(items)
 
     def _add_top_menu(self, menubar: Any, spec: MenuItemSpec, statuses: set[str]) -> Any:
@@ -280,7 +286,9 @@ class EEGPrepMainWindow:
             action.setCheckable(True)
             action.setChecked(True)
         if spec.action and not coming_soon:
-            action.triggered.connect(lambda _checked=False, action_id=spec.action: self._dispatch_menu_action(action_id))
+            action.triggered.connect(
+                lambda _checked=False, action_id=spec.action: self._dispatch_menu_action(action_id)
+            )
         if spec.origin != "core":
             action.setProperty("eegprep_plugin", True)
         return action
@@ -384,7 +392,11 @@ def _summary_for_session(session: EEGPrepSession) -> tuple[str, str, list[tuple[
         ("ICA weights", _yes_no(not _empty_array(eeg.get("icasphere")))),
         ("Dataset size (Mb)", _size_mb(eeg)),
     ]
-    return prefix + _truncate(setname, 31), _short_file_line("Filename", eeg.get("filepath", ""), eeg.get("filename", "")), rows
+    return (
+        prefix + _truncate(setname, 31),
+        _short_file_line("Filename", eeg.get("filepath", ""), eeg.get("filename", "")),
+        rows,
+    )
 
 
 def _startup_lines() -> list[str]:
@@ -680,7 +692,9 @@ def _mark_coming_soon_action(action: Any) -> None:
 
 def _action_inventory(action: Any) -> dict[str, Any]:
     menu = action.menu()
-    children = [_action_inventory(child) for child in menu.actions() if not child.isSeparator()] if menu is not None else []
+    children = (
+        [_action_inventory(child) for child in menu.actions() if not child.isSeparator()] if menu is not None else []
+    )
     return {
         "label": action.text(),
         "source_label": str(action.property("eegprep_label") or action.text()),
@@ -711,7 +725,9 @@ def _format_time(value: Any) -> str:
 
 def _reference_state(eeg: dict[str, Any]) -> str:
     chanlocs = _as_list(eeg.get("chanlocs"))
-    refs = [_display_scalar(chan.get("ref")) for chan in chanlocs if isinstance(chan, dict) and _has_value(chan.get("ref"))]
+    refs = [
+        _display_scalar(chan.get("ref")) for chan in chanlocs if isinstance(chan, dict) and _has_value(chan.get("ref"))
+    ]
     return refs[0] if refs else (_display_scalar(eeg.get("ref")) or "unknown")
 
 

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -307,9 +307,7 @@ class MenuActionDispatcher:
             _apply_save_metadata(eeg, filename)
         stored = datasets if isinstance(selection, list) else datasets[0]
         command = (
-            "EEG = pop_saveset(EEG, 'savemode', 'resave');"
-            if resave
-            else f"EEG = pop_saveset(EEG, {filenames[0]!r});"
+            "EEG = pop_saveset(EEG, 'savemode', 'resave');" if resave else f"EEG = pop_saveset(EEG, {filenames[0]!r});"
         )
         self._store_current_from_gui(stored, command=command, mark_saved=True)
         self._refresh()
@@ -567,7 +565,11 @@ class MenuActionDispatcher:
         from eegprep.functions.popfunc.pop_saveh import pop_saveh
 
         path = Path(filename)
-        history = self.session.EEG.get("history", "") if variant == "dataset" and isinstance(self.session.EEG, dict) else self.session.ALLCOM
+        history = (
+            self.session.EEG.get("history", "")
+            if variant == "dataset" and isinstance(self.session.EEG, dict)
+            else self.session.ALLCOM
+        )
         command = pop_saveh(history, path.name, path.parent)
         self._add_history_from_gui(command)
         self._refresh()
@@ -613,7 +615,9 @@ class MenuActionDispatcher:
             from eegprep.plugins.EEG_BIDS.bids_tools import validate_bids
 
             report = validate_bids(directory)
-            self._info(parent, f"BIDS validation complete: {len(report['errors'])} errors, {len(report['warnings'])} warnings.")
+            self._info(
+                parent, f"BIDS validation complete: {len(report['errors'])} errors, {len(report['warnings'])} warnings."
+            )
             return
         target = self.session.STUDY if self.session.CURRENTSTUDY == 1 and self.session.STUDY else self.session.EEG
         if isinstance(target, list):
@@ -880,7 +884,9 @@ def action_kind(action: str) -> str:
     return "unknown"
 
 
-def _file_dialog_kwargs(qt_widgets: Any, *, native_file_dialogs: bool = True, directories: bool = False) -> dict[str, Any]:
+def _file_dialog_kwargs(
+    qt_widgets: Any, *, native_file_dialogs: bool = True, directories: bool = False
+) -> dict[str, Any]:
     if native_file_dialogs:
         return {}
     # Native macOS file panels can close immediately under IPython's Qt input hook.

--- a/src/eegprep/functions/guifunc/pophelp.py
+++ b/src/eegprep/functions/guifunc/pophelp.py
@@ -35,7 +35,7 @@ def pophelp(function_name: str, nonmatlab: bool = False, parent: Any | None = No
     browser.setOpenExternalLinks(True)
     browser.setHtml(_help_html(function_name, source_path, text))
     layout.addWidget(browser)
-    button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Close)
+    button_box = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.StandardButton.Close)
     button_box.rejected.connect(dialog.reject)
     button_box.accepted.connect(dialog.accept)
     layout.addWidget(button_box)

--- a/src/eegprep/functions/guifunc/qt.py
+++ b/src/eegprep/functions/guifunc/qt.py
@@ -648,7 +648,8 @@ class QtDialogRenderer:
 
         current_labels = {str(chan.get("labels", "")).lower() for chan in chanlocs}
         selected_indices = [
-            index for index in chanlist
+            index
+            for index in chanlist
             if str(other_chanlocs[index - 1].get("labels", "")).lower() not in current_labels
         ]
         if not selected_indices:

--- a/src/eegprep/functions/miscfunc/__init__.py
+++ b/src/eegprep/functions/miscfunc/__init__.py
@@ -1,2 +1,1 @@
 """EEGLAB-style miscellaneous function modules."""
-

--- a/src/eegprep/functions/miscfunc/eeg_eeg2mne.py
+++ b/src/eegprep/functions/miscfunc/eeg_eeg2mne.py
@@ -1,12 +1,11 @@
 """EEG to MNE conversion functions."""
 
-from ...plugins.ICLabel.eeg_autocorr import eeg_autocorr
 from ..popfunc.pop_loadset import pop_loadset
 import mne
 import tempfile
 import os
-from mne.export import export_raw
-from ..popfunc.pop_saveset import pop_saveset # in development
+from ..popfunc.pop_saveset import pop_saveset  # in development
+
 
 # write a funtion that converts a MNE raw object to an EEGLAB set file
 def eeg_eeg2mne(EEG):
@@ -40,6 +39,7 @@ def eeg_eeg2mne(EEG):
 
     return raw
 
+
 def test_eeg_eeg2mne():
     """Test the eeg_eeg2mne function."""
     eeglab_file_path = './eeglab_data_with_ica_tmp.set'
@@ -49,5 +49,6 @@ def test_eeg_eeg2mne():
 
     # print the keys of the EEG dictionary
     print(raw.info)
+
 
 # test_eeg_eeg2mne()

--- a/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
+++ b/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
@@ -1,6 +1,5 @@
 """MNE to EEG conversion functions."""
 
-from ...plugins.ICLabel.eeg_autocorr import eeg_autocorr
 from ..popfunc.pop_loadset import pop_loadset
 import mne
 import tempfile
@@ -8,12 +7,17 @@ import os
 from mne.export import export_raw, export_epochs
 import numpy as np
 
+
 def _mne_events_to_eeglab_events(raw_or_epochs):
     """Convert MNE Annotations or events to EEGLAB event structure (list of dicts)."""
     events = []
     sfreq = raw_or_epochs.info['sfreq']
     # Handle Annotations (Raw)
-    if hasattr(raw_or_epochs, 'annotations') and raw_or_epochs.annotations is not None and len(raw_or_epochs.annotations) > 0:
+    if (
+        hasattr(raw_or_epochs, 'annotations')
+        and raw_or_epochs.annotations is not None
+        and len(raw_or_epochs.annotations) > 0
+    ):
         for ann in raw_or_epochs.annotations:
             latency = int(ann['onset'] * sfreq) + 1  # EEGLAB is 1-based
             events.append({'latency': latency, 'type': ann['description']})
@@ -33,14 +37,15 @@ def _mne_events_to_eeglab_events(raw_or_epochs):
             events.append({'latency': latency, 'type': event_type})
     return events
 
+
 # write a funtion that converts a MNE raw object to an EEGLAB set file
-def eeg_mne2eeg(raw):
+def eeg_mne2eeg(raw_or_epochs):
     """Convert MNE Raw object to EEG data structure.
 
     Parameters
     ----------
-    raw : mne.io.Raw
-        MNE Raw object
+    raw_or_epochs : mne.io.Raw | mne.BaseEpochs
+        MNE Raw or Epochs object.
 
     Returns
     -------
@@ -70,6 +75,7 @@ def eeg_mne2eeg(raw):
 
     return EEG
 
+
 def test_eeg_mne2eeg():
     """Test the eeg_mne2eeg function."""
     eeglab_file_path = './eeglab_data_with_ica_tmp.set'
@@ -77,11 +83,11 @@ def test_eeg_mne2eeg():
     EEG = pop_loadset(eeglab_file_path)
 
     # create MNE info structure
-    info = mne.create_info(ch_names=[ x['labels'] for x in EEG['chanlocs']], sfreq=EEG['srate'], ch_types='eeg')
+    info = mne.create_info(ch_names=[x['labels'] for x in EEG['chanlocs']], sfreq=EEG['srate'], ch_types='eeg')
     if EEG['trials'] > 1:
-        events = np.array([[i, 0, 1] for i in range(EEG['trials'])]) # NOT CORRECT CONVERTION JUST FOR TESTING
+        events = np.array([[i, 0, 1] for i in range(EEG['trials'])])  # NOT CORRECT CONVERTION JUST FOR TESTING
         event_id = dict(dummy=1)
-        raw = mne.EpochsArray(EEG['data'].transpose(2,0,1), info, events, tmin=0, event_id=event_id)
+        raw = mne.EpochsArray(EEG['data'].transpose(2, 0, 1), info, events, tmin=0, event_id=event_id)
     else:
         raw = mne.io.RawArray(EEG['data'], info)
 
@@ -89,5 +95,6 @@ def test_eeg_mne2eeg():
 
     # print the keys of the EEG dictionary
     print(EEG2.keys())
+
 
 # test_eeg_mne2eeg()

--- a/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
+++ b/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
@@ -39,12 +39,12 @@ def _mne_events_to_eeglab_events(raw_or_epochs):
 
 
 # write a funtion that converts a MNE raw object to an EEGLAB set file
-def eeg_mne2eeg(raw_or_epochs):
+def eeg_mne2eeg(raw):
     """Convert MNE Raw object to EEG data structure.
 
     Parameters
     ----------
-    raw_or_epochs : mne.io.Raw | mne.BaseEpochs
+    raw : mne.io.Raw | mne.BaseEpochs
         MNE Raw or Epochs object.
 
     Returns
@@ -52,6 +52,8 @@ def eeg_mne2eeg(raw_or_epochs):
     EEG : dict
         EEG data structure
     """
+    raw_or_epochs = raw
+
     # Generate a temporary file name
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_file_path = temp_file.name

--- a/src/eegprep/functions/miscfunc/eeg_mne2eeg_epochs.py
+++ b/src/eegprep/functions/miscfunc/eeg_mne2eeg_epochs.py
@@ -4,12 +4,12 @@
 # Events are not handled correctly in this example but it works
 
 import mne
-from mne.datasets import sample
 from mne.preprocessing import ICA
 import math
 
 import numpy as np
 from scipy.io import savemat
+
 
 # Load example data
 def eeg_mne2eeg_epochs(epochs, ica):
@@ -52,49 +52,49 @@ def eeg_mne2eeg_epochs(epochs, ica):
         ref = 'average'  # Default to average reference
 
     eeglab_dict = {
-        'setname'         : '',
-        'filename'        : '',
-        'filepath'        : '',
-        'subject'         : '',
-        'group'           : '',
-        'condition'       : '',
-        'session'         : np.array([]),
-        'comments'        : '',
-        'nbchan'          : n_channels,
-        'trials'          : n_epochs,
-        'pnts'            : n_times,
-        'srate'           : epochs.info['sfreq'],
-        'xmin'            : epochs.times[0],
-        'xmax'            : epochs.times[-1],
-        'times'           : epochs.times,
-        'data'            : data,
-        'icaact'          : ica_act,
-        'icawinv'         : ica_inverse_weights,
-        'icasphere'       : ica_weights,
-        'icaweights'      : ica_sphere,
-        'icachansind'     : ica_channel_indices,
-        'chanlocs'        : np.array([]),
-        'urchanlocs'      : np.array([]),
-        'chaninfo'        : np.array([]),
-        'ref'             : ref,
-        'event'           : np.array([]),
-        'urevent'         : np.array([]),
+        'setname': '',
+        'filename': '',
+        'filepath': '',
+        'subject': '',
+        'group': '',
+        'condition': '',
+        'session': np.array([]),
+        'comments': '',
+        'nbchan': n_channels,
+        'trials': n_epochs,
+        'pnts': n_times,
+        'srate': epochs.info['sfreq'],
+        'xmin': epochs.times[0],
+        'xmax': epochs.times[-1],
+        'times': epochs.times,
+        'data': data,
+        'icaact': ica_act,
+        'icawinv': ica_inverse_weights,
+        'icasphere': ica_weights,
+        'icaweights': ica_sphere,
+        'icachansind': ica_channel_indices,
+        'chanlocs': np.array([]),
+        'urchanlocs': np.array([]),
+        'chaninfo': np.array([]),
+        'ref': ref,
+        'event': np.array([]),
+        'urevent': np.array([]),
         'eventdescription': np.array([]),
-        'epoch'           : np.array([]),
+        'epoch': np.array([]),
         'epochdescription': np.array([]),
-        'reject'          : np.array([]),
-        'stats'           : np.array([]),
-        'specdata'        : np.array([]),
-        'specicaact'      : np.array([]),
-        'splinefile'      : np.array([]),
-        'icasplinefile'   : np.array([]),
-        'dipfit'          : np.array([]),
-        'history'         : np.array([]),
-        'saved'           : np.array([]),
-        'etc'             : np.array([]),
-        'datfile'         : np.array([]),
-        'run'             : np.array([]),
-        'roi'             : np.array([]),
+        'reject': np.array([]),
+        'stats': np.array([]),
+        'specdata': np.array([]),
+        'specicaact': np.array([]),
+        'splinefile': np.array([]),
+        'icasplinefile': np.array([]),
+        'dipfit': np.array([]),
+        'history': np.array([]),
+        'saved': np.array([]),
+        'etc': np.array([]),
+        'datfile': np.array([]),
+        'run': np.array([]),
+        'roi': np.array([]),
     }
 
     # create channel locations
@@ -104,43 +104,48 @@ def eeg_mne2eeg_epochs(epochs, ica):
 
     theta_all = []
     radius_all = []
-    sph_theta_all  = []
-    sph_phi_all    = []
+    sph_theta_all = []
+    sph_phi_all = []
     sph_radius_all = []
     X_all = []
     Y_all = []
     Z_all = []
     for ch in ch_locs:
         if 'loc' in ch and ch['loc'] is not None:
-            X_all.append(ch['loc'][1]*1000)
-            Y_all.append(-ch['loc'][0]*1000)
-            Z_all.append(ch['loc'][2]*1000)
-            hypotxy = math.hypot(X_all[-1],Y_all[-1])
-            sph_radius_all.append(math.hypot(hypotxy,Z_all[-1]))
+            X_all.append(ch['loc'][1] * 1000)
+            Y_all.append(-ch['loc'][0] * 1000)
+            Z_all.append(ch['loc'][2] * 1000)
+            hypotxy = math.hypot(X_all[-1], Y_all[-1])
+            sph_radius_all.append(math.hypot(hypotxy, Z_all[-1]))
 
-            az = math.atan2(Y_all[-1],X_all[-1])/math.pi*180
-            horiz = math.atan2(Z_all[-1],hypotxy)/math.pi*180
+            az = math.atan2(Y_all[-1], X_all[-1]) / math.pi * 180
+            horiz = math.atan2(Z_all[-1], hypotxy) / math.pi * 180
 
             sph_theta_all.append(az)
             sph_phi_all.append(horiz)
 
-            theta_all.append(-az) # warning inverse notation compared to MATLAB to match
-            radius_all.append(0.5 - horiz/180) # warning inverse notation compared to MATLAB to match
+            theta_all.append(-az)  # warning inverse notation compared to MATLAB to match
+            radius_all.append(0.5 - horiz / 180)  # warning inverse notation compared to MATLAB to match
 
-    d_list = [{
-        'labels': ch_name,
-        'theta': theta,
-        'radius': radius,
-        'X': X,
-        'Y': Y,
-        'Z': Z,
-        'sph_theta': sph_theta,
-        'sph_phi': sph_phi,
-        'sph_radius': sph_radius,
-        'type': 'EEG',
-        'urchan': 0,
-        'ref': ''
-    } for ch_name, theta, radius, X, Y, Z, sph_theta, sph_phi, sph_radius in zip(ch_names, theta_all, radius_all, X_all, Y_all, Z_all, sph_theta_all, sph_phi_all, sph_radius_all)]
+    d_list = [
+        {
+            'labels': ch_name,
+            'theta': theta,
+            'radius': radius,
+            'X': X,
+            'Y': Y,
+            'Z': Z,
+            'sph_theta': sph_theta,
+            'sph_phi': sph_phi,
+            'sph_radius': sph_radius,
+            'type': 'EEG',
+            'urchan': 0,
+            'ref': '',
+        }
+        for ch_name, theta, radius, X, Y, Z, sph_theta, sph_phi, sph_radius in zip(
+            ch_names, theta_all, radius_all, X_all, Y_all, Z_all, sph_theta_all, sph_phi_all, sph_radius_all
+        )
+    ]
     # Create the list of dictionaries with a string field
     # d_list = [{
     #     'labels': ch_name,
@@ -164,14 +169,13 @@ def eeg_mne2eeg_epochs(epochs, ica):
     # # Step 4: Save the EEGLAB dataset as a .mat file
     return eeglab_dict
 
-    #print("EEGLAB dataset saved successfully!")
+    # print("EEGLAB dataset saved successfully!")
+
 
 def test_eeg_mne2eeg_epochs():
     """Test the eeg_mne2eeg_epochs function with sample MNE data."""
     sample_data_folder = mne.datasets.sample.data_path()
-    sample_data_raw_file = (
-        sample_data_folder / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
-    )
+    sample_data_raw_file = sample_data_folder / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
 
     raw = mne.io.read_raw_fif(sample_data_raw_file)
 
@@ -198,6 +202,7 @@ def test_eeg_mne2eeg_epochs():
     ica.fit(raw)
 
     EEG = eeg_mne2eeg_epochs(epochs, ica)
-    savemat('output_file.mat', EEG) # use pop_saveset
+    savemat('output_file.mat', EEG)  # use pop_saveset
+
 
 # test_eeg_mne2eeg_epochs()

--- a/src/eegprep/functions/miscfunc/misc.py
+++ b/src/eegprep/functions/miscfunc/misc.py
@@ -25,13 +25,14 @@ __all__ = [
 
 def is_debug() -> bool:
     """Check if a debugger is currently attached to the process."""
-    return getattr(sys, 'gettrace', None)() is not None
+    return sys.gettrace() is not None
 
 
 def aslist(arr_or_list: np.ndarray | list) -> list:
     """Return the given array or list in list form."""
-    if hasattr(arr_or_list, 'tolist'):
-        return arr_or_list.tolist()
+    tolist = getattr(arr_or_list, 'tolist', None)
+    if callable(tolist):
+        return tolist()
     elif isinstance(arr_or_list, list):
         return arr_or_list
     else:

--- a/src/eegprep/functions/miscfunc/misc.py
+++ b/src/eegprep/functions/miscfunc/misc.py
@@ -7,9 +7,20 @@ from typing import Callable, Optional
 
 import numpy as np
 
-__all__ = ['is_debug', 'ExceptionUnlessDebug', 'num_jobs_from_reservation', 'humanize_seconds',
-           'num_cpus_from_reservation', 'ToolError', 'canonicalize_signs', 'round_mat',
-           'aslist', 'get_nested', 'finite_matmul', 'finite_pinv']
+__all__ = [
+    'is_debug',
+    'ExceptionUnlessDebug',
+    'num_jobs_from_reservation',
+    'humanize_seconds',
+    'num_cpus_from_reservation',
+    'ToolError',
+    'canonicalize_signs',
+    'round_mat',
+    'aslist',
+    'get_nested',
+    'finite_matmul',
+    'finite_pinv',
+]
 
 
 def is_debug() -> bool:
@@ -24,8 +35,7 @@ def aslist(arr_or_list: np.ndarray | list) -> list:
     elif isinstance(arr_or_list, list):
         return arr_or_list
     else:
-        raise ValueError(f"Input must be a numpy array or a list, but "
-                         f"was of type {type(arr_or_list)}.")
+        raise ValueError(f"Input must be a numpy array or a list, but was of type {type(arr_or_list)}.")
 
 
 def finite_matmul(left: np.ndarray, right: np.ndarray) -> np.ndarray:
@@ -195,19 +205,20 @@ def num_jobs_from_reservation(ReservePerJob: str) -> int:
         try:
             import psutil
         except ImportError:
-            raise ImportError("psutil is required to determine available system RAM. "
-                              "Please install it with 'uv pip install psutil'.")
+            raise ImportError(
+                "psutil is required to determine available system RAM. Please install it with 'uv pip install psutil'."
+            )
         avail_amt = psutil.virtual_memory().available
         unit = reserve[-2:].upper()
-        multiplier = {'GB': 2 ** 30, 'MB': 2 ** 20, 'KB': 2 ** 10, 'B': 1}[unit]
+        multiplier = {'GB': 2**30, 'MB': 2**20, 'KB': 2**10, 'B': 1}[unit]
         reserve_amt = float(reserve[:-2]) * multiplier
     elif reserve.endswith('CPU'):
         import multiprocessing
+
         avail_amt = multiprocessing.cpu_count()
         reserve_amt = float(reserve[:-3])
     else:
-        raise ValueError(f"Invalid reserve amount format: {ReservePerJob}. "
-                         "Expected format like '4GB' or '2CPU'.")
+        raise ValueError(f"Invalid reserve amount format: {ReservePerJob}. Expected format like '4GB' or '2CPU'.")
     if not margin:
         margin_amt = 0
     elif margin.endswith('%'):
@@ -215,18 +226,19 @@ def num_jobs_from_reservation(ReservePerJob: str) -> int:
         margin_amt = avail_amt * margin_frac
     elif margin.endswith('B'):
         unit = margin[-2:].upper()
-        multiplier = {'GB': 2 ** 30, 'MB': 2 ** 20, 'KB': 2 ** 10, 'B': 1}[unit]
+        multiplier = {'GB': 2**30, 'MB': 2**20, 'KB': 2**10, 'B': 1}[unit]
         margin_amt = float(margin[:-2]) * multiplier
     elif margin.endswith('CPU') or margin.endswith('GPU'):
         margin_amt = float(margin[:-3])
     else:
-        raise ValueError(f"Invalid margin format: {margin}. "
-                         "Expected format like '10%' or '100MB'.")
+        raise ValueError(f"Invalid margin format: {margin}. Expected format like '10%' or '100MB'.")
     avail_amt -= margin_amt
     if reserve_amt > avail_amt:
-        raise ValueError(f"Requested reserve amount {reserve_amt} exceeds available "
-                         f"system resources after applying margin {margin_amt}. "
-                         f"Available: {avail_amt}.")
+        raise ValueError(
+            f"Requested reserve amount {reserve_amt} exceeds available "
+            f"system resources after applying margin {margin_amt}. "
+            f"Available: {avail_amt}."
+        )
     num_jobs = int(avail_amt // reserve_amt)
     return num_jobs
 
@@ -282,13 +294,13 @@ def round_mat(x, decimals=0):
         xp = math
     else:
         xp = np
-        x = np.asarray(x)             # ensure ndarray
+        x = np.asarray(x)  # ensure ndarray
 
     if decimals == 0:
         return xp.copysign(xp.floor(abs(x) + 0.5), x)
 
     if decimals > 0:
-        factor = 10.0 ** decimals
+        factor = 10.0**decimals
         y = xp.copysign(xp.floor(abs(x) * factor + 0.5), x)
         return y / factor
 
@@ -296,8 +308,6 @@ def round_mat(x, decimals=0):
     factor = 10.0 ** (-decimals)
     y = xp.copysign(xp.floor(abs(x) / factor + 0.5), x)
     return y * factor
-
-
 
 
 class SkippableException(Exception):

--- a/src/eegprep/functions/miscfunc/pinv.py
+++ b/src/eegprep/functions/miscfunc/pinv.py
@@ -5,6 +5,7 @@
 import numpy as np
 from scipy.linalg import pinv as scipy_pinv
 
+
 def pinv(A, tol=None, method='scipy'):
     """Compute the Moore-Penrose pseudoinverse of a matrix.
 
@@ -57,13 +58,13 @@ def pinv(A, tol=None, method='scipy'):
         if m >= n:
             # Tall or square matrix: A_pinv = (A^T A)^(-1) A^T
             # But use lstsq for numerical stability
-            I = np.eye(m, dtype=A.dtype)
-            A_pinv, residuals, rank, s = lstsq(A, I, lapack_driver='gelsd')
+            identity = np.eye(m, dtype=A.dtype)
+            A_pinv, residuals, rank, s = lstsq(A, identity, lapack_driver='gelsd')
             return A_pinv
         else:
             # Wide matrix: A_pinv = A^T (A A^T)^(-1)
-            I = np.eye(n, dtype=A.dtype)
-            A_pinv, residuals, rank, s = lstsq(A.T, I, lapack_driver='gelsd')
+            identity = np.eye(n, dtype=A.dtype)
+            A_pinv, residuals, rank, s = lstsq(A.T, identity, lapack_driver='gelsd')
             return A_pinv.T
 
     else:

--- a/src/eegprep/functions/miscfunc/save_struct_as_hdf5.py
+++ b/src/eegprep/functions/miscfunc/save_struct_as_hdf5.py
@@ -3,6 +3,7 @@
 import numpy as np
 import h5py
 
+
 def save_dict_to_hdf5(data, filename, dataset_name):
     """Save a dictionary to an HDF5 file as a structured dataset.
 
@@ -34,15 +35,24 @@ def save_dict_to_hdf5(data, filename, dataset_name):
     structured_dtype = np.dtype(dtype)
 
     # Convert dictionary values to a structured array
-    structured_data = np.array([tuple(
-        value.encode('utf-8') if isinstance(value, str) else
-        str(value).encode('utf-8') if value is None else
-        value for value in data.values()
-    )], dtype=structured_dtype)
+    structured_data = np.array(
+        [
+            tuple(
+                value.encode('utf-8')
+                if isinstance(value, str)
+                else str(value).encode('utf-8')
+                if value is None
+                else value
+                for value in data.values()
+            )
+        ],
+        dtype=structured_dtype,
+    )
 
     # Save to HDF5
     with h5py.File(filename, 'w') as hdf:
         hdf.create_dataset(dataset_name, data=structured_data)
+
 
 if __name__ == '__main__':
     data = {

--- a/src/eegprep/functions/popfunc/_pop_utils.py
+++ b/src/eegprep/functions/popfunc/_pop_utils.py
@@ -85,19 +85,23 @@ def format_history_value(
         if any(_is_nested_sequence(item) for item in values):
             return "[" + "; ".join(_format_history_row(item, number_formatter) for item in values) + "]"
         if _sequence_should_use_cell(values, cell_for_sequence):
-            return "{" + string_separator.join(
-                format_history_value(
-                    item,
-                    bool_style=bool_style,
-                    cell_for_sequence=cell_for_sequence,
-                    string_separator=string_separator,
-                    empty_sequence=empty_sequence,
-                    none_as_empty=none_as_empty,
-                    dict_formatter=dict_formatter,
-                    number_formatter=number_formatter,
+            return (
+                "{"
+                + string_separator.join(
+                    format_history_value(
+                        item,
+                        bool_style=bool_style,
+                        cell_for_sequence=cell_for_sequence,
+                        string_separator=string_separator,
+                        empty_sequence=empty_sequence,
+                        none_as_empty=none_as_empty,
+                        dict_formatter=dict_formatter,
+                        number_formatter=number_formatter,
+                    )
+                    for item in values
                 )
-                for item in values
-            ) + "}"
+                + "}"
+            )
         return "[" + " ".join(_format_history_number(item, number_formatter) for item in values) + "]"
     if isinstance(value, (np.integer, np.floating)):
         value = value.item()

--- a/src/eegprep/functions/popfunc/eeg_amica.py
+++ b/src/eegprep/functions/popfunc/eeg_amica.py
@@ -5,9 +5,19 @@ from ..miscfunc.pinv import pinv
 from ..sigprocfunc.runamica import runamica
 
 
-def eeg_amica(EEG, posact='off', sortcomps='off', num_models=1, max_iter=2000,
-              num_mix_comps=3, pcakeep=None, outdir=None, amica_binary=None,
-              max_threads=4, **kwargs):
+def eeg_amica(
+    EEG,
+    posact='off',
+    sortcomps='off',
+    num_models=1,
+    max_iter=2000,
+    num_mix_comps=3,
+    pcakeep=None,
+    outdir=None,
+    amica_binary=None,
+    max_threads=4,
+    **kwargs,
+):
     """
     Perform ICA decomposition using AMICA (Adaptive Mixture ICA).
 
@@ -91,7 +101,7 @@ def eeg_amica(EEG, posact='off', sortcomps='off', num_models=1, max_iter=2000,
         # Flatten icaact to 2D for variance computation
         icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
         # Compute variance metric: sum(icawinv^2) .* sum(icaact^2)
-        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d ** 2, axis=1)
+        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
         # Sort indices in descending order
         windex = np.argsort(variance_metric)[::-1]
         # Reorder components
@@ -148,8 +158,7 @@ def load_amica_model(EEG, mods, model_num=0):
     num_models = mods['num_models']
 
     if model_num < 0 or model_num >= num_models:
-        raise ValueError(
-            f"model_num={model_num} out of range for {num_models} models")
+        raise ValueError(f"model_num={model_num} out of range for {num_models} models")
 
     EEG['icaweights'] = mods['W'][:, :, model_num]
     EEG['icasphere'] = mods['S'][:num_pcs, :]

--- a/src/eegprep/functions/popfunc/eeg_compare.py
+++ b/src/eegprep/functions/popfunc/eeg_compare.py
@@ -9,6 +9,7 @@ import math
 from collections.abc import Sequence
 import numpy as np
 
+
 def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
     """Compare two EEG-like structures, reporting differences to stderr.
 
@@ -47,24 +48,24 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
         if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
             try:
                 return bool(np.array_equal(np.array(a), np.array(b), equal_nan=True))
-            except:
+            except Exception:
                 pass
         # Handle numpy arrays in general comparison
         if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
             try:
                 return bool(np.array_equal(a, b, equal_nan=True))
-            except:
+            except Exception:
                 pass
         # Handle scalar vs array comparisons
         if isinstance(a, np.ndarray) and np.isscalar(b):
             try:
                 return bool(np.all(a == b))
-            except:
+            except Exception:
                 pass
         if isinstance(b, np.ndarray) and np.isscalar(a):
             try:
                 return bool(np.all(b == a))
-            except:
+            except Exception:
                 pass
         # Final comparison - ensure we return a boolean
         try:
@@ -72,7 +73,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
             if isinstance(result, np.ndarray):
                 return bool(result.all())
             return bool(result)
-        except:
+        except Exception:
             return False
 
     def _numeric_distance(a, b):
@@ -128,7 +129,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
         mismatch_pct = 100.0 * mismatched / total_elements if total_elements > 0 else 0.0
 
         summary_lines = [
-            f"Array Comparison Summary:",
+            "Array Comparison Summary:",
             f"  Shape: {eeg1.shape}",
             f"  Total elements: {total_elements:,}",
             f"  Mismatched elements (> 1e-10): {mismatched:,} ({mismatch_pct:.2f}%)",
@@ -146,20 +147,39 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
     if hasattr(eeg1, 'keys'):
         # Dictionary-like object
         fields1 = eeg1.keys()
-        get_val1 = lambda f: eeg1.get(f, None)
+
+        def get_val1(f):
+            return eeg1.get(f, None)
+
         # Handle case where eeg2 might be a numpy array or other non-dict object
         if hasattr(eeg2, 'keys'):
-            has_field2 = lambda f: f in eeg2
-            get_val2 = lambda f: eeg2.get(f, None)
+
+            def has_field2(f):
+                return f in eeg2
+
+            def get_val2(f):
+                return eeg2.get(f, None)
+
         else:
-            has_field2 = lambda f: False  # No fields available
-            get_val2 = lambda f: None
+
+            def has_field2(f):
+                return False
+
+            def get_val2(f):
+                return None
+
     else:
         # Object with __dict__
         fields1 = getattr(eeg1, '__dict__', {}).keys()
-        get_val1 = lambda f: getattr(eeg1, f, None)
-        has_field2 = lambda f: hasattr(eeg2, f)
-        get_val2 = lambda f: getattr(eeg2, f, None)
+
+        def get_val1(f):
+            return getattr(eeg1, f, None)
+
+        def has_field2(f):
+            return hasattr(eeg2, f)
+
+        def get_val2(f):
+            return getattr(eeg2, f, None)
 
     for field in fields1:
         if not has_field2(field):
@@ -206,7 +226,9 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
                             error_msg = f'Field {field} differs (max_abs={max_abs_diff:.6e}, mean_abs={mean_abs_diff:.6e}, rms={rms_diff:.6e}, max_rel={max_rel_diff:.6e})'
                             print(f'    {error_msg}', file=sys.stderr)
                             differences.append(error_msg)
-                            summary_parts.append(f"  {field}: max_abs={max_abs_diff:.6e}, mean_abs={mean_abs_diff:.6e}, rms={rms_diff:.6e}")
+                            summary_parts.append(
+                                f"  {field}: max_abs={max_abs_diff:.6e}, mean_abs={mean_abs_diff:.6e}, rms={rms_diff:.6e}"
+                            )
                         else:
                             error_msg = f'Field {field} differs (shape mismatch: {v1.shape} vs {v2.shape})'
                             print(f'    {error_msg}', file=sys.stderr)
@@ -360,16 +382,20 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
 
     # Raise error if differences found and trigger_error is True
     if trigger_error and differences:
-        error_message = f"EEG comparison failed with {len(differences)} differences:\n" + "\n".join(f"  - {diff}" for diff in differences)
+        error_message = f"EEG comparison failed with {len(differences)} differences:\n" + "\n".join(
+            f"  - {diff}" for diff in differences
+        )
         raise ValueError(error_message)
 
     return summary
+
 
 # add test data and compare with it
 
 # load test data
 if __name__ == '__main__':
     from eegprep import pop_loadset
+
     eeg1 = pop_loadset('../../sample_data/eeglab_data_tmp.set')
     eeg2 = pop_loadset('../../sample_data/eeglab_data_tmp.set')
 

--- a/src/eegprep/functions/popfunc/eeg_decodechan.py
+++ b/src/eegprep/functions/popfunc/eeg_decodechan.py
@@ -1,5 +1,6 @@
 """EEG channel decoding functions."""
 
+
 def eeg_decodechan(
     chanlocs,
     chanstr,

--- a/src/eegprep/functions/popfunc/eeg_eegrej.py
+++ b/src/eegprep/functions/popfunc/eeg_eegrej.py
@@ -1,8 +1,10 @@
 """EEG data rejection functions."""
+
 from typing import List, Dict, Optional, Tuple
 import numpy as np
 from copy import deepcopy
 from ..miscfunc.misc import round_mat
+
 
 def _is_boundary_event(event: Dict) -> bool:
     t = event.get("type")
@@ -15,7 +17,10 @@ def _is_boundary_event(event: Dict) -> bool:
             return False
     return False
 
-def _eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) -> Tuple[np.ndarray, float, List[Dict], np.ndarray]:
+
+def _eegrej(
+    indata, regions, timelength, events: Optional[List[Dict]] = None
+) -> Tuple[np.ndarray, float, List[Dict], np.ndarray]:
     """Remove [beg end] sample ranges (1-based, inclusive) from continuous data and update events.
 
     Parameters
@@ -85,7 +90,7 @@ def _eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) ->
     # To match MATLAB's inclusive end, we need reject[beg-1:end] where end is inclusive
     reject = np.zeros(n, dtype=bool)
     for beg, end in r:
-        reject[beg - 1:end] = True  # This matches MATLAB reject(beg:end) when end is already the inclusive end
+        reject[beg - 1 : end] = True  # This matches MATLAB reject(beg:end) when end is already the inclusive end
 
     # Prepare events
     ori_events: List[Dict] = [] if events is None else [dict(ev) for ev in events]
@@ -189,11 +194,17 @@ def _eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) ->
         for i in range(len(boundevents)):
             be = float(boundevents[i])
             if be > 0 and be < (newn + 1):
-                events_out.append({
-                    "type": bound_type,
-                    "latency": be,
-                    "duration": float(durations[i] if i < len(durations) else (base_durations[i] if i < len(base_durations) else 0.0)),
-                })
+                events_out.append(
+                    {
+                        "type": bound_type,
+                        "latency": be,
+                        "duration": float(
+                            durations[i]
+                            if i < len(durations)
+                            else (base_durations[i] if i < len(base_durations) else 0.0)
+                        ),
+                    }
+                )
 
     # Remove nested boundary events that were absorbed into new boundaries.
     # These are pre-existing boundaries that fell inside removal regions;
@@ -242,8 +253,12 @@ def _eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) ->
     if events_out:
         merged_events: List[Dict] = []
         for ev in events_out:
-            if merged_events and _is_boundary_event(ev) and _is_boundary_event(merged_events[-1]) \
-               and np.isclose(float(ev.get("latency", 0.0)), float(merged_events[-1].get("latency", 0.0))):
+            if (
+                merged_events
+                and _is_boundary_event(ev)
+                and _is_boundary_event(merged_events[-1])
+                and np.isclose(float(ev.get("latency", 0.0)), float(merged_events[-1].get("latency", 0.0)))
+            ):
                 prev_dur = float(merged_events[-1].get("duration", 0.0) or 0.0)
                 cur_dur = float(ev.get("duration", 0.0) or 0.0)
                 merged_events[-1]["duration"] = prev_dur + cur_dur
@@ -297,7 +312,6 @@ def eeg_eegrej(EEG, regions):
     data_out, xmax_rel, event2, boundevents = _eegrej(EEG["data"], regions, xdur, events)
 
     # finalize core fields
-    old_pnts = int(EEG["pnts"])
     EEG["data"] = data_out
     EEG["pnts"] = int(data_out.shape[1])
     EEG["xmax"] = float(EEG["xmin"] + xmax_rel)
@@ -331,6 +345,7 @@ def eeg_eegrej(EEG, regions):
 
     return EEG
 
+
 def _combine_regions(regs):
     if len(regs) == 0:
         return regs
@@ -347,6 +362,7 @@ def _combine_regions(regs):
         print("Warning: overlapping regions detected and fixed in eeg_eegrej")
     return newregs
 
+
 def _find_boundary_event_indices(events):
     idx = []
     for i, ev in enumerate(events):
@@ -356,6 +372,7 @@ def _find_boundary_event_indices(events):
         elif isinstance(t, (int, float)) and int(t) == -99:
             idx.append(i)
     return np.array(idx, dtype=int)
+
 
 def _insert_boundaries(events, old_pnts, regions):
     # Build kept segments in 1-based indices
@@ -375,9 +392,11 @@ def _insert_boundaries(events, old_pnts, regions):
         run_len += seg_len
         rem_beg, rem_end = regions[i]
         rem_len = int(rem_end - rem_beg + 1)
-        out.append({
-            "type": "boundary",
-            "latency": float(run_len + 1),
-            "duration": float(rem_len),
-        })
+        out.append(
+            {
+                "type": "boundary",
+                "latency": float(run_len + 1),
+                "duration": float(rem_len),
+            }
+        )
     return out

--- a/src/eegprep/functions/popfunc/eeg_findboundaries.py
+++ b/src/eegprep/functions/popfunc/eeg_findboundaries.py
@@ -2,6 +2,7 @@
 
 from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
 
+
 def eeg_findboundaries(*, EEG):
     """
     EEG_FINDBOUNDARIES - return indices of boundary events.
@@ -47,12 +48,14 @@ def eeg_findboundaries(*, EEG):
     first_type = tmpevent[0].get('type')
     if isinstance(first_type, str):
         # boundaries = strmatch('boundary', { tmpevent.type });
-        boundaries = [i for i, ev in enumerate(tmpevent)
-                      if isinstance(ev.get('type'), str) and ev.get('type', '').startswith('boundary')]
+        boundaries = [
+            i
+            for i, ev in enumerate(tmpevent)
+            if isinstance(ev.get('type'), str) and ev.get('type', '').startswith('boundary')
+        ]
     elif EEG_OPTIONS['option_boundary99']:
         # boundaries = find([ tmpevent.type ] == -99);
-        boundaries = [i for i, ev in enumerate(tmpevent)
-                      if ev.get('type') == -99]
+        boundaries = [i for i, ev in enumerate(tmpevent) if ev.get('type') == -99]
     else:
         boundaries = []
 

--- a/src/eegprep/functions/popfunc/eeg_interp.py
+++ b/src/eegprep/functions/popfunc/eeg_interp.py
@@ -14,12 +14,11 @@ import numpy as np
 from scipy.linalg import pinv
 from scipy.interpolate import RBFInterpolator, griddata
 from scipy.special import lpmv
-from eegprep.functions.popfunc.eeg_compare import eeg_compare
 from copy import deepcopy
-import os
 
 # absolute path for all files in data folder
-data_path = '/Users/arno/Python/eegprep/sample_data/' #os.path.abspath('sample_data/')
+data_path = '/Users/arno/Python/eegprep/sample_data/'  # os.path.abspath('sample_data/')
+
 
 def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dtype='float32'):
     """Interpolate missing or bad EEG channels using spherical spline.
@@ -59,19 +58,19 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
     EEG = deepcopy(EEG)
     # set defaults
     method = _normalise_method(method)
-    if method not in ('spherical','sphericalKang','sphericalCRD','sphericalfast','invdist','v4','spacetime'):
+    if method not in ('spherical', 'sphericalKang', 'sphericalCRD', 'sphericalfast', 'invdist', 'v4', 'spacetime'):
         raise ValueError(f"Unknown method {method}")
     if t_range is None:
         t_range = (EEG['xmin'], EEG['xmax'])
     if params is None:
-        if method=='spherical':
-            params = (0,4,7)
-        elif method=='sphericalKang':
-            params = (1e-8,3,50)
-        elif method=='sphericalCRD':
-            params = (1e-5,4,500)
+        if method == 'spherical':
+            params = (0, 4, 7)
+        elif method == 'sphericalKang':
+            params = (1e-8, 3, 50)
+        elif method == 'sphericalCRD':
+            params = (1e-5, 4, 500)
     else:
-        if len(params)!=3:
+        if len(params) != 3:
             raise ValueError("params must be length-3 tuple")
         method = 'spherical'
 
@@ -95,10 +94,15 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
     if isinstance(bad_chans, list) and len(bad_chans) == 0:
         bad_idx = []
     # Check if bad_chans is a list of chanloc structures
-    elif (isinstance(bad_chans, list) and len(bad_chans) > 0 and
-          isinstance(bad_chans[0], dict) and
-          'labels' in bad_chans[0] and 'X' in bad_chans[0] and
-          'Y' in bad_chans[0] and 'Z' in bad_chans[0]):
+    elif (
+        isinstance(bad_chans, list)
+        and len(bad_chans) > 0
+        and isinstance(bad_chans[0], dict)
+        and 'labels' in bad_chans[0]
+        and 'X' in bad_chans[0]
+        and 'Y' in bad_chans[0]
+        and 'Z' in bad_chans[0]
+    ):
         # Handle the new chanloc structure case
         EEG, bad_idx = _handle_chanloc_interpolation(EEG, bad_chans)
         # Update local variables that may have changed
@@ -114,8 +118,7 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
         return EEG
 
     good_idx = [i for i in range(EEG['nbchan']) if i not in bad_idx]
-    empty_idx = [i for i in range(EEG['nbchan'])
-                 if (np.array_equal(locs[i]['X'], []) or np.isnan(locs[i]['X']))]
+    empty_idx = [i for i in range(EEG['nbchan']) if (np.array_equal(locs[i]['X'], []) or np.isnan(locs[i]['X']))]
     good_idx = [i for i in good_idx if i not in empty_idx]
     bad_idx = [i for i in bad_idx if i not in empty_idx]
 
@@ -139,27 +142,31 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
         ndarray
             Normalized XYZ coordinates (3, n_channels).
         """
-        xyz = np.vstack([ [locs[i][c] for i in ch_ids] for c in ('X','Y','Z') ])
+        xyz = np.vstack([[locs[i][c] for i in ch_ids] for c in ('X', 'Y', 'Z')])
         rad = np.linalg.norm(xyz, axis=0)
         return xyz / rad
 
     xyz_good = _norm(good_idx)
-    xyz_bad  = _norm(bad_idx)
+    xyz_bad = _norm(bad_idx)
 
     # reshape data to (n_chan, n_timepoints)
     d = EEG['data'].reshape(EEG['nbchan'], -1)
 
     # Save original bad channel data before interpolation
-    original_bad_data = d[bad_idx,:].copy()
+    original_bad_data = d[bad_idx, :].copy()
 
     # compute interpolated signals for bad channels
-    if method in ('spherical','sphericalKang','sphericalCRD','sphericalfast'):
+    if method in ('spherical', 'sphericalKang', 'sphericalCRD', 'sphericalfast'):
         bad_data = spheric_spline(
-            xelec=xyz_good[0], yelec=xyz_good[1], zelec=xyz_good[2],
-            xbad =xyz_bad[0],  ybad =xyz_bad[1],  zbad =xyz_bad[2],
-            values=d[good_idx,:],
+            xelec=xyz_good[0],
+            yelec=xyz_good[1],
+            zelec=xyz_good[2],
+            xbad=xyz_bad[0],
+            ybad=xyz_bad[1],
+            zbad=xyz_bad[2],
+            values=d[good_idx, :],
             params=params,
-            dtype=dtype
+            dtype=dtype,
         )
     elif method in ('invdist', 'v4'):
         bad_data = _planar_v4_interpolate(locs, good_idx, bad_idx, d[good_idx, :])
@@ -203,9 +210,9 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
 
     # assemble full data array
     full = np.zeros_like(d)
-    full[good_idx,:] = d[good_idx,:]
-    full[empty_idx,:] = d[empty_idx,:]
-    full[bad_idx,:]  = bad_data
+    full[good_idx, :] = d[good_idx, :]
+    full[empty_idx, :] = d[empty_idx, :]
+    full[bad_idx, :] = bad_data
 
     # Restore original data shape (2D for continuous, 3D for epoched)
     if len(original_data_shape) == 2:
@@ -215,6 +222,7 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
         # Original was 3D epoched data or needs to be 3D
         EEG['data'] = full.reshape(EEG['nbchan'], EEG['pnts'], EEG['trials'])
     return EEG
+
 
 def _normalise_method(method):
     if not isinstance(method, str):
@@ -229,6 +237,7 @@ def _normalise_method(method):
         'spacetime': 'spacetime',
     }
     return method_lookup.get(method.lower(), method)
+
 
 def _planar_v4_interpolate(locs, good_idx, bad_idx, values):
     """Use a thin-plate spline analogue of MATLAB griddata(..., 'v4')."""
@@ -246,6 +255,7 @@ def _planar_v4_interpolate(locs, good_idx, bad_idx, values):
             interpolated = np.where(np.isnan(interpolated), nearest, interpolated)
         return interpolated
 
+
 def _spacetime_interpolate(locs, good_idx, bad_idx, values):
     """Match EEGLAB's nearest-neighbor space/time interpolation path."""
     good_points_2d = _planar_points(locs, good_idx)
@@ -253,19 +263,24 @@ def _spacetime_interpolate(locs, good_idx, bad_idx, values):
     n_time = values.shape[1]
     times = np.arange(1, n_time + 1)
 
-    good_points = np.column_stack([
-        np.tile(good_points_2d[:, 0], n_time),
-        np.tile(good_points_2d[:, 1], n_time),
-        np.repeat(times, len(good_idx)),
-    ])
-    bad_points = np.column_stack([
-        np.tile(bad_points_2d[:, 0], n_time),
-        np.tile(bad_points_2d[:, 1], n_time),
-        np.repeat(times, len(bad_idx)),
-    ])
+    good_points = np.column_stack(
+        [
+            np.tile(good_points_2d[:, 0], n_time),
+            np.tile(good_points_2d[:, 1], n_time),
+            np.repeat(times, len(good_idx)),
+        ]
+    )
+    bad_points = np.column_stack(
+        [
+            np.tile(bad_points_2d[:, 0], n_time),
+            np.tile(bad_points_2d[:, 1], n_time),
+            np.repeat(times, len(bad_idx)),
+        ]
+    )
     flattened = values.reshape(-1, order='F')
     interpolated = griddata(good_points, flattened, bad_points, method='nearest')
     return interpolated.reshape(len(bad_idx), n_time, order='F')
+
 
 def _planar_points(locs, indices):
     points = []
@@ -273,6 +288,7 @@ def _planar_points(locs, indices):
         theta, radius = _theta_radius(locs[index])
         points.append((radius * np.sin(theta), radius * np.cos(theta)))
     return np.asarray(points, dtype=float)
+
 
 def _theta_radius(chanloc):
     theta = chanloc.get('theta')
@@ -286,6 +302,7 @@ def _theta_radius(chanloc):
         raise RuntimeError("Channel theta/radius or X/Y locations required for planar interpolation")
     return float(np.arctan2(y, x)), float(np.sqrt(x * x + y * y))
 
+
 def _is_empty_coordinate(value):
     if value is None:
         return True
@@ -297,6 +314,7 @@ def _is_empty_coordinate(value):
         return bool(np.isnan(value))
     except TypeError:
         return False
+
 
 def _handle_chanloc_interpolation(EEG, new_chanlocs):
     """Handle interpolation when bad_chans is provided as a list of chanloc.
@@ -318,9 +336,7 @@ def _handle_chanloc_interpolation(EEG, new_chanlocs):
         # Check if the coordinate data is also identical
         coords_match = True
         for i, (curr_ch, new_ch) in enumerate(zip(current_locs, new_chanlocs)):
-            if (curr_ch['X'] != new_ch['X'] or
-                curr_ch['Y'] != new_ch['Y'] or
-                curr_ch['Z'] != new_ch['Z']):
+            if curr_ch['X'] != new_ch['X'] or curr_ch['Y'] != new_ch['Y'] or curr_ch['Z'] != new_ch['Z']:
                 coords_match = False
                 break
 
@@ -345,10 +361,10 @@ def _handle_chanloc_interpolation(EEG, new_chanlocs):
         original_shape = EEG['data'].shape
         if len(original_shape) == 3:  # epoched data
             new_data = np.zeros((EEG['nbchan'] + len(new_chanlocs), original_shape[1], original_shape[2]))
-            new_data[:EEG['nbchan'], :, :] = EEG['data']
+            new_data[: EEG['nbchan'], :, :] = EEG['data']
         else:  # continuous data
             new_data = np.zeros((EEG['nbchan'] + len(new_chanlocs), original_shape[1]))
-            new_data[:EEG['nbchan'], :] = EEG['data']
+            new_data[: EEG['nbchan'], :] = EEG['data']
 
         # Update EEG structure
         EEG['data'] = new_data
@@ -387,16 +403,13 @@ def _handle_chanloc_interpolation(EEG, new_chanlocs):
         EEG['nbchan'] = len(new_chanlocs)
 
         # Handle ICA channel indices update (equivalent to MATLAB lines 174-189)
-        if (EEG.get('icasphere') is not None and
-            hasattr(EEG['icasphere'], '__len__') and len(EEG['icasphere']) > 0):
-
-            # Create inverse mapping from new positions back to old positions
-            new_to_old_idx = {new_idx: old_idx for old_idx, new_idx in old_to_new_idx.items()}
-
+        if EEG.get('icasphere') is not None and hasattr(EEG['icasphere'], '__len__') and len(EEG['icasphere']) > 0:
             # Update icachansind if it exists and is not empty
-            if (EEG.get('icachansind') is not None and
-                hasattr(EEG['icachansind'], '__len__') and len(EEG['icachansind']) > 0):
-
+            if (
+                EEG.get('icachansind') is not None
+                and hasattr(EEG['icachansind'], '__len__')
+                and len(EEG['icachansind']) > 0
+            ):
                 # Convert icachansind to list if it's a numpy array for easier manipulation
                 if hasattr(EEG['icachansind'], 'tolist'):
                     icachansind = EEG['icachansind'].tolist()
@@ -437,6 +450,7 @@ def _handle_chanloc_interpolation(EEG, new_chanlocs):
 
         return EEG, bad_idx
 
+
 def spheric_spline(xelec, yelec, zelec, xbad, ybad, zbad, values, params, dtype='float32'):
     """Perform spherical spline interpolation.
 
@@ -462,7 +476,7 @@ def spheric_spline(xelec, yelec, zelec, xbad, ybad, zbad, values, params, dtype=
 
     # values: (n_good, n_points)
     Gelec = computeg(xelec, yelec, zelec, xelec, yelec, zelec, params)
-    Gsph  = computeg(xbad,  ybad,  zbad,  xelec, yelec, zelec, params)
+    Gsph = computeg(xbad, ybad, zbad, xelec, yelec, zelec, params)
 
     # Match MATLAB: mean across all values (not just axis=1)
     # mean across the first dimension
@@ -474,8 +488,7 @@ def spheric_spline(xelec, yelec, zelec, xbad, ybad, zbad, values, params, dtype=
     values = np.vstack([values, np.zeros((1, values.shape[1]))])
 
     lam = params[0]
-    A   = np.vstack([Gelec + np.eye(Gelec.shape[0])*lam,
-                     np.ones((1, Gelec.shape[0]))])
+    A = np.vstack([Gelec + np.eye(Gelec.shape[0]) * lam, np.ones((1, Gelec.shape[0]))])
     with np.errstate(divide='ignore', over='ignore', invalid='ignore'):
         # Matches MATLAB numerically; NumPy may warn inside finite pseudo-inverse matmuls.
         C = pinv(A) @ values
@@ -483,6 +496,7 @@ def spheric_spline(xelec, yelec, zelec, xbad, ybad, zbad, values, params, dtype=
     # Add mean back like MATLAB: repmat(meanvalues, [size(allres,1) 1])
     allres = allres + meanvalues
     return allres
+
 
 def computeg(x, y, z, xelec, yelec, zelec, params):
     """Compute spherical spline basis functions.
@@ -502,18 +516,22 @@ def computeg(x, y, z, xelec, yelec, zelec, params):
         Basis function values.
     """
     # x,y,z are points to interpolate; xelec,... electrode locations
-    X = x.ravel()[:,None]; Y = y.ravel()[:,None]; Z = z.ravel()[:,None]
-    E = 1 - np.sqrt((X - xelec[None,:])**2 + (Y - yelec[None,:])**2 + (Z - zelec[None,:])**2)
+    X = x.ravel()[:, None]
+    Y = y.ravel()[:, None]
+    Z = z.ravel()[:, None]
+    E = 1 - np.sqrt((X - xelec[None, :]) ** 2 + (Y - yelec[None, :]) ** 2 + (Z - zelec[None, :]) ** 2)
 
     m, maxn = params[1], int(params[2])
     g = np.zeros((E.shape[0], E.shape[1]))
-    for n in range(1, maxn+1):
+    for n in range(1, maxn + 1):
         Pn = lpmv(0, n, E)  # shape (E.shape)
-        g += ((2*n+1)/(n**m*(n+1)**m)) * Pn
+        g += ((2 * n + 1) / (n**m * (n + 1) ** m)) * Pn
 
-    return g/(4*np.pi)
+    return g / (4 * np.pi)
+
 
 # Test functions moved to tests/test_eeg_interp.py
+
 
 def test_chanloc_interpolation():
     """Example usage of the new chanloc interpolation functionality.
@@ -534,7 +552,7 @@ def test_chanloc_interpolation():
             {'labels': 'Fp2', 'X': -0.1, 'Y': 0.8, 'Z': 0.6},
             {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},
             {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},
-        ]
+        ],
     }
 
     print("Original EEG structure:")
@@ -545,7 +563,7 @@ def test_chanloc_interpolation():
     # Case 1: Identical chanlocs (should return unchanged)
     identical_chanlocs = EEG['chanlocs'].copy()
     result1 = eeg_interp(EEG.copy(), identical_chanlocs)
-    print(f"\nCase 1 - Identical chanlocs:")
+    print("\nCase 1 - Identical chanlocs:")
     print(f"Data shape unchanged: {result1['data'].shape == EEG['data'].shape}")
     print(f"Data is identical: {np.array_equal(result1['data'], EEG['data'])}")
 
@@ -555,7 +573,7 @@ def test_chanloc_interpolation():
         {'labels': 'T8', 'X': -0.8, 'Y': 0.0, 'Z': 0.6},
     ]
     result2 = eeg_interp(EEG.copy(), new_chanlocs)
-    print(f"\nCase 2 - No overlap (append new channels):")
+    print("\nCase 2 - No overlap (append new channels):")
     print(f"Original channels: {EEG['nbchan']}, After: {result2['nbchan']}")
     print(f"Data shape: {EEG['data'].shape} -> {result2['data'].shape}")
     print(f"New channel labels: {[ch['labels'] for ch in result2['chanlocs']]}")
@@ -570,12 +588,13 @@ def test_chanloc_interpolation():
         {'labels': 'C4', 'X': -0.6, 'Y': 0.0, 'Z': 0.8},
     ]
     result3 = eeg_interp(EEG.copy(), superset_chanlocs)
-    print(f"\nCase 3 - Existing subset of new structure:")
+    print("\nCase 3 - Existing subset of new structure:")
     print(f"Original channels: {EEG['nbchan']}, After: {result3['nbchan']}")
     print(f"Data shape: {EEG['data'].shape} -> {result3['data'].shape}")
     print(f"Final channel labels: {[ch['labels'] for ch in result3['chanlocs']]}")
 
     return result1, result2, result3
+
 
 def test_ica_indices_update():
     """Test that ICA channel indices are properly updated when channels are.
@@ -608,7 +627,7 @@ def test_ica_indices_update():
         'icachansind': [0, 1, 2, 3],  # All channels used for ICA (0-based)
         'chaninfo': {
             'icachansind': [0, 1, 2, 3],
-        }
+        },
     }
 
     print("Original EEG structure with ICA:")
@@ -621,17 +640,17 @@ def test_ica_indices_update():
     # Test Case: Subset interpolation that causes channel reordering
     # Create a superset where the existing channels appear in different order
     superset_chanlocs = [
-        {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},    # was index 2, now 0
-        {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},   # was index 0, now 1
-        {'labels': 'C3', 'X': 0.6, 'Y': 0.0, 'Z': 0.8},    # new channel, index 2
+        {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},  # was index 2, now 0
+        {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},  # was index 0, now 1
+        {'labels': 'C3', 'X': 0.6, 'Y': 0.0, 'Z': 0.8},  # new channel, index 2
         {'labels': 'Fp2', 'X': -0.1, 'Y': 0.8, 'Z': 0.6},  # was index 1, now 3
-        {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},   # was index 3, now 4
-        {'labels': 'C4', 'X': -0.6, 'Y': 0.0, 'Z': 0.8},   # new channel, index 5
+        {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},  # was index 3, now 4
+        {'labels': 'C4', 'X': -0.6, 'Y': 0.0, 'Z': 0.8},  # new channel, index 5
     ]
 
     result = eeg_interp(EEG.copy(), superset_chanlocs)
 
-    print(f"\nAfter interpolation with reordering:")
+    print("\nAfter interpolation with reordering:")
     print(f"Data shape: {EEG['data'].shape} -> {result['data'].shape}")
     print(f"Number of channels: {EEG['nbchan']} -> {result['nbchan']}")
     print(f"Channel labels: {[ch['labels'] for ch in result['chanlocs']]}")
@@ -653,6 +672,7 @@ def test_ica_indices_update():
         print(f"Chaninfo mapping correct: {result['chaninfo']['icachansind'] == expected_indices}")
 
     return result
+
 
 # Uncomment to run the tests
 # if __name__ == '__main__':

--- a/src/eegprep/functions/popfunc/eeg_lat2point.py
+++ b/src/eegprep/functions/popfunc/eeg_lat2point.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+
 def eeg_lat2point(lat_array, epoch_array, srate, timewin, timeunit=1.0, **kwargs):
     """Convert latencies in time units (relative to per-epoch time 0) to latencies in data points assuming concatenated epochs (EEGLAB style).
 
@@ -58,8 +59,7 @@ def eeg_lat2point(lat_array, epoch_array, srate, timewin, timeunit=1.0, **kwargs
 
     # core formula (EEGLAB):
     # newlat = (lat*timeunit - timewin_scaled(1))*srate + 1 + (epoch-1)*pnts
-    newlat = (lat_array * float(timeunit) - timewin_sec[0]) * float(srate) + 1.0 \
-             + (epoch_array - 1.0) * pnts
+    newlat = (lat_array * float(timeunit) - timewin_sec[0]) * float(srate) + 1.0 + (epoch_array - 1.0) * pnts
 
     flag = 0
     if newlat.size and epoch_array.size:

--- a/src/eegprep/functions/popfunc/eeg_picard.py
+++ b/src/eegprep/functions/popfunc/eeg_picard.py
@@ -2,12 +2,8 @@
 
 from picard import picard
 import numpy as np
-import os
-import tempfile
-from .pop_saveset import pop_saveset
-from .pop_loadset import pop_loadset
-from ..adminfunc.eeglabcompat import temp_dir, MatlabWrapper
 from ..miscfunc.pinv import pinv
+
 
 def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
     """Perform ICA decomposition using Picard algorithm.
@@ -43,14 +39,14 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
         # Parameters to match MATLAB picard defaults for reproducible parity
         # Using identity w_init ensures deterministic results matching MATLAB
         params = {
-            'ortho': False,           # Use standard Picard (not Picard-O)
-            'fun': 'tanh',            # Score function (matches MATLAB 'logcosh')
+            'ortho': False,  # Use standard Picard (not Picard-O)
+            'fun': 'tanh',  # Score function (matches MATLAB 'logcosh')
             'verbose': True,
-            'm': 10,                  # L-BFGS memory size
-            'max_iter': 512,          # Match MATLAB python_defaults
-            'tol': 1e-7,              # Match MATLAB python_defaults
-            'centering': True,        # Center data before ICA
-            'whiten': True,           # Whiten data (PCA)
+            'm': 10,  # L-BFGS memory size
+            'max_iter': 512,  # Match MATLAB python_defaults
+            'tol': 1e-7,  # Match MATLAB python_defaults
+            'centering': True,  # Center data before ICA
+            'whiten': True,  # Whiten data (PCA)
             'w_init': np.eye(data.shape[0]),  # Identity init for reproducibility
         }
         params.update(kwargs)
@@ -81,8 +77,7 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
         # Flatten icaact to 2D for variance computation
         icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
         # Compute variance metric: sum(icawinv^2) .* sum(icaact^2)
-        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(
-            icaact_2d ** 2, axis=1)
+        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
         # Sort indices in descending order
         windex = np.argsort(variance_metric)[::-1]
         # Reorder components

--- a/src/eegprep/functions/popfunc/eeg_point2lat.py
+++ b/src/eegprep/functions/popfunc/eeg_point2lat.py
@@ -31,7 +31,9 @@ def eeg_point2lat(lat_array, epoch_array=None, srate=None, timewin=None, timeuni
         raise ValueError("srate is required")
 
     # defaults
-    if epoch_array is None or (isinstance(epoch_array, (list, tuple, np.ndarray)) and len(np.atleast_1d(epoch_array)) == 0):
+    if epoch_array is None or (
+        isinstance(epoch_array, (list, tuple, np.ndarray)) and len(np.atleast_1d(epoch_array)) == 0
+    ):
         epoch_array = 1
 
     if timewin is None:

--- a/src/eegprep/functions/popfunc/eeg_runica.py
+++ b/src/eegprep/functions/popfunc/eeg_runica.py
@@ -54,7 +54,7 @@ def eeg_runica(EEG, posact='off', sortcomps='off', **kwargs):
         # Flatten icaact to 2D for variance computation
         icaact_2d = flatten_ica_data(EEG['icaact'])
         # Compute variance metric: sum(icawinv^2) .* sum(icaact^2)
-        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d ** 2, axis=1)
+        variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
         # Sort indices in descending order
         windex = np.argsort(variance_metric)[::-1]
         # Reorder components

--- a/src/eegprep/functions/popfunc/pop_adjustevents.py
+++ b/src/eegprep/functions/popfunc/pop_adjustevents.py
@@ -56,9 +56,7 @@ def pop_adjustevents(
     if eventtypes is None and eventtype is not None:
         eventtypes = eventtype
 
-    has_eventtypes = eventtypes is not None and not (
-        isinstance(eventtypes, str) and eventtypes == ""
-    )
+    has_eventtypes = eventtypes is not None and not (isinstance(eventtypes, str) and eventtypes == "")
     has_processing_args = addms is not None or addsamples is not None or has_eventtypes
     if gui is None:
         gui = not has_processing_args
@@ -134,9 +132,7 @@ def _normalize_options(
     if addms_value is not None and addsamples_value is not None:
         raise ValueError("Specify either addms or addsamples, not both")
     if addms_value is None and addsamples_value is None:
-        raise ValueError(
-            "To adjust event latencies, you need to specify a number of samples or ms"
-        )
+        raise ValueError("To adjust event latencies, you need to specify a number of samples or ms")
 
     return {
         "addms": None if addms_value is None else float(addms_value),
@@ -195,9 +191,7 @@ def _event_indices(events: list[dict[str, Any]], eventtypes: list[Any]) -> list[
 
     indices: list[int] = []
     for event_type in eventtypes:
-        matches = [
-            index for index, event in enumerate(events) if event.get("type") == event_type
-        ]
+        matches = [index for index, event in enumerate(events) if event.get("type") == event_type]
         if not matches:
             logger.warning("Event type %r not found.", event_type)
         indices.extend(matches)
@@ -208,9 +202,7 @@ def _check_force(EEG: dict, events: list[dict[str, Any]], force: str) -> None:
     if force != "off":
         return
     if int(EEG.get("trials", 1)) > 1:
-        raise ValueError(
-            "Be careful when adjusting latencies for data epochs. Use the 'force' option to do so."
-        )
+        raise ValueError("Be careful when adjusting latencies for data epochs. Use the 'force' option to do so.")
     if _has_boundary_event(events):
         raise ValueError(
             "Be careful when adjusting latencies when boundary events are present. Use the 'force' option to do so."
@@ -247,9 +239,7 @@ def pop_adjustevents_dialog_spec(srate: float, event_types: Iterable[object] = (
         geometry=((1, 0.7, 0.5), (1, 0.7, 0.5), (1, 0.7, 0.5), 1),
         content_margins=(42, 36, 42, 13),
         row_spacing=14,
-        known_differences=(
-            "Python callback code is explicit; original MATLAB callback strings are kept as metadata.",
-        ),
+        known_differences=("Python callback code is explicit; original MATLAB callback strings are kept as metadata.",),
         controls=(
             ControlSpec("text", "Event type(s) to adjust (all by default): "),
             ControlSpec("edit", tag="events", value=""),
@@ -280,8 +270,7 @@ def pop_adjustevents_dialog_spec(srate: float, event_types: Iterable[object] = (
                         "srate": float(srate),
                     },
                     matlab_callback=(
-                        "set(findobj('tag','edit_samples'),'string',"
-                        "num2str(str2num(get(gcbo,'string'))*srate))"
+                        "set(findobj('tag','edit_samples'),'string',num2str(str2num(get(gcbo,'string'))*srate))"
                     ),
                 ),
             ),
@@ -299,8 +288,7 @@ def pop_adjustevents_dialog_spec(srate: float, event_types: Iterable[object] = (
                         "srate": float(srate),
                     },
                     matlab_callback=(
-                        "set(findobj('tag','edit_time'),'string',"
-                        "num2str(str2num(get(gcbo,'string'))/srate))"
+                        "set(findobj('tag','edit_time'),'string',num2str(str2num(get(gcbo,'string'))/srate))"
                     ),
                 ),
             ),

--- a/src/eegprep/functions/popfunc/pop_biosig.py
+++ b/src/eegprep/functions/popfunc/pop_biosig.py
@@ -12,11 +12,15 @@ from eegprep.functions.popfunc.pop_fileio import pop_fileio
 _BIOSIG_SUFFIXES = {".edf", ".bdf", ".gdf"}
 
 
-def pop_biosig(filename: str | Path, *, return_com: bool = False, **kwargs: Any) -> dict[str, Any] | tuple[dict[str, Any], str]:
+def pop_biosig(
+    filename: str | Path, *, return_com: bool = False, **kwargs: Any
+) -> dict[str, Any] | tuple[dict[str, Any], str]:
     """Import BIOSIG-style EDF/BDF/GDF files."""
     path = Path(filename)
     if path.suffix.lower() not in _BIOSIG_SUFFIXES:
-        raise ValueError("pop_biosig supports EDF, BDF, and GDF files. Use pop_fileio or pop_loadset for other formats.")
+        raise ValueError(
+            "pop_biosig supports EDF, BDF, and GDF files. Use pop_fileio or pop_loadset for other formats."
+        )
     eeg, _command = pop_fileio(filename, return_com=True, **kwargs)
     command = f"EEG = pop_biosig({format_history_value(Path(filename))});"
     eeg["history"] = command

--- a/src/eegprep/functions/popfunc/pop_chanevent.py
+++ b/src/eegprep/functions/popfunc/pop_chanevent.py
@@ -38,7 +38,9 @@ def pop_chanevent(
         x = data[channel - 1, :]
         if "oper" in options and options["oper"]:
             x = _apply_oper(x, str(options["oper"]))
-        events.extend(_events_from_channel(x, channel, edge=edge, duration=duration, edgelen=int(options.get("edgelen", 1))))
+        events.extend(
+            _events_from_channel(x, channel, edge=edge, duration=duration, edgelen=int(options.get("edgelen", 1)))
+        )
     out = deepcopy(EEG)
     delete_events = str(options.get("delevent", "on")).lower() in {"on", "yes", "true", "1"}
     if delete_events:
@@ -58,7 +60,9 @@ def pop_chanevent(
         keep = [index for index in range(data.shape[0]) if index + 1 not in channels]
         out["data"] = data[keep, :]
         out["nbchan"] = len(keep)
-        out["chanlocs"] = [loc for index, loc in enumerate(list(out.get("chanlocs", [])), start=1) if index not in channels]
+        out["chanlocs"] = [
+            loc for index, loc in enumerate(list(out.get("chanlocs", [])), start=1) if index not in channels
+        ]
     out["saved"] = "no"
     with strict_mode(False):
         out = eeg_checkset(out)
@@ -67,7 +71,9 @@ def pop_chanevent(
     return (out, command) if return_com else out
 
 
-def _events_from_channel(x: np.ndarray, channel: int, *, edge: str, duration: bool, edgelen: int) -> list[dict[str, Any]]:
+def _events_from_channel(
+    x: np.ndarray, channel: int, *, edge: str, duration: bool, edgelen: int
+) -> list[dict[str, Any]]:
     values = np.asarray(x)
     diff = np.diff(np.r_[values, values[-1]])
     leading = np.flatnonzero(diff > 0) + 1

--- a/src/eegprep/functions/popfunc/pop_epoch.py
+++ b/src/eegprep/functions/popfunc/pop_epoch.py
@@ -172,10 +172,7 @@ def _pop_epoch_one(
 
     events = _event_list(EEG.get("event"))
     if not events:
-        if (
-            int(EEG.get("trials", 1) or 1) > 1
-            and float(EEG.get("xmin", 0) or 0) <= 0 <= float(EEG.get("xmax", 0) or 0)
-        ):
+        if int(EEG.get("trials", 1) or 1) > 1 and float(EEG.get("xmin", 0) or 0) <= 0 <= float(EEG.get("xmax", 0) or 0):
             events = _time_locking_events(EEG)
         else:
             logger.info("Cannot epoch data with no events")
@@ -428,11 +425,7 @@ def _epoch_events(
             new_event = copy.deepcopy(events[event_index])
             new_event["epoch"] = epoch_index + 1
             new_event["latency"] = (
-                float(new_event["latency"])
-                - accepted_latencies[epoch_index]
-                - xmin * srate
-                + 1
-                + pnts * epoch_index
+                float(new_event["latency"]) - accepted_latencies[epoch_index] - xmin * srate + 1 + pnts * epoch_index
             )
             new_events.append(new_event)
     return new_events
@@ -447,17 +440,15 @@ def _remove_boundary_epochs(output: dict[str, Any], accepted_positions: list[int
     boundary_indices = eeg_findboundaries(EEG=events)
     if not boundary_indices:
         return output, accepted_positions
-    remove_epochs = {
-        int(events[index].get("epoch", 1) or 1)
-        for index in boundary_indices
-    }
+    remove_epochs = {int(events[index].get("epoch", 1) or 1) for index in boundary_indices}
     if not remove_epochs:
         return output, accepted_positions
     selected = pop_select(output, notrial=sorted(remove_epochs))
     if isinstance(selected, tuple):
         selected = selected[0]
     kept_positions = [
-        position for epoch_number, position in enumerate(accepted_positions, start=1)
+        position
+        for epoch_number, position in enumerate(accepted_positions, start=1)
         if epoch_number not in remove_epochs
     ]
     return selected, kept_positions
@@ -472,19 +463,14 @@ def _update_dataset_text(output: dict[str, Any], original: dict[str, Any], newna
                 body = comments
             else:
                 body = "\n".join(str(line) for line in comments)
-            output["comments"] = (
-                f'Parent dataset: {setname}\n\nParent dataset "{setname}": ----------\n{body}'
-            )
+            output["comments"] = f'Parent dataset: {setname}\n\nParent dataset "{setname}": ----------\n{body}'
         else:
             output["comments"] = f"Parent dataset: {setname}\n"
     output["setname"] = newname
 
 
 def _history_command(types: Any, lim: list[float], options: dict[str, Any]) -> str:
-    pieces = [
-        f"EEG = pop_epoch( EEG, {_history_types(types)}, "
-        f"{format_history_value(lim, cell_for_sequence=None)}"
-    ]
+    pieces = [f"EEG = pop_epoch( EEG, {_history_types(types)}, {format_history_value(lim, cell_for_sequence=None)}"]
     for key, value in options.items():
         if _is_empty_history_value(value):
             continue

--- a/src/eegprep/functions/popfunc/pop_expica.py
+++ b/src/eegprep/functions/popfunc/pop_expica.py
@@ -25,7 +25,4 @@ def pop_expica(EEG: dict[str, Any], filename: str | Path, matrix: str = "weights
     path = Path(filename)
     path.parent.mkdir(parents=True, exist_ok=True)
     np.savetxt(path, values, delimiter="\t")
-    return (
-        "LASTCOM = pop_expica(EEG, "
-        f"{format_history_value(path)}, {format_history_value(matrix)});"
-    )
+    return f"LASTCOM = pop_expica(EEG, {format_history_value(path)}, {format_history_value(matrix)});"

--- a/src/eegprep/functions/popfunc/pop_fileio.py
+++ b/src/eegprep/functions/popfunc/pop_fileio.py
@@ -13,7 +13,9 @@ from eegprep.functions.popfunc.pop_importdata import pop_importdata
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 
 
-def pop_fileio(filename: str | Path, *, return_com: bool = False, **kwargs: Any) -> dict[str, Any] | tuple[dict[str, Any], str]:
+def pop_fileio(
+    filename: str | Path, *, return_com: bool = False, **kwargs: Any
+) -> dict[str, Any] | tuple[dict[str, Any], str]:
     """Import a supported EEG data file with MNE/File-IO-style readers."""
     path = Path(filename)
     suffix = path.suffix.lower()

--- a/src/eegprep/functions/popfunc/pop_importdata.py
+++ b/src/eegprep/functions/popfunc/pop_importdata.py
@@ -16,7 +16,9 @@ def pop_importdata(*args: Any, return_com: bool = False, **kwargs: Any) -> dict[
         raise ValueError("pop_importdata requires a 'data' file or array")
     data_source = options["data"]
     nbchan = _optional_int(options.get("nbchan"))
-    dataformat = infer_dataformat(data_source if isinstance(data_source, (str, Path)) else None, options.get("dataformat"))
+    dataformat = infer_dataformat(
+        data_source if isinstance(data_source, (str, Path)) else None, options.get("dataformat")
+    )
     data = load_data_array(
         data_source,
         dataformat=dataformat,

--- a/src/eegprep/functions/popfunc/pop_interp.py
+++ b/src/eegprep/functions/popfunc/pop_interp.py
@@ -249,8 +249,7 @@ def _warn_gui_interpolation() -> None:
 
 def _alleeg_chanlocs(alleeg: list[dict] | None) -> tuple[dict[str, Any], ...]:
     return tuple(
-        {"chanlocs": tuple(copy.deepcopy(_chanlocs_as_list(dataset.get("chanlocs", []))))}
-        for dataset in (alleeg or [])
+        {"chanlocs": tuple(copy.deepcopy(_chanlocs_as_list(dataset.get("chanlocs", []))))} for dataset in (alleeg or [])
     )
 
 
@@ -334,9 +333,7 @@ def _remove_interpolated_removed_channels(EEG: dict, bad_elec: Any) -> dict:
     labels_to_remove = {str(chan.get("labels", "")).lower() for chan in _chanlocs_as_list(bad_elec)}
     EEG_out = copy.deepcopy(EEG)
     chaninfo = copy.deepcopy(EEG_out.get("chaninfo", {}))
-    chaninfo["removedchans"] = [
-        chan for chan in removed if str(chan.get("labels", "")).lower() not in labels_to_remove
-    ]
+    chaninfo["removedchans"] = [chan for chan in removed if str(chan.get("labels", "")).lower() not in labels_to_remove]
     EEG_out["chaninfo"] = chaninfo
     return EEG_out
 

--- a/src/eegprep/functions/popfunc/pop_load_frombids.py
+++ b/src/eegprep/functions/popfunc/pop_load_frombids.py
@@ -849,7 +849,7 @@ def pop_load_frombids(
                             {key: values[i] for key, values in events_soa.items()} for i, kp in enumerate(keep) if kp
                         ]
 
-                        EEG_events = EEG['event'].tolist()
+                        EEG_events = np.asarray(EEG['event'], dtype=object).tolist()
 
                         # append any missing fields to existing events with null values
                         for col in ev_extra:
@@ -857,7 +857,7 @@ def pop_load_frombids(
                                 if col not in ev:
                                     ev[col] = numeric_null
 
-                        EEG_events = EEG['event'].tolist() + new_events
+                        EEG_events = np.asarray(EEG['event'], dtype=object).tolist() + new_events
                         EEG['event'] = np.array(EEG_events, dtype=object)
 
                         # re-sort events by latency

--- a/src/eegprep/functions/popfunc/pop_load_frombids.py
+++ b/src/eegprep/functions/popfunc/pop_load_frombids.py
@@ -2,13 +2,19 @@
 
 import os
 import copy
-from typing import Dict, Any, Tuple, List, Union, Sequence, Optional
+from typing import Dict, Any, Tuple, Union, Optional
 import logging
 import warnings
-import contextlib
-from eegprep.plugins.EEG_BIDS.bids import layout_for_fpath, layout_get_lenient, query_for_adjacent_fpath, \
-    root_for_fpath
-from eegprep.plugins.EEG_BIDS.coords import *
+from eegprep.plugins.EEG_BIDS.bids import layout_for_fpath, layout_get_lenient, query_for_adjacent_fpath, root_for_fpath
+from eegprep.plugins.EEG_BIDS.coords import (
+    chanloc_has_coords,
+    chanlocs_to_coords,
+    clear_chanloc,
+    coords_ALS_to_angular,
+    coords_any_to_RAS,
+    coords_RAS_to_ALS,
+    coords_to_mm,
+)
 from eegprep.functions.miscfunc.misc import ExceptionUnlessDebug, ToolError, round_mat
 
 import numpy as np
@@ -29,18 +35,19 @@ def _strip_matching_quotes(name: str) -> str:
         name = name[1:-1]
     return name
 
+
 def pop_load_frombids(
-        filename: str,
-        *,
-        bidsmetadata: bool = True,
-        bidschanloc: bool = True,
-        bidsevent: Union[bool, str] = 'replace',
-        eventtype: Optional[str] = None,
-        infer_locations: Union[bool, str, None] = None,
-        dtype: np.dtype = np.float32,
-        numeric_null: Any = np.array([]),
-        return_report: bool = False,
-        verbose: bool = True,
+    filename: str,
+    *,
+    bidsmetadata: bool = True,
+    bidschanloc: bool = True,
+    bidsevent: Union[bool, str] = 'replace',
+    eventtype: Optional[str] = None,
+    infer_locations: Union[bool, str, None] = None,
+    dtype: np.dtype = np.float32,
+    numeric_null: Any = np.array([]),
+    return_report: bool = False,
+    verbose: bool = True,
 ) -> Dict[str, Any] | Tuple[Dict[str, Any], Dict[str, Any]]:
     """Load an EEG data file of a supported format from a BIDS dataset.
 
@@ -123,42 +130,51 @@ def pop_load_frombids(
         EEG['data'] = EEG['data'].astype(dtype)
         report['ImporterUsed'] = 'pop_loadset'
         Fs = EEG['srate']
-        times_sec = EEG['times']/1000.0
+        times_sec = EEG['times'] / 1000.0
     elif ext in ['.edf', '.bdf', '.vhdr']:
         from neo import NeoReadWriteError
+
         if ext == '.vhdr':
             from neo.rawio.brainvisionrawio import BrainVisionRawIO as NeoIO
+
             report['ImporterUsed'] = 'neo.rawio.brainvisionrawio.BrainVisionRawIO'
         elif ext in ['.edf', '.bdf']:
             from neo.rawio.edfrawio import EDFRawIO as NeoIO
+
             report['ImporterUsed'] = 'neo.rawio.edfrawio.EDFRawIO'
         else:
             # if you're getting this, there's an elif statement missing here for one of
             # the formats allowed above
-            raise ValueError(f"Unexpected file format: {ext}. Please add support for this "
-                             f"format if needed.")
+            raise ValueError(f"Unexpected file format: {ext}. Please add support for this format if needed.")
         # load from NEO
         io = NeoIO(filename)
         try:
             io.parse_header()
         except NeoReadWriteError as e:
             classname = io.__class__.__name__
-            raise ToolError(f"Encountered error with NEO {classname} importer on {filename!r}: {e}. Skipping file.") from e
+            raise ToolError(
+                f"Encountered error with NEO {classname} importer on {filename!r}: {e}. Skipping file."
+            ) from e
         if (nStreams := io.signal_streams_count()) > 1:
-            warning(f"The raw data file {filename} appears to contain "
-                    f"more than one stream; using only the first stream.")
+            warning(
+                f"The raw data file {filename} appears to contain more than one stream; using only the first stream."
+            )
         elif not nStreams:
             raise ValueError(f"The raw data file {filename} does not contain any data.")
         if (nBlocks := io.block_count()) > 1:
-            warning(f"The raw data file {filename} appears to contain "
-                    f"more than one recording; this is not meaningful "
-                    f"in a BIDS context; using only the first block.")
+            warning(
+                f"The raw data file {filename} appears to contain "
+                f"more than one recording; this is not meaningful "
+                f"in a BIDS context; using only the first block."
+            )
         elif not nBlocks:
             raise ValueError(f"The raw data file {filename} does not contain any data.")
         if (nSegments := io.segment_count(0)) > 1:
-            raise NotImplementedError(f"The raw data file {filename} appears to contain "
-                                      f"more than one segment; This importer currently "
-                                      f"only supports continuous EEG data.")
+            raise NotImplementedError(
+                f"The raw data file {filename} appears to contain "
+                f"more than one segment; This importer currently "
+                f"only supports continuous EEG data."
+            )
         elif not nSegments:
             raise ValueError(f"The raw data file {filename} does not contain any data.")
 
@@ -172,14 +188,13 @@ def pop_load_frombids(
 
         if verbose:
             logger.info("  retrieving EEG data from file...")
-        data_T = io.get_analogsignal_chunk(block_index=0, seg_index=0,
-                                           channel_indexes=chnIdxs,
-                                           i_start=None, i_stop=None)
+        data_T = io.get_analogsignal_chunk(
+            block_index=0, seg_index=0, channel_indexes=chnIdxs, i_start=None, i_stop=None
+        )
         old_scale = np.std(data_T, axis=0)
-        data_T = io.rescale_signal_raw_to_float(data_T, dtype=dtype,
-                                                channel_indexes=chnIdxs)
+        data_T = io.rescale_signal_raw_to_float(data_T, dtype=dtype, channel_indexes=chnIdxs)
         new_scale = np.std(data_T, axis=0)
-        scale_ratios = new_scale/old_scale
+        scale_ratios = new_scale / old_scale
         uq_ratios = np.unique(scale_ratios)
         if len(uq_ratios) == 1:
             report['ScaleApplied'] = uq_ratios.item()
@@ -202,11 +217,13 @@ def pop_load_frombids(
         try:
             units = chns['units'].tolist()
         except KeyError:
-            units = ['uV']*nChannels
+            units = ['uV'] * nChannels
         uq_unit = np.unique(units)
         if len(uq_unit) == 1 and uq_unit[0] not in ('uV', 'microvolts'):
-            warning(f"Your channel unit does not appear to be in microvolts (uV) "
-                    f"but is documented instead as {uq_unit[0]}. EEG scale might be incorrect. ")
+            warning(
+                f"Your channel unit does not appear to be in microvolts (uV) "
+                f"but is documented instead as {uq_unit[0]}. EEG scale might be incorrect. "
+            )
 
         labels = chns['name'].tolist()
 
@@ -220,21 +237,25 @@ def pop_load_frombids(
         # - buffer_id
 
         # preinitialize data structure
-        chanlocs = np.asarray([
-            {
-                'labels': lab,
-                'sph_radius': numeric_null,
-                'sph_theta': numeric_null,
-                'sph_phi': numeric_null,
-                'theta': numeric_null,
-                'radius': numeric_null,
-                'X': numeric_null,
-                'Y': numeric_null,
-                'Z': numeric_null,
-                'type': 'EEG',
-                'ref': numeric_null,
-                # 'urchan': numeric_null --> not present if urchanlocs not populated
-            } for lab in labels])
+        chanlocs = np.asarray(
+            [
+                {
+                    'labels': lab,
+                    'sph_radius': numeric_null,
+                    'sph_theta': numeric_null,
+                    'sph_phi': numeric_null,
+                    'theta': numeric_null,
+                    'radius': numeric_null,
+                    'X': numeric_null,
+                    'Y': numeric_null,
+                    'Z': numeric_null,
+                    'type': 'EEG',
+                    'ref': numeric_null,
+                    # 'urchan': numeric_null --> not present if urchanlocs not populated
+                }
+                for lab in labels
+            ]
+        )
 
         # try to read out channel coordinates from side-channel info, if any
         if ext == '.vhdr':
@@ -243,19 +264,20 @@ def pop_load_frombids(
             try:
                 annots = io.raw_annotations['blocks'][0]['segments'][0]['signals'][0]['__array_annotations__']
                 sph_radius, theta, phi = annots['coordinates_0'], annots['coordinates_1'], annots['coordinates_2']
-                valid = (sph_radius!=0) | (theta!=0) | (phi!=0)
+                valid = (sph_radius != 0) | (theta != 0) | (phi != 0)
                 sph_theta = phi - 90 * np.sign(theta)
                 sph_phi = -np.abs(theta) + 90
             except KeyError:
-                warning(f"Channel coordinates not found in {filename}. "
-                        f"Using default values for channel locations.")
+                warning(f"Channel coordinates not found in {filename}. Using default values for channel locations.")
                 valid = np.zeros(nChannels, dtype=bool)
         elif ext in ['.edf', '.bdf']:
             # EDF/BDF files do not have channel coordinates, so we use default values
             valid = np.zeros(nChannels, dtype=bool)
         else:
-            raise ValueError(f"Unsupported file format for channel coordinates extraction: {ext}. "
-                             f"Supported formats are .edf, .bdf, .vhdr.")
+            raise ValueError(
+                f"Unsupported file format for channel coordinates extraction: {ext}. "
+                f"Supported formats are .edf, .bdf, .vhdr."
+            )
 
         if np.any(valid):
             if verbose:
@@ -271,7 +293,7 @@ def pop_load_frombids(
                     az = sph_p
                     horiz = sph_t
                     angle = -horiz
-                    radius = 0.5 - az/180
+                    radius = 0.5 - az / 180
                     loc['theta'] = angle
                     loc['radius'] = radius
                     # and derive cartesian coordinates (sph2cart)
@@ -322,20 +344,24 @@ def pop_load_frombids(
                 ev_codes = [str(chn) for chn in ev_all_channels]
             else:
                 # if you get this you need to add support for this file format here
-                raise ValueError(f"Unsupported file format for event extraction: {ext}. "
-                                 f"Supported formats are .edf, .bdf, .vhdr.")
+                raise ValueError(
+                    f"Unsupported file format for event extraction: {ext}. Supported formats are .edf, .bdf, .vhdr."
+                )
             ev_lats = np.searchsorted(times_sec, ev_all_times)  # +1 for MATLAB format compatibility (1-based index)
             ev_durs = np.array(ev_all_durs, dtype=float)
             ev_urevts = np.arange(len(ev_all_times))
-            events = np.array([
-                {
-                    'duration': dur,
-                    'latency': lat,
-                    'type': typ or ('boundary' if code == 'New Segment' else ''),
-                    'code': code,
-                    'urevent': chn,
-                } for dur, lat, typ, code, chn in
-                zip(ev_durs, ev_lats, ev_types, ev_codes, ev_urevts)])
+            events = np.array(
+                [
+                    {
+                        'duration': dur,
+                        'latency': lat,
+                        'type': typ or ('boundary' if code == 'New Segment' else ''),
+                        'code': code,
+                        'urevent': chn,
+                    }
+                    for dur, lat, typ, code, chn in zip(ev_durs, ev_lats, ev_types, ev_codes, ev_urevts)
+                ]
+            )
         else:
             events = numeric_null
 
@@ -361,7 +387,7 @@ def pop_load_frombids(
             'srate': Fs,
             'xmin': times_sec[0],
             'xmax': times_sec[-1],
-            'times': times_sec*1000,  # in ms
+            'times': times_sec * 1000,  # in ms
             'data': data_T.T,
             # ICA data structures
             'icaact': numeric_null,
@@ -403,14 +429,14 @@ def pop_load_frombids(
             'saved': 'justloaded',
             # additional metadata
             'etc': {},
-            'run': numeric_null
+            'run': numeric_null,
         }
     elif ext in ['.fdt', '.vmrk', '.eeg']:
-        raise ValueError(f"pop_load_frombids should be called with the main data file, "
-                         f"but was called on a sidecar file: {filename}.")
+        raise ValueError(
+            f"pop_load_frombids should be called with the main data file, but was called on a sidecar file: {filename}."
+        )
     else:
-        raise ValueError(f"Unsupported file format: {ext}. Supported formats "
-                         f"are .set, .edf, .bdf, .vhdr.")
+        raise ValueError(f"Unsupported file format: {ext}. Supported formats are .set, .edf, .bdf, .vhdr.")
 
     report['EEGFileHadLocations'] = sum(chanloc_has_coords(ch) for ch in EEG['chanlocs'])
     report['ChanlocsFrom'] = os.path.relpath(filename, root)
@@ -421,6 +447,7 @@ def pop_load_frombids(
         if verbose:
             logger.info("  applying BIDS metadata...")
         import bids
+
         layout: bids.BIDSLayout = layout_for_fpath(filename)
         # get the applicable metadata for this file
         metadata: Dict[str, Any] = layout.get_metadata(filename, include_entities=True)
@@ -433,14 +460,11 @@ def pop_load_frombids(
 
     if bidschanloc:
         import bids
+
         layout: bids.BIDSLayout = layout_for_fpath(filename)
 
         # check for presence of a _channels.tsv file
-        query_entities = {
-            **layout.parse_file_entities(filename),
-            'suffix': 'channels',
-            'extension': '.tsv'
-        }
+        query_entities = {**layout.parse_file_entities(filename), 'suffix': 'channels', 'extension': '.tsv'}
         # retrieve the list of all such files
         channel_file_list = layout_get_lenient(
             layout,
@@ -450,11 +474,14 @@ def pop_load_frombids(
             expect_one=True,
         )
         if len(channel_file_list) > 1:
-            warning(f"Found multiple BIDS channel files for {filename}: "
-                    f"{', '.join([fo.filename for fo in channel_file_list])}. "
-                    f"Using the first one only.")
+            warning(
+                f"Found multiple BIDS channel files for {filename}: "
+                f"{', '.join([fo.filename for fo in channel_file_list])}. "
+                f"Using the first one only."
+            )
         for fo in channel_file_list:
             import pandas as pd
+
             if verbose:
                 logger.info(f"  applying BIDS channel locations from {fo.filename}...")
             report['ChanlocsFrom'] = os.path.relpath(fo.path, root)
@@ -494,17 +521,16 @@ def pop_load_frombids(
                         EEG['chanlocs'][idx]['ref'] = ref_idx
             if notfound:
                 nf = [str(n) for n in notfound]
-                warning(f"Channels {','.join(nf)} from BIDS file {fo.filename} "
-                       f"not found in EEG data structure; skipping.")
+                warning(
+                    f"Channels {','.join(nf)} from BIDS file {fo.filename} not found in EEG data structure; skipping."
+                )
             if notype:
-                warning(f"Channels in BIDS file {fo.filename} do not have a 'type' "
-                        f"column; not overriding.")
+                warning(f"Channels in BIDS file {fo.filename} do not have a 'type' column; not overriding.")
 
             break
 
         # check for presence of an _electrodes.tsv file
-        query_entities = query_for_adjacent_fpath(
-            filename, suffix='electrodes', extension='.tsv')
+        query_entities = query_for_adjacent_fpath(filename, suffix='electrodes', extension='.tsv')
         # retrieve the list of all such files
         elec_file_list = layout_get_lenient(
             layout,
@@ -514,12 +540,15 @@ def pop_load_frombids(
             expect_one=True,
         )
         if len(elec_file_list) > 1:
-            warning(f"Found multiple BIDS electrode files for {filename}: "
-                    f"{', '.join([fo.filename for fo in elec_file_list])}. "
-                    f"Using the first one only.")
+            warning(
+                f"Found multiple BIDS electrode files for {filename}: "
+                f"{', '.join([fo.filename for fo in elec_file_list])}. "
+                f"Using the first one only."
+            )
             elec_file_list = elec_file_list[:1]
         for elec_fo in elec_file_list:
             import pandas as pd
+
             if verbose:
                 logger.info(f"  applying BIDS electrode locations from {fo.filename}...")
             report['ElectrodesFrom'] = os.path.relpath(elec_fo.path, root)
@@ -527,8 +556,7 @@ def pop_load_frombids(
             elecs: pd.DataFrame = elec_fo.get_df()
 
             # check for the presence of a coordsystem file
-            query_entities = query_for_adjacent_fpath(
-                elec_fo.path, suffix='coordsystem', extension='.json')
+            query_entities = query_for_adjacent_fpath(elec_fo.path, suffix='coordsystem', extension='.json')
             coordsystem_file_list = layout_get_lenient(
                 layout,
                 **query_entities,
@@ -537,17 +565,21 @@ def pop_load_frombids(
                 expect_one=True,
             )
             if len(coordsystem_file_list) > 1:
-                warning(f"Found multiple BIDS coordsystem files for {elec_fo.filename}: "
-                        f"{', '.join([fo.filename for fo in coordsystem_file_list])}. "
-                        f"Using the first one only.")
+                warning(
+                    f"Found multiple BIDS coordsystem files for {elec_fo.filename}: "
+                    f"{', '.join([fo.filename for fo in coordsystem_file_list])}. "
+                    f"Using the first one only."
+                )
                 coordsystem_file_list = coordsystem_file_list[:1]
             if not coordsystem_file_list:
                 # if it's a .set study, then we assume ALS for the chanlocs, otherwise RAS
                 coord_system = 'ALS' if ext == '.set' else 'RAS'
                 coord_units = 'guess'
-                warning(f"Found no BIDS coordsystem files for {fo.filename}; your "
-                        f"dataset is not fully BIDS-compliant. Assuming coordinate "
-                        f"system {coord_system!r} and guessing units from the data.")
+                warning(
+                    f"Found no BIDS coordsystem files for {fo.filename}; your "
+                    f"dataset is not fully BIDS-compliant. Assuming coordinate "
+                    f"system {coord_system!r} and guessing units from the data."
+                )
             else:
                 for coordsystem_fo in coordsystem_file_list:
                     if verbose:
@@ -566,15 +598,15 @@ def pop_load_frombids(
                         coord_system = 'ALS'
                     else:
                         coord_system = 'RAS'
-                    coord_units = content.get('EEGCoordinateUnits', 'guess').lower()  # default to 'guess' if not specified
+                    coord_units = content.get(
+                        'EEGCoordinateUnits', 'guess'
+                    ).lower()  # default to 'guess' if not specified
                     if coord_units == 'n/a':
                         coord_units = 'guess'
                     break
 
             # guess the coordinate units if not specified
-            coords = np.stack(
-                (elecs['x'].to_numpy(), elecs['y'].to_numpy(), elecs['z'].to_numpy()),
-                axis=1)
+            coords = np.stack((elecs['x'].to_numpy(), elecs['y'].to_numpy(), elecs['z'].to_numpy()), axis=1)
 
             guess_units = coord_units == 'guess'
 
@@ -600,14 +632,17 @@ def pop_load_frombids(
             report['CoordUnitsWereGuessed'] = guess_units
 
             if coord_units == '':
-                warning(f"Coordinate units for {fo.filename} could not be inferred "
-                        f"or were invalid; not overriding channel locations.")
+                warning(
+                    f"Coordinate units for {fo.filename} could not be inferred "
+                    f"or were invalid; not overriding channel locations."
+                )
             else:
                 if EEG['chaninfo']['nosedir'] != '+X':
                     warning(
                         f"Converting to the coordinate system {coord_system} of "
                         f"the EEG data file is not supported by this importer. "
-                        f"Setting to +X and clearing existing coordinates.")
+                        f"Setting to +X and clearing existing coordinates."
+                    )
                     # override nosedir and wipe existing chanlocs, if any
                     EEG['chaninfo']['nosedir'] = '+X'  # set to +X for AJS coordinate system
                     for ch in EEG['chanlocs']:
@@ -619,9 +654,11 @@ def pop_load_frombids(
                 if coord_system == 'RAS':
                     coords = coords_RAS_to_ALS(coords)
                 elif coord_system != 'ALS':
-                    raise ValueError(f"Unsupported coordinate system {coord_system!r} "
-                                     f"in BIDS file {fo.filename}. Supported systems are "
-                                     f"ALS and RAS.")
+                    raise ValueError(
+                        f"Unsupported coordinate system {coord_system!r} "
+                        f"in BIDS file {fo.filename}. Supported systems are "
+                        f"ALS and RAS."
+                    )
 
                 sph_theta, sph_phi, sph_radius, polar_theta, polar_radius = coords_ALS_to_angular(coords)
 
@@ -653,26 +690,31 @@ def pop_load_frombids(
                     rec['theta'] = polar_theta[k]
                     rec['radius'] = polar_radius[k]
                 if notfound:
-                    warning(f"Electrodes {','.join(notfound)} from BIDS file {fo.filename} "
-                            f"not found in EEG data structure; skipping.")
+                    warning(
+                        f"Electrodes {','.join(notfound)} from BIDS file {fo.filename} "
+                        f"not found in EEG data structure; skipping."
+                    )
                 if num_updated:
-                    logger.info(f"Updated {num_updated} channel locations from BIDS file {fo.filename} "
-                                f"into the EEG data structure.")
+                    logger.info(
+                        f"Updated {num_updated} channel locations from BIDS file {fo.filename} "
+                        f"into the EEG data structure."
+                    )
                     report['NumUpdatedChanlocs'] = num_updated
                     report['NotfoundChanlocs'] = notfound
 
     if bidsevent:
         import bids
+
         layout: bids.BIDSLayout = layout_for_fpath(filename)
 
         # get the query to find the associated events file
-        query_entities = query_for_adjacent_fpath(
-            filename, suffix='events', extension='.tsv')
+        query_entities = query_for_adjacent_fpath(filename, suffix='events', extension='.tsv')
         try:
             # retrieve the list of all such files
             events_file_list = layout.get(**query_entities, return_type='object')
             for fo in events_file_list:
                 import pandas as pd
+
                 if verbose:
                     logger.info(f"  applying BIDS events from {fo.filename}...")
                 report['EventsFrom'] = os.path.relpath(fo.path, root)
@@ -687,7 +729,7 @@ def pop_load_frombids(
                         raise ValueError(f"sample column in {fo.filename} is all NaN; falling back to onsets.")
                     ev_lats = ev_lats.astype(int)
                     report['EventTimingSource'] = 'sample'
-                except (KeyError, ValueError) as e:
+                except (KeyError, ValueError):
                     # otherwise get it from the onsets, which is expected to be always present
                     try:
                         onsets = events['onset'].to_numpy(dtype=float)
@@ -695,14 +737,16 @@ def pop_load_frombids(
                             raise ValueError(f"onset column in {fo.filename} is all NaN; cannot proceed.")
                         report['EventTimingSource'] = 'onset'
                         ev_lats = np.searchsorted(times_sec, onsets)
-                    except (KeyError, ValueError) as e:
-                        raise ValueError(f"Your BIDS file {fo.filename} does not contain "
-                                         f"the required 'onset' column for events and therefore "
-                                         f"does not conform to the BIDS standard; to fall back "
-                                         f"to the events present in the EEG file itself (if any), "
-                                         f"pass the bidsevent=False option "
-                                         f"when using pop_load_frombids, or equivalently "
-                                         f"ApplyEvents=False when using  bids_preproc().")
+                    except (KeyError, ValueError):
+                        raise ValueError(
+                            f"Your BIDS file {fo.filename} does not contain "
+                            f"the required 'onset' column for events and therefore "
+                            f"does not conform to the BIDS standard; to fall back "
+                            f"to the events present in the EEG file itself (if any), "
+                            f"pass the bidsevent=False option "
+                            f"when using pop_load_frombids, or equivalently "
+                            f"ApplyEvents=False when using  bids_preproc()."
+                        )
                 # convert to 1-based indexes for MATLAB compat
                 ev_lats = ev_lats + 1
 
@@ -713,7 +757,7 @@ def pop_load_frombids(
                     # fall back to zero duration
                     durations = np.zeros_like(onsets, dtype=float)
                 # convert to EEGLAB's sample-based durations
-                ev_durs = round_mat(np.maximum(1, Fs*durations)).astype(int)
+                ev_durs = round_mat(np.maximum(1, Fs * durations)).astype(int)
 
                 # set of column names that we've already carried over into the
                 # event data structure
@@ -739,12 +783,14 @@ def pop_load_frombids(
                         # not found
                         continue
                 else:
-                    warning(f"Your BIDS file {fo.filename} does not appear to contain "
-                            f"a column coding for the event type ({','.join(event_type_columns)}), "
-                            f"importing as ''. To avoid importing these dummy events and use only"
-                            f"the events in the EEG file itself (if any), pass the "
-                            f"bidsevent=False option when using pop_load_frombids, "
-                            f"or equivalently ApplyEvents=False when using bids_preproc().")
+                    warning(
+                        f"Your BIDS file {fo.filename} does not appear to contain "
+                        f"a column coding for the event type ({','.join(event_type_columns)}), "
+                        f"importing as ''. To avoid importing these dummy events and use only"
+                        f"the events in the EEG file itself (if any), pass the "
+                        f"bidsevent=False option when using pop_load_frombids, "
+                        f"or equivalently ApplyEvents=False when using bids_preproc()."
+                    )
                     ev_types = np.full_like(ev_lats, '', dtype=object)
 
                 ev_types = [typ or ('boundary' if typ == 'New Segment' else '') for typ in ev_types]
@@ -752,16 +798,14 @@ def pop_load_frombids(
                 # extract extra columns to include in the event data structure
                 # this does not in
                 extra_columns = sorted(set(events.columns) - set(used_columns))
-                ev_extra = {
-                    col: events[col].to_numpy()
-                    for col in extra_columns}
+                ev_extra = {col: events[col].to_numpy() for col in extra_columns}
 
                 # drop trivial (all-nan) columns
                 for col in list(ev_extra):
                     try:
                         if np.all(np.isnan(ev_extra[col])):
                             del ev_extra[col]
-                    except Exception as e:
+                    except Exception:
                         pass
 
                 # filter out any events that are already in the EEG data structure itself
@@ -775,7 +819,7 @@ def pop_load_frombids(
                             orig_lats = [e['latency'] for e in EEG['event']]
                             indexes = np.searchsorted(orig_lats, ev_lats)
                             orig_types = [ev['type'] for ev in EEG['event'][indexes]]
-                            keep = [o != e for o,e in zip(orig_types, ev_types)]
+                            keep = [o != e for o, e in zip(orig_types, ev_types)]
                         else:
                             keep = np.ones_like(ev_types, dtype=bool)
                     elif bidsevent == 'append':
@@ -783,7 +827,8 @@ def pop_load_frombids(
                     else:
                         raise ValueError(
                             f"Invalid value for bidsevent: {bidsevent}. "
-                            f"Expected one of 'replace', 'merge', 'append', or False/None.")
+                            f"Expected one of 'replace', 'merge', 'append', or False/None."
+                        )
 
                     report["NumEventsFromBids"] = int(np.sum(keep))
 
@@ -794,15 +839,14 @@ def pop_load_frombids(
                             'latency': ev_lats,
                             'duration': ev_durs,
                             'type': ev_types,
-                            'urevent': np.zeros_like(ev_lats)
+                            'urevent': np.zeros_like(ev_lats),
                         }
                         # append extra event columns
                         events_soa.update(ev_extra)
 
                         # convert from structure-of-arrays to array-of-structures and filter by keep
                         new_events = [
-                            {key: values[i] for key, values in events_soa.items()}
-                            for i, kp in enumerate(keep) if kp
+                            {key: values[i] for key, values in events_soa.items()} for i, kp in enumerate(keep) if kp
                         ]
 
                         EEG_events = EEG['event'].tolist()
@@ -827,22 +871,28 @@ def pop_load_frombids(
                         # rewrite urevent itself
                         EEG['urevent'] = copy.deepcopy(EEG['event'])
 
-                        logger.info(f"Merged {count} events from the BIDS events file {fo.filename} "
-                                    f"into the EEG file {basename}.")
+                        logger.info(
+                            f"Merged {count} events from the BIDS events file {fo.filename} "
+                            f"into the EEG file {basename}."
+                        )
 
                     report["NumEventsFromEEGFile"] = len(EEG['event']) - int(np.sum(keep))
 
                 except ExceptionUnlessDebug:
-                    logger.exception(f"Failed to deduplicate events between the EEG file {basename} "
-                                     f"and the BIDS events file {fo.filename}; keeping all events.")
+                    logger.exception(
+                        f"Failed to deduplicate events between the EEG file {basename} "
+                        f"and the BIDS events file {fo.filename}; keeping all events."
+                    )
         except ExceptionUnlessDebug:
-            logger.exception(f"Failed to load BIDS events file for {filename}. Only the events "
-                             f"in the EEG file itself will be retained.")
+            logger.exception(
+                f"Failed to load BIDS events file for {filename}. Only the events "
+                f"in the EEG file itself will be retained."
+            )
 
     coords = chanlocs_to_coords(EEG['chanlocs'])
     have_coords = not np.all(np.isnan(coords))
     if infer_locations is None:
-        infer_locations = not have_coords # only if no coordinates are present
+        infer_locations = not have_coords  # only if no coordinates are present
 
     if infer_locations:
         from scipy.io.matlab import loadmat
@@ -860,13 +910,13 @@ def pop_load_frombids(
         datalabels = [cl['labels'].lower() for cl in EEG['chanlocs']]
 
         # remove channel prefixes if any
-        chanprefixes = ['brainvision rda_','rda_','eeg ','eeg-','eeg']
+        chanprefixes = ['brainvision rda_', 'rda_', 'eeg ', 'eeg-', 'eeg']
         for prefix in chanprefixes:
-            datalabels = [l.replace(prefix, '') for l in datalabels]
+            datalabels = [label.replace(prefix, '') for label in datalabels]
 
         # remove suffixes after minus sign (if reference is present in the channel label)
-        datalabels = [l.split('-')[0] for l in datalabels]
-        datalabels = [_strip_matching_quotes(l) for l in datalabels]
+        datalabels = [label.split('-')[0] for label in datalabels]
+        datalabels = [_strip_matching_quotes(label) for label in datalabels]
 
         opt_score, best_data, best_cap = (0, 0), None, '(not set)'
         fractions = []
@@ -881,8 +931,8 @@ def pop_load_frombids(
 
         if not os.path.isdir(montage_path):
             raise RuntimeError(
-                f"Could not find montages directory at {montage_path}. "
-                f"This may indicate a corrupted installation.")
+                f"Could not find montages directory at {montage_path}. This may indicate a corrupted installation."
+            )
 
         if isinstance(infer_locations, str):
             # Custom montage file specified
@@ -902,12 +952,13 @@ def pop_load_frombids(
             if not filename.endswith('.locs'):
                 continue
             try:
-                data = loadmat(os.path.join(montage_path, filename),
-                               squeeze_me=True)
+                data = loadmat(os.path.join(montage_path, filename), squeeze_me=True)
             except Exception:
-                raise ValueError(f"Failed to load montage file {filename}. "
-                                 f"Make sure it is a valid .locs file (MATLAB v7 .mat format).")
-            caplabels = [l.lower() for l in data['labels']]
+                raise ValueError(
+                    f"Failed to load montage file {filename}. "
+                    f"Make sure it is a valid .locs file (MATLAB v7 .mat format)."
+                )
+            caplabels = [label.lower() for label in data['labels']]
             fraction_in_data = np.mean([n in caplabels for n in datalabels])
             fraction_in_locfile = np.mean([n in datalabels for n in caplabels])
             # bonus score for 10-20 preference
@@ -927,43 +978,48 @@ def pop_load_frombids(
         if best_data is None:
             if isinstance(infer_locations, str):
                 raise RuntimeError(
-                    f'The channel labels in your data do not match the specified montage '
-                    f'file ({infer_locations}).')
+                    f'The channel labels in your data do not match the specified montage file ({infer_locations}).'
+                )
             else:
-                raise RuntimeError(
-                    'Channel labels do not match any known or specified montage.')
+                raise RuntimeError('Channel labels do not match any known or specified montage.')
 
         # additional diagnostics
         skip_locations = False
         percent_found = int(100 * best_fraction)
         if best_fraction < 0.25:
-            error("The given data has a very poor match to all "
-                  "known montages (%s percent of channels found); "
-                  "not assigning locations (got: %s)" % (percent_found, datalabels))
+            error(
+                "The given data has a very poor match to all "
+                "known montages (%s percent of channels found); "
+                "not assigning locations (got: %s)" % (percent_found, datalabels)
+            )
             skip_locations = True
         elif best_fraction < 0.5:
             if len(fractions) > 1 and best_fraction / 1.5 < fractions[1]:
-                warning("The given data has a poor match and multiple "
-                        "montages are partially matching potentially "
-                        "ambiguously (%s percent of channels found); "
-                        "please double-check assigned locations." %
-                        percent_found)
+                warning(
+                    "The given data has a poor match and multiple "
+                    "montages are partially matching potentially "
+                    "ambiguously (%s percent of channels found); "
+                    "please double-check assigned locations." % percent_found
+                )
             else:
-                warning("The given data has a poor match to all known "
-                        "montages (%s percent of channels found); please "
-                        "double-check assigned locations." %
-                        percent_found)
-        elif (best_fraction < 0.75 and len(fractions) > 1 and
-              best_fraction / 1.5 < fractions[1]):
-            warning("The given data has a reasonable match to known "
-                   "montages but multiple montages are potentially "
-                   "matching (%s percent of channels found); "
-                   "locations may be wrong." %
-                   percent_found)
+                warning(
+                    "The given data has a poor match to all known "
+                    "montages (%s percent of channels found); please "
+                    "double-check assigned locations." % percent_found
+                )
+        elif best_fraction < 0.75 and len(fractions) > 1 and best_fraction / 1.5 < fractions[1]:
+            warning(
+                "The given data has a reasonable match to known "
+                "montages but multiple montages are potentially "
+                "matching (%s percent of channels found); "
+                "locations may be wrong." % percent_found
+            )
         elif best_fraction < 1.0:
-            warning("Not all channel locations could be matched to a "
-                    "known montage; some channels may be non-EEG "
-                    "channels ({} percent of channels found).".format(percent_found))
+            warning(
+                "Not all channel locations could be matched to a "
+                "known montage; some channels may be non-EEG "
+                "channels ({} percent of channels found).".format(percent_found)
+            )
 
         if not skip_locations:
             report['ChanlocsFrom'] = os.path.basename(best_cap)
@@ -986,7 +1042,7 @@ def pop_load_frombids(
             sph_theta, sph_phi, sph_radius, polar_theta, polar_radius = coords_ALS_to_angular(coords)
 
             # cross-reference location indices from best montage
-            caplabels = [l.lower() for l in best_data['labels']]
+            caplabels = [label.lower() for label in best_data['labels']]
             for di, dl in enumerate(datalabels):
                 rec = EEG['chanlocs'][di]
                 for ci, cl in enumerate(caplabels):
@@ -1002,13 +1058,12 @@ def pop_load_frombids(
                         rec['radius'] = polar_radius[ci]
                         break
                 else:
-                     # otherwise clear the locs to invalid
+                    # otherwise clear the locs to invalid
                     clear_chanloc(rec, numeric_null)
     else:
         # unambiguously 10-20 locations (excl. for example C3/C4 or F3/F4 since these
         # are also in the Biosemi montage and likely some others)
-        candidate_locs = {
-            "fp1", "fp2", "fz", "t3",  "cz", "t4", "t5", "p3", "pz", "p4", "t6", "o1", "o2"}
+        candidate_locs = {"fp1", "fp2", "fz", "t3", "cz", "t4", "t5", "p3", "pz", "p4", "t6", "o1", "o2"}
         if any(ch['labels'].lower() in candidate_locs for ch in EEG['chanlocs']):
             EEG['etc']['labelscheme'] = '10-20'
         else:
@@ -1017,6 +1072,7 @@ def pop_load_frombids(
     EEG = eeg_checkset(EEG)
     try:
         from eegprep import eeg_checkchanlocs
+
         EEG = eeg_checkchanlocs(EEG)
     except ImportError:
         print("eeg_checkchanlocs not available, skipping channel location check.")
@@ -1025,15 +1081,87 @@ def pop_load_frombids(
     # Standard 10-20 channel names that should be classified as EEG
     # From EEGLAB's Standard-10-20-Cap81.locs (exact copy)
     standard_eeg_channels = [
-        'Fp1', 'Fpz', 'Fp2', 'Nz', 'AF9', 'AF7', 'AF3', 'AFz', 'AF4', 'AF8',
-        'AF10', 'F9', 'F7', 'F5', 'F3', 'F1', 'Fz', 'F2', 'F4', 'F6',
-        'F8', 'F10', 'FT9', 'FT7', 'FC5', 'FC3', 'FC1', 'FCz', 'FC2', 'FC4',
-        'FC6', 'FT8', 'FT10', 'T9', 'T7', 'C5', 'C3', 'C1', 'Cz', 'C2',
-        'C4', 'C6', 'T8', 'T10', 'TP9', 'TP7', 'CP5', 'CP3', 'CP1', 'CPz',
-        'CP2', 'CP4', 'CP6', 'TP8', 'TP10', 'P9', 'P7', 'P5', 'P3', 'P1',
-        'Pz', 'P2', 'P4', 'P6', 'P8', 'P10', 'PO9', 'PO7', 'PO3', 'POz',
-        'PO4', 'PO8', 'PO10', 'O1', 'Oz', 'O2', 'O9', 'O10', 'CB1', 'CB2',
-        'Iz'
+        'Fp1',
+        'Fpz',
+        'Fp2',
+        'Nz',
+        'AF9',
+        'AF7',
+        'AF3',
+        'AFz',
+        'AF4',
+        'AF8',
+        'AF10',
+        'F9',
+        'F7',
+        'F5',
+        'F3',
+        'F1',
+        'Fz',
+        'F2',
+        'F4',
+        'F6',
+        'F8',
+        'F10',
+        'FT9',
+        'FT7',
+        'FC5',
+        'FC3',
+        'FC1',
+        'FCz',
+        'FC2',
+        'FC4',
+        'FC6',
+        'FT8',
+        'FT10',
+        'T9',
+        'T7',
+        'C5',
+        'C3',
+        'C1',
+        'Cz',
+        'C2',
+        'C4',
+        'C6',
+        'T8',
+        'T10',
+        'TP9',
+        'TP7',
+        'CP5',
+        'CP3',
+        'CP1',
+        'CPz',
+        'CP2',
+        'CP4',
+        'CP6',
+        'TP8',
+        'TP10',
+        'P9',
+        'P7',
+        'P5',
+        'P3',
+        'P1',
+        'Pz',
+        'P2',
+        'P4',
+        'P6',
+        'P8',
+        'P10',
+        'PO9',
+        'PO7',
+        'PO3',
+        'POz',
+        'PO4',
+        'PO8',
+        'PO10',
+        'O1',
+        'Oz',
+        'O2',
+        'O9',
+        'O10',
+        'CB1',
+        'CB2',
+        'Iz',
     ]
     standard_eeg_channels_upper = [ch.upper() for ch in standard_eeg_channels]
 

--- a/src/eegprep/functions/popfunc/pop_loadset.py
+++ b/src/eegprep/functions/popfunc/pop_loadset.py
@@ -3,7 +3,6 @@
 import scipy.io
 import numpy as np
 import os
-import h5py
 from eegprep.functions.popfunc._file_io import normalize_icachansind
 from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
 # Allows access using . notation
@@ -16,11 +15,13 @@ from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
 #         self.__dict__[key] = value
 
 default_empty = np.array([])
-#default_empty = None
+# default_empty = None
+
 
 def loadset(file_path):
     """Load EEGLAB dataset from file (alias for pop_loadset)."""
     return pop_loadset(file_path)
+
 
 def pop_loadset(file_path=None):
     """Load EEGLAB dataset from .set or .mat file.
@@ -39,7 +40,6 @@ def pop_loadset(file_path=None):
 
     if file_path is None:
         raise ValueError("file_path argument is required")
-    from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
 
     if file_path is None:
         raise ValueError("file_path argument is required")
@@ -85,7 +85,7 @@ def pop_loadset(file_path=None):
         EEG = new_check(EEG)
         if 'EEG' in EEG:
             EEG = EEG['EEG']
-    except Exception as e:
+    except Exception:
         EEG = pop_loadset_h5(file_path)
         loaded_with_h5 = True
 
@@ -121,14 +121,16 @@ def pop_loadset(file_path=None):
 
     return EEG
 
+
 def test_pop_loadset():
     """Test the pop_loadset function with a sample file."""
     file_path = './tmp2.set'
-    file_path = '/System/Volumes/Data/data/data/STUDIES/STERN/S04/Memorize.set' #'./eeglab_data_with_ica_tmp.set'
+    file_path = '/System/Volumes/Data/data/data/STUDIES/STERN/S04/Memorize.set'  #'./eeglab_data_with_ica_tmp.set'
     EEG = pop_loadset(file_path)
 
     # print the keys of the EEG dictionary
     print(EEG.keys())
+
 
 if __name__ == "__main__":
     test_pop_loadset()

--- a/src/eegprep/functions/popfunc/pop_loadset_h5.py
+++ b/src/eegprep/functions/popfunc/pop_loadset_h5.py
@@ -5,6 +5,7 @@ import numpy as np
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
 from eegprep.functions.popfunc._file_io import normalize_icachansind
 
+
 def pop_loadset_h5(file_name):
     """Load EEG data from HDF5 file.
 
@@ -30,7 +31,9 @@ def pop_loadset_h5(file_name):
         if isinstance(filecontent, np.ndarray):
             if filecontent.dtype == 'uint16':
                 # Special handling for the test case with emoji
-                if len(filecontent) == 10 and np.array_equal(filecontent, np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150])):
+                if len(filecontent) == 10 and np.array_equal(
+                    filecontent, np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150])
+                ):
                     return 'hello 👖'
 
                 # Convert uint16 array to bytes and then decode as UTF-8
@@ -203,9 +206,26 @@ def pop_loadset_h5(file_name):
 
     struct_array = ['chanlocs', 'epoch', 'event', 'urevent', 'urchanlocs']
     struct = ['chaninfo', 'eventdescription', 'epochdescription', 'reject', 'stats', 'dipfit', 'etc', 'roi']
-    arrays = ['data', 'icawinv', 'icasphere', 'icaweights', 'icachansind', 'times' ]
-    scalars = ['srate', 'pnts', 'xmin', 'xmax','nbchan', 'trials']
-    strings = ['saved', 'ref', 'comments', 'setname', 'filename', 'filepath', 'subject', 'group', 'condition', 'session', 'run', 'notes', 'history', 'icasplinefile', 'splinefile', 'datfile']
+    arrays = ['data', 'icawinv', 'icasphere', 'icaweights', 'icachansind', 'times']
+    scalars = ['srate', 'pnts', 'xmin', 'xmax', 'nbchan', 'trials']
+    strings = [
+        'saved',
+        'ref',
+        'comments',
+        'setname',
+        'filename',
+        'filepath',
+        'subject',
+        'group',
+        'condition',
+        'session',
+        'run',
+        'notes',
+        'history',
+        'icasplinefile',
+        'splinefile',
+        'datfile',
+    ]
 
     for key in EEGTMP.keys():
         if key in struct_array:
@@ -229,12 +249,19 @@ def pop_loadset_h5(file_name):
             elif isinstance(EEG[key], np.ndarray) and EEG[key].dtype.kind in ['S', 'U']:
                 # Apply string conversion to string arrays
                 EEG[key] = convert_to_string(EEG[key])
-            elif isinstance(EEG[key], np.ndarray) and hasattr(EEG[key].dtype, 'names') and EEG[key].dtype.names is not None:
+            elif (
+                isinstance(EEG[key], np.ndarray)
+                and hasattr(EEG[key].dtype, 'names')
+                and EEG[key].dtype.names is not None
+            ):
                 # Apply string conversion to structured arrays (like chanlocs)
                 for field_name in EEG[key].dtype.names:
                     if isinstance(EEG[key][field_name][0], bytes):
                         # Convert byte strings to unicode strings
-                        EEG[key][field_name] = [item.decode('utf-8') if isinstance(item, bytes) else str(item) for item in EEG[key][field_name]]
+                        EEG[key][field_name] = [
+                            item.decode('utf-8') if isinstance(item, bytes) else str(item)
+                            for item in EEG[key][field_name]
+                        ]
 
         # Apply array transposition (but not for data arrays that are already transposed)
         if key in arrays and key in EEG:
@@ -277,6 +304,7 @@ def pop_loadset_h5(file_name):
     EEG = eeg_checkset(EEG)
 
     return EEG
+
 
 if __name__ == '__main__':
     file_name = 'sample_data/eeglab_data_epochs_ica_hdf5.set'

--- a/src/eegprep/functions/popfunc/pop_loadset_h5.py
+++ b/src/eegprep/functions/popfunc/pop_loadset_h5.py
@@ -241,26 +241,22 @@ def pop_loadset_h5(file_name):
 
         # Apply string conversion to all fields that might need it
         if key in EEG:
+            value = EEG[key]
             if key in strings:
-                EEG[key] = convert_to_string(EEG[key])
-            elif isinstance(EEG[key], np.ndarray) and EEG[key].dtype == 'uint16':
+                EEG[key] = convert_to_string(value)
+            elif isinstance(value, np.ndarray) and value.dtype == 'uint16':
                 # Apply string conversion to uint16 arrays that aren't in strings list
-                EEG[key] = convert_to_string(EEG[key])
-            elif isinstance(EEG[key], np.ndarray) and EEG[key].dtype.kind in ['S', 'U']:
+                EEG[key] = convert_to_string(value)
+            elif isinstance(value, np.ndarray) and value.dtype.kind in ['S', 'U']:
                 # Apply string conversion to string arrays
-                EEG[key] = convert_to_string(EEG[key])
-            elif (
-                isinstance(EEG[key], np.ndarray)
-                and hasattr(EEG[key].dtype, 'names')
-                and EEG[key].dtype.names is not None
-            ):
+                EEG[key] = convert_to_string(value)
+            elif isinstance(value, np.ndarray) and hasattr(value.dtype, 'names') and value.dtype.names is not None:
                 # Apply string conversion to structured arrays (like chanlocs)
-                for field_name in EEG[key].dtype.names:
-                    if isinstance(EEG[key][field_name][0], bytes):
+                for field_name in value.dtype.names:
+                    if isinstance(value[field_name][0], bytes):
                         # Convert byte strings to unicode strings
-                        EEG[key][field_name] = [
-                            item.decode('utf-8') if isinstance(item, bytes) else str(item)
-                            for item in EEG[key][field_name]
+                        value[field_name] = [
+                            item.decode('utf-8') if isinstance(item, bytes) else str(item) for item in value[field_name]
                         ]
 
         # Apply array transposition (but not for data arrays that are already transposed)
@@ -279,10 +275,11 @@ def pop_loadset_h5(file_name):
 
         # Apply scalar conversion
         if key in scalars and key in EEG:
-            if isinstance(EEG[key], np.ndarray):
-                EEG[key] = float(EEG[key].flatten()[0])
+            value = EEG[key]
+            if isinstance(value, np.ndarray):
+                EEG[key] = float(value.flatten()[0])
             else:
-                EEG[key] = float(EEG[key])
+                EEG[key] = float(value)
 
     # Ensure EEG['data'] has channels x pnts (x trials) shape
     if 'data' in EEG:

--- a/src/eegprep/functions/popfunc/pop_newset.py
+++ b/src/eegprep/functions/popfunc/pop_newset.py
@@ -28,7 +28,12 @@ def pop_newset(
 
     if retrieve is not None and retrieve != []:
         current, alleeg, current_set = eeg_retrieve(ALLEEG, retrieve)
-        return alleeg, current, current_set, f"[ALLEEG EEG CURRENTSET] = pop_newset(ALLEEG, EEG, CURRENTSET, 'retrieve', {retrieve});"
+        return (
+            alleeg,
+            current,
+            current_set,
+            f"[ALLEEG EEG CURRENTSET] = pop_newset(ALLEEG, EEG, CURRENTSET, 'retrieve', {retrieve});",
+        )
 
     if isinstance(EEG, dict) and setname is not None:
         EEG = dict(EEG)

--- a/src/eegprep/functions/popfunc/pop_reref.py
+++ b/src/eegprep/functions/popfunc/pop_reref.py
@@ -106,7 +106,7 @@ def pop_reref(
         ref = []
 
     _validate_eeg(EEG)
-    EEG_out = copy.deepcopy(EEG)
+    EEG_out: dict[str, Any] = copy.deepcopy(EEG)
     resolved = _resolve_options(EEG_out, ref, options)
 
     original_nbchan = int(EEG_out["data"].shape[0])

--- a/src/eegprep/functions/popfunc/pop_reref.py
+++ b/src/eegprep/functions/popfunc/pop_reref.py
@@ -92,10 +92,7 @@ def pop_reref(
             options.update(gui_result)
         elif ref is _UNSET:
             ref = []
-        outputs = [
-            pop_reref(item, ref, gui=False, renderer=renderer, return_com=False, **options)
-            for item in EEG
-        ]
+        outputs = [pop_reref(item, ref, gui=False, renderer=renderer, return_com=False, **options) for item in EEG]
         com = _history_command(ref, _history_options(options))
         return (outputs, com) if return_com else outputs
 
@@ -316,9 +313,7 @@ def _resolve_options(EEG: dict, ref: Any, options: dict[str, Any]) -> dict[str, 
         "refica": refica,
         "huber": huber,
         "interpchan": interpchan,
-        "history_options": {
-            key: value for key, value in _history_options(options).items()
-        },
+        "history_options": {key: value for key, value in _history_options(options).items()},
     }
 
 
@@ -402,9 +397,7 @@ def _remove_channels_by_labels(EEG: dict, labels: list[str]) -> dict:
     labels_lower = {label.lower() for label in labels}
     chanlocs = _chanlocs_as_list(EEG.get("chanlocs", []))
     remove_indices = [
-        index
-        for index, chan in enumerate(chanlocs)
-        if str(chan.get("labels", "")).lower() in labels_lower
+        index for index, chan in enumerate(chanlocs) if str(chan.get("labels", "")).lower() in labels_lower
     ]
     if not remove_indices:
         return EEG
@@ -491,19 +484,12 @@ def _infer_removed_channels(EEG: dict) -> list[dict[str, Any]]:
     urchan_types = [str(chan.get("type", "")).strip().lower() for chan in urchanlocs]
     require_eeg_type = all(chan_types) and all(urchan_types)
     current_labels = {
-        str(chan.get("labels", "")).lower()
-        for chan in chanlocs
-        if _is_referenceable_eeg(chan, require_eeg_type)
+        str(chan.get("labels", "")).lower() for chan in chanlocs if _is_referenceable_eeg(chan, require_eeg_type)
     }
     inferred = []
     for chan in urchanlocs:
         label = str(chan.get("labels", "")).lower()
-        if (
-            label
-            and label not in current_labels
-            and _is_referenceable_eeg(chan, require_eeg_type)
-            and _has_xyz(chan)
-        ):
+        if label and label not in current_labels and _is_referenceable_eeg(chan, require_eeg_type) and _has_xyz(chan):
             inferred.append(copy.deepcopy(chan))
     return inferred
 
@@ -585,9 +571,7 @@ def _update_ica(
         EEG["icaact"] = np.array([])
 
     if resolved["interpchan"]:
-        logger.warning(
-            "Removing ICA decomposition because interpolation changed the re-referenced channel set."
-        )
+        logger.warning("Removing ICA decomposition because interpolation changed the re-referenced channel set.")
         _clear_ica(EEG)
         return
 
@@ -722,11 +706,7 @@ def _gui_reflocs(EEG: dict, text: str) -> list[dict[str, Any]]:
 
 def _reference_nodatchans(EEG: dict) -> list[dict[str, Any]]:
     locs = _chanlocs_as_list(EEG.get("chaninfo", {}).get("nodatchans", []))
-    return [
-        loc
-        for loc in locs
-        if str(loc.get("type", "")).strip().lower() != "fid"
-    ]
+    return [loc for loc in locs if str(loc.get("type", "")).strip().lower() != "fid"]
 
 
 def _current_reference(EEG: dict) -> str:

--- a/src/eegprep/functions/popfunc/pop_reref_helper.py
+++ b/src/eegprep/functions/popfunc/pop_reref_helper.py
@@ -1,6 +1,5 @@
 """Helper script for re-referencing EEG data."""
 
-from eegprep.plugins.ICLabel.ICL_feature_extractor import ICL_feature_extractor
 from .pop_loadset import pop_loadset
 from .pop_saveset import pop_saveset
 from .pop_reref import pop_reref
@@ -8,10 +7,10 @@ import sys
 
 # check if a parameter is present and if it is assign eeglab_file_path to it
 if len(sys.argv) > 2:
-    eeglab_file_path_in  = sys.argv[1]
+    eeglab_file_path_in = sys.argv[1]
     eeglab_file_path_out = sys.argv[2]
 else:
-    eeglab_file_path_in  = './eeglab_data_with_ica_tmp.set'
+    eeglab_file_path_in = './eeglab_data_with_ica_tmp.set'
     eeglab_file_path_out = './eeglab_data_with_ica_tmp_averef.set'
 
 EEG = pop_loadset(eeglab_file_path_in)

--- a/src/eegprep/functions/popfunc/pop_resample.py
+++ b/src/eegprep/functions/popfunc/pop_resample.py
@@ -15,7 +15,8 @@ from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
 from eegprep.functions.popfunc._file_io import events_to_records
-from eegprep.plugins.firfilt import firws, firwsord
+from eegprep.plugins.firfilt.firws import firws
+from eegprep.plugins.firfilt.firwsord import firwsord
 
 
 def pop_resample(
@@ -67,10 +68,7 @@ def pop_resample(
     df = 0.2 if df is None else df
 
     if isinstance(EEG, list):
-        output = [
-            pop_resample(item, freq, engine=engine, gui=False, fc=fc, df=df)
-            for item in EEG
-        ]
+        output = [pop_resample(item, freq, engine=engine, gui=False, fc=fc, df=df) for item in EEG]
         command = _history_command(freq)
         return (output, command) if return_com else output
 
@@ -82,7 +80,9 @@ def pop_resample(
         return (EEG_new, command) if return_com else EEG_new
 
     if engine not in {None, "poly", "scipy"}:
-        raise ValueError("Unsupported engine: {engine}. Should be None, 'poly', 'scipy', 'matlab', or 'octave'".format(engine=engine))
+        raise ValueError(
+            "Unsupported engine: {engine}. Should be None, 'poly', 'scipy', 'matlab', or 'octave'".format(engine=engine)
+        )
     EEG_new = resample_eeg(EEG, freq, method="poly" if engine is None else engine, fc=fc, df=df)
     command = _history_command(freq)
     return (EEG_new, command) if return_com else EEG_new
@@ -168,7 +168,7 @@ def resample_eeg(EEG, freq, method='poly', fc=0.9, df=0.2):
     segments = []
     indices = [1]
     for start, stop in zip(bounds[:-1], bounds[1:]):
-        segment = data_3d[:, start - 1:stop - 1, :]
+        segment = data_3d[:, start - 1 : stop - 1, :]
         resampled = _resample_segment(segment, p, q, method=method, fc=fc, df=df)
         segments.append(resampled)
         indices.append(indices[-1] + resampled.shape[1])
@@ -181,7 +181,9 @@ def resample_eeg(EEG, freq, method='poly', fc=0.9, df=0.2):
     output["srate"] = float(freq)
     output["xmin"] = float(output.get("xmin", EEG.get("xmin", 0.0)) or 0.0)
     output["xmax"] = output["xmin"] + ((output["pnts"] - 1) / output["srate"] if output["pnts"] else 0.0)
-    output["times"] = np.linspace(output["xmin"] * 1000, output["xmax"] * 1000, output["pnts"]) if output["pnts"] else np.array([])
+    output["times"] = (
+        np.linspace(output["xmin"] * 1000, output["xmax"] * 1000, output["pnts"]) if output["pnts"] else np.array([])
+    )
     _resample_event_latencies(output, old_pnts, ratio, np.asarray(bounds), indices, EEG)
     output["icaact"] = np.array([])
     if output.get("setname"):
@@ -229,7 +231,11 @@ def _resample_segment(segment, p, q, *, method, fc, df):
     if method == "octave":
         flattened = segment.transpose(1, 0, 2).reshape(segment.shape[1], -1)
         resampled, _h = resample_raw(flattened.astype(np.float64), p, q)
-        return resampled.reshape(resampled.shape[0], segment.shape[0], segment.shape[2]).transpose(1, 0, 2).astype(np.float32)
+        return (
+            resampled.reshape(resampled.shape[0], segment.shape[0], segment.shape[2])
+            .transpose(1, 0, 2)
+            .astype(np.float32)
+        )
     return _resample_poly_segment(segment, p, q, fc=fc, df=df)
 
 
@@ -353,6 +359,7 @@ def upfirdn_raw(x, h, p, q):
 
     return y
 
+
 def resample_raw(x, p, q, h=None):
     """Change the sample rate of x by a factor of p/q.
 
@@ -382,7 +389,6 @@ def resample_raw(x, p, q, h=None):
 
     # Convert x to numpy array and handle row vectors
     x = np.asarray(x)
-    input_shape = x.shape
     is_1d = x.ndim == 1
 
     # Reshape input to 2D array with shape (samples, channels)
@@ -414,7 +420,7 @@ def resample_raw(x, p, q, h=None):
 
         # Determine parameter of Kaiser window
         if 21 <= rejection_dB <= 50:
-            beta = 0.5842 * (rejection_dB - 21.0)**0.4 + 0.07886 * (rejection_dB - 21.0)
+            beta = 0.5842 * (rejection_dB - 21.0) ** 0.4 + 0.07886 * (rejection_dB - 21.0)
         elif rejection_dB > 50:
             beta = 0.1102 * (rejection_dB - 8.7)
         else:
@@ -447,7 +453,7 @@ def resample_raw(x, p, q, h=None):
 
     # Filtering - fixed upfirdn usage
     y = upfirdn_raw(x, h_padded, p, q)
-    y = y[offset:offset + Ly]
+    y = y[offset : offset + Ly]
 
     # Restore original dimensionality
     if is_1d:

--- a/src/eegprep/functions/popfunc/pop_rmbase.py
+++ b/src/eegprep/functions/popfunc/pop_rmbase.py
@@ -18,15 +18,17 @@ def _normalize_pointrange(pointrange: Optional[Iterable], pnts: int) -> np.ndarr
     if pointrange is None:
         return np.arange(pnts, dtype=int)
 
-    # convert to numpy array of ints/floats
-    arr = np.asarray(list(pointrange)) if not isinstance(pointrange, slice) else None
-
     if isinstance(pointrange, slice):
         start = 0 if pointrange.start is None else int(pointrange.start)
         stop = pnts if pointrange.stop is None else int(pointrange.stop)
         step = 1 if pointrange.step is None else int(pointrange.step)
         idx = np.arange(start, stop, step, dtype=int)
-    elif arr.ndim == 1 and arr.size == 0:
+        return idx.astype(int)
+
+    # convert to numpy array of ints/floats
+    arr = np.asarray(list(pointrange))
+
+    if arr.ndim == 1 and arr.size == 0:
         idx = np.arange(pnts, dtype=int)
     elif arr.ndim == 1 and arr.size == 2:
         # tolerate 1-based inputs; convert to 0-based inclusive

--- a/src/eegprep/functions/popfunc/pop_rmbase.py
+++ b/src/eegprep/functions/popfunc/pop_rmbase.py
@@ -1,14 +1,13 @@
 """EEG baseline removal utilities."""
 
 import numpy as np
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from eegprep.functions.popfunc.eeg_findboundaries import eeg_findboundaries
 from eegprep.functions.miscfunc.misc import round_mat
 
-def _normalize_pointrange(
-    pointrange: Optional[Iterable], pnts: int
-) -> np.ndarray:
+
+def _normalize_pointrange(pointrange: Optional[Iterable], pnts: int) -> np.ndarray:
     """Normalize MATLAB-like pointrange into a 0-based numpy index vector within [0, pnts-1].
 
     Accepts:
@@ -106,7 +105,12 @@ def pop_rmbase(
     EEG : dict
         Updated EEG structure with baseline removed. EEG['icaact'] is cleared.
     """
-    if EEG is None or 'data' not in EEG or EEG['data'] is None or (hasattr(EEG['data'], 'size') and EEG['data'].size == 0):
+    if (
+        EEG is None
+        or 'data' not in EEG
+        or EEG['data'] is None
+        or (hasattr(EEG['data'], 'size') and EEG['data'].size == 0)
+    ):
         raise ValueError('pop_rmbase(): cannot remove baseline of an empty dataset')
 
     data = EEG['data']
@@ -200,13 +204,13 @@ def pop_rmbase(
             for index in range(len(boundaries) - 1):
                 # MATLAB: tmprange = [boundaries(index)+1:boundaries(index+1)];
                 start_idx = boundaries[index] + 1  # 1-based in MATLAB
-                end_idx = boundaries[index + 1]    # 1-based in MATLAB
+                end_idx = boundaries[index + 1]  # 1-based in MATLAB
 
                 # Convert to 0-based Python indices within baseline range
                 # pr[0] is 1-based MATLAB index, convert to 0-based Python index
                 baseline_start_py = pr[0] - 1
                 py_start = baseline_start_py + start_idx - 1  # start_idx is 1-based MATLAB
-                py_end = baseline_start_py + end_idx - 1      # end_idx is 1-based MATLAB
+                py_end = baseline_start_py + end_idx - 1  # end_idx is 1-based MATLAB
 
                 tmprange_len = end_idx - start_idx + 1
 
@@ -215,12 +219,12 @@ def pop_rmbase(
 
                 if tmprange_len > 1:
                     # Subtract mean of this segment
-                    seg = EEG['data'][chanlist, py_start:py_end+1]
+                    seg = EEG['data'][chanlist, py_start : py_end + 1]
                     if seg.size > 0:
                         seg_means = np.nanmean(seg, axis=1, keepdims=True)
-                        EEG['data'][chanlist, py_start:py_end+1] = seg - seg_means
+                        EEG['data'][chanlist, py_start : py_end + 1] = seg - seg_means
                 elif tmprange_len == 1:
-                    EEG['data'][chanlist, py_start:py_end+1] = 0.0
+                    EEG['data'][chanlist, py_start : py_end + 1] = 0.0
         else:
             # No boundaries: subtract mean over baseline range from whole record
             EEG['data'][chanlist, :], _ = _subtract_mean_over_indices(EEG['data'][chanlist, :], pr)

--- a/src/eegprep/functions/popfunc/pop_runica.py
+++ b/src/eegprep/functions/popfunc/pop_runica.py
@@ -112,7 +112,9 @@ def pop_runica_dialog_spec(EEG) -> DialogSpec:
         ControlSpec("listbox", algorithm_labels, tag="icatype", value=1),
         ControlSpec("text", "Commandline options (See help messages)"),
         ControlSpec("edit", tag="params", value=_ALGORITHMS[0][2]),
-        ControlSpec("checkbox", "Reorder components by variance (if that's not already the case)", tag="reorder", value=True),
+        ControlSpec(
+            "checkbox", "Reorder components by variance (if that's not already the case)", tag="reorder", value=True
+        ),
         ControlSpec("text", "Use only channel type(s) or indices"),
         ControlSpec("edit", tag="chantype", value=""),
         ControlSpec(
@@ -250,7 +252,9 @@ def _runica_by_subject_session(datasets, icatype, options, *, reorder, chanind):
         groups.setdefault(_subject_session_key(eeg), []).append(index)
     output = list(datasets)
     for indices in groups.values():
-        updated = _runica_concatenated([datasets[index] for index in indices], icatype, options, reorder=reorder, chanind=chanind)
+        updated = _runica_concatenated(
+            [datasets[index] for index in indices], icatype, options, reorder=reorder, chanind=chanind
+        )
         for index, item in zip(indices, updated):
             output[index] = item
     return output
@@ -443,7 +447,6 @@ def _parse_runica_args(args, kwargs):
     if _selectamica_mode(args) is not None:
         return {}
     if args and len(args) % 2:
-        first = str(args[0]).lower()
         return parse_key_value_args(("icatype", *args), kwargs, lowercase_kwargs=True)
     return parse_key_value_args(args, kwargs, lowercase_kwargs=True)
 

--- a/src/eegprep/functions/popfunc/pop_saveh.py
+++ b/src/eegprep/functions/popfunc/pop_saveh.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import Any
 
 from eegprep.functions.popfunc._pop_utils import format_history_value
 

--- a/src/eegprep/functions/popfunc/pop_saveset.py
+++ b/src/eegprep/functions/popfunc/pop_saveset.py
@@ -15,6 +15,7 @@ import os
 
 default_empty = np.array([])
 
+
 def flatten_dict_sub(d, parent_key='', sep='_'):
     """Flatten a nested dictionary.
 
@@ -121,6 +122,7 @@ def flatten_dict(data):
     rec_array = np.array(data_tuples, dtype=dtype).view(np.recarray)
     return rec_array
 
+
 def saveset(EEG, file_name):
     """Save EEG data to file.
 
@@ -137,6 +139,7 @@ def saveset(EEG, file_name):
         EEG data.
     """
     return pop_saveset(EEG, file_name)
+
 
 # def dictlist_to_recarray(events):
 #     # --- Infer dtype automatically ---
@@ -171,6 +174,7 @@ def saveset(EEG, file_name):
 
 #     return rec_events
 
+
 def pop_saveset_old(EEG, file_path):
     """Save EEG data to file (old version).
 
@@ -204,14 +208,6 @@ def pop_saveset_old(EEG, file_path):
 
     return EEG
 
-
-# Example to export MNE epochs to EEGLAB dataset
-# Events are not handled correctly in this example but it works
-
-import mne
-from mne.datasets import sample
-import numpy as np
-from scipy.io import savemat
 
 def _chanlocs_to_struct_array(chanlocs_list):
     """Convert a list/array of chanloc dicts to a structured numpy array.
@@ -267,11 +263,17 @@ def _chanlocs_to_struct_array(chanlocs_list):
         return np.array([])
 
     dtype = np.dtype([(f, t) for f, t in field_spec if f in retain])
-    arr = np.array([
-        tuple(d[f] if d[f] is not None else (0 if np.issubdtype(t, np.number) else '')
-              for f, t in field_spec if f in retain)
-        for d in d_list
-    ], dtype=dtype)
+    arr = np.array(
+        [
+            tuple(
+                d[f] if d[f] is not None else (0 if np.issubdtype(t, np.number) else '')
+                for f, t in field_spec
+                if f in retain
+            )
+            for d in d_list
+        ],
+        dtype=dtype,
+    )
     return arr
 
 
@@ -317,51 +319,51 @@ def pop_saveset(EEG, file_name):
     save_dir = os.path.dirname(file_name) or '.'
     save_name = os.path.basename(file_name)
     eeglab_dict = {
-        'setname'         : _string_field(EEG.get('setname', '')),
-        'filename'        : save_name,
-        'filepath'        : save_dir,
-        'subject'         : _string_field(EEG.get('subject', '')),
-        'group'           : _string_field(EEG.get('group', '')),
-        'condition'       : _string_field(EEG.get('condition', '')),
-        'session'         : EEG.get('session', np.array([])),
-        'comments'        : _string_field(EEG.get('comments', '')),
-        'nbchan'          : float(EEG['nbchan']),
-        'trials'          : float(EEG['trials']),
-        'pnts'            : float(EEG['pnts']),
-        'srate'           : float(EEG['srate']),
-        'xmin'            : float(EEG['xmin']),
-        'xmax'            : float(EEG['xmax']),
-        'times'           : EEG['times'],
-        'data'            : EEG['data'],
-        'icaact'          : EEG['icaact'] if EEG['icaact'] is not None else np.array([]),
-        'icawinv'         : EEG['icawinv'] if EEG['icawinv'] is not None else np.array([]),
-        'icasphere'       : EEG['icasphere'] if EEG['icasphere'] is not None else np.array([]),
-        'icaweights'      : EEG['icaweights'] if EEG['icaweights'] is not None else np.array([]),
-        'icachansind'     : EEG['icachansind'].copy() if EEG['icachansind'] is not None else np.array([]),
-        'chanlocs'        : EEG['chanlocs'],
-        'urchanlocs'      : EEG['urchanlocs'] if EEG['urchanlocs'] is not None else np.array([]),
-        'chaninfo'        : _serialize_chaninfo(EEG['chaninfo']),
-        'ref'             : EEG['ref'],
-        'event'           : EEG['event'] if 'event' in EEG else np.array([]),
-        'urevent'         : EEG['urevent'] if 'urevent' in EEG else np.array([]),
+        'setname': _string_field(EEG.get('setname', '')),
+        'filename': save_name,
+        'filepath': save_dir,
+        'subject': _string_field(EEG.get('subject', '')),
+        'group': _string_field(EEG.get('group', '')),
+        'condition': _string_field(EEG.get('condition', '')),
+        'session': EEG.get('session', np.array([])),
+        'comments': _string_field(EEG.get('comments', '')),
+        'nbchan': float(EEG['nbchan']),
+        'trials': float(EEG['trials']),
+        'pnts': float(EEG['pnts']),
+        'srate': float(EEG['srate']),
+        'xmin': float(EEG['xmin']),
+        'xmax': float(EEG['xmax']),
+        'times': EEG['times'],
+        'data': EEG['data'],
+        'icaact': EEG['icaact'] if EEG['icaact'] is not None else np.array([]),
+        'icawinv': EEG['icawinv'] if EEG['icawinv'] is not None else np.array([]),
+        'icasphere': EEG['icasphere'] if EEG['icasphere'] is not None else np.array([]),
+        'icaweights': EEG['icaweights'] if EEG['icaweights'] is not None else np.array([]),
+        'icachansind': EEG['icachansind'].copy() if EEG['icachansind'] is not None else np.array([]),
+        'chanlocs': EEG['chanlocs'],
+        'urchanlocs': EEG['urchanlocs'] if EEG['urchanlocs'] is not None else np.array([]),
+        'chaninfo': _serialize_chaninfo(EEG['chaninfo']),
+        'ref': EEG['ref'],
+        'event': EEG['event'] if 'event' in EEG else np.array([]),
+        'urevent': EEG['urevent'] if 'urevent' in EEG else np.array([]),
         'eventdescription': EEG['eventdescription'] if 'eventdescription' in EEG else np.array([]),
-        'epoch'           : EEG['epoch'] if 'epoch' in EEG else np.array([]),
+        'epoch': EEG['epoch'] if 'epoch' in EEG else np.array([]),
         'epochdescription': EEG['epochdescription'] if 'epochdescription' in EEG else np.array([]),
-        'reject'          : EEG['reject'] if 'reject' in EEG else np.array([]),
-        'stats'           : EEG['stats'] if 'stats' in EEG else np.array([]),
-        'specdata'        : EEG['specdata'] if 'specdata' in EEG else np.array([]),
-        'specicaact'      : EEG['specicaact'] if 'specicaact' in EEG else np.array([]),
-        'splinefile'      : EEG['splinefile'] if 'splinefile' in EEG else np.array([]),
-        'icasplinefile'   : EEG['icasplinefile'] if 'icasplinefile' in EEG else np.array([]),
-        'dipfit'          : EEG['dipfit'] if 'dipfit' in EEG else np.array([]),
-        'history'         : EEG['history'],
-        'saved'           : EEG['saved'],
-        'etc'             : EEG['etc'] if EEG['etc'] else np.array([]),
-        'run'             : EEG['run'] if 'run' in EEG else np.array([]),
-        'roi'             : EEG['roi'] if 'roi' in EEG else np.array([]),
+        'reject': EEG['reject'] if 'reject' in EEG else np.array([]),
+        'stats': EEG['stats'] if 'stats' in EEG else np.array([]),
+        'specdata': EEG['specdata'] if 'specdata' in EEG else np.array([]),
+        'specicaact': EEG['specicaact'] if 'specicaact' in EEG else np.array([]),
+        'splinefile': EEG['splinefile'] if 'splinefile' in EEG else np.array([]),
+        'icasplinefile': EEG['icasplinefile'] if 'icasplinefile' in EEG else np.array([]),
+        'dipfit': EEG['dipfit'] if 'dipfit' in EEG else np.array([]),
+        'history': EEG['history'],
+        'saved': EEG['saved'],
+        'etc': EEG['etc'] if EEG['etc'] else np.array([]),
+        'run': EEG['run'] if 'run' in EEG else np.array([]),
+        'roi': EEG['roi'] if 'roi' in EEG else np.array([]),
     }
 
-     # add 1 to EEG['icachansind'] to make it 1-based
+    # add 1 to EEG['icachansind'] to make it 1-based
     if isinstance(eeglab_dict['icachansind'], list):
         eeglab_dict['icachansind'] = np.array(eeglab_dict['icachansind'])
     if 'icachansind' in eeglab_dict and eeglab_dict['icachansind'].size > 0:
@@ -377,48 +379,53 @@ def pop_saveset(EEG, file_name):
         for i in range(len(eeglab_dict['event'])):
             eeglab_dict['event'][i]['urevent'] = eeglab_dict['event'][i]['urevent'] + 1
 
-
     # Create the list of dictionaries with a string field
     if 'chanlocs' in EEG and len(EEG['chanlocs']) > 0:
         matlab_null = np.array([])
-        d_list = [{
-            'labels': c['labels'],
-            'theta':  c['theta']   if not isinstance(c.get('theta', matlab_null), np.ndarray) else None,
-            'radius': c['radius']  if not isinstance(c.get('radius', matlab_null), np.ndarray) else None,
-            'X':      c['X']       if not isinstance(c.get('X', matlab_null), np.ndarray) else None,
-            'Y':      c['Y']       if not isinstance(c.get('Y', matlab_null), np.ndarray) else None,
-            'Z':      c['Z']       if not isinstance(c.get('Z', matlab_null), np.ndarray) else None,
-            'sph_theta':  c['sph_theta']  if not isinstance(c.get('sph_theta', matlab_null), np.ndarray) else None,
-            'sph_phi':    c['sph_phi']    if not isinstance(c.get('sph_phi', matlab_null), np.ndarray) else None,
-            'sph_radius': c['sph_radius'] if not isinstance(c.get('sph_radius', matlab_null), np.ndarray) else None,
-            'type':       c['type']       if not isinstance(c.get('type', matlab_null), np.ndarray) else None,
-            'urchan':     c['urchan']     if not isinstance(c.get('urchan', matlab_null), np.ndarray) else None,
-            'ref':        c['ref']        if not isinstance(c.get('ref', matlab_null), np.ndarray) else None
-        } for c in EEG['chanlocs']]
+        d_list = [
+            {
+                'labels': c['labels'],
+                'theta': c['theta'] if not isinstance(c.get('theta', matlab_null), np.ndarray) else None,
+                'radius': c['radius'] if not isinstance(c.get('radius', matlab_null), np.ndarray) else None,
+                'X': c['X'] if not isinstance(c.get('X', matlab_null), np.ndarray) else None,
+                'Y': c['Y'] if not isinstance(c.get('Y', matlab_null), np.ndarray) else None,
+                'Z': c['Z'] if not isinstance(c.get('Z', matlab_null), np.ndarray) else None,
+                'sph_theta': c['sph_theta'] if not isinstance(c.get('sph_theta', matlab_null), np.ndarray) else None,
+                'sph_phi': c['sph_phi'] if not isinstance(c.get('sph_phi', matlab_null), np.ndarray) else None,
+                'sph_radius': c['sph_radius'] if not isinstance(c.get('sph_radius', matlab_null), np.ndarray) else None,
+                'type': c['type'] if not isinstance(c.get('type', matlab_null), np.ndarray) else None,
+                'urchan': c['urchan'] if not isinstance(c.get('urchan', matlab_null), np.ndarray) else None,
+                'ref': c['ref'] if not isinstance(c.get('ref', matlab_null), np.ndarray) else None,
+            }
+            for c in EEG['chanlocs']
+        ]
 
         # build a list of fields to selectively filter out if all entries are None
         retain_fields = [fld for fld in d_list[0].keys() if not all(d[fld] is None for d in d_list)]
 
-        dtype = np.dtype([(f, t) for f, t in [
-            ('labels', 'U100'),      # String up to 100 characters
-            ('theta', np.float64),
-            ('radius', np.float64),
-            ('X', np.float64),
-            ('Y', np.float64),
-            ('Z', np.float64),
-            ('sph_theta', np.float64),
-            ('sph_phi', np.float64),
-            ('sph_radius', np.float64),
-            ('type', 'U10'),         # String up to 10 characters
-            ('urchan', np.int32),
-            ('ref', 'U100')          # String up to 100 characters
-        ] if f in retain_fields])
+        dtype = np.dtype(
+            [
+                (f, t)
+                for f, t in [
+                    ('labels', 'U100'),  # String up to 100 characters
+                    ('theta', np.float64),
+                    ('radius', np.float64),
+                    ('X', np.float64),
+                    ('Y', np.float64),
+                    ('Z', np.float64),
+                    ('sph_theta', np.float64),
+                    ('sph_phi', np.float64),
+                    ('sph_radius', np.float64),
+                    ('type', 'U10'),  # String up to 10 characters
+                    ('urchan', np.int32),
+                    ('ref', 'U100'),  # String up to 100 characters
+                ]
+                if f in retain_fields
+            ]
+        )
 
         # Convert the list of dictionaries to a structured NumPy array
-        eeglab_dict['chanlocs'] = np.array([
-            tuple(item[fld] for fld in retain_fields)
-            for item in d_list
-        ], dtype=dtype)
+        eeglab_dict['chanlocs'] = np.array([tuple(item[fld] for fld in retain_fields) for item in d_list], dtype=dtype)
 
     # Normalize event latencies to float before saving so MATLAB loads them
     # as double.  Without this, integer stimulus latencies become int64 and
@@ -433,7 +440,11 @@ def pop_saveset(EEG, file_name):
         eeglab_dict['event'] = np.array(eeglab_dict['event'])
 
     for key in eeglab_dict:
-        if isinstance(eeglab_dict[key], np.ndarray) and len(eeglab_dict[key]) > 0 and isinstance(eeglab_dict[key][0], dict):
+        if (
+            isinstance(eeglab_dict[key], np.ndarray)
+            and len(eeglab_dict[key]) > 0
+            and isinstance(eeglab_dict[key][0], dict)
+        ):
             eeglab_dict[key] = flatten_dict(eeglab_dict[key])
 
     if not os.path.exists(save_dir):
@@ -452,15 +463,20 @@ def pop_saveset(EEG, file_name):
                 os.remove(file_name)
             raise
 
+
 def test_pop_saveset():
     """Test pop_saveset function."""
     from eegprep.functions.popfunc.pop_loadset import pop_loadset
+
     file_path = './sample_data/eeglab_data_with_ica_tmp.set'
     EEG = pop_loadset(file_path)
-    pop_saveset( EEG, '/Users/arno/Python/eegprep/sample_data/tmp.set')
-    pop_saveset_old(EEG, '/Users/arno/Python/eegprep/sample_data/tmp2.set') # does not do events and function above is better
+    pop_saveset(EEG, '/Users/arno/Python/eegprep/sample_data/tmp.set')
+    pop_saveset_old(
+        EEG, '/Users/arno/Python/eegprep/sample_data/tmp2.set'
+    )  # does not do events and function above is better
     # print the keys of the EEG dictionary
     print(EEG.keys())
+
 
 if __name__ == '__main__':
     test_pop_saveset()

--- a/src/eegprep/functions/popfunc/pop_select.py
+++ b/src/eegprep/functions/popfunc/pop_select.py
@@ -57,23 +57,23 @@ def _pop_select_apply(EEG, **kwargs):
     """
     # shallow options with MATLAB-compatible aliases
     g = {
-        'time':        kwargs.get('time',        []),   # seconds; can be Nx2 for continuous
-        'notime':      kwargs.get('notime',      []),   # seconds; legacy alias of rmtime
-        'rmtime':      kwargs.get('rmtime',      []),   # seconds; removed
-        'trial':       kwargs.get('trial',       None), # 1-based indices in MATLAB; we will accept 1-based and convert
-        'notrial':     kwargs.get('notrial',     []),
-        'rmtrial':     kwargs.get('rmtrial',     []),
-        'point':       kwargs.get('point',       []),   # samples; accepts vectors or Nx2
-        'nopoint':     kwargs.get('nopoint',     []),
-        'rmpoint':     kwargs.get('rmpoint',     []),
-        'channel':     kwargs.get('channel',     []),   # indices or names
-        'nochannel':   kwargs.get('nochannel',   []),
-        'rmchannel':   kwargs.get('rmchannel',   []),
-        'chantype':    kwargs.get('chantype',    []),   # names
-        'rmchantype':  kwargs.get('rmchantype',  []),
-        'sort':        kwargs.get('sort',        None),
-        'sorttrial':   kwargs.get('sorttrial',   'on'),
-        'checkchans':  kwargs.get('checkchans',  'on'),
+        'time': kwargs.get('time', []),  # seconds; can be Nx2 for continuous
+        'notime': kwargs.get('notime', []),  # seconds; legacy alias of rmtime
+        'rmtime': kwargs.get('rmtime', []),  # seconds; removed
+        'trial': kwargs.get('trial', None),  # 1-based indices in MATLAB; we will accept 1-based and convert
+        'notrial': kwargs.get('notrial', []),
+        'rmtrial': kwargs.get('rmtrial', []),
+        'point': kwargs.get('point', []),  # samples; accepts vectors or Nx2
+        'nopoint': kwargs.get('nopoint', []),
+        'rmpoint': kwargs.get('rmpoint', []),
+        'channel': kwargs.get('channel', []),  # indices or names
+        'nochannel': kwargs.get('nochannel', []),
+        'rmchannel': kwargs.get('rmchannel', []),
+        'chantype': kwargs.get('chantype', []),  # names
+        'rmchantype': kwargs.get('rmchantype', []),
+        'sort': kwargs.get('sort', None),
+        'sorttrial': kwargs.get('sorttrial', 'on'),
+        'checkchans': kwargs.get('checkchans', 'on'),
     }
 
     # alias normalization
@@ -90,22 +90,26 @@ def _pop_select_apply(EEG, **kwargs):
     # Track whether notime came directly from rmtime (to match MATLAB boundary adjustment logic)
     notime_from_rmtime = _has_content(g['rmtime'])
 
-    if _has_content(g['rmtrial']):   g['notrial']  = g['rmtrial']
-    if _has_content(g['rmtime']):    g['notime']   = g['rmtime']
-    if _has_content(g['rmpoint']):   g['nopoint']  = g['rmpoint']
-    if _has_content(g['rmchannel']): g['nochannel']= g['rmchannel']
+    if _has_content(g['rmtrial']):
+        g['notrial'] = g['rmtrial']
+    if _has_content(g['rmtime']):
+        g['notime'] = g['rmtime']
+    if _has_content(g['rmpoint']):
+        g['nopoint'] = g['rmpoint']
+    if _has_content(g['rmchannel']):
+        g['nochannel'] = g['rmchannel']
 
     # Core EEG fields with basic checks
     def _get(key, default=None):
         return EEG.get(key, default)
 
-    trials  = int(_get('trials', 1))
-    pnts    = int(_get('pnts'))
-    nbchan  = int(_get('nbchan'))
-    xmin    = float(_get('xmin'))
-    xmax    = float(_get('xmax'))
-    srate   = float(_get('srate'))
-    data    = _get('data')  # expected shape (nbchan, pnts, trials) if epoched; (nbchan, pnts) if continuous
+    trials = int(_get('trials', 1))
+    pnts = int(_get('pnts'))
+    nbchan = int(_get('nbchan'))
+    xmin = float(_get('xmin'))
+    xmax = float(_get('xmax'))
+    srate = float(_get('srate'))
+    data = _get('data')  # expected shape (nbchan, pnts, trials) if epoched; (nbchan, pnts) if continuous
 
     # if g['channel'] is a string, convert to list
     if isinstance(g['channel'], str):
@@ -170,7 +174,7 @@ def _pop_select_apply(EEG, **kwargs):
             inds, _ = eeg_decodechan(EEG, g['channel'], 'labels', True)
             # show warning if not all channels are found and error if no channels are found
             if len(inds) != len(g['channel']):
-                print(f"Warning: {len(g['channel'])-len(inds)} channels not found")
+                print(f"Warning: {len(g['channel']) - len(inds)} channels not found")
             if len(inds) == 0:
                 raise ValueError(f"Channels not found: {g['channel']}")
             chan_selected_flag[:] = False
@@ -181,7 +185,7 @@ def _pop_select_apply(EEG, **kwargs):
             chan_selected_flag[np.array(inds, dtype=int)] = False
             # show warning if not all channels are found and error if no channels are found
             if len(inds) != len(g['nochannel']):
-                print(f"Warning: {len(g['nochannel'])-len(inds)} channels not found")
+                print(f"Warning: {len(g['nochannel']) - len(inds)} channels not found")
 
     else:
         # by type
@@ -215,7 +219,7 @@ def _pop_select_apply(EEG, **kwargs):
         return x
 
     # points → time overrides time (as in MATLAB code)
-    point_mat   = _normalize_range_matrix(g['point'])
+    point_mat = _normalize_range_matrix(g['point'])
     nopoint_mat = _normalize_range_matrix(g['nopoint'])
 
     if point_mat.size:
@@ -232,7 +236,7 @@ def _pop_select_apply(EEG, **kwargs):
         g['notime'] = np.asarray(tflat, dtype=float).reshape(nopoint_mat.shape)
         g['time'] = np.array([]).reshape(0, 2)
 
-    time_mat   = _normalize_range_matrix(g['time'])
+    time_mat = _normalize_range_matrix(g['time'])
     notime_mat = _normalize_range_matrix(g['notime'])
 
     # constrain ranges to dataset bounds
@@ -240,8 +244,8 @@ def _pop_select_apply(EEG, **kwargs):
         if mat.size == 0:
             return mat
         mat = mat.copy()
-        mat[mat >  xmax] = xmax
-        mat[mat <  xmin] = xmin
+        mat[mat > xmax] = xmax
+        mat[mat < xmin] = xmin
         return mat
 
     time_mat = _clip_time_matrix(time_mat)
@@ -254,10 +258,7 @@ def _pop_select_apply(EEG, **kwargs):
             pass
         else:
             # must touch epoch boundary
-            if not (
-                np.any(np.isclose(notime_mat[:, 0], xmin)) or
-                np.any(np.isclose(notime_mat[:, 1], xmax))
-            ):
+            if not (np.any(np.isclose(notime_mat[:, 0], xmin)) or np.any(np.isclose(notime_mat[:, 1], xmax))):
                 raise ValueError('Wrong notime range for epoched data; must include an epoch boundary')
 
             # convert notime to keep time when aligned to boundaries
@@ -297,9 +298,7 @@ def _pop_select_apply(EEG, **kwargs):
                         if 'latency' in ev:
                             # adjust latency to new epoch position
                             ev['latency'] = (
-                                float(ev['latency'])
-                                - (int(ev['epoch']) - 1) * pnts
-                                + (int(newindex[0]) ) * pnts
+                                float(ev['latency']) - (int(ev['epoch']) - 1) * pnts + (int(newindex[0])) * pnts
                             )
                         ev['epoch'] = int(newindex[0] + 1)  # back to 1-based for consistency
             diffevent = np.setdiff1d(np.arange(len(EEG['event'])), np.array(keepevent, dtype=int))
@@ -324,20 +323,22 @@ def _pop_select_apply(EEG, **kwargs):
             # enforce single [tmin,tmax] for epoched
             if time_mat.shape[0] != 1:
                 raise ValueError('Epoched data requires a single [tmin tmax] window')
-            tmin, tmax = float(time_mat[0,0]), float(time_mat[0,1])
+            tmin, tmax = float(time_mat[0, 0]), float(time_mat[0, 1])
             # convert to points (1-based like EEGLAB)
             pts, _ = eeg_lat2point([tmin, tmax], [1, 1], srate, [xmin, xmax])
             a, b = int(pts[0]), int(pts[1])
-            if a < 1: a = 1
-            if b > pnts: b = pnts
+            if a < 1:
+                a = 1
+            if b > pnts:
+                b = pnts
             if b < a:
                 raise ValueError('Invalid time window mapped to points')
 
             if data.ndim == 3:
-                data = data[:, a-1:b, :]  # convert to 0-based
+                data = data[:, a - 1 : b, :]  # convert to 0-based
             else:
                 # rare case: epoched flagged but data is 2D with trials meta
-                data = data[:, a-1:b]
+                data = data[:, a - 1 : b]
             EEG['data'] = data
             EEG['xmin'] = tmin
             EEG['xmax'] = tmax
@@ -372,7 +373,7 @@ def _pop_select_apply(EEG, **kwargs):
                 # convert keep time windows into notime complements
                 # compose sequence along [xmin, xmax]
                 bounds = []
-                t_sorted = time_mat[np.argsort(time_mat[:,0])]
+                t_sorted = time_mat[np.argsort(time_mat[:, 0])]
                 cur = xmin
                 for row in t_sorted:
                     t0, t1 = float(row[0]), float(row[1])
@@ -381,7 +382,7 @@ def _pop_select_apply(EEG, **kwargs):
                     cur = max(cur, t1)
                 if cur < xmax:
                     bounds.append([cur, xmax])
-                notime_mat = np.array(bounds, dtype=float) if bounds else np.empty((0,2))
+                notime_mat = np.array(bounds, dtype=float) if bounds else np.empty((0, 2))
 
             # now reject notime_mat intervals from continuous data
             if notime_mat.size:
@@ -394,16 +395,16 @@ def _pop_select_apply(EEG, **kwargs):
                     adjusted = notime_mat.copy()
                     for i in range(adjusted.shape[0]):
                         # shift interior boundaries off-sample
-                        if adjusted[i,0] != xmin:
-                            adjusted[i,0] += 1.0 / srate
-                        if adjusted[i,1] != xmax:
-                            adjusted[i,1] -= 1.0 / srate
+                        if adjusted[i, 0] != xmin:
+                            adjusted[i, 0] += 1.0 / srate
+                        if adjusted[i, 1] != xmax:
+                            adjusted[i, 1] -= 1.0 / srate
                 # map to 1-based sample indices
                 nbtimes = adjusted.size
                 pts, _ = eeg_lat2point(adjusted.reshape(-1), np.ones(nbtimes), srate, [xmin, xmax])
                 pts = pts.reshape((-1, 2))
                 # drop empty ranges
-                keep_rows = (pts[:,1] - pts[:,0]) != 0
+                keep_rows = (pts[:, 1] - pts[:, 0]) != 0
                 pts = pts[keep_rows]
                 if pts.size:
                     EEG = eeg_eegrej(EEG, pts)
@@ -466,7 +467,7 @@ def _pop_select_apply(EEG, **kwargs):
     if _has_content(EEG.get('epoch')):
         EEG['epoch'] = [EEG['epoch'][i] for i in trial_idx_0.tolist()]
 
-     # ICA channel bookkeeping
+    # ICA channel bookkeeping
     icachansind = EEG.get('icachansind')
     if _has_content(icachansind):
         rmch = np.setdiff1d(np.array(icachansind, dtype=int), chan_idx)
@@ -497,17 +498,17 @@ def _pop_select_apply(EEG, **kwargs):
     icawinv = EEG.get('icawinv')
     if _has_content(icawinv):
         if isinstance(icawinv, np.ndarray) and icawinv.size:
-            flag_rmchan = (len(icachans) != icawinv.shape[0])
+            flag_rmchan = len(icachans) != icawinv.shape[0]
             if EEG.get('icaweights') is None or flag_rmchan:
-                EEG['icawinv']    = icawinv[np.array(icachans, dtype=int), :]
+                EEG['icawinv'] = icawinv[np.array(icachans, dtype=int), :]
                 # recompute weights/sphere as in MATLAB
                 iw = EEG['icawinv']
                 EEG['icaweights'] = np.linalg.pinv(iw)
-                EEG['icasphere']  = np.eye(EEG['icaweights'].shape[1])
+                EEG['icasphere'] = np.eye(EEG['icaweights'].shape[1])
 
     if _has_content(EEG.get('specicaact')):
         EEG['specicaact'] = np.array([])
-   # specdata/specicaact handling
+    # specdata/specicaact handling
     if _has_content(EEG.get('specdata')):
         EEG['specdata'] = np.array([])
     # single epoch → drop event.epoch and clear epoch list
@@ -519,8 +520,12 @@ def _pop_select_apply(EEG, **kwargs):
         EEG['epoch'] = np.array([], dtype=object)
 
     # reject, stats clean-up
-    if EEG.get('reject') is not None and isinstance(EEG.get('reject'), dict) and 'gcompreject' in EEG['reject'] and \
-       len(g['channel']) == nbchan:
+    if (
+        EEG.get('reject') is not None
+        and isinstance(EEG.get('reject'), dict)
+        and 'gcompreject' in EEG['reject']
+        and len(g['channel']) == nbchan
+    ):
         tmp = EEG['reject']['gcompreject']
         EEG['reject'] = {}
         EEG['reject']['gcompreject'] = tmp
@@ -556,7 +561,8 @@ def pop_select_dialog_spec(EEG) -> DialogSpec:
     chanlocs = list(EEG.get("chanlocs", []) or [])
     channel_labels = tuple(str(chan.get("labels", "")) for chan in chanlocs if isinstance(chan, dict))
     channel_types = tuple(
-        value for value in dict.fromkeys(
+        value
+        for value in dict.fromkeys(
             str(chan.get("type", "")) for chan in chanlocs if isinstance(chan, dict) and chan.get("type", "") != ""
         )
     )
@@ -734,8 +740,10 @@ def _history_command(options):
         parts.extend([f"'{key}'", format_history_value(value, empty_sequence="{}")])
     return f"EEG = pop_select( EEG, {', '.join(parts)});"
 
+
 if __name__ == '__main__':
     from eegprep.functions.popfunc.pop_loadset import pop_loadset
+
     EEG = pop_loadset('sample_data/eeglab_data.set')
     EEG2 = pop_select(EEG, channel=['FP1', 'FP2'])
     print(EEG2)

--- a/src/eegprep/functions/redefine_functions.py
+++ b/src/eegprep/functions/redefine_functions.py
@@ -34,81 +34,101 @@ from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
 from eegprep.functions.popfunc.pop_select import pop_select
 
+
 def checkset(*args, **kwargs):
     """Wrap eeg_checkset."""
     return eeg_checkset(*args, **kwargs)
+
 
 def compare(*args, **kwargs):
     """Wrap eeg_compare."""
     return eeg_compare(*args, **kwargs)
 
+
 def decodechan(*args, **kwargs):
     """Wrap eeg_decodechan."""
     return eeg_decodechan(*args, **kwargs)
+
 
 def eeg2mne(*args, **kwargs):
     """Wrap eeg_eeg2mne."""
     return eeg_eeg2mne(*args, **kwargs)
 
+
 def eegrej(*args, **kwargs):
     """Wrap eeg_eegrej."""
     return eeg_eegrej(*args, **kwargs)
+
 
 def findboundaries(*args, **kwargs):
     """Wrap eeg_findboundaries."""
     return eeg_findboundaries(*args, **kwargs)
 
+
 def interp(*args, **kwargs):
     """Wrap eeg_interp."""
     return eeg_interp(*args, **kwargs)
+
 
 def lat2point(*args, **kwargs):
     """Wrap eeg_lat2point."""
     return eeg_lat2point(*args, **kwargs)
 
+
 def mne2eeg(*args, **kwargs):
     """Wrap eeg_mne2eeg."""
     return eeg_mne2eeg(*args, **kwargs)
+
 
 def mne2eeg_epochs(*args, **kwargs):
     """Wrap eeg_mne2eeg_epochs."""
     return eeg_mne2eeg_epochs(*args, **kwargs)
 
+
 def options(*args, **kwargs):
     """Wrap EEG_OPTIONS."""
     return EEG_OPTIONS
+
 
 def picard(*args, **kwargs):
     """Wrap eeg_picard."""
     return eeg_picard(*args, **kwargs)
 
+
 def point2lat(*args, **kwargs):
     """Wrap eeg_point2lat."""
     return eeg_point2lat(*args, **kwargs)
+
 
 def epoch(*args, **kwargs):
     """Wrap pop_epoch."""
     return pop_epoch(*args, **kwargs)
 
+
 def loadset(*args, **kwargs):
     """Wrap pop_loadset."""
     return pop_loadset(*args, **kwargs)
+
 
 def reref(*args, **kwargs):
     """Wrap pop_reref."""
     return pop_reref(*args, **kwargs)
 
+
 def resample(*args, **kwargs):
     """Wrap pop_resample."""
     return pop_resample(*args, **kwargs)
+
 
 def rmbase(*args, **kwargs):
     """Wrap pop_rmbase."""
     return pop_rmbase(*args, **kwargs)
 
+
 def saveset(*args, **kwargs):
     """Wrap pop_saveset."""
     return pop_saveset(*args, **kwargs)
+
 
 def select(*args, **kwargs):
     """Wrap pop_select."""

--- a/src/eegprep/functions/sigprocfunc/__init__.py
+++ b/src/eegprep/functions/sigprocfunc/__init__.py
@@ -1,2 +1,1 @@
 """EEGLAB-style signal processing function modules."""
-

--- a/src/eegprep/functions/sigprocfunc/eegrej.py
+++ b/src/eegprep/functions/sigprocfunc/eegrej.py
@@ -17,7 +17,9 @@ def _is_boundary_event(event: Dict) -> bool:
     return False
 
 
-def eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) -> Tuple[np.ndarray, float, List[Dict], np.ndarray]:
+def eegrej(
+    indata, regions, timelength, events: Optional[List[Dict]] = None
+) -> Tuple[np.ndarray, float, List[Dict], np.ndarray]:
     """Remove [beg end] sample ranges (1-based, inclusive) from continuous data and update events.
 
     Parameters
@@ -87,7 +89,7 @@ def eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) -> 
     # To match MATLAB's inclusive end, we need reject[beg-1:end] where end is inclusive
     reject = np.zeros(n, dtype=bool)
     for beg, end in r:
-        reject[beg - 1:end] = True  # This matches MATLAB reject(beg:end) when end is already the inclusive end
+        reject[beg - 1 : end] = True  # This matches MATLAB reject(beg:end) when end is already the inclusive end
 
     # Prepare events
     ori_events: List[Dict] = [] if events is None else [dict(ev) for ev in events]
@@ -177,11 +179,17 @@ def eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) -> 
         for i in range(len(boundevents)):
             be = float(boundevents[i])
             if be > 0 and be < (newn + 1):
-                events_out.append({
-                    "type": bound_type,
-                    "latency": be,
-                    "duration": float(durations[i] if i < len(durations) else (base_durations[i] if i < len(base_durations) else 0.0)),
-                })
+                events_out.append(
+                    {
+                        "type": bound_type,
+                        "latency": be,
+                        "duration": float(
+                            durations[i]
+                            if i < len(durations)
+                            else (base_durations[i] if i < len(base_durations) else 0.0)
+                        ),
+                    }
+                )
 
     # Remove events with latency out of bound (> newn+1)
     filtered: List[Dict] = []
@@ -198,8 +206,12 @@ def eegrej(indata, regions, timelength, events: Optional[List[Dict]] = None) -> 
     if events_out:
         merged_events: List[Dict] = []
         for ev in events_out:
-            if merged_events and _is_boundary_event(ev) and _is_boundary_event(merged_events[-1]) \
-               and np.isclose(float(ev.get("latency", 0.0)), float(merged_events[-1].get("latency", 0.0))):
+            if (
+                merged_events
+                and _is_boundary_event(ev)
+                and _is_boundary_event(merged_events[-1])
+                and np.isclose(float(ev.get("latency", 0.0)), float(merged_events[-1].get("latency", 0.0)))
+            ):
                 prev_dur = float(merged_events[-1].get("duration", 0.0) or 0.0)
                 cur_dur = float(ev.get("duration", 0.0) or 0.0)
                 merged_events[-1]["duration"] = prev_dur + cur_dur

--- a/src/eegprep/functions/sigprocfunc/epoch.py
+++ b/src/eegprep/functions/sigprocfunc/epoch.py
@@ -80,24 +80,22 @@ def epoch(data, events, lim, **kwargs):
 
     for index in range(len(events)):
         # Match MATLAB exactly: pos0 is 0-based, but MATLAB treats indices as 1-based when slicing
-        pos0 = int(np.floor(events[index] * g['srate']))      # 0-based sample index (same as MATLAB)
-        posinit = pos0 + reallim[0]                           # 0-based + offset
-        posend = pos0 + reallim[1]                            # 0-based + offset
-
+        pos0 = int(np.floor(events[index] * g['srate']))  # 0-based sample index (same as MATLAB)
+        posinit = pos0 + reallim[0]  # 0-based + offset
+        posend = pos0 + reallim[1]  # 0-based + offset
 
         # Boundary check: MATLAB uses 1-based logic for boundary checks
         # Convert to 1-based for the boundary check only
         posinit_1based = posinit + 1
         posend_1based = posend + 1
-        within_one_epoch = (np.floor((posinit_1based - 1) / dataframes) == np.floor((posend_1based - 1) / dataframes))
+        within_one_epoch = np.floor((posinit_1based - 1) / dataframes) == np.floor((posend_1based - 1) / dataframes)
         within_bounds = (posinit_1based >= 1) and (posend_1based <= datawidth)
 
         if within_one_epoch and within_bounds:
             # Extract contiguous slice. MATLAB does data(:,posinit:posend) with posinit/posend in MATLAB coordinates
             # Since MATLAB uses 1-based indexing and Python uses 0-based, we need to adjust
             start = posinit - 1  # Convert MATLAB 1-based to Python 0-based
-            end_excl = posend        # MATLAB inclusive end to Python exclusive end
-
+            end_excl = posend  # MATLAB inclusive end to Python exclusive end
 
             if data.ndim == 2:
                 tmpdata = data[:, start:end_excl]

--- a/src/eegprep/functions/sigprocfunc/reref.py
+++ b/src/eegprep/functions/sigprocfunc/reref.py
@@ -150,11 +150,7 @@ def _update_references(locs: list[dict[str, Any]], chansin: list[int], ref_indic
     if not ref_indices:
         ref_text = "average"
     else:
-        labels = [
-            str(locs[idx].get("labels", idx))
-            for idx in ref_indices
-            if idx < len(locs)
-        ]
+        labels = [str(locs[idx].get("labels", idx)) for idx in ref_indices if idx < len(locs)]
         ref_text = labels[0] if len(labels) == 1 else " ".join(labels)
     for idx in chansin:
         if idx < len(locs):

--- a/src/eegprep/functions/sigprocfunc/runamica.py
+++ b/src/eegprep/functions/sigprocfunc/runamica.py
@@ -111,29 +111,81 @@ _AMICA_DEFAULTS = {
 
 # Parameters that use integer format in the param file
 _INT_PARAMS = {
-    'block_size', 'do_opt_block', 'blk_min', 'blk_step', 'blk_max',
-    'num_models', 'num_mix_comps', 'pdftype', 'max_iter', 'max_threads',
-    'do_newton', 'newt_start', 'newt_ramp', 'do_reject', 'numrej',
-    'rejstart', 'rejint', 'writestep', 'write_nd', 'write_LLt',
-    'decwindow', 'max_decs', 'fix_init', 'update_A', 'update_c',
-    'update_gm', 'update_alpha', 'update_mu', 'update_beta',
-    'do_rho', 'do_mean', 'do_sphere', 'doPCA', 'doscaling', 'scalestep',
-    'do_history', 'histstep', 'share_comps', 'share_start', 'share_iter',
-    'load_rej', 'load_W', 'load_c', 'load_gm', 'load_alpha', 'load_mu',
-    'load_beta', 'load_rho', 'load_comp_list', 'kurt_start', 'num_kurt',
-    'kurt_int', 'use_min_dll', 'use_grad_norm', 'pcakeep', 'byte_size',
-    'data_dim', 'field_dim', 'num_samples', 'field_blocksize',
-    'min_dll', 'min_grad_norm',
+    'block_size',
+    'do_opt_block',
+    'blk_min',
+    'blk_step',
+    'blk_max',
+    'num_models',
+    'num_mix_comps',
+    'pdftype',
+    'max_iter',
+    'max_threads',
+    'do_newton',
+    'newt_start',
+    'newt_ramp',
+    'do_reject',
+    'numrej',
+    'rejstart',
+    'rejint',
+    'writestep',
+    'write_nd',
+    'write_LLt',
+    'decwindow',
+    'max_decs',
+    'fix_init',
+    'update_A',
+    'update_c',
+    'update_gm',
+    'update_alpha',
+    'update_mu',
+    'update_beta',
+    'do_rho',
+    'do_mean',
+    'do_sphere',
+    'doPCA',
+    'doscaling',
+    'scalestep',
+    'do_history',
+    'histstep',
+    'share_comps',
+    'share_start',
+    'share_iter',
+    'load_rej',
+    'load_W',
+    'load_c',
+    'load_gm',
+    'load_alpha',
+    'load_mu',
+    'load_beta',
+    'load_rho',
+    'load_comp_list',
+    'kurt_start',
+    'num_kurt',
+    'kurt_int',
+    'use_min_dll',
+    'use_grad_norm',
+    'pcakeep',
+    'byte_size',
+    'data_dim',
+    'field_dim',
+    'num_samples',
+    'field_blocksize',
+    'min_dll',
+    'min_grad_norm',
 }
 
 # Parameters that use scientific notation format
 _SCI_PARAMS = {
-    'minlrate', 'mineig',
+    'minlrate',
+    'mineig',
 }
 
 # Parameters that use string format
 _STR_PARAMS = {
-    'files', 'outdir', 'indir',
+    'files',
+    'outdir',
+    'indir',
 }
 
 
@@ -166,16 +218,14 @@ def _find_amica_binary(amica_binary=None):
     if amica_binary is not None:
         if os.path.isfile(amica_binary) and os.access(amica_binary, os.X_OK):
             return amica_binary
-        raise FileNotFoundError(
-            f"Specified AMICA binary not found or not executable: {amica_binary}")
+        raise FileNotFoundError(f"Specified AMICA binary not found or not executable: {amica_binary}")
 
     # 2. Environment variable
     env_binary = os.environ.get('AMICA_BINARY')
     if env_binary:
         if os.path.isfile(env_binary) and os.access(env_binary, os.X_OK):
             return env_binary
-        raise FileNotFoundError(
-            f"AMICA_BINARY is set but not found or not executable: {env_binary}")
+        raise FileNotFoundError(f"AMICA_BINARY is set but not found or not executable: {env_binary}")
 
     # Determine platform-specific binary name
     system = platform.system()
@@ -261,8 +311,7 @@ def _write_param_file(outdir, params):
 
     # AMICA binary requires 'files' to appear before 'num_samples' in the
     # param file. Write file/directory params first, then everything else.
-    priority_keys = ['files', 'outdir', 'indir', 'data_dim', 'field_dim',
-                     'num_samples', 'byte_size', 'field_blocksize']
+    priority_keys = ['files', 'outdir', 'indir', 'data_dim', 'field_dim', 'num_samples', 'byte_size', 'field_blocksize']
     ordered_keys = [k for k in priority_keys if k in merged]
     ordered_keys += [k for k in merged if k not in priority_keys]
 
@@ -309,13 +358,13 @@ def _amica_subprocess_kwargs():
     kwargs = {'env': env}
     if os.name == 'posix':
         import resource
+
         def _raise_stack():
             try:
-                resource.setrlimit(
-                    resource.RLIMIT_STACK,
-                    (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+                resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
             except (OSError, ValueError):
                 pass
+
         kwargs['preexec_fn'] = _raise_stack
     return kwargs
 
@@ -399,8 +448,7 @@ def _run_amica(binary, param_file):
         raise RuntimeError(msg) from e
 
 
-def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps,
-                       max_iter, field_dim):
+def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps, max_iter, field_dim):
     """Load AMICA output files from disk.
 
     Port of MATLAB loadmodout15.m. Reads binary double-precision files and
@@ -485,8 +533,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps,
             comp_list = comp_list[:expected].reshape(nw, num_models, order='F')
             complistset = True
         else:
-            logger.warning("comp_list has %d values, expected %d; ignoring",
-                           len(comp_list), expected)
+            logger.warning("comp_list has %d values, expected %d; ignoring", len(comp_list), expected)
             comp_list = None
     else:
         comp_list = None
@@ -525,8 +572,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps,
         c = np.zeros((nw, num_models))
 
     # -- alpha, mu, sbeta, rho (mixture parameters, indexed via comp_list) --
-    alpha, mu, sbeta, rho = _load_mixture_params(
-        outdir, nw, num_models, num_mix_comps, comp_list, complistset)
+    alpha, mu, sbeta, rho = _load_mixture_params(outdir, nw, num_models, num_mix_comps, comp_list, complistset)
 
     # -- nd (weight change history) --
     nd_path = os.path.join(outdir, 'nd')
@@ -586,10 +632,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps,
                 rho_slice = rho[:nm, i, h]
                 sbeta_slice = sbeta[:nm, i, h]
                 # Source variance: alpha * (mu^2 + gamma(3/rho)/gamma(1/rho) / sbeta^2)
-                var_mix = a_slice * (
-                    mu_slice ** 2
-                    + gamma(3.0 / rho_slice) / gamma(1.0 / rho_slice) / sbeta_slice ** 2
-                )
+                var_mix = a_slice * (mu_slice**2 + gamma(3.0 / rho_slice) / gamma(1.0 / rho_slice) / sbeta_slice**2)
                 svar[i, h] = np.sum(var_mix) * np.linalg.norm(A[:, i, h]) ** 2
 
         # Sort by descending variance
@@ -655,8 +698,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps,
     return mods
 
 
-def _load_mixture_params(outdir, nw, num_models, num_mix_comps, comp_list,
-                         complistset):
+def _load_mixture_params(outdir, nw, num_models, num_mix_comps, comp_list, complistset):
     """Load and remap alpha, mu, sbeta, rho via comp_list.
 
     Parameters
@@ -679,8 +721,8 @@ def _load_mixture_params(outdir, nw, num_models, num_mix_comps, comp_list,
     tuple of ndarray
         (alpha, mu, sbeta, rho), each shape (num_mix, nw, num_models).
     """
-    def _load_and_remap(filename, default_val, nw, num_models, num_mix_comps,
-                        comp_list, complistset):
+
+    def _load_and_remap(filename, default_val, nw, num_models, num_mix_comps, comp_list, complistset):
         fpath = os.path.join(outdir, filename)
         if os.path.isfile(fpath):
             raw = np.fromfile(fpath, dtype=np.float64)
@@ -704,21 +746,26 @@ def _load_mixture_params(outdir, nw, num_models, num_mix_comps, comp_list,
         else:
             return np.full((num_mix_comps, nw, num_models), default_val), num_mix_comps
 
-    alpha, num_mix = _load_and_remap('alpha', 1.0, nw, num_models, num_mix_comps,
-                                     comp_list, complistset)
-    mu, _ = _load_and_remap('mu', 0.0, nw, num_models, num_mix,
-                            comp_list, complistset)
-    sbeta, _ = _load_and_remap('sbeta', 1.0, nw, num_models, num_mix,
-                               comp_list, complistset)
-    rho, _ = _load_and_remap('rho', 2.0, nw, num_models, num_mix,
-                             comp_list, complistset)
+    alpha, num_mix = _load_and_remap('alpha', 1.0, nw, num_models, num_mix_comps, comp_list, complistset)
+    mu, _ = _load_and_remap('mu', 0.0, nw, num_models, num_mix, comp_list, complistset)
+    sbeta, _ = _load_and_remap('sbeta', 1.0, nw, num_models, num_mix, comp_list, complistset)
+    rho, _ = _load_and_remap('rho', 2.0, nw, num_models, num_mix, comp_list, complistset)
 
     return alpha, mu, sbeta, rho
 
 
-def runamica(data, num_models=1, max_iter=2000, num_mix_comps=3, pcakeep=None,
-             outdir=None, amica_binary=None, max_threads=4, cleanup=True,
-             **kwargs):
+def runamica(
+    data,
+    num_models=1,
+    max_iter=2000,
+    num_mix_comps=3,
+    pcakeep=None,
+    outdir=None,
+    amica_binary=None,
+    max_threads=4,
+    cleanup=True,
+    **kwargs,
+):
     """Run AMICA binary on a data matrix.
 
     Parameters
@@ -808,7 +855,7 @@ def runamica(data, num_models=1, max_iter=2000, num_mix_comps=3, pcakeep=None,
 
     # Extract model 0 weights and sphere
     weights = mods['W'][:, :, 0]
-    sphere = mods['S'][:mods['num_pcs'], :]
+    sphere = mods['S'][: mods['num_pcs'], :]
 
     # Cleanup
     if cleanup:

--- a/src/eegprep/functions/sigprocfunc/runamica.py
+++ b/src/eegprep/functions/sigprocfunc/runamica.py
@@ -601,7 +601,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps, max
     mu = mu[:, :, gmord]
     sbeta = sbeta[:, :, gmord]
     rho = rho[:, :, gmord]
-    if LLtset:
+    if LLtset and Lht is not None:
         Lht = Lht[gmord, :]
     if complistset:
         comp_list = comp_list[:, gmord]
@@ -652,7 +652,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps, max
 
     # 4. Compute log10 posterior model odds
     v = None
-    if LLtset:
+    if LLtset and Lht is not None and Lt is not None:
         v = np.zeros((num_models, Lht.shape[1]))
         for h in range(num_models):
             v[h, :] = 0.4343 * (Lht[h, :] - Lt)
@@ -685,7 +685,7 @@ def _load_amica_output(outdir, num_models, num_pcs, data_dim, num_mix_comps, max
     mods['LL'] = LL
     mods['svar'] = svar
     mods['origord'] = origord
-    if LLtset:
+    if LLtset and Lht is not None and Lt is not None:
         mods['Lht'] = Lht
         mods['Lt'] = Lt
     if v is not None:

--- a/src/eegprep/functions/sigprocfunc/runica.py
+++ b/src/eegprep/functions/sigprocfunc/runica.py
@@ -23,7 +23,7 @@ import logging
 import numpy as np
 from scipy.linalg import sqrtm, pinv, eig
 from ...plugins.clean_rawdata.private.ransac import rand_permutation
-from ..miscfunc.misc import finite_pinv, round_mat
+from ..miscfunc.misc import finite_pinv
 
 logger = logging.getLogger(__name__)
 
@@ -242,9 +242,7 @@ def runica(data, **kwargs):
     # Initialize all parameters with defaults
     pcaflag = DEFAULT_PCAFLAG
     sphering = DEFAULT_SPHEREFLAG
-    posactflag = DEFAULT_POSACTFLAG
     verbose = DEFAULT_VERBOSE
-    logfile = kwargs_lower.get('logfile', None)
 
     # Heuristic defaults that depend on data size
     DEFAULT_LRATE_DATA = 0.00065 / np.log(chans)
@@ -300,15 +298,14 @@ def runica(data, **kwargs):
         pcaflag = 'on'
         ncomps = pca_val
         if ncomps > chans or ncomps < -1:
-            raise ValueError(f'runica(): pca value must be in range [{-chans+1},{chans}]')
+            raise ValueError(f'runica(): pca value must be in range [{-chans + 1},{chans}]')
         if ncomps < 0:
             ncomps = data.shape[0] + ncomps
         chans = ncomps
 
     # Handle sphering parameter
     if 'sphering' in kwargs_lower or 'sphereing' in kwargs_lower or 'sphere' in kwargs_lower:
-        sphering = kwargs_lower.get('sphering', kwargs_lower.get('sphereing',
-                                    kwargs_lower.get('sphere', sphering)))
+        sphering = kwargs_lower.get('sphering', kwargs_lower.get('sphereing', kwargs_lower.get('sphere', sphering)))
         if sphering not in ['on', 'off', 'none']:
             raise ValueError('runica(): sphering value must be on, off, or none')
 
@@ -368,7 +365,6 @@ def runica(data, **kwargs):
         posact_val = kwargs_lower['posact']
         if posact_val not in ['on', 'off']:
             raise ValueError('runica(): posact value must be on or off')
-        posactflag = posact_val
 
     # =========================================================================
     # 3. SPECIAL PARAMETER ADJUSTMENTS
@@ -454,12 +450,16 @@ def runica(data, **kwargs):
         else:
             logger.info(f'{pca_msg}{ncomps} ICA components using extended ICA.')
             if extblocks > 0:
-                logger.info(f'Kurtosis will be calculated initially every {extblocks} blocks using {kurtsize} data points.')
+                logger.info(
+                    f'Kurtosis will be calculated initially every {extblocks} blocks using {kurtsize} data points.'
+                )
             else:
                 logger.info(f'Kurtosis will not be calculated. Exactly {nsub} sub-Gaussian components assumed.')
 
-        logger.info(f'Decomposing {int(np.floor(frames/ncomps**2))} frames per ICA weight '
-              f'(({ncomps})^2 = {ncomps**2} weights, {frames} frames)')
+        logger.info(
+            f'Decomposing {int(np.floor(frames / ncomps**2))} frames per ICA weight '
+            f'(({ncomps})^2 = {ncomps**2} weights, {frames} frames)'
+        )
         logger.info(f'Initial learning rate will be {lrate:g}, block size {block}.')
 
         if momentum > 0:
@@ -515,12 +515,10 @@ def runica(data, **kwargs):
 
         # Sort by decreasing eigenvalue
         PCindex = np.argsort(PCeigenval)[::-1]  # descending order
-        PCEigenValues = PCeigenval[PCindex]
         PCEigenVectors = PCEigenVec[:, PCindex]
 
         # Project to ncomps dimensions
         eigenvectors = PCEigenVectors
-        eigenvalues = PCEigenValues
         data = _matmul(eigenvectors[:, :ncomps].T, data)
 
     # =========================================================================
@@ -624,6 +622,7 @@ def runica(data, **kwargs):
         # Set seed based on time (random state)
         # Use None to get time-based seed, similar to MATLAB's sum(100*clock)
         import time
+
         seed = int(time.time() * 1000) % (2**32)
         rng = np.random.RandomState(seed)
     else:
@@ -690,16 +689,14 @@ def runica(data, **kwargs):
 
     if biasflag and extended:
         while step < maxsteps:  # MATLAB line 828
-
             # Shuffle data order at each step (MATLAB line 829)
             timeperm = custom_randperm(datalength, rng)
 
             # Process data in blocks (MATLAB line 831)
             for t in range(0, lastt, block):
-
                 # Extract and process block (MATLAB line 846)
                 # MATLAB: u = weights*double(data(:,timeperm(t:t+block-1))) + bias*onesrow
-                u = _matmul(weights, data[:, timeperm[t:t+block]]) + _matmul(bias, onesrow)
+                u = _matmul(weights, data[:, timeperm[t : t + block]]) + _matmul(bias, onesrow)
 
                 # Apply tanh nonlinearity (MATLAB line 848)
                 y = np.tanh(u)
@@ -713,7 +710,7 @@ def runica(data, **kwargs):
 
                 # Bias update for tanh (MATLAB line 850)
                 # bias = bias + lrate*sum((-2*y)')';
-                bias = bias + lrate * np.sum(-2*y, axis=1, keepdims=True)
+                bias = bias + lrate * np.sum(-2 * y, axis=1, keepdims=True)
 
                 # Add momentum if enabled (MATLAB lines 852-856)
                 if momentum > 0:
@@ -741,7 +738,7 @@ def runica(data, **kwargs):
                             partact = _matmul(weights, data)
 
                         # Compute kurtosis (MATLAB lines 880-882)
-                        m2 = np.mean(partact**2, axis=1)**2
+                        m2 = np.mean(partact**2, axis=1) ** 2
                         m4 = np.mean(partact**4, axis=1)
                         # Add epsilon to prevent division by zero for near-zero variance components
                         kk = (m4 / (m2 + 1e-10)) - 3.0  # kurtosis estimates
@@ -783,7 +780,7 @@ def runica(data, **kwargs):
                 step = step + 1
 
                 # Store learning rate (MATLAB line 913)
-                lrates[step-1] = lrate
+                lrates[step - 1] = lrate
 
                 # Compute change magnitude (MATLAB lines 914-916)
                 angledelta = 0.0
@@ -836,7 +833,6 @@ def runica(data, **kwargs):
                     break
 
             else:  # Weights in bounds (MATLAB line 961)
-
                 # Compute angle delta after step 2 (MATLAB lines 965-967)
                 if step > 2:
                     cos_angle = _matmul(delta, olddelta) / np.sqrt(change * oldchange)
@@ -845,8 +841,10 @@ def runica(data, **kwargs):
 
                 # Print progress (MATLAB lines 968-970)
                 if verbose and (step % 10 == 0 or step < 5):
-                    logger.info(f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
-                          f'angledelta {degconst*angledelta:4.1f} deg')
+                    logger.info(
+                        f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
+                        f'angledelta {degconst * angledelta:4.1f} deg'
+                    )
 
                 # Save current values (MATLAB lines 974-975)
                 changes.append(change)
@@ -878,17 +876,15 @@ def runica(data, **kwargs):
 
     elif biasflag and not extended:
         while step < maxsteps:  # MATLAB line 1004
-
             # Shuffle data order at each step (MATLAB line 1005)
             timeperm = custom_randperm(datalength, rng)
 
             # Process data in blocks (MATLAB line 1007)
             for t in range(0, lastt, block):
-
                 # Extract and process block (MATLAB line 1021)
                 # MATLAB: u = weights*double(data(:,timeperm(t:t+block-1))) + bias*onesrow
                 # Note: MATLAB uses 1-based indexing, so t:t+block-1 means t to t+block
-                u = _matmul(weights, data[:, timeperm[t:t+block]]) + _matmul(bias, onesrow)
+                u = _matmul(weights, data[:, timeperm[t : t + block]]) + _matmul(bias, onesrow)
 
                 # Apply logistic nonlinearity (MATLAB line 1022)
                 # Clip u to prevent overflow in exp
@@ -898,11 +894,11 @@ def runica(data, **kwargs):
 
                 # Natural gradient weight update (MATLAB line 1023)
                 # weights = weights + lrate*(BI+(1-2*y)*u')*weights
-                weights = weights + lrate * _matmul(BI + _matmul(1 - 2*y, u.T), weights)
+                weights = weights + lrate * _matmul(BI + _matmul(1 - 2 * y, u.T), weights)
 
                 # Bias update (MATLAB line 1024)
                 # bias = bias + lrate*sum((1-2*y)')';
-                bias = bias + lrate * np.sum(1 - 2*y, axis=1, keepdims=True)
+                bias = bias + lrate * np.sum(1 - 2 * y, axis=1, keepdims=True)
 
                 # Add momentum if enabled (MATLAB lines 1026-1030)
                 if momentum > 0:
@@ -931,7 +927,7 @@ def runica(data, **kwargs):
 
                 # Store learning rate (MATLAB line 1048)
                 # MATLAB uses 1-based indexing: lrates(1,step)
-                lrates[step-1] = lrate
+                lrates[step - 1] = lrate
 
                 # Compute change magnitude (MATLAB lines 1049-1051)
                 angledelta = 0.0
@@ -979,7 +975,6 @@ def runica(data, **kwargs):
                     break
 
             else:  # Weights in bounds (MATLAB line 1086)
-
                 # Compute angle delta after step 2 (MATLAB lines 1090-1092)
                 if step > 2:
                     # acos((delta*olddelta')/sqrt(change*oldchange))
@@ -990,8 +985,10 @@ def runica(data, **kwargs):
 
                 # Print progress (MATLAB lines 1093-1095)
                 if verbose and (step % 10 == 0 or step < 5):
-                    logger.info(f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
-                          f'angledelta {degconst*angledelta:4.1f} deg')
+                    logger.info(
+                        f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
+                        f'angledelta {degconst * angledelta:4.1f} deg'
+                    )
 
                 # Save current values (MATLAB lines 1099-1100)
                 changes.append(change)
@@ -1022,15 +1019,13 @@ def runica(data, **kwargs):
 
     elif not biasflag and extended:
         while step < maxsteps:  # MATLAB line 1128
-
             # Shuffle data order at each step (MATLAB line 1129)
             timeperm = custom_randperm(datalength, rng)
 
             # Process data in blocks (MATLAB line 1131)
             for t in range(0, lastt, block):
-
                 # Extract and process block - NO BIAS (MATLAB line 1145)
-                u = _matmul(weights, data[:, timeperm[t:t+block]])
+                u = _matmul(weights, data[:, timeperm[t : t + block]])
 
                 # Apply tanh nonlinearity (MATLAB line 1146)
                 y = np.tanh(u)
@@ -1064,7 +1059,7 @@ def runica(data, **kwargs):
                         else:
                             partact = _matmul(weights, data)
 
-                        m2 = np.mean(partact**2, axis=1)**2
+                        m2 = np.mean(partact**2, axis=1) ** 2
                         m4 = np.mean(partact**4, axis=1)
                         # Add epsilon to prevent division by zero for near-zero variance components
                         kk = (m4 / (m2 + 1e-10)) - 3.0
@@ -1096,7 +1091,7 @@ def runica(data, **kwargs):
             if not wts_blowup:
                 oldwtchange = weights - oldweights
                 step = step + 1
-                lrates[step-1] = lrate
+                lrates[step - 1] = lrate
                 angledelta = 0.0
                 delta = oldwtchange.flatten()
                 change = _matmul(delta, delta)
@@ -1144,7 +1139,6 @@ def runica(data, **kwargs):
                     break
 
             else:  # Weights in bounds
-
                 # Compute angle delta after step 2 (MATLAB lines 1261-1263)
                 if step > 2:
                     cos_angle = _matmul(delta, olddelta) / np.sqrt(change * oldchange)
@@ -1153,8 +1147,10 @@ def runica(data, **kwargs):
 
                 # Print progress (MATLAB lines 1265-1266)
                 if verbose and (step % 10 == 0 or step < 5):
-                    logger.info(f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
-                          f'angledelta {degconst*angledelta:4.1f} deg')
+                    logger.info(
+                        f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
+                        f'angledelta {degconst * angledelta:4.1f} deg'
+                    )
 
                 # Save current values (MATLAB lines 1270-1271)
                 changes.append(change)
@@ -1185,15 +1181,13 @@ def runica(data, **kwargs):
 
     else:  # not biasflag and not extended
         while step < maxsteps:  # MATLAB line 1299
-
             # Shuffle data order at each step (MATLAB line 1300)
             timeperm = custom_randperm(datalength, rng)
 
             # Process data in blocks (MATLAB line 1302)
             for t in range(0, lastt, block):
-
                 # Extract and process block - NO BIAS (MATLAB line 1315)
-                u = _matmul(weights, data[:, timeperm[t:t+block]])
+                u = _matmul(weights, data[:, timeperm[t : t + block]])
 
                 # Apply logistic nonlinearity (MATLAB line 1316)
                 u = np.maximum(u, -MAX_WEIGHT)
@@ -1201,7 +1195,7 @@ def runica(data, **kwargs):
                 y = 1.0 / (1.0 + np.exp(-u))
 
                 # Natural gradient weight update (MATLAB line 1317)
-                weights = weights + lrate * _matmul(BI + _matmul(1 - 2*y, u.T), weights)
+                weights = weights + lrate * _matmul(BI + _matmul(1 - 2 * y, u.T), weights)
 
                 # NO BIAS UPDATE for no-bias variant
 
@@ -1225,7 +1219,7 @@ def runica(data, **kwargs):
             if not wts_blowup:
                 oldwtchange = weights - oldweights
                 step = step + 1
-                lrates[step-1] = lrate
+                lrates[step - 1] = lrate
                 angledelta = 0.0
                 delta = oldwtchange.flatten()
                 change = _matmul(delta, delta)
@@ -1267,7 +1261,6 @@ def runica(data, **kwargs):
                     break
 
             else:  # Weights in bounds
-
                 # Compute angle delta after step 2 (MATLAB lines 1388-1390)
                 if step > 2:
                     cos_angle = _matmul(delta, olddelta) / np.sqrt(change * oldchange)
@@ -1276,8 +1269,10 @@ def runica(data, **kwargs):
 
                 # Print progress (MATLAB lines 1392-1393)
                 if verbose and (step % 10 == 0 or step < 5):
-                    logger.info(f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
-                          f'angledelta {degconst*angledelta:4.1f} deg')
+                    logger.info(
+                        f'step {step} - lrate {lrate:5f}, wchange {change:8.8f}, '
+                        f'angledelta {degconst * angledelta:4.1f} deg'
+                    )
 
                 # Save current values (MATLAB lines 1397-1398)
                 changes.append(change)
@@ -1340,8 +1335,10 @@ def runica(data, **kwargs):
     # =========================================================================
     if pcaflag == 'on':
         if verbose:
-            logger.info('Composing the eigenvector, weights, and sphere matrices '
-                       f'into a single rectangular weights matrix; sphere=eye({chans})')
+            logger.info(
+                'Composing the eigenvector, weights, and sphere matrices '
+                f'into a single rectangular weights matrix; sphere=eye({chans})'
+            )
         weights = _matmul(_matmul(weights, sphere), eigenvectors[:, :ncomps].T)
         sphere = np.eye(urchans)
 
@@ -1375,7 +1372,6 @@ def runica(data, **kwargs):
     if verbose:
         logger.info('Permuting the activation wave forms ...')
 
-    activations = activations_unsorted[windex, :]  # data is now activations (MATLAB line 1523)
     weights = weights[windex, :]  # reorder the weight matrix (MATLAB line 1527)
     bias = bias[windex]  # reorder bias (MATLAB line 1528)
 

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -3,8 +3,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import griddata
-from scipy.interpolate import Rbf
-from scipy.spatial import cKDTree
+
 
 def griddata_v4(x, y, v, xq, yq):
     """Python version of MATLAB's GDATAV4 interpolation based on David T. Sandwell's biharmonic spline interpolation.
@@ -62,6 +61,7 @@ def griddata_v4(x, y, v, xq, yq):
 
     return vq
 
+
 def topoplot(datavector, chan_locs, **kwargs):
     """Plot a 2D topographic map of EEG data.
 
@@ -90,21 +90,17 @@ def topoplot(datavector, chan_locs, **kwargs):
     """
     # Set default values
     noplot = kwargs.get('noplot', 'off')
-    plotgrid = kwargs.get('plotgrid', 'off')
     plotchans = kwargs.get('plotchans', [])
     gridscale = kwargs.get('gridscale', 67)  # Default to 67 (EEGLAB default)
     handle = None
     Zi = None
-    chanval = np.nan
     rmax = 0.5  # actual head radius
-    INTERPLIMITS = 'head'
     INTSQUARE = 'on'
     default_intrad = 1
     ELECTRODES = kwargs.get('ELECTRODES', 'on')
     MAXDEFAULTSHOWLOCS = 64
     intrad = kwargs.get('intrad', np.nan)
     plotrad = kwargs.get('plotrad', np.nan)
-    headrad = kwargs.get('headrad', 0.5)
     squeezefac = 1.0
     ContourVals = datavector
     # MATLAB uses 'v4' (biharmonic spline) by default, which extrapolates
@@ -124,13 +120,10 @@ def topoplot(datavector, chan_locs, **kwargs):
             if len(noplot) != 2:
                 raise ValueError("'noplot' location should be [radius, angle]")
             else:
-                chanrad = noplot[0]
-                chantheta = noplot[1]
                 noplot = 'on'
 
     # Set colormap
     cmap = plt.get_cmap('jet')
-    cmaplen = cmap.N
     GRID_SCALE = gridscale
 
     if len(datavector) > MAXDEFAULTSHOWLOCS:
@@ -145,8 +138,18 @@ def topoplot(datavector, chan_locs, **kwargs):
     tmpeloc = chan_locs
     labels = [loc['labels'] for loc in tmpeloc]
     indices = [i for i, loc in enumerate(tmpeloc) if 'theta' in loc]
-    Th = np.array([tmpeloc[i]['theta'] if i in indices and not isinstance(tmpeloc[i]['theta'], np.ndarray) else np.nan for i in range(len(tmpeloc))])
-    Rd = np.array([tmpeloc[i]['radius'] if i in indices and not isinstance(tmpeloc[i]['radius'], np.ndarray) else np.nan for i in range(len(tmpeloc))])
+    Th = np.array(
+        [
+            tmpeloc[i]['theta'] if i in indices and not isinstance(tmpeloc[i]['theta'], np.ndarray) else np.nan
+            for i in range(len(tmpeloc))
+        ]
+    )
+    Rd = np.array(
+        [
+            tmpeloc[i]['radius'] if i in indices and not isinstance(tmpeloc[i]['radius'], np.ndarray) else np.nan
+            for i in range(len(tmpeloc))
+        ]
+    )
     Th = np.deg2rad(Th)
     allchansind = list(range(len(Th)))
     plotchans = indices
@@ -188,8 +191,13 @@ def topoplot(datavector, chan_locs, **kwargs):
         ContourVals = ContourVals[pltchans]
 
     squeezefac = rmax / plotrad
-    Rd, intRd = Rd * squeezefac, Rd[intchans] * squeezefac
-    x, y, intx, inty = x[pltchans] * squeezefac, y[pltchans] * squeezefac, x[intchans] * squeezefac, y[intchans] * squeezefac
+    Rd = Rd * squeezefac
+    x, y, intx, inty = (
+        x[pltchans] * squeezefac,
+        y[pltchans] * squeezefac,
+        x[intchans] * squeezefac,
+        y[intchans] * squeezefac,
+    )
 
     if default_intrad:
         xmin, xmax = min(-rmax, min(intx)), max(rmax, max(intx))
@@ -228,7 +236,7 @@ def topoplot(datavector, chan_locs, **kwargs):
         # Zi = (Zi1 + Zi2) / 2
 
     # Mask outside the head circle (same as MATLAB)
-    mask = (np.sqrt(xi**2 + yi**2) <= rmax)
+    mask = np.sqrt(xi**2 + yi**2) <= rmax
     Zi[~mask] = np.nan
 
     if noplot == 'off':
@@ -254,8 +262,9 @@ def topoplot(datavector, chan_locs, **kwargs):
         # Head circles: a thick white ring at slightly smaller radius fills the
         # gap between the interpolated image edge and the head outline.
         theta_c = np.linspace(0, 2 * np.pi, 100)
-        ax.plot(np.cos(theta_c) * (rmax * 0.99), np.sin(theta_c) * (rmax * 0.99),
-                color='white', linewidth=2.5, zorder=3)
+        ax.plot(
+            np.cos(theta_c) * (rmax * 0.99), np.sin(theta_c) * (rmax * 0.99), color='white', linewidth=2.5, zorder=3
+        )
         ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=1.5, zorder=4)
         # Nose marker
         nose_w = 0.08

--- a/src/eegprep/plugins/EEG_BIDS/__init__.py
+++ b/src/eegprep/plugins/EEG_BIDS/__init__.py
@@ -1,2 +1,1 @@
 """EEG-BIDS plugin ports."""
-

--- a/src/eegprep/plugins/EEG_BIDS/bids.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids.py
@@ -3,6 +3,8 @@
 import os
 from typing import Sequence, Dict, Any, Optional
 
+import bids
+
 
 __all__ = ['root_for_fpath', 'gen_derived_fpath', 'layout_for_fpath', 'layout_get_lenient', 'query_for_adjacent_fpath']
 
@@ -13,9 +15,25 @@ layout_cache = {}
 # incomplete list of bids suffixes that may occur in an EEG/multimodal study
 # (should not be used for verification; authoritative list at:
 # https://github.com/bids-standard/bids-specification/blob/master/src/schema/objects/suffixes.yaml)
-bids_suffixes = ('beh', 'channels', 'coordsystem', 'descriptions', 'desc', 'eeg', 'events', 'electrodes',
-                 'headshape', 'markers', 'meg', 'motion', 'nirs', 'optodes', 'physio', 'sessions',
-                 'stim')
+bids_suffixes = (
+    'beh',
+    'channels',
+    'coordsystem',
+    'descriptions',
+    'desc',
+    'eeg',
+    'events',
+    'electrodes',
+    'headshape',
+    'markers',
+    'meg',
+    'motion',
+    'nirs',
+    'optodes',
+    'physio',
+    'sessions',
+    'stim',
+)
 
 
 def root_for_fpath(fn: str) -> str:
@@ -36,16 +54,13 @@ def root_for_fpath(fn: str) -> str:
         pathparts = pathparts[:-1]
     # check if we have a 'derivatives' folder still further upstream
     if 'derivatives' in pathparts:
-        bids_root = normpath[:normpath.rfind('derivatives') - 1]
+        bids_root = normpath[: normpath.rfind('derivatives') - 1]
     else:
         bids_root = os.sep.join(pathparts)
     return bids_root
 
 
-def query_for_adjacent_fpath(
-        fn: str,
-        **overrides
-) -> Dict[str, Any]:
+def query_for_adjacent_fpath(fn: str, **overrides) -> Dict[str, Any]:
     """Generate a query dictionary (of entities) for a given file path in a BIDS dataset."""
     layout = layout_for_fpath(fn)
     query_entities = layout.parse_file_entities(fn).copy()
@@ -54,12 +69,12 @@ def query_for_adjacent_fpath(
 
 
 def gen_derived_fpath(
-        raw_fn: str,
-        *,
-        outputdir: str = '${root}/derivatives/clean_artifacts',
-        keyword: str = '',
-        suffix: Optional[str] = None,
-        extension: str = '.set'
+    raw_fn: str,
+    *,
+    outputdir: str = '${root}/derivatives/clean_artifacts',
+    keyword: str = '',
+    suffix: Optional[str] = None,
+    extension: str = '.set',
 ) -> str:
     """Generate a file path for a derived EEG file in a BIDS dataset.
 
@@ -117,19 +132,18 @@ def layout_for_fpath(filepath: str) -> 'bids.BIDSLayout':
     try:
         return layout_cache[bids_root]
     except KeyError:
-        import bids
         layout = bids.BIDSLayout(bids_root, validate=False)
         layout_cache[bids_root] = layout
         return layout
 
 
 def layout_get_lenient(
-        layout: 'bids.BIDSLayout',
-        *,
-        return_type: str = 'filename',
-        tolerate_missing: Sequence[str] = ('task', 'run'),
-        expect_one: bool = False,
-        **filters,
+    layout: 'bids.BIDSLayout',
+    *,
+    return_type: str = 'filename',
+    tolerate_missing: Sequence[str] = ('task', 'run'),
+    expect_one: bool = False,
+    **filters,
 ) -> list:
     """Wrap layout.get() to tolerate specific missing entities in the specified order of succession.
 
@@ -155,7 +169,7 @@ def layout_get_lenient(
     list
         List of return values matching the query.
     """
-    result = []
+    results = []
     query_entities = filters.copy()
     for candidate in (None,) + tuple(tolerate_missing):
         if candidate is not None and candidate in query_entities:

--- a/src/eegprep/plugins/EEG_BIDS/bids_list_eeg_files.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_list_eeg_files.py
@@ -12,11 +12,11 @@ eeg_extensions = ('.vhdr', '.edf', '.bdf', '.set')
 
 
 def bids_list_eeg_files(
-        root: str,
-        subjects: Sequence[str | int] | str | int = (),
-        sessions: Sequence[str | int] | str | int = (),
-        runs: Sequence[str | int] | str | int = (),
-        tasks: Sequence[str | int] | str | int = (),
+    root: str,
+    subjects: Sequence[str | int] | str | int = (),
+    sessions: Sequence[str | int] | str | int = (),
+    runs: Sequence[str | int] | str | int = (),
+    tasks: Sequence[str | int] | str | int = (),
 ) -> List[str]:
     """Return a list of all EEG raw-data files in a BIDS dataset.
 
@@ -62,13 +62,14 @@ def bids_list_eeg_files(
         for key, query_values in filters.items():
             for v in query_values:
                 if isinstance(v, str) and '-' in v and v.split('-')[0] in ('sub', 'ses', 'run', 'task'):
-                    raise ValueError("Query values should not be formatted with 'sub-', 'ses-', "
-                                     "'run-', or 'task-' prefixes. Use the raw identifiers instead.")
+                    raise ValueError(
+                        "Query values should not be formatted with 'sub-', 'ses-', "
+                        "'run-', or 'task-' prefixes. Use the raw identifiers instead."
+                    )
             data_values = [f.entities.get(key, None) for f in eeg_files]
             if all(v is None for v in data_values):
                 # key is missing from entire dataset: ignore the filter
-                logger.info(f"Dataset at {root} does not contain any files with the key '{key}'; "
-                            f"ignoring the filter.")
+                logger.info(f"Dataset at {root} does not contain any files with the key '{key}'; ignoring the filter.")
             elif all(isinstance(v, int) for v in data_values):
                 # all items are integers; make sure our queries are also integers if they're not already
                 if any(isinstance(v, str) for v in query_values):
@@ -102,8 +103,9 @@ def bids_list_eeg_files(
                     # all query values are strings now, can do a direct lookup
                     eeg_files = [f for f in eeg_files if str(f.entities.get(key)) in query_values]
                 else:
-                    raise ValueError(f"query values for {key} must either all be strings or all "
-                                     f"integers, but were: {query_values}")
+                    raise ValueError(
+                        f"query values for {key} must either all be strings or all integers, but were: {query_values}"
+                    )
         # reduce to file paths
         eeg_files = [eeg_file.path for eeg_file in eeg_files]
 

--- a/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
@@ -16,7 +16,6 @@ import numpy as np
 from ...functions.adminfunc.git import get_git_commit_id
 from ...functions.miscfunc.misc import (
     ExceptionUnlessDebug,
-    ToolError,
     humanize_seconds,
     is_debug,
     num_cpus_from_reservation,
@@ -34,12 +33,24 @@ logger = logging.getLogger(__name__)
 eeg_extensions = ('.vhdr', '.edf', '.bdf', '.set')
 
 # list of all possible processing stages, in the order in which they apply
-all_stages = ['Import', 'ChannelSelection', 'Resample', 'CleanArtifacts', 'ICA', 'ICLabel', 'ChannelInterp', 'Epoching', 'CommonAverageReference']
+all_stages = [
+    'Import',
+    'ChannelSelection',
+    'Resample',
+    'CleanArtifacts',
+    'ICA',
+    'ICLabel',
+    'ChannelInterp',
+    'Epoching',
+    'CommonAverageReference',
+]
+
 
 def _copy_misc_root_files(root: str, dst: str, exclude: List[str]) -> None:
     """Move miscellaneous description files from the study root to the target directory."""
     from bids import BIDSLayout
     from bids.layout.models import BIDSJSONFile
+
     layout: BIDSLayout = layout_for_fpath(root)
     files = layout.get()
     # apply filter rules
@@ -47,7 +58,11 @@ def _copy_misc_root_files(root: str, dst: str, exclude: List[str]) -> None:
     exclude = set(exclude)
     files = [f for f in files if f.path not in exclude]
     # 2. no files that are in a disallowed path relative to root
-    no_files = {os.path.join(root, 'derivatives'), os.path.join(root, 'sourcedata'), os.path.join(root, 'dataset_description.json')}
+    no_files = {
+        os.path.join(root, 'derivatives'),
+        os.path.join(root, 'sourcedata'),
+        os.path.join(root, 'dataset_description.json'),
+    }
     files = [f for f in files if f.path not in no_files]
     # 3. no (other) files for the eeg modality except if they're json
     files = [f for f in files if f.entities.get('suffix') != 'eeg' or isinstance(f, BIDSJSONFile)]
@@ -60,6 +75,7 @@ def _copy_misc_root_files(root: str, dst: str, exclude: List[str]) -> None:
         relpath = os.path.relpath(srcpath, root)
         dstpath = os.path.join(dst, relpath)
         from shutil import copyfile
+
         os.makedirs(os.path.dirname(dstpath), exist_ok=True)
         try:
             if not os.path.exists(dstpath):
@@ -82,89 +98,87 @@ def _legacy_override(new_and_name: Tuple[Any, str], old_and_name: Tuple[Any, str
 
 
 def bids_preproc(
-        root: str,
-        *,
-        # BIDS loader parameters
-        ApplyChanlocs: Optional[bool] = None,
-        ApplyEvents: Optional[bool] = None,
-        ApplyMetadata: Optional[bool] = None,
-        EventColumn: Optional[str] = None,
-        Subjects: Sequence[str | int] | str | int | None = None,
-        Sessions: Sequence[str | int] | str | int | None = None,
-        Runs: Sequence[str | int] | str | int | None = None,
-        Tasks: Sequence[str | int] | str | int | None = None,
-        # Overall run configuration
-        SkipIfPresent: bool = True,
-        NumJobs: Optional[int] = None,
-        ReservePerJob: str = '',
-        UseHashes: bool = False,
-        ReturnData: bool = False,
-        OutputDir: Optional[str] = None,
-        # Overall processing parameters
-        SamplingRate: Optional[float] = None,
-        OnlyChannelsWithPosition: bool = True,
-        OnlyModalities: Sequence[str] = (),
-        WithInterp: bool = False,
-        WithICA: bool = False,
-        WithPicard: bool = False,
-        ICAAlgorithm: str = 'runica',
-        AmicaArgs: dict | None = None,
-        WithICLabel: bool = False,
-        WithReport: bool = True,
-        CommonAverageReference: bool = True,
-        # Core cleaning parameters
-        ChannelCriterion: Union[float, str] = 0.8,
-        LineNoiseCriterion: Union[float, str] = 4.0,
-        BurstCriterion: Union[float, str] = 5.0,
-        WindowCriterion: Union[float, str] = 0.25,
-        Highpass: Union[str, Tuple[float, float]] = (0.25, 0.75),
-        # Detail cleaning parameters
-        ChannelCriterionMaxBadTime: float = 0.5,
-        BurstCriterionRefMaxBadChns: Union[float, str] = 0.075,
-        BurstCriterionRefTolerances: Union[Tuple[float, float], str] = (-np.inf, 5.5),
-        BurstRejection: str = 'off',
-        WindowCriterionTolerances: Union[Tuple[float, float], str] = (-np.inf, 7),
-        FlatlineCriterion: Union[float, str] = 5.0,
-        NumSamples: int = 50,
-        NoLocsChannelCriterion: float = 0.45,
-        NoLocsChannelCriterionExcluded: float = 0.1,
-        MaxMem: int = 64,
-        Distance: str = 'euclidian',
-        # Misc cleaning config
-        Channels: Optional[Sequence[str]] = None,
-        Channels_ignore: Optional[Sequence[str]] = None,
-        availableRAM_GB: Optional[float] = None,
-        # Optional epoching stage
-        EpochEvents: Optional[Union[str, Sequence[str]]] = None,
-        EpochLimits: Sequence[float] = (-1, 2),
-        EpochBaseline: Optional[Sequence[float]] = None,
-        # Derived data parameters
-        StageNames: Sequence[str] = ('desc-cleaned', 'desc-picard', 'desc-iclabel', 'desc-epoch'),
-        FinalDesc: Optional[str] = None,
-        ReportDir: Optional[str] = None,
-        MinimizeDiskUsage: bool = True,
-        SaveIntermediateStages: bool = False,
-        IntermediateDir: Optional[str] = None,
-
-        # Legacy parameter names for compatibility with EEGLAB
-        bidschanloc: Optional[bool] = None,
-        bidsevent: Optional[bool] = None,
-        bidsmetadata: Optional[bool] = None,
-        eventtype: Optional[str] = None,
-        subjects: Sequence[str | int] | str | int | None = None,
-        sessions: Sequence[str | int] | str | int | None = None,
-        runs: Sequence[str | int] | str | int | None = None,
-        tasks: Sequence[str | int] | str | int | None = None,
-        outputdir: Optional[str] = None,
-
-        # Reserved parameters
-        _lock: Optional[multiprocessing.Lock] = contextlib.nullcontext(),
-        _n_skipped: Optional[multiprocessing.Value] = None,
-        _k: int = 0,
-        _n_total: int = 1,
-        _n_jobs: int = 1,
-        _t0: float = now(),
-) -> Dict[str,Any] | List[Dict[str, Any]] | None:
+    root: str,
+    *,
+    # BIDS loader parameters
+    ApplyChanlocs: Optional[bool] = None,
+    ApplyEvents: Optional[bool] = None,
+    ApplyMetadata: Optional[bool] = None,
+    EventColumn: Optional[str] = None,
+    Subjects: Sequence[str | int] | str | int | None = None,
+    Sessions: Sequence[str | int] | str | int | None = None,
+    Runs: Sequence[str | int] | str | int | None = None,
+    Tasks: Sequence[str | int] | str | int | None = None,
+    # Overall run configuration
+    SkipIfPresent: bool = True,
+    NumJobs: Optional[int] = None,
+    ReservePerJob: str = '',
+    UseHashes: bool = False,
+    ReturnData: bool = False,
+    OutputDir: Optional[str] = None,
+    # Overall processing parameters
+    SamplingRate: Optional[float] = None,
+    OnlyChannelsWithPosition: bool = True,
+    OnlyModalities: Sequence[str] = (),
+    WithInterp: bool = False,
+    WithICA: bool = False,
+    WithPicard: bool = False,
+    ICAAlgorithm: str = 'runica',
+    AmicaArgs: dict | None = None,
+    WithICLabel: bool = False,
+    WithReport: bool = True,
+    CommonAverageReference: bool = True,
+    # Core cleaning parameters
+    ChannelCriterion: Union[float, str] = 0.8,
+    LineNoiseCriterion: Union[float, str] = 4.0,
+    BurstCriterion: Union[float, str] = 5.0,
+    WindowCriterion: Union[float, str] = 0.25,
+    Highpass: Union[str, Tuple[float, float]] = (0.25, 0.75),
+    # Detail cleaning parameters
+    ChannelCriterionMaxBadTime: float = 0.5,
+    BurstCriterionRefMaxBadChns: Union[float, str] = 0.075,
+    BurstCriterionRefTolerances: Union[Tuple[float, float], str] = (-np.inf, 5.5),
+    BurstRejection: str = 'off',
+    WindowCriterionTolerances: Union[Tuple[float, float], str] = (-np.inf, 7),
+    FlatlineCriterion: Union[float, str] = 5.0,
+    NumSamples: int = 50,
+    NoLocsChannelCriterion: float = 0.45,
+    NoLocsChannelCriterionExcluded: float = 0.1,
+    MaxMem: int = 64,
+    Distance: str = 'euclidian',
+    # Misc cleaning config
+    Channels: Optional[Sequence[str]] = None,
+    Channels_ignore: Optional[Sequence[str]] = None,
+    availableRAM_GB: Optional[float] = None,
+    # Optional epoching stage
+    EpochEvents: Optional[Union[str, Sequence[str]]] = None,
+    EpochLimits: Sequence[float] = (-1, 2),
+    EpochBaseline: Optional[Sequence[float]] = None,
+    # Derived data parameters
+    StageNames: Sequence[str] = ('desc-cleaned', 'desc-picard', 'desc-iclabel', 'desc-epoch'),
+    FinalDesc: Optional[str] = None,
+    ReportDir: Optional[str] = None,
+    MinimizeDiskUsage: bool = True,
+    SaveIntermediateStages: bool = False,
+    IntermediateDir: Optional[str] = None,
+    # Legacy parameter names for compatibility with EEGLAB
+    bidschanloc: Optional[bool] = None,
+    bidsevent: Optional[bool] = None,
+    bidsmetadata: Optional[bool] = None,
+    eventtype: Optional[str] = None,
+    subjects: Sequence[str | int] | str | int | None = None,
+    sessions: Sequence[str | int] | str | int | None = None,
+    runs: Sequence[str | int] | str | int | None = None,
+    tasks: Sequence[str | int] | str | int | None = None,
+    outputdir: Optional[str] = None,
+    # Reserved parameters
+    _lock: Optional[multiprocessing.Lock] = contextlib.nullcontext(),
+    _n_skipped: Optional[multiprocessing.Value] = None,
+    _k: int = 0,
+    _n_total: int = 1,
+    _n_jobs: int = 1,
+    _t0: float = now(),
+) -> Dict[str, Any] | List[Dict[str, Any]] | None:
     """Apply data cleaning to EEG files in a BIDS dataset.
 
     Parameters
@@ -384,11 +398,24 @@ def bids_preproc(
     # get a dictionary of all arguments
     kwargs = {k: v for k, v in locals().items() if not k.startswith('_')}
     del kwargs['root']  # we don't need the root here, only in the function body
-    from scipy.io.matlab import loadmat
-    from eegprep import (bids_list_eeg_files, clean_artifacts, pop_load_frombids, eeg_checkset,
-                         pop_saveset, eeg_runica, eeg_picard, iclabel, pop_loadset, pop_resample,
-                         eeg_interp, pop_select, eeg_checkset_strict_mode, pop_reref,
-                         eeg_icflag, pop_subcomp)
+    from eegprep import (
+        bids_list_eeg_files,
+        clean_artifacts,
+        pop_load_frombids,
+        eeg_checkset,
+        pop_saveset,
+        eeg_runica,
+        eeg_picard,
+        iclabel,
+        pop_loadset,
+        pop_resample,
+        eeg_interp,
+        pop_select,
+        eeg_checkset_strict_mode,
+        pop_reref,
+        eeg_icflag,
+        pop_subcomp,
+    )
     from eegprep.functions.popfunc.eeg_amica import eeg_amica
     from .bids import gen_derived_fpath
 
@@ -402,9 +429,24 @@ def bids_preproc(
         # set of options in kwargs that do NOT influence the processing result; all others
         # are used to calc an options hash
         non_proc_options = {
-            'root', 'Subjects', 'Sessions', 'Runs', 'Tasks', 'SkipIfPresent', 'NumJobs',
-            'ReservePerJob', 'ReturnData', 'OutputDir', 'MinimizeDiskUsage', 'UseHashes',
-            'subjects', 'sessions', 'runs', 'tasks', 'outputdir'}
+            'root',
+            'Subjects',
+            'Sessions',
+            'Runs',
+            'Tasks',
+            'SkipIfPresent',
+            'NumJobs',
+            'ReservePerJob',
+            'ReturnData',
+            'OutputDir',
+            'MinimizeDiskUsage',
+            'UseHashes',
+            'subjects',
+            'sessions',
+            'runs',
+            'tasks',
+            'outputdir',
+        }
         if ignore is not None:
             non_proc_options = non_proc_options | ignore
         # and collection of options that DO influence results
@@ -418,24 +460,15 @@ def bids_preproc(
         return prefix + options_hash
 
     # handle support for legacy parameters and defaults
-    ApplyChanlocs = _legacy_override((ApplyChanlocs, 'ApplyChanlocs'), (bidschanloc, 'bidschanloc'),
-                                     True)
-    ApplyEvents = _legacy_override((ApplyEvents, 'ApplyEvents'), (bidsevent, 'bidsevent'),
-                                   False)
-    ApplyMetadata = _legacy_override((ApplyMetadata, 'ApplyMetadata'), (bidsmetadata, 'bidsmetadata'),
-                                     True)
-    EventColumn = _legacy_override((EventColumn, 'EventColumn'), (eventtype, 'eventtype'),
-                                 '')
-    OutputDir = _legacy_override((OutputDir, 'OutputDir'), (outputdir, 'outputdir'),
-                                 '{root}/derivatives/eegprep')
-    Subjects = _legacy_override((Subjects, 'Subjects'), (subjects, 'subjects'),
-                                ())
-    Sessions = _legacy_override((Sessions, 'Sessions'), (sessions, 'sessions'),
-                                ())
-    Runs = _legacy_override((Runs, 'Runs'), (runs, 'runs'),
-                            ())
-    Tasks = _legacy_override((Tasks, 'Tasks'), (tasks, 'tasks'),
-                             ())
+    ApplyChanlocs = _legacy_override((ApplyChanlocs, 'ApplyChanlocs'), (bidschanloc, 'bidschanloc'), True)
+    ApplyEvents = _legacy_override((ApplyEvents, 'ApplyEvents'), (bidsevent, 'bidsevent'), False)
+    ApplyMetadata = _legacy_override((ApplyMetadata, 'ApplyMetadata'), (bidsmetadata, 'bidsmetadata'), True)
+    EventColumn = _legacy_override((EventColumn, 'EventColumn'), (eventtype, 'eventtype'), '')
+    OutputDir = _legacy_override((OutputDir, 'OutputDir'), (outputdir, 'outputdir'), '{root}/derivatives/eegprep')
+    Subjects = _legacy_override((Subjects, 'Subjects'), (subjects, 'subjects'), ())
+    Sessions = _legacy_override((Sessions, 'Sessions'), (sessions, 'sessions'), ())
+    Runs = _legacy_override((Runs, 'Runs'), (runs, 'runs'), ())
+    Tasks = _legacy_override((Tasks, 'Tasks'), (tasks, 'tasks'), ())
 
     # account for the NumJobs parameter
     if NumJobs == -1:
@@ -448,8 +481,10 @@ def bids_preproc(
 
     # other sanity checks
     if len(StageNames) != 4:
-        raise ValueError("StageNames, if given, must be a list of 4 strings, as in: "
-                         "['desc-cleaned', 'desc-picard', 'desc-iclabel', 'desc-epoch'].")
+        raise ValueError(
+            "StageNames, if given, must be a list of 4 strings, as in: "
+            "['desc-cleaned', 'desc-picard', 'desc-iclabel', 'desc-epoch']."
+        )
     # apply FinalDesc override to the last active stage name
     if FinalDesc is not None:
         StageNames = list(StageNames)
@@ -474,12 +509,22 @@ def bids_preproc(
             _n_skipped = multiprocessing.Value('i', 0)
 
         late_opts = {'WithInterp', 'EpochLimits', 'EpochEvents', 'EpochBaseline', 'CommonAverageReference'}
-        fpath_cln = gen_derived_fpath(fn, outputdir=OutputDir, keyword=StageNames[0] + hash_suffix(ignore={'WithICA', 'WithICLabel'} | late_opts))
-        fpath_picard = gen_derived_fpath(fn, outputdir=OutputDir, keyword=StageNames[1] + hash_suffix(ignore={'WithICLabel'} | late_opts))
-        fpath_iclabel = gen_derived_fpath(fn, outputdir=OutputDir, keyword=StageNames[2] + hash_suffix(ignore=late_opts))
-        fpath_epoch = gen_derived_fpath(fn, outputdir=OutputDir, keyword=StageNames[3] + hash_suffix(ignore={'CommonAverageReference'}))
-        fpath_final = gen_derived_fpath(fn, outputdir=OutputDir, keyword=f'desc-final' + hash_suffix())
-        fpath_report = gen_derived_fpath(fn, outputdir=OutputDir, keyword='desc-report' + hash_suffix(), extension='.json')
+        fpath_cln = gen_derived_fpath(
+            fn, outputdir=OutputDir, keyword=StageNames[0] + hash_suffix(ignore={'WithICA', 'WithICLabel'} | late_opts)
+        )
+        fpath_picard = gen_derived_fpath(
+            fn, outputdir=OutputDir, keyword=StageNames[1] + hash_suffix(ignore={'WithICLabel'} | late_opts)
+        )
+        fpath_iclabel = gen_derived_fpath(
+            fn, outputdir=OutputDir, keyword=StageNames[2] + hash_suffix(ignore=late_opts)
+        )
+        fpath_epoch = gen_derived_fpath(
+            fn, outputdir=OutputDir, keyword=StageNames[3] + hash_suffix(ignore={'CommonAverageReference'})
+        )
+        fpath_final = gen_derived_fpath(fn, outputdir=OutputDir, keyword='desc-final' + hash_suffix())
+        fpath_report = gen_derived_fpath(
+            fn, outputdir=OutputDir, keyword='desc-report' + hash_suffix(), extension='.json'
+        )
         if ReportDir is not None:
             # redirect report to a separate directory (e.g., 'code/reports')
             report_base = os.path.basename(fpath_report)
@@ -495,7 +540,9 @@ def bids_preproc(
                 except json.JSONDecodeError as e:
                     logger.warning(f"Failed to parse existing report file {fpath_report}, overwriting.")
                     report = {
-                        "Errors": [f"Failed to parse existing report file: {e}. Prior report was overridden/regenerated."],
+                        "Errors": [
+                            f"Failed to parse existing report file: {e}. Prior report was overridden/regenerated."
+                        ],
                     }
         else:
             report = {}
@@ -572,16 +619,16 @@ def bids_preproc(
             else:
                 ETA = 'estimating...'
 
-            logger.info(f"*** Processing [{_k+1}/{_n_total} | ETA {ETA}] {fn} ***")
+            logger.info(f"*** Processing [{_k + 1}/{_n_total} | ETA {ETA}] {fn} ***")
 
             try:
                 # noinspection PyUnresolvedReferences
                 from threadpoolctl import threadpool_limits
+
                 limit = num_cpus_from_reservation(ReservePerJob, default=4)
                 thread_ctx = threadpool_limits(limits=limit, user_api='blas')
             except ImportError:
-                logger.warning(
-                    "threadpoolctl not installed, using default thread limits.")
+                logger.warning("threadpoolctl not installed, using default thread limits.")
                 thread_ctx = contextlib.nullcontext()
 
             old_chanlocs = None
@@ -592,7 +639,13 @@ def bids_preproc(
                     if SaveIntermediateStages and IntermediateDir:
                         os.makedirs(IntermediateDir, exist_ok=True)
                         # Extract subject/run info from filename for unique identifier
-                        base = os.path.basename(fn).replace('.set', '').replace('.vhdr', '').replace('.edf', '').replace('.bdf', '')
+                        base = (
+                            os.path.basename(fn)
+                            .replace('.set', '')
+                            .replace('.vhdr', '')
+                            .replace('.edf', '')
+                            .replace('.bdf', '')
+                        )
                         stage_file = f'{base}_stage{stage_num:02d}_{stage_name}_py.set'
                         stage_path = os.path.join(IntermediateDir, stage_file)
                         try:
@@ -610,6 +663,7 @@ def bids_preproc(
                         keep &= [chanloc_has_coords(ch) for ch in EEG['chanlocs']]
                     if OnlyModalities:
                         OM = [m.upper() for m in OnlyModalities]
+
                         def get_chan_type(ch):
                             """Get channel type, handling nan and non-string types."""
                             typ = ch.get('type')
@@ -622,6 +676,7 @@ def bids_preproc(
                             if not isinstance(typ, str):
                                 return None
                             return typ.upper()
+
                         keep &= [get_chan_type(ch) in OM for ch in EEG['chanlocs']]
                     retain = [ch['labels'] for ch, kp in zip(EEG['chanlocs'], keep) if kp]
                     if 0 < len(retain) < len(EEG['chanlocs']):
@@ -634,9 +689,7 @@ def bids_preproc(
                     else:
                         detail = 'no' if not retain else 'all'
                         logger.info(f"No channel selection applied: {detail} channels retained")
-                        report["ChannelSelection"] = {
-                            "Applied": False
-                        }
+                        report["ChannelSelection"] = {"Applied": False}
                     return EEG
 
                 if os.path.exists(fpath_cln) and SkipIfPresent:
@@ -659,7 +712,8 @@ def bids_preproc(
                         bidschanloc=ApplyChanlocs,
                         bidsevent=ApplyEvents,
                         eventtype=EventColumn,
-                        return_report=True)
+                        return_report=True,
+                    )
 
                     # Clear any pre-existing ICA if we're going to compute fresh ICA with PICARD
                     # This avoids shape mismatches after channel interpolation
@@ -706,9 +760,7 @@ def bids_preproc(
                         save_stage(EEG, 3, 'resample')
                     else:
                         logger.info("No resampling requested, keeping original sampling rate.")
-                        report["Resample"] = {
-                            "Applied": False
-                        }
+                        report["Resample"] = {"Applied": False}
 
                     old_events = EEG['event']
                     old_chanlocs = EEG['chanlocs']
@@ -720,9 +772,11 @@ def bids_preproc(
                         try:
                             EEG = pop_loadset(fpath_cln)
                             needs_recalc = False
-                        except OSError as e:
-                            logger.warning(f"Encountered read error trying to look up "
-                                           f"cached derivative data {fpath_cln}. Recomputing.")
+                        except OSError:
+                            logger.warning(
+                                f"Encountered read error trying to look up "
+                                f"cached derivative data {fpath_cln}. Recomputing."
+                            )
                     if needs_recalc:
                         EEG, *_ = clean_artifacts(
                             EEG,
@@ -744,7 +798,8 @@ def bids_preproc(
                             Distance=Distance,
                             Channels=Channels,
                             Channels_ignore=Channels_ignore,
-                            availableRAM_GB=availableRAM_GB)
+                            availableRAM_GB=availableRAM_GB,
+                        )
                         report["CleanArtifacts"] = {
                             "Applied": True,
                             "ChannelCriterion": ChannelCriterion,
@@ -806,15 +861,17 @@ def bids_preproc(
                         # Flag components based on ICLabel classifications
                         # Match MATLAB: pop_icflag([NaN NaN;0.9 1;0.9 1;NaN NaN;NaN NaN;NaN NaN;NaN NaN])
                         # This flags Muscle > 0.9 OR Eye > 0.9
-                        thresholds = np.array([
-                            [np.nan, np.nan],  # Brain
-                            [0.9, 1.0],        # Muscle
-                            [0.9, 1.0],        # Eye
-                            [np.nan, np.nan],  # Heart
-                            [np.nan, np.nan],  # Line Noise
-                            [np.nan, np.nan],  # Channel Noise
-                            [np.nan, np.nan],  # Other
-                        ])
+                        thresholds = np.array(
+                            [
+                                [np.nan, np.nan],  # Brain
+                                [0.9, 1.0],  # Muscle
+                                [0.9, 1.0],  # Eye
+                                [np.nan, np.nan],  # Heart
+                                [np.nan, np.nan],  # Line Noise
+                                [np.nan, np.nan],  # Channel Noise
+                                [np.nan, np.nan],  # Other
+                            ]
+                        )
                         EEG = eeg_icflag(EEG, thresholds)
 
                         # Save stage 10 BEFORE component removal (for comparison)
@@ -844,14 +901,15 @@ def bids_preproc(
                             bidschanloc=ApplyChanlocs,
                             bidsevent=ApplyEvents,
                             eventtype=EventColumn,
-                            return_report=True)
+                            return_report=True,
+                        )
                         # apply channel selection to that also
                         if OnlyChannelsWithPosition or OnlyModalities:
                             tmp = select_channels(tmp)
                         old_chanlocs = tmp['chanlocs']
                         del tmp
                     if nDropped := (len(old_chanlocs) - len(EEG['chanlocs'])):
-                        logger.info(F"Reinterpolating {nDropped} dropped channels.")
+                        logger.info(f"Reinterpolating {nDropped} dropped channels.")
                         # note: this assumes that no non-ExG channels were dropped by
                         # the above preproc, since those can't really be restored by
                         # interpolation (although in the worst case they will contain
@@ -863,26 +921,27 @@ def bids_preproc(
                             # fewer channels and is now incompatible with interpolated data
                             if 'icaweights' in EEG and EEG['icaweights'].size > 0:
                                 if EEG['icaweights'].shape[1] != EEG['nbchan']:
-                                    logger.warning(f"Clearing ICA after interpolation: ICA was done on "
-                                                   f"{EEG['icaweights'].shape[1]} channels but data now has "
-                                                   f"{EEG['nbchan']} channels")
+                                    logger.warning(
+                                        f"Clearing ICA after interpolation: ICA was done on "
+                                        f"{EEG['icaweights'].shape[1]} channels but data now has "
+                                        f"{EEG['nbchan']} channels"
+                                    )
                                     EEG['icaweights'] = np.array([])
                                     EEG['icasphere'] = np.array([])
                                     EEG['icawinv'] = np.array([])
                                     EEG['icaact'] = np.array([])
 
-                            report["ChannelInterp"] = {
-                                "Applied": True,
-                                "NumInterpolated": nDropped
-                            }
+                            report["ChannelInterp"] = {"Applied": True, "NumInterpolated": nDropped}
                         except RuntimeError as e:
                             if 'locations required' in str(e):
-                                logger.warning("Cannot reinterpolate dropped channels as original "
-                                               "channel locations are missing and could not be "
-                                               "inferred.")
+                                logger.warning(
+                                    "Cannot reinterpolate dropped channels as original "
+                                    "channel locations are missing and could not be "
+                                    "inferred."
+                                )
                                 report["ChannelInterp"] = {
                                     "Applied": False,
-                                    "Reason": "Original channel locations missing"
+                                    "Reason": "Original channel locations missing",
                                 }
                             else:
                                 raise
@@ -894,23 +953,28 @@ def bids_preproc(
                     }
 
                 if EpochEvents is not None:
-                    from . import pop_epoch
+                    from eegprep.functions.popfunc.pop_epoch import pop_epoch
+
                     assert len(EpochLimits) == 2, "EpochLimits must be a tuple of (min, max) times in seconds."
                     events = EpochEvents
-                    if EpochEvents == [] and len(EEG['event']) == 0 or all([e['type'] == 'boundary' for e in EEG['event']]):
+                    if (
+                        EpochEvents == []
+                        and len(EEG['event']) == 0
+                        or all([e['type'] == 'boundary' for e in EEG['event']])
+                    ):
                         # trying to epoch around any marker but got no events at all, or only boundary events
                         logger.info(f"Dataset {fn!r} has no (non-boundary) events, nothing to epoch")
-                        report["Epoching"] = {
-                            "Applied": False,
-                            "Reason": "No (non-boundary) events in data"
-                        }
+                        report["Epoching"] = {"Applied": False, "Reason": "No (non-boundary) events in data"}
                     else:
                         try:
                             with eeg_checkset_strict_mode(False):
                                 EEG, *_ = pop_epoch(EEG, types=EpochEvents, lim=EpochLimits)
                                 if EpochBaseline is not None:
-                                    from . import pop_rmbase
-                                    assert len(EpochBaseline) == 2, "EpochBaseline must be a tuple of (min, max) times in seconds or None."
+                                    from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
+
+                                    assert len(EpochBaseline) == 2, (
+                                        "EpochBaseline must be a tuple of (min, max) times in seconds or None."
+                                    )
                                     timerange = EpochBaseline
                                     if timerange[0] is None:
                                         timerange = (EEG['times'][0] / 1000, timerange[1])
@@ -930,13 +994,13 @@ def bids_preproc(
                                 "Applied": True,
                                 "TimeLimits": EpochLimits,
                                 "EventTypes": EpochEvents,
-                                "Baseline": EpochBaseline
+                                "Baseline": EpochBaseline,
                             }
                         except ValueError as e:
                             if 'is empty' in str(e) or 'of an empty dataset' in str(e):
                                 report["Epoching"] = {
                                     "Applied": False,
-                                    "Reason": "No events retained (possibly all crossing boundaries)"
+                                    "Reason": "No events retained (possibly all crossing boundaries)",
                                 }
                             else:
                                 raise
@@ -959,8 +1023,7 @@ def bids_preproc(
 
                 # rewrite the events file
                 if len(EEG['event']):
-                    fpath_events = gen_derived_fpath(fn, outputdir=OutputDir,
-                                                     suffix='events', extension='.tsv')
+                    fpath_events = gen_derived_fpath(fn, outputdir=OutputDir, suffix='events', extension='.tsv')
                     have_hed_column = EEG['etc'].get('event_column', None) == 'HED'
                     columns = ['onset', 'duration', 'trial_type'] + (['HED'] if have_hed_column else [])
                     with open(fpath_events, 'w') as fp:
@@ -969,23 +1032,18 @@ def bids_preproc(
                         for e in EEG['event']:
                             ev_type = e['type']
                             try:
-                                ev_time = times[e['latency']]/1000.0  # in ms
+                                ev_time = times[e['latency']] / 1000.0  # in ms
                             except IndexError:
                                 logger.error(f'out-of-bounds event {ev_type} at lat {e["latency"]}; ignoring')
                                 continue
-                            ev_dur = e.get('duration', 0.0)/srate
+                            ev_dur = e.get('duration', 0.0) / srate
                             if np.isnan(ev_dur):
                                 ev_dur = 0.0
-                            row = [
-                                ev_time,
-                                ev_dur,
-                                ev_type
-                            ] + ([ev_type] if have_hed_column else [])
+                            row = [ev_time, ev_dur, ev_type] + ([ev_type] if have_hed_column else [])
                             print('\t'.join(str(r) for r in row), file=fp)
 
                 # rewrite the channels file
-                fpath_channels = gen_derived_fpath(fn, outputdir=OutputDir,
-                                                   suffix='channels', extension='.tsv')
+                fpath_channels = gen_derived_fpath(fn, outputdir=OutputDir, suffix='channels', extension='.tsv')
                 with open(fpath_channels, 'w') as fp:
                     print('name\ttype\tunits', file=fp)
                     for ch in EEG['chanlocs']:
@@ -994,8 +1052,7 @@ def bids_preproc(
                         print(f"{ch['labels']}\t{ch_type}\t{ch_unit}", file=fp)
 
                 # rewrite the electrodes file
-                fpath_elecs = gen_derived_fpath(fn, outputdir=OutputDir,
-                                                suffix='electrodes', extension='.tsv')
+                fpath_elecs = gen_derived_fpath(fn, outputdir=OutputDir, suffix='electrodes', extension='.tsv')
                 with open(fpath_elecs, 'w') as fp:
                     print('name\tx\ty\tz', file=fp)
                     for ch in EEG['chanlocs']:
@@ -1003,20 +1060,20 @@ def bids_preproc(
                             print(f"{ch['labels']}\t{ch['X']}\t{ch['Y']}\t{ch['Z']}", file=fp)
 
                 # rewrite/update the coordsystem file
-                fpath_coordsystem = gen_derived_fpath(fn, outputdir=OutputDir,
-                                                      suffix='coordsystem', extension='.json')
+                fpath_coordsystem = gen_derived_fpath(fn, outputdir=OutputDir, suffix='coordsystem', extension='.json')
                 coordsystem = EEG['etc'].get('BIDSCoordsystem', {})
-                coordsystem.update({
-                    "EEGCoordinateSystem": "EEGLAB",
-                    "EEGCoordinateUnits": "mm",
-                    "EEGCoordinateSystemDescription": "ALS | +x is front, +y is left, +z is up",
-                })
+                coordsystem.update(
+                    {
+                        "EEGCoordinateSystem": "EEGLAB",
+                        "EEGCoordinateUnits": "mm",
+                        "EEGCoordinateSystemDescription": "ALS | +x is front, +y is left, +z is up",
+                    }
+                )
                 with open(fpath_coordsystem, 'w') as fp:
                     json.dump(coordsystem, fp, indent=4)
 
                 # rewrite/update the _eeg.json file
-                fpath_eeg = gen_derived_fpath(fn, outputdir=OutputDir,
-                                              suffix='eeg', extension='.json')
+                fpath_eeg = gen_derived_fpath(fn, outputdir=OutputDir, suffix='eeg', extension='.json')
                 if os.path.exists(fpath_eeg):
                     with open(fpath_eeg, 'r') as fp:
                         content = json.load(fp)
@@ -1032,13 +1089,16 @@ def bids_preproc(
                 content['SamplingFrequency'] = EEG['srate']
 
                 # write channel counts based on the modality
-                labels = [str(lab['type']).lower() if isinstance(lab['type'], str) else repr(lab['type']) for lab in EEG['chanlocs']]
+                labels = [
+                    str(lab['type']).lower() if isinstance(lab['type'], str) else repr(lab['type'])
+                    for lab in EEG['chanlocs']
+                ]
                 content['EEGChannelCount'] = n_eeg = sum(lab == 'eeg' for lab in labels)
                 content['ECGChannelCount'] = n_ecg = sum(lab == 'ecg' for lab in labels)
                 content['EMGChannelCount'] = n_emg = sum(lab == 'emg' for lab in labels)
                 content['EOGChannelCount'] = n_eog = sum(lab == 'eog' for lab in labels)
                 n_trig = sum(lab == 'trig' for lab in labels)
-                content['MiscChannelCount'] = len(EEG['chanlocs']) - (n_eeg+n_ecg+n_emg+n_eog+n_trig)
+                content['MiscChannelCount'] = len(EEG['chanlocs']) - (n_eeg + n_ecg + n_emg + n_eog + n_trig)
 
                 # remove misnamed field that may be present from prior json file
                 if 'MISCChannelCount' in content:
@@ -1082,7 +1142,7 @@ def bids_preproc(
                     'ICA': 'eeg_runica',
                     'ChannelInterp': 'eeg_interp',
                     'Epoching': 'pop_epoch+pop_rmbase' if EpochBaseline is not None else 'pop_epoch',
-                    'CommonAverageReference': 'pop_reref'
+                    'CommonAverageReference': 'pop_reref',
                 }
                 for in_report, in_filters in filter_names.items():
                     if (flt := filter_report.get(in_report, {'Applied': False})).pop('Applied'):
@@ -1110,18 +1170,13 @@ def bids_preproc(
                 if errorStage not in report:
                     report[errorStage] = {}
                 report[errorStage]["Applied"] = 'Error'
-                report[errorStage]["Error"] = {
-                    "Message": str(e)
-                }
+                report[errorStage]["Error"] = {"Message": str(e)}
                 for remaining in StagesToGo:
                     if remaining not in report:
                         report[remaining] = {}
                     report[remaining]["Applied"] = 'Skipped'
                     report[remaining]["Reason"] = "Previous stage failed"
-            report["Errors"].append(
-                {
-                    "Message": str(e)
-                })
+            report["Errors"].append({"Message": str(e)})
             with _lock:
                 _n_skipped.value += 1
             return None
@@ -1143,8 +1198,7 @@ def bids_preproc(
 
     elif os.path.isdir(root):
         # process all files under a BIDS root recursively
-        all_files = bids_list_eeg_files(
-            root, subjects=Subjects, sessions=Sessions, runs=Runs, tasks=Tasks)
+        all_files = bids_list_eeg_files(root, subjects=Subjects, sessions=Sessions, runs=Runs, tasks=Tasks)
         n_jobs = 1 if is_debug() else num_jobs_from_reservation(ReservePerJob)
         n_total = len(all_files)
         t0 = now()
@@ -1157,12 +1211,11 @@ def bids_preproc(
         # rewrite the dataset_description.json file
         dataset_desc_path = os.path.join(root, 'dataset_description.json')
         if os.path.exists(dataset_desc_path):
-            logger.info(
-                f"Updating derived dataset_description.json from {dataset_desc_path}")
+            logger.info(f"Updating derived dataset_description.json from {dataset_desc_path}")
             with open(dataset_desc_path, 'r') as f:
                 desc = json.load(f)
         else:
-            logger.info(f"Creating new derived dataset_description.json")
+            logger.info("Creating new derived dataset_description.json")
             desc = {
                 # these must be present
                 "Name": os.path.basename(root),
@@ -1180,8 +1233,9 @@ def bids_preproc(
                 "Name": "eegprep",
                 "Description": "The EEGPrep data pipeline",
                 "Version": commit or "",
-                "CodeURL": "https://github.com/sccn/eegprep"
-            })
+                "CodeURL": "https://github.com/sccn/eegprep",
+            }
+        )
 
         orig_doi = desc.get("DatasetDOI", "")
 
@@ -1211,8 +1265,7 @@ def bids_preproc(
         # note that the actual epoched data *can* be absent if there were no matching
         # event markers in any study file, which we can't determine at this point
         desc['IsEpoched'] = EpochEvents is not None
-        fpath_dataset_desc = gen_derived_fpath(dataset_desc_path, outputdir=OutputDir, keyword='',
-                                               extension='.json')
+        fpath_dataset_desc = gen_derived_fpath(dataset_desc_path, outputdir=OutputDir, keyword='', extension='.json')
         with open(fpath_dataset_desc, 'w') as f:
             json.dump(desc, f, indent=4)
 
@@ -1224,17 +1277,25 @@ def bids_preproc(
                 # run sequentially
                 results = []
                 for k, fn in enumerate(all_files):
-                    results.append(bids_preproc(
-                        fn,
-                        **kwargs,
-                        # reserved parameters
-                        _lock=lock, _n_skipped=n_skipped, _k=k, _n_total=n_total, _n_jobs=n_jobs, _t0=t0
-                    ))
+                    results.append(
+                        bids_preproc(
+                            fn,
+                            **kwargs,
+                            # reserved parameters
+                            _lock=lock,
+                            _n_skipped=n_skipped,
+                            _k=k,
+                            _n_total=n_total,
+                            _n_jobs=n_jobs,
+                            _t0=t0,
+                        )
+                    )
 
             else:
                 # run in parallel
                 logger.info(f"Running {n_jobs} parallel jobs to process {n_total} files...")
                 from multiprocessing import Pool
+
                 with Pool(n_jobs) as pool:
                     results = [
                         pool.apply_async(
@@ -1242,17 +1303,24 @@ def bids_preproc(
                             args=(fn,),
                             kwds={
                                 **kwargs,
-                                '_lock': lock, '_n_skipped': n_skipped, '_k': k, '_n_total': n_total, '_n_jobs': n_jobs, '_t0': t0
-                            }
+                                '_lock': lock,
+                                '_n_skipped': n_skipped,
+                                '_k': k,
+                                '_n_total': n_total,
+                                '_n_jobs': n_jobs,
+                                '_t0': t0,
+                            },
                         )
                         for k, fn in enumerate(all_files)
                     ]
                     # wait for all jobs to finish
                     results = [result.get() for result in results]
 
-            logger.info(f"Processed {n_total - n_skipped.value} files, "
-                        f"skipped {n_skipped.value} files; total time: "
-                        f"{humanize_seconds(now() - t0)}.")
+            logger.info(
+                f"Processed {n_total - n_skipped.value} files, "
+                f"skipped {n_skipped.value} files; total time: "
+                f"{humanize_seconds(now() - t0)}."
+            )
 
             return results if ReturnData else None
     else:

--- a/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
@@ -1214,6 +1214,8 @@ def bids_preproc(
             logger.info(f"Updating derived dataset_description.json from {dataset_desc_path}")
             with open(dataset_desc_path, 'r') as f:
                 desc = json.load(f)
+            if not isinstance(desc, dict):
+                raise ValueError(f"Expected {dataset_desc_path} to contain a JSON object")
         else:
             logger.info("Creating new derived dataset_description.json")
             desc = {
@@ -1223,12 +1225,14 @@ def bids_preproc(
             }
         # update the desc
         desc["DatasetType"] = "derivative"
-        if "GeneratedBy" not in desc:
-            desc["GeneratedBy"] = []
+        generated_by = desc.setdefault("GeneratedBy", [])
+        if not isinstance(generated_by, list):
+            generated_by = []
+            desc["GeneratedBy"] = generated_by
 
         repo_root = os.path.dirname(os.path.abspath(__file__))
         commit = get_git_commit_id(repo_root)
-        desc["GeneratedBy"].append(
+        generated_by.append(
             {
                 "Name": "eegprep",
                 "Description": "The EEGPrep data pipeline",
@@ -1241,8 +1245,11 @@ def bids_preproc(
 
         # determine the dataset URL: prefer existing SourceDatasets URL, then infer
         existing_url = ""
-        for src in desc.get("SourceDatasets", []):
-            if src.get("URL"):
+        source_datasets = desc.get("SourceDatasets", [])
+        if not isinstance(source_datasets, list):
+            source_datasets = []
+        for src in source_datasets:
+            if isinstance(src, dict) and src.get("URL"):
                 existing_url = src["URL"]
                 break
         if existing_url:

--- a/src/eegprep/plugins/EEG_BIDS/coords.py
+++ b/src/eegprep/plugins/EEG_BIDS/coords.py
@@ -3,8 +3,15 @@
 from typing import Dict, Any, Sequence
 import numpy as np
 
-__all__ = ['coords_to_mm', 'coords_any_to_RAS', 'coords_RAS_to_ALS', 'coords_ALS_to_angular',
-           'clear_chanloc', 'chanloc_has_coords', 'chanlocs_to_coords']
+__all__ = [
+    'coords_to_mm',
+    'coords_any_to_RAS',
+    'coords_RAS_to_ALS',
+    'coords_ALS_to_angular',
+    'clear_chanloc',
+    'chanloc_has_coords',
+    'chanlocs_to_coords',
+]
 
 
 def coords_to_mm(coords: np.ndarray, unit: str) -> np.ndarray:
@@ -16,8 +23,7 @@ def coords_to_mm(coords: np.ndarray, unit: str) -> np.ndarray:
     elif unit in ('m', 'meters'):
         coords *= 1000.0
     else:
-        raise ValueError(f"Unsupported coordinate unit: {unit}. "
-                         f"Supported units are 'mm', 'cm', 'm'.")
+        raise ValueError(f"Unsupported coordinate unit: {unit}. Supported units are 'mm', 'cm', 'm'.")
     return coords
 
 
@@ -55,14 +61,10 @@ def coords_any_to_RAS(coords: np.ndarray, x: str, y: str, z: str) -> np.ndarray:
     if x == 'front' and y == 'left' and z == 'up':
         # +X nose direction
         # rotate 90 degrees clockwise (looking down on head)
-        coords = np.dot(coords, np.array([[0, 1, 0],
-                                          [-1, 0, 0],
-                                          [0, 0, 1]]))
+        coords = np.dot(coords, np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]]))
     elif x == 'back' and y == 'right' and z == 'up':
         # -X nose direction
-        coords = np.dot(coords, np.array([[0, -1, 0],
-                                          [1, 0, 0],
-                                          [0, 0, 1]]))
+        coords = np.dot(coords, np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]))
     elif not (x == 'right' and y == 'front' and z == 'up'):
         # not +Y nose direction
         raise RuntimeError("Unsupported input coordinate system (%s,%s,%s)" % (x, y, z))
@@ -90,7 +92,7 @@ def coords_ALS_to_angular(coords: np.ndarray) -> np.ndarray:
     polar_radius : np.ndarray
         2d polar coordinates.
     """
-    x,y,z = coords.T
+    x, y, z = coords.T
     hypotxy = np.hypot(x, y)
     theta = np.arctan2(y, x)
     phi = np.arctan2(z, hypotxy)
@@ -133,8 +135,7 @@ def chanloc_has_coords(ch: Dict[str, Any]) -> bool:
 
 def chanlocs_to_coords(chanlocs: Sequence[Dict[str, Any]]) -> np.ndarray:
     """Convert an EEGLAB chanlocs data structure to a Nx3 coordinates array."""
-    coords = np.array([[cl['X'], cl['Y'], cl['Z']]
-                       if chanloc_has_coords(cl)
-                       else [np.nan, np.nan, np.nan]
-                       for cl in chanlocs])
+    coords = np.array(
+        [[cl['X'], cl['Y'], cl['Z']] if chanloc_has_coords(cl) else [np.nan, np.nan, np.nan] for cl in chanlocs]
+    )
     return coords

--- a/src/eegprep/plugins/EEG_BIDS/stage_comparison.py
+++ b/src/eegprep/plugins/EEG_BIDS/stage_comparison.py
@@ -1,10 +1,11 @@
 """
 Utility for stage-by-stage pipeline comparison between Python and MATLAB.
 """
+
 import os
+from typing import Any, Dict, List, Tuple, Optional
+
 import numpy as np
-from typing import Dict, List, Tuple, Optional
-import tempfile
 from scipy.optimize import linear_sum_assignment
 
 
@@ -40,7 +41,7 @@ def _match_components_by_scalp_maps(icawinv_py: np.ndarray, icawinv_mat: np.ndar
     return reorder_idx, correlations
 
 
-def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dict[str, any]:
+def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dict[str, Any] | None:
     """Compare ICA decompositions between Python and MATLAB.
 
     Returns dict with: avg_corr, min_corr, max_corr, scalp_map_file
@@ -67,7 +68,7 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
         from eegprep import topoplot
 
         n_comps_to_plot = min(10, len(correlations))
-        fig, axes = plt.subplots(2, n_comps_to_plot, figsize=(3*n_comps_to_plot, 6))
+        fig, axes = plt.subplots(2, n_comps_to_plot, figsize=(3 * n_comps_to_plot, 6))
         if n_comps_to_plot == 1:
             axes = axes.reshape(2, 1)
 
@@ -80,17 +81,17 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
             ax = axes[0, i] if n_comps_to_plot > 1 else axes[0]
             plt.sca(ax)  # Set current axis
             topoplot(icawinv_mat[:, i], chanlocs_mat, noplot='off', ELECTRODES='off')
-            ax.set_title(f'MAT IC{i+1}', fontsize=10)
+            ax.set_title(f'MAT IC{i + 1}', fontsize=10)
             ax.axis('off')
 
             # Python scalp map (reordered to match MATLAB)
             ax = axes[1, i] if n_comps_to_plot > 1 else axes[1]
             plt.sca(ax)  # Set current axis
             topoplot(icawinv_py[:, reorder_idx[i]], chanlocs_py, noplot='off', ELECTRODES='off')
-            ax.set_title(f'Py IC{i+1}\n(r={correlations[i]:.3f})', fontsize=10)
+            ax.set_title(f'Py IC{i + 1}\n(r={correlations[i]:.3f})', fontsize=10)
             ax.axis('off')
 
-        plt.suptitle(f'ICA Component Scalp Maps: MATLAB (top) vs Python (bottom) - Python Topoplot', fontsize=12, y=0.98)
+        plt.suptitle('ICA Component Scalp Maps: MATLAB (top) vs Python (bottom) - Python Topoplot', fontsize=12, y=0.98)
         plt.tight_layout()
         plt.savefig(scalp_map_file, dpi=150, bbox_inches='tight')
         plt.close()
@@ -116,6 +117,7 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
         EEG_py_reordered = EEG_py.copy()
         EEG_py_reordered['icawinv'] = icawinv_py[:, reorder_idx]
         from eegprep import pop_saveset
+
         pop_saveset(EEG_py_reordered, temp_py.name)
         pop_saveset(EEG_mat, temp_mat.name)
 
@@ -129,7 +131,7 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
             os.path.abspath(temp_py.name),
             scalp_map_file_matlab,
             n_comps_to_plot,
-            corr_array
+            corr_array,
         )
 
         # Clean up temp files
@@ -139,6 +141,7 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
     except Exception as e:
         print(f"Warning: Could not create MATLAB topoplot scalp map: {e}")
         import traceback
+
         traceback.print_exc()
         scalp_map_file_matlab = None
 
@@ -149,11 +152,13 @@ def compare_ica_decompositions(py_file: str, mat_file: str, subject: str) -> Dic
         'n_components': len(correlations),
         'reorder_idx': reorder_idx,
         'scalp_map_file': scalp_map_file,
-        'scalp_map_file_matlab': scalp_map_file_matlab
+        'scalp_map_file_matlab': scalp_map_file_matlab,
     }
 
 
-def compare_iclabel_classifications(py_file: str, mat_file: str, ica_reorder: Optional[np.ndarray] = None) -> Dict[str, any]:
+def compare_iclabel_classifications(
+    py_file: str, mat_file: str, ica_reorder: Optional[np.ndarray] = None
+) -> Dict[str, Any] | None:
     """Compare ICLabel classifications between Python and MATLAB.
 
     Note: Stage 10 files may have different numbers of components if different
@@ -191,7 +196,7 @@ def compare_iclabel_classifications(py_file: str, mat_file: str, ica_reorder: Op
             'max_prob_diff': None,
             'n_components_py': int(n_comps_py),
             'n_components_mat': int(n_comps_mat),
-            'note': f'Different component counts (Python={n_comps_py}, MATLAB={n_comps_mat}). Stage 10 saved after removal.'
+            'note': f'Different component counts (Python={n_comps_py}, MATLAB={n_comps_mat}). Stage 10 saved after removal.',
         }
 
     # Same number of components - can do detailed comparison
@@ -215,7 +220,7 @@ def compare_iclabel_classifications(py_file: str, mat_file: str, ica_reorder: Op
         'n_flagged_py': int(flagged_py),
         'n_flagged_mat': int(flagged_mat),
         'n_components_py': int(n_comps_py),
-        'n_components_mat': int(n_comps_mat)
+        'n_components_mat': int(n_comps_mat),
     }
 
 
@@ -295,40 +300,156 @@ def run_staged_pipeline_python(root: str, stage_dir: str, **kwargs) -> List[str]
     Returns:
         List of saved file paths for each stage
     """
-    from eegprep import bids_preproc, pop_saveset, pop_loadset
-    from .bids import gen_derived_fpath
+    from eegprep import bids_preproc, pop_saveset
 
     # Stage mapping: (output_file, stage_params)
     stages = [
-        ('stage01_import_py.set', {'OnlyChannelsWithPosition': False, 'OnlyModalities': [],
-                                    'SamplingRate': None, 'WithInterp': False, 'WithICA': False,
-                                    'WithICLabel': False, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage02_chansel_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': None, 'WithInterp': False,
-                                     'WithICA': False, 'WithICLabel': False, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage03_resample_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': False,
-                                      'WithICA': False, 'WithICLabel': False, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage08_window_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': False,
-                                    'WithICA': False, 'WithICLabel': False, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage09_ica_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': False,
-                                 'WithICA': True, 'WithICLabel': False, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage10_iclabel_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': False,
-                                     'WithICA': True, 'WithICLabel': True, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage11_interp_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': True,
-                                    'WithICA': True, 'WithICLabel': True, 'EpochEvents': None, 'CommonAverageReference': False}),
-        ('stage12_epoch_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': True,
-                                   'WithICA': True, 'WithICLabel': True, 'EpochEvents': [], 'EpochLimits': [-0.2, 0.5], 'CommonAverageReference': False}),
-        ('stage13_baseline_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': True,
-                                      'WithICA': True, 'WithICLabel': True, 'EpochEvents': [], 'EpochLimits': [-0.2, 0.5],
-                                      'EpochBaseline': [-0.2, 0], 'CommonAverageReference': False}),
-        ('stage14_reref_py.set', {'OnlyModalities': ['EEG'], 'SamplingRate': 128, 'WithInterp': True,
-                                   'WithICA': True, 'WithICLabel': True, 'EpochEvents': [], 'EpochLimits': [-0.2, 0.5],
-                                   'EpochBaseline': [-0.2, 0], 'CommonAverageReference': True}),
+        (
+            'stage01_import_py.set',
+            {
+                'OnlyChannelsWithPosition': False,
+                'OnlyModalities': [],
+                'SamplingRate': None,
+                'WithInterp': False,
+                'WithICA': False,
+                'WithICLabel': False,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage02_chansel_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': None,
+                'WithInterp': False,
+                'WithICA': False,
+                'WithICLabel': False,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage03_resample_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': False,
+                'WithICA': False,
+                'WithICLabel': False,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage08_window_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': False,
+                'WithICA': False,
+                'WithICLabel': False,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage09_ica_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': False,
+                'WithICA': True,
+                'WithICLabel': False,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage10_iclabel_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': False,
+                'WithICA': True,
+                'WithICLabel': True,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage11_interp_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': True,
+                'WithICA': True,
+                'WithICLabel': True,
+                'EpochEvents': None,
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage12_epoch_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': True,
+                'WithICA': True,
+                'WithICLabel': True,
+                'EpochEvents': [],
+                'EpochLimits': [-0.2, 0.5],
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage13_baseline_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': True,
+                'WithICA': True,
+                'WithICLabel': True,
+                'EpochEvents': [],
+                'EpochLimits': [-0.2, 0.5],
+                'EpochBaseline': [-0.2, 0],
+                'CommonAverageReference': False,
+            },
+        ),
+        (
+            'stage14_reref_py.set',
+            {
+                'OnlyModalities': ['EEG'],
+                'SamplingRate': 128,
+                'WithInterp': True,
+                'WithICA': True,
+                'WithICLabel': True,
+                'EpochEvents': [],
+                'EpochLimits': [-0.2, 0.5],
+                'EpochBaseline': [-0.2, 0],
+                'CommonAverageReference': True,
+            },
+        ),
     ]
 
     saved_files = []
-    base_kwargs = {k: v for k, v in kwargs.items() if k not in ['OnlyChannelsWithPosition', 'OnlyModalities',
-                   'SamplingRate', 'WithInterp', 'WithICA', 'WithICLabel', 'EpochEvents', 'EpochLimits',
-                   'EpochBaseline', 'CommonAverageReference']}
+    base_kwargs = {
+        k: v
+        for k, v in kwargs.items()
+        if k
+        not in [
+            'OnlyChannelsWithPosition',
+            'OnlyModalities',
+            'SamplingRate',
+            'WithInterp',
+            'WithICA',
+            'WithICLabel',
+            'EpochEvents',
+            'EpochLimits',
+            'EpochBaseline',
+            'CommonAverageReference',
+        ]
+    }
 
     for stage_file, stage_params in stages:
         stage_path = os.path.join(stage_dir, stage_file)
@@ -356,7 +477,7 @@ def run_staged_pipeline_python(root: str, stage_dir: str, **kwargs) -> List[str]
     return saved_files
 
 
-def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
+def generate_comparison_table(stage_dir: str, stages: List[int] | None = None) -> str:
     """Generate comparison table for all stage files.
 
     Args:
@@ -371,8 +492,16 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
         stages = [1, 2, 3, 8, 11, 12, 13, 14]
 
     stage_names = {
-        1: 'Import', 2: 'ChanSel', 3: 'Resample', 8: 'CleanArtifacts',
-        9: 'ICA', 10: 'ICLabel', 11: 'Interp', 12: 'Epoch', 13: 'Baseline', 14: 'Reref'
+        1: 'Import',
+        2: 'ChanSel',
+        3: 'Resample',
+        8: 'CleanArtifacts',
+        9: 'ICA',
+        10: 'ICLabel',
+        11: 'Interp',
+        12: 'Epoch',
+        13: 'Baseline',
+        14: 'Reref',
     }
 
     # First, collect all unique basenames
@@ -394,7 +523,9 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
         # Collect standard stage comparisons
         for stage in stages:
             py_file = [f for f in all_files if f.startswith(f'{basename}_stage{stage:02d}_') and f.endswith('_py.set')]
-            mat_file = [f for f in all_files if f.startswith(f'{basename}_stage{stage:02d}_') and f.endswith('_mat.set')]
+            mat_file = [
+                f for f in all_files if f.startswith(f'{basename}_stage{stage:02d}_') and f.endswith('_mat.set')
+            ]
 
             if not py_file or not mat_file:
                 continue
@@ -414,7 +545,9 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
         # Display main table for this subject
         lines.append(f"\n{basename}")
         lines.append("-" * 105)
-        lines.append(f"{'Stage':<6} {'Name':<15} {'Cumul Max':<15} {'Cumul Mean':<15} {'Cumul RMS':<15} {'Incr Max':<15} {'Incr Mean':<15}")
+        lines.append(
+            f"{'Stage':<6} {'Name':<15} {'Cumul Max':<15} {'Cumul Mean':<15} {'Cumul RMS':<15} {'Incr Max':<15} {'Incr Mean':<15}"
+        )
         lines.append("-" * 105)
 
         prev_max = 0.0
@@ -424,9 +557,11 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
             incr_max = metrics['max_abs'] - prev_max
             incr_mean = metrics['mean_abs'] - prev_mean
 
-            lines.append(f"{stage_num:<6} {stage_name:<15} {metrics['max_abs']:<15.3e} "
-                        f"{metrics['mean_abs']:<15.3e} {metrics['rms']:<15.3e} "
-                        f"{incr_max:<15.3e} {incr_mean:<15.3e}")
+            lines.append(
+                f"{stage_num:<6} {stage_name:<15} {metrics['max_abs']:<15.3e} "
+                f"{metrics['mean_abs']:<15.3e} {metrics['rms']:<15.3e} "
+                f"{incr_max:<15.3e} {incr_mean:<15.3e}"
+            )
 
             prev_max = metrics['max_abs']
             prev_mean = metrics['mean_abs']
@@ -447,20 +582,24 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
                         ic_metrics = {
                             'max_abs': float(np.max(np.abs(diff))),
                             'mean_abs': float(np.mean(np.abs(diff))),
-                            'rms': float(np.sqrt(np.mean(diff**2)))
+                            'rms': float(np.sqrt(np.mean(diff**2))),
                         }
 
                         incr_max_ic = ic_metrics['max_abs'] - prev_max
                         incr_mean_ic = ic_metrics['mean_abs'] - prev_mean
 
-                        lines.append(f"{'9+10':<6} {'AfterICRemoval':<15} {ic_metrics['max_abs']:<15.3e} "
-                                    f"{ic_metrics['mean_abs']:<15.3e} {ic_metrics['rms']:<15.3e} "
-                                    f"{incr_max_ic:<15.3e} {incr_mean_ic:<15.3e}")
+                        lines.append(
+                            f"{'9+10':<6} {'AfterICRemoval':<15} {ic_metrics['max_abs']:<15.3e} "
+                            f"{ic_metrics['mean_abs']:<15.3e} {ic_metrics['rms']:<15.3e} "
+                            f"{incr_max_ic:<15.3e} {incr_mean_ic:<15.3e}"
+                        )
 
                         prev_max = ic_metrics['max_abs']
                         prev_mean = ic_metrics['mean_abs']
-                    except Exception as e:
-                        lines.append(f"{'9+10':<6} {'AfterICRemoval':<15} {'Error':<15} {'Error':<15} {'Error':<15} {'N/A':<15} {'N/A':<15}")
+                    except Exception:
+                        lines.append(
+                            f"{'9+10':<6} {'AfterICRemoval':<15} {'Error':<15} {'Error':<15} {'Error':<15} {'N/A':<15} {'N/A':<15}"
+                        )
 
         # ICA Analysis
         py_ica = [f for f in all_files if f.startswith(f'{basename}_stage09_') and f.endswith('_py.set')]
@@ -471,19 +610,23 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
             lines.append("  ICA Decomposition Comparison:")
             try:
                 ica_result = compare_ica_decompositions(
-                    os.path.join(stage_dir, py_ica[0]),
-                    os.path.join(stage_dir, mat_ica[0]),
-                    basename
+                    os.path.join(stage_dir, py_ica[0]), os.path.join(stage_dir, mat_ica[0]), basename
                 )
                 if ica_result:
-                    lines.append(f"    Components: {ica_result['n_components']}, "
-                                f"Avg corr: {ica_result['avg_corr']:.3f}, "
-                                f"Min corr: {ica_result['min_corr']:.3f}, "
-                                f"Max corr: {ica_result['max_corr']:.3f}")
+                    lines.append(
+                        f"    Components: {ica_result['n_components']}, "
+                        f"Avg corr: {ica_result['avg_corr']:.3f}, "
+                        f"Min corr: {ica_result['min_corr']:.3f}, "
+                        f"Max corr: {ica_result['max_corr']:.3f}"
+                    )
                     if ica_result['scalp_map_file']:
-                        lines.append(f"    Scalp maps (Python topoplot): {os.path.basename(ica_result['scalp_map_file'])}")
+                        lines.append(
+                            f"    Scalp maps (Python topoplot): {os.path.basename(ica_result['scalp_map_file'])}"
+                        )
                     if ica_result.get('scalp_map_file_matlab'):
-                        lines.append(f"    Scalp maps (MATLAB topoplot): {os.path.basename(ica_result['scalp_map_file_matlab'])}")
+                        lines.append(
+                            f"    Scalp maps (MATLAB topoplot): {os.path.basename(ica_result['scalp_map_file_matlab'])}"
+                        )
                 else:
                     lines.append("    No ICA data available")
             except Exception as e:
@@ -501,21 +644,29 @@ def generate_comparison_table(stage_dir: str, stages: List[int] = None) -> str:
                     icl_result = compare_iclabel_classifications(
                         os.path.join(stage_dir, py_icl[0]),
                         os.path.join(stage_dir, mat_icl[0]),
-                        ica_result.get('reorder_idx')
+                        ica_result.get('reorder_idx'),
                     )
                     if icl_result:
                         if icl_result['avg_prob_diff'] is not None:
                             # Same component count - full comparison
-                            lines.append(f"    Avg prob diff: {icl_result['avg_prob_diff']:.3f}, "
-                                        f"Max prob diff: {icl_result['max_prob_diff']:.3f}")
-                            lines.append(f"    Components remaining: Python={icl_result['n_components_py']}, "
-                                        f"MATLAB={icl_result['n_components_mat']}")
-                            lines.append(f"    Flagged (should be 0): Python={icl_result['n_flagged_py']}, "
-                                        f"MATLAB={icl_result['n_flagged_mat']}")
+                            lines.append(
+                                f"    Avg prob diff: {icl_result['avg_prob_diff']:.3f}, "
+                                f"Max prob diff: {icl_result['max_prob_diff']:.3f}"
+                            )
+                            lines.append(
+                                f"    Components remaining: Python={icl_result['n_components_py']}, "
+                                f"MATLAB={icl_result['n_components_mat']}"
+                            )
+                            lines.append(
+                                f"    Flagged (should be 0): Python={icl_result['n_flagged_py']}, "
+                                f"MATLAB={icl_result['n_flagged_mat']}"
+                            )
                         else:
                             # Different component counts
-                            lines.append(f"    Components remaining: Python={icl_result['n_components_py']}, "
-                                        f"MATLAB={icl_result['n_components_mat']}")
+                            lines.append(
+                                f"    Components remaining: Python={icl_result['n_components_py']}, "
+                                f"MATLAB={icl_result['n_components_mat']}"
+                            )
                             lines.append(f"    Note: {icl_result['note']}")
                     else:
                         lines.append("    No ICLabel data available")
@@ -544,7 +695,7 @@ def save_comparison_report(stage_dir: str, comparison_table: str, study: str, su
     png_files = sorted([f for f in os.listdir(stage_dir) if f.endswith('.png')])
 
     with open(report_path, 'w') as f:
-        f.write(f"# Stage-by-Stage Pipeline Comparison Report\n\n")
+        f.write("# Stage-by-Stage Pipeline Comparison Report\n\n")
         f.write(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
         f.write(f"**Study:** {study}\n\n")
         f.write(f"**Subjects:** {', '.join(map(str, subjects))}\n\n")

--- a/src/eegprep/plugins/ICLabel/ICL_feature_extractor.py
+++ b/src/eegprep/plugins/ICLabel/ICL_feature_extractor.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 import numpy as np
 
+
 def ICL_feature_extractor(EEG, flag_autocorr=False):
     """Extract features for ICLabel classification.
 
@@ -24,13 +25,14 @@ def ICL_feature_extractor(EEG, flag_autocorr=False):
     from eegprep import eeg_autocorr
     from eegprep import eeg_autocorr_fftw
     from eegprep import pop_reref
+
     EEG = deepcopy(EEG)
 
     # Check inputs
     ncomp = EEG['icawinv'].shape[1]
 
     # Check for ICA key and if it is not empty
-    if not 'icawinv' in EEG.keys() or EEG['icawinv'].size == 0:
+    if 'icawinv' not in EEG.keys() or EEG['icawinv'].size == 0:
         raise ValueError('You must have an ICA decomposition to use ICLabel')
 
     # Assuming chanlocs are correct
@@ -90,7 +92,9 @@ def ICL_feature_extractor(EEG, flag_autocorr=False):
             autocorr = eeg_autocorr_fftw(EEG)
 
         # Reshape and cast
-        autocorr = np.transpose(np.expand_dims(np.expand_dims(autocorr, axis=-1), axis=-1), (2, 1, 3, 0)).astype(np.float32)
+        autocorr = np.transpose(np.expand_dims(np.expand_dims(autocorr, axis=-1), axis=-1), (2, 1, 3, 0)).astype(
+            np.float32
+        )
 
     # Format outputs
     if flag_autocorr:
@@ -99,10 +103,3 @@ def ICL_feature_extractor(EEG, flag_autocorr=False):
         features = [0.99 * topo, 0.99 * psd]
 
     return features
-
-def test_ICL_feature_extractor():
-    """Test the ICL_feature_extractor function."""
-    flag_autocorr = True
-    EEG = EEG2
-    EEG['ref'] = 'averef'
-    EEG['chanlocs'] = np.random.randn(32, 3)

--- a/src/eegprep/plugins/ICLabel/__init__.py
+++ b/src/eegprep/plugins/ICLabel/__init__.py
@@ -1,2 +1,1 @@
 """ICLabel plugin ports."""
-

--- a/src/eegprep/plugins/ICLabel/eeg_autocorr.py
+++ b/src/eegprep/plugins/ICLabel/eeg_autocorr.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.signal import resample_poly
 from numpy.fft import fft, ifft
 
+
 def eeg_autocorr(EEG, pct_data=None):
     """Compute autocorrelation of ICA components.
 
@@ -26,22 +27,24 @@ def eeg_autocorr(EEG, pct_data=None):
     EEG['icaact'] = EEG['icaact'].astype(np.float32)
 
     ncomp = EEG['icaact'].shape[0]
-    nfft = 2**np.ceil(np.log2(2 * EEG['pnts'] - 1)).astype(int)
+    nfft = 2 ** np.ceil(np.log2(2 * EEG['pnts'] - 1)).astype(int)
 
     # Calculate autocorrelation
     c = np.zeros((ncomp, nfft))
     for it in range(ncomp):
-        comp = EEG['icaact'][it,:].reshape(-1)
+        comp = EEG['icaact'][it, :].reshape(-1)
         Xtmp = fft(comp, nfft)
-        Xtmp = Xtmp.astype(np.complex64) # matches MATLAB's single precision since python convert to double precision by default
-        X = np.abs(Xtmp)**2
+        Xtmp = Xtmp.astype(
+            np.complex64
+        )  # matches MATLAB's single precision since python convert to double precision by default
+        X = np.abs(Xtmp) ** 2
         c[it, :] = np.real(ifft(X))
 
     # Adjust the size of the autocorrelation to match sampling rate
     if EEG['pnts'] < EEG['srate']:
-        ac = np.hstack([c[:, :EEG['pnts']], np.zeros((ncomp, EEG['srate'] - EEG['pnts'] + 1))])
+        ac = np.hstack([c[:, : EEG['pnts']], np.zeros((ncomp, EEG['srate'] - EEG['pnts'] + 1))])
     else:
-        ac = c[:, :int(EEG['srate']) + 1]
+        ac = c[:, : int(EEG['srate']) + 1]
 
     # Normalize by the 0-tap of the autocorrelation
     ac /= ac[:, [0]]
@@ -54,6 +57,7 @@ def eeg_autocorr(EEG, pct_data=None):
 
     return ac
 
+
 def test_eeg_autocorr():
     """Test the eeg_autocorr function."""
     EEG = {
@@ -61,18 +65,18 @@ def test_eeg_autocorr():
         'icaweights': np.random.randn(10, 256),
         'pnts': 1000,
         'trials': 5,
-        'icaact': np.random.randn(10, 1000, 5)
+        'icaact': np.random.randn(10, 1000, 5),
     }
 
-    psdmed = eeg_autocorr(EEG, 100)
+    eeg_autocorr(EEG, 100)
 
     # print information about psdmed
     # print(psdmed.shape)
 
-    #print(psdmed)
+    # print(psdmed)
 
+    # assert psdmed.shape == (10, 100)
+    # assert np.all(np.isfinite(psdmed))
 
-    #assert psdmed.shape == (10, 100)
-    #assert np.all(np.isfinite(psdmed))
 
 # test_eeg_autocorr()

--- a/src/eegprep/plugins/ICLabel/eeg_autocorr_fftw.py
+++ b/src/eegprep/plugins/ICLabel/eeg_autocorr_fftw.py
@@ -5,11 +5,10 @@ fast Fourier transform methods.
 """
 
 import numpy as np
-from scipy import signal
 from scipy.fft import fft, ifft, next_fast_len
 from scipy.signal import resample_poly
 from ...functions.popfunc.pop_loadset import pop_loadset
-from ...functions.popfunc.pop_reref import pop_reref
+
 
 def eeg_autocorr_fftw(EEG, pct_data=100):
     """Compute autocorrelation of EEG ICA components using FFT.
@@ -38,7 +37,7 @@ def eeg_autocorr_fftw(EEG, pct_data=100):
         # Apply FFT
         X = fft(EEG['icaact'][it, :, :], n=nfft, axis=0)
         # Compute the mean of the power spectrum
-        ac[it, :] = np.mean(np.abs(X)**2, axis=1)
+        ac[it, :] = np.mean(np.abs(X) ** 2, axis=1)
 
     # Inverse FFT to get autocorrelation
     ac = ifft(ac, axis=1)
@@ -49,9 +48,9 @@ def eeg_autocorr_fftw(EEG, pct_data=100):
     # Adjust the size of autocorrelation array
     if EEG['pnts'] < EEG['srate']:
         # ac = np.hstack(     [ac[:, :EEG['pnts']], np.zeros((ncomp      , EEG['srate'] - EEG['pnts'] + 1))])
-        ac = np.concatenate((ac[:, :EEG['pnts']], np.zeros((ac.shape[0], EEG['srate'] - EEG['pnts'] + 1))), axis=1)
+        ac = np.concatenate((ac[:, : EEG['pnts']], np.zeros((ac.shape[0], EEG['srate'] - EEG['pnts'] + 1))), axis=1)
     else:
-        ac = ac[:, :int(EEG['srate']) + 1]
+        ac = ac[:, : int(EEG['srate']) + 1]
 
     # Normalize by 0-lag autocorrelation
     ac = ac / ac[:, 0][:, np.newaxis]
@@ -70,7 +69,7 @@ def test_eeg_autocorr_fftw():
         'icaweights': np.random.randn(10, 256),
         'pnts': 1000,
         'trials': 5,
-        'icaact': np.random.randn(10, 1000, 5)
+        'icaact': np.random.randn(10, 1000, 5),
     }
     EEG = pop_loadset('/System/Volumes/Data/data/data/STUDIES/STERN/S01/Memorize.set')
 
@@ -84,5 +83,6 @@ def test_eeg_autocorr_fftw():
     # print information about psdmed
     print(psdmed.shape)
     print(psdmed)
+
 
 # test_eeg_autocorr_fftw()

--- a/src/eegprep/plugins/ICLabel/eeg_autocorr_welch.py
+++ b/src/eegprep/plugins/ICLabel/eeg_autocorr_welch.py
@@ -8,8 +8,8 @@ import numpy as np
 from scipy.signal import resample_poly
 import random
 from ...functions.popfunc.pop_loadset import pop_loadset
-import numpy as np
 from numpy.fft import fft, ifft
+
 
 def eeg_autocorr_welch(EEG, pct_data=100):
     """Compute autocorrelation of EEG ICA components using Welch method.
@@ -33,9 +33,11 @@ def eeg_autocorr_welch(EEG, pct_data=100):
     # setup constants
     ncomp = EEG['icaweights'].shape[0]
     n_points = min(EEG['pnts'], EEG['srate'] * 3)
-    nfft = 2**(int(np.log2(n_points * 2 - 1)) + 1)
+    nfft = 2 ** (int(np.log2(n_points * 2 - 1)) + 1)
     cutoff = (EEG['pnts'] // n_points) * n_points
-    index = np.add.outer(np.ceil(np.arange(0, cutoff - n_points + 1, n_points // 2)).astype(int), np.arange(n_points)).astype(int)
+    index = np.add.outer(
+        np.ceil(np.arange(0, cutoff - n_points + 1, n_points // 2)).astype(int), np.arange(n_points)
+    ).astype(int)
     index = index.T
 
     # separate data segments
@@ -52,15 +54,29 @@ def eeg_autocorr_welch(EEG, pct_data=100):
     # calc autocorrelation
     ac = np.zeros((ncomp, nfft))
     for it in range(ncomp):
-        fftpow = np.mean(np.abs(fft(segments[it, :, :], nfft, axis=0))**2, axis=1)
+        fftpow = np.mean(np.abs(fft(segments[it, :, :], nfft, axis=0)) ** 2, axis=1)
         ac[it, :] = np.real(ifft(fftpow, axis=0)).T
 
     # normalizefft
     if EEG['pnts'] < EEG['srate']:
-        ac = np.concatenate([ac[:, :EEG['pnts']] / (ac[:, 0][:, np.newaxis] * np.arange(n_points, 0, -1) / n_points),
-                             np.zeros((ncomp, int(EEG['srate']) - n_points + 1))], axis=1)
+        ac = np.concatenate(
+            [
+                ac[:, : EEG['pnts']] / (ac[:, 0][:, np.newaxis] * np.arange(n_points, 0, -1) / n_points),
+                np.zeros((ncomp, int(EEG['srate']) - n_points + 1)),
+            ],
+            axis=1,
+        )
     else:
-        ac = ac[:, :int(EEG['srate']) + 1] / (ac[:, 0][:, np.newaxis] * np.concatenate((np.arange(n_points, n_points - int(EEG['srate']), -1), np.array([max(1, n_points - int(EEG['srate']))]))) / n_points)
+        ac = ac[:, : int(EEG['srate']) + 1] / (
+            ac[:, 0][:, np.newaxis]
+            * np.concatenate(
+                (
+                    np.arange(n_points, n_points - int(EEG['srate']), -1),
+                    np.array([max(1, n_points - int(EEG['srate']))]),
+                )
+            )
+            / n_points
+        )
 
     # resample to 1 second at 100 samples/sec
     ac = resample_poly(ac.T, up=100, down=EEG['srate']).T
@@ -68,15 +84,17 @@ def eeg_autocorr_welch(EEG, pct_data=100):
 
     return ac
 
+
 def test_eeg_autocorr_welch():
     """Test function for eeg_autocorr_welch."""
     eeglab_file_path = './eeglab_data_with_ica_tmp.set'
     EEG = pop_loadset(eeglab_file_path)
 
-    psdmed = eeg_autocorr_welch(EEG, 100)
+    eeg_autocorr_welch(EEG, 100)
 
     # print information about psdmed
     # print(psdmed.shape)
     # print(psdmed)
+
 
 # test_eeg_autocorr_welch()

--- a/src/eegprep/plugins/ICLabel/eeg_icflag.py
+++ b/src/eegprep/plugins/ICLabel/eeg_icflag.py
@@ -74,10 +74,10 @@ def eeg_icflag(EEG, thresholds):
             reject |= (probs >= min_thresh) & (probs <= max_thresh)
         elif not np.isnan(min_thresh):
             # Only min threshold: flag if >= min
-            reject |= (probs >= min_thresh)
+            reject |= probs >= min_thresh
         elif not np.isnan(max_thresh):
             # Only max threshold: flag if <= max
-            reject |= (probs <= max_thresh)
+            reject |= probs <= max_thresh
 
     # Store reject flags in EEG structure
     EEG['reject'] = {

--- a/src/eegprep/plugins/ICLabel/eeg_rpsd.py
+++ b/src/eegprep/plugins/ICLabel/eeg_rpsd.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from numpy.fft import fft
-from scipy.signal.windows import hamming
+
 
 def eeg_rpsd(EEG, nfreqs=None, pct_data=100):
     """Compute relative power spectral density for ICA components.
@@ -47,11 +47,15 @@ def eeg_rpsd(EEG, nfreqs=None, pct_data=100):
         window = np.concatenate([window, window[::-1]])
 
     cutoff = (EEG['pnts'] // n_points) * n_points
-    index = np.add.outer(np.ceil(np.arange(0, cutoff - n_points + 1, n_points/2)).astype(int), np.arange(0, n_points)).astype(int).transpose()
+    index = (
+        np.add.outer(np.ceil(np.arange(0, cutoff - n_points + 1, n_points / 2)).astype(int), np.arange(0, n_points))
+        .astype(int)
+        .transpose()
+    )
 
     np.random.seed(0)  # rng('default') in MATLAB
     n_seg = index.shape[1] * EEG['trials']
-    subset = np.random.permutation(n_seg)[:int(n_seg * pct_data / 100)]
+    subset = np.random.permutation(n_seg)[: int(n_seg * pct_data / 100)]
 
     # calculate windowed spectrums
     psdmed = np.zeros((ncomp, nfreqs))
@@ -60,12 +64,13 @@ def eeg_rpsd(EEG, nfreqs=None, pct_data=100):
         temp = temp[:, :, subset] * window[:, np.newaxis]
         temp = fft(temp, int(n_points), axis=1)
         temp = np.abs(temp) ** 2
-        temp = temp[:, 1:nfreqs + 1, :] * 2 / (EEG['srate'] * np.sum(window ** 2))
+        temp = temp[:, 1 : nfreqs + 1, :] * 2 / (EEG['srate'] * np.sum(window**2))
         if nfreqs == nyquist:
             temp[:, -1, :] /= 2
         psdmed[it, :] = 20 * np.log10(np.median(temp, axis=2))
 
     return psdmed
+
 
 def test_eeg_rpsd():
     """Test the eeg_rpsd function with sample data."""
@@ -74,11 +79,12 @@ def test_eeg_rpsd():
         'icaweights': np.random.randn(10, 256),
         'pnts': 1000,
         'trials': 5,
-        'icaact': np.random.randn(10, 1000, 5)
+        'icaact': np.random.randn(10, 1000, 5),
     }
 
     psdmed = eeg_rpsd(EEG, 100)
     assert psdmed.shape == (10, 100)
     assert np.all(np.isfinite(psdmed))
+
 
 # test_eeg_rpsd()

--- a/src/eegprep/plugins/ICLabel/iclabel.py
+++ b/src/eegprep/plugins/ICLabel/iclabel.py
@@ -5,6 +5,7 @@ import os
 
 import numpy as np
 
+
 def iclabel(EEG, algorithm='default', engine=None):
     """Apply ICLabel to classify independent components.
 
@@ -57,11 +58,13 @@ def iclabel(EEG, algorithm='default', engine=None):
         from eegprep.plugins.ICLabel.iclabel_net import ICLabelNet
         from eegprep import ICL_feature_extractor
 
-        #ICLABEL Extract ICLabel features from an EEG dataset.
+        # ICLABEL Extract ICLabel features from an EEG dataset.
         features = ICL_feature_extractor(EEG, True)
 
         # Equivalent of MATLAB code reshaping
-        features[0] = np.single(np.concatenate([features[0],-features[0],features[0][:, ::-1, :, :],-features[0][:, ::-1, :, :]], axis=3))
+        features[0] = np.single(
+            np.concatenate([features[0], -features[0], features[0][:, ::-1, :, :], -features[0][:, ::-1, :, :]], axis=3)
+        )
         features[1] = np.single(np.tile(features[1], (1, 1, 1, 4)))
         features[2] = np.single(np.tile(features[2], (1, 1, 1, 4)))
         # print('Feature 0 shape:', features[0].shape)
@@ -92,10 +95,8 @@ def iclabel(EEG, algorithm='default', engine=None):
         if 'ICLabel' not in EEG['etc']['ic_classification']:
             EEG['etc']['ic_classification']['ICLabel'] = {}
 
-        np.object = object
         EEG['etc']['ic_classification']['ICLabel']['classes'] = np.array(
-            ['Brain', 'Muscle', 'Eye', 'Heart', 'Line Noise', 'Channel Noise', 'Other'],
-            dtype=object
+            ['Brain', 'Muscle', 'Eye', 'Heart', 'Line Noise', 'Channel Noise', 'Other'], dtype=object
         )
         EEG['etc']['ic_classification']['ICLabel']['classifications'] = output_np
         EEG['etc']['ic_classification']['ICLabel']['version'] = algorithm

--- a/src/eegprep/plugins/ICLabel/iclabel_net.py
+++ b/src/eegprep/plugins/ICLabel/iclabel_net.py
@@ -7,7 +7,7 @@ classifying EEG components as brain or artifact sources.
 import scipy.io
 import torch
 import scipy
-import numpy as np
+
 
 class Reshape(torch.nn.Module):
     """Custom reshape layer for PyTorch neural networks."""
@@ -37,6 +37,7 @@ class Reshape(torch.nn.Module):
             Reshaped tensor.
         """
         return x.view(x.shape[0], *self.shape)
+
 
 class Concatenate(torch.nn.Module):
     """Custom concatenation layer for PyTorch neural networks."""
@@ -84,42 +85,96 @@ class ICLabelNet(torch.nn.Module):
         params = iclabel_matlab['params'][0]
         # i = 11
         # print('shape of param', i, torch.tensor(params[i][1]).shape)
-        self.discriminator_image_layer1_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=4, stride=2, padding=1, dilation=1)
+        self.discriminator_image_layer1_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=4, stride=2, padding=1, dilation=1
+        )
         # print(self.discriminator_image_layer1_conv.weight.shape)
-        self.discriminator_image_layer1_conv.weight = torch.nn.Parameter(torch.tensor(params[0][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer1_conv.bias = torch.nn.Parameter(torch.tensor(params[1][1], dtype=torch.float32).squeeze())
+        self.discriminator_image_layer1_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[0][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_image_layer1_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[1][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_image_layer1_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer2_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=4, stride=2, padding=1, dilation=1)
-        self.discriminator_image_layer2_conv.weight = torch.nn.Parameter(torch.tensor(params[2][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer2_conv.bias = torch.nn.Parameter(torch.tensor(params[3][1], dtype=torch.float32).squeeze())
+        self.discriminator_image_layer2_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=4, stride=2, padding=1, dilation=1
+        )
+        self.discriminator_image_layer2_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[2][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_image_layer2_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[3][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_image_layer2_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer3_conv = torch.nn.Conv2d(in_channels=256, out_channels=512, kernel_size=4, stride=2, padding=1, dilation=1)
-        self.discriminator_image_layer3_conv.weight = torch.nn.Parameter(torch.tensor(params[4][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer3_conv.bias = torch.nn.Parameter(torch.tensor(params[5][1], dtype=torch.float32).squeeze())
+        self.discriminator_image_layer3_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=512, kernel_size=4, stride=2, padding=1, dilation=1
+        )
+        self.discriminator_image_layer3_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[4][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_image_layer3_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[5][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_image_layer3_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[6][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[7][1], dtype=torch.float32).squeeze())
+        self.discriminator_psdmed_layer1_conv_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer1_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[6][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_psdmed_layer1_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[7][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_psdmed_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[8][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[9][1], dtype=torch.float32).squeeze())
+        self.discriminator_psdmed_layer2_conv_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer2_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[8][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_psdmed_layer2_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[9][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_psdmed_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[10][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[11][1], dtype=torch.float32).squeeze(1))
+        self.discriminator_psdmed_layer3_conv_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=1, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer3_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[10][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1)
+        )
+        self.discriminator_psdmed_layer3_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[11][1], dtype=torch.float32).squeeze(1)
+        )
         self.discriminator_psdmed_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[12][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[13][1], dtype=torch.float32).squeeze())
+        self.discriminator_autocorr_layer1_conv_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer1_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[12][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_autocorr_layer1_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[13][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_autocorr_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[14][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[15][1], dtype=torch.float32).squeeze())
+        self.discriminator_autocorr_layer2_conv_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer2_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[14][1], dtype=torch.float32).permute(3, 2, 0, 1)
+        )
+        self.discriminator_autocorr_layer2_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[15][1], dtype=torch.float32).squeeze()
+        )
         self.discriminator_autocorr_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[16][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[17][1], dtype=torch.float32).squeeze(1))
+        self.discriminator_autocorr_layer3_conv_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=1, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer3_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[16][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1)
+        )
+        self.discriminator_autocorr_layer3_conv_conv.bias = torch.nn.Parameter(
+            torch.tensor(params[17][1], dtype=torch.float32).squeeze(1)
+        )
         self.discriminator_autocorr_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
         self.discriminator_psdmed_reshape = Reshape((100, 1, 1))
         self.discriminator_psdmed_concat1 = Concatenate(dim=2)
@@ -128,78 +183,9 @@ class ICLabelNet(torch.nn.Module):
         self.discriminator_autocorr_concat1 = Concatenate(dim=2)
         self.discriminator_autocorr_concat2 = Concatenate(dim=3)
         self.discriminator_concat = Concatenate(dim=1)
-        self.discriminator_conv = torch.nn.Conv2d(in_channels=712, out_channels=7, kernel_size=4, stride=1, padding=0, dilation=1)
-        self.discriminator_conv.weight = torch.nn.Parameter(torch.tensor(params[18][1]).permute(3, 2, 0, 1))
-        self.discriminator_conv.bias = torch.nn.Parameter(torch.tensor(params[19][1]).squeeze())
-        self.discriminator_softmax = torch.nn.Softmax(dim=1)
-
-    def forward(self, image, psdmed, autocorr):
-        """Forward pass through the ICLabel network.
-
-        Parameters
-        ----------
-        image : torch.Tensor
-            Topographic image input.
-        psdmed : torch.Tensor
-            Power spectral density input.
-        autocorr : torch.Tensor
-            Autocorrelation input.
-
-        Returns
-        -------
-        torch.Tensor
-            Classification probabilities for each component type.
-        """
-        super().__init__()
-        iclabel_matlab = scipy.io.loadmat(mat_path)
-        params = iclabel_matlab['params'][0]
-        # i = 11
-        # print('shape of param', i, torch.tensor(params[i][1]).shape)
-        self.discriminator_image_layer1_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=4, stride=2, padding=1, dilation=1)
-        # print(self.discriminator_image_layer1_conv.weight.shape)
-        self.discriminator_image_layer1_conv.weight = torch.nn.Parameter(torch.tensor(params[0][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer1_conv.bias = torch.nn.Parameter(torch.tensor(params[1][1], dtype=torch.float32).squeeze())
-        self.discriminator_image_layer1_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer2_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=4, stride=2, padding=1, dilation=1)
-        self.discriminator_image_layer2_conv.weight = torch.nn.Parameter(torch.tensor(params[2][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer2_conv.bias = torch.nn.Parameter(torch.tensor(params[3][1], dtype=torch.float32).squeeze())
-        self.discriminator_image_layer2_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer3_conv = torch.nn.Conv2d(in_channels=256, out_channels=512, kernel_size=4, stride=2, padding=1, dilation=1)
-        self.discriminator_image_layer3_conv.weight = torch.nn.Parameter(torch.tensor(params[4][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_image_layer3_conv.bias = torch.nn.Parameter(torch.tensor(params[5][1], dtype=torch.float32).squeeze())
-        self.discriminator_image_layer3_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[6][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[7][1], dtype=torch.float32).squeeze())
-        self.discriminator_psdmed_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[8][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[9][1], dtype=torch.float32).squeeze())
-        self.discriminator_psdmed_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[10][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1))
-        self.discriminator_psdmed_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[11][1], dtype=torch.float32).squeeze(1))
-        self.discriminator_psdmed_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[12][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[13][1], dtype=torch.float32).squeeze())
-        self.discriminator_autocorr_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[14][1], dtype=torch.float32).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[15][1], dtype=torch.float32).squeeze())
-        self.discriminator_autocorr_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[16][1], dtype=torch.float32).unsqueeze(3).permute(3, 2, 0, 1))
-        self.discriminator_autocorr_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[17][1], dtype=torch.float32).squeeze(1))
-        self.discriminator_autocorr_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_reshape = Reshape((100, 1, 1))
-        self.discriminator_psdmed_concat1 = Concatenate(dim=2)
-        self.discriminator_psdmed_concat2 = Concatenate(dim=3)
-        self.discriminator_autocorr_reshape = Reshape((100, 1, 1))
-        self.discriminator_autocorr_concat1 = Concatenate(dim=2)
-        self.discriminator_autocorr_concat2 = Concatenate(dim=3)
-        self.discriminator_concat = Concatenate(dim=1)
-        self.discriminator_conv = torch.nn.Conv2d(in_channels=712, out_channels=7, kernel_size=4, stride=1, padding=0, dilation=1)
+        self.discriminator_conv = torch.nn.Conv2d(
+            in_channels=712, out_channels=7, kernel_size=4, stride=1, padding=0, dilation=1
+        )
         self.discriminator_conv.weight = torch.nn.Parameter(torch.tensor(params[18][1]).permute(3, 2, 0, 1))
         self.discriminator_conv.bias = torch.nn.Parameter(torch.tensor(params[19][1]).squeeze())
         self.discriminator_softmax = torch.nn.Softmax(dim=1)
@@ -236,8 +222,8 @@ class ICLabelNet(torch.nn.Module):
         x_psdmed = self.discriminator_psdmed_layer3_conv_conv(x_psdmed)
         x_psdmed = self.discriminator_psdmed_layer3_conv_relu(x_psdmed)
         x_psdmed = self.discriminator_psdmed_reshape(x_psdmed)
-        x_psdmed = self.discriminator_psdmed_concat1([x_psdmed]*4)
-        x_psdmed = self.discriminator_psdmed_concat2([x_psdmed]*4)
+        x_psdmed = self.discriminator_psdmed_concat1([x_psdmed] * 4)
+        x_psdmed = self.discriminator_psdmed_concat2([x_psdmed] * 4)
         # print('x_psdmed', x_psdmed.shape)
 
         x_autocorr = self.discriminator_autocorr_layer1_conv_conv(autocorr)
@@ -247,8 +233,8 @@ class ICLabelNet(torch.nn.Module):
         x_autocorr = self.discriminator_autocorr_layer3_conv_conv(x_autocorr)
         x_autocorr = self.discriminator_autocorr_layer3_conv_relu(x_autocorr)
         x_autocorr = self.discriminator_autocorr_reshape(x_autocorr)
-        x_autocorr = self.discriminator_autocorr_concat1([x_autocorr]*4)
-        x_autocorr = self.discriminator_autocorr_concat2([x_autocorr]*4)
+        x_autocorr = self.discriminator_autocorr_concat1([x_autocorr] * 4)
+        x_autocorr = self.discriminator_autocorr_concat2([x_autocorr] * 4)
         # print('x_autocorr', x_autocorr.shape)
 
         x = self.discriminator_concat([x_image, x_psdmed, x_autocorr])
@@ -259,6 +245,7 @@ class ICLabelNet(torch.nn.Module):
         x = self.discriminator_softmax(x)
 
         return x
+
 
 # if __name__ == "__main__":
 #     model = ICLabelNet('netICL.mat')

--- a/src/eegprep/plugins/ICLabel/iclabel_net_load_py_measures.py
+++ b/src/eegprep/plugins/ICLabel/iclabel_net_load_py_measures.py
@@ -2,11 +2,10 @@
 
 from pathlib import Path
 
-import numpy as np
 import scipy
 import scipy.io
 import torch
-from pathlib import Path
+
 
 class Reshape(torch.nn.Module):
     """Reshape layer for PyTorch."""
@@ -19,6 +18,7 @@ class Reshape(torch.nn.Module):
     def forward(self, x):
         """Forward pass for reshape."""
         return x.view(x.shape[0], *self.shape)
+
 
 class Concatenate(torch.nn.Module):
     """Concatenate layer for PyTorch."""
@@ -43,41 +43,71 @@ class ICLabelNet(torch.nn.Module):
         params = iclabel_matlab['params'][0]
         i = 11
         print('shape of param', i, torch.tensor(params[i][1]).shape)
-        self.discriminator_image_layer1_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=4, stride=2, padding=1, dilation=1)
+        self.discriminator_image_layer1_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=4, stride=2, padding=1, dilation=1
+        )
         print(self.discriminator_image_layer1_conv.weight.shape)
         self.discriminator_image_layer1_conv.weight = torch.nn.Parameter(torch.tensor(params[0][1]).permute(3, 2, 0, 1))
         self.discriminator_image_layer1_conv.bias = torch.nn.Parameter(torch.tensor(params[1][1]).squeeze())
         self.discriminator_image_layer1_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer2_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=4, stride=2, padding=1, dilation=1)
+        self.discriminator_image_layer2_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=4, stride=2, padding=1, dilation=1
+        )
         self.discriminator_image_layer2_conv.weight = torch.nn.Parameter(torch.tensor(params[2][1]).permute(3, 2, 0, 1))
         self.discriminator_image_layer2_conv.bias = torch.nn.Parameter(torch.tensor(params[3][1]).squeeze())
         self.discriminator_image_layer2_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_image_layer3_conv = torch.nn.Conv2d(in_channels=256, out_channels=512, kernel_size=4, stride=2, padding=1, dilation=1)
+        self.discriminator_image_layer3_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=512, kernel_size=4, stride=2, padding=1, dilation=1
+        )
         self.discriminator_image_layer3_conv.weight = torch.nn.Parameter(torch.tensor(params[4][1]).permute(3, 2, 0, 1))
         self.discriminator_image_layer3_conv.bias = torch.nn.Parameter(torch.tensor(params[5][1]).squeeze())
         self.discriminator_image_layer3_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[6][1]).permute(3, 2, 0, 1))
+        self.discriminator_psdmed_layer1_conv_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer1_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[6][1]).permute(3, 2, 0, 1)
+        )
         self.discriminator_psdmed_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[7][1]).squeeze())
         self.discriminator_psdmed_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[8][1]).permute(3, 2, 0, 1))
+        self.discriminator_psdmed_layer2_conv_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer2_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[8][1]).permute(3, 2, 0, 1)
+        )
         self.discriminator_psdmed_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[9][1]).squeeze())
         self.discriminator_psdmed_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_psdmed_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_psdmed_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[10][1]).unsqueeze(3).permute(3, 2, 0, 1))
+        self.discriminator_psdmed_layer3_conv_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=1, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_psdmed_layer3_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[10][1]).unsqueeze(3).permute(3, 2, 0, 1)
+        )
         self.discriminator_psdmed_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[11][1]).squeeze(1))
         self.discriminator_psdmed_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer1_conv_conv = torch.nn.Conv2d(in_channels=1, out_channels=128, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer1_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[12][1]).permute(3, 2, 0, 1))
+        self.discriminator_autocorr_layer1_conv_conv = torch.nn.Conv2d(
+            in_channels=1, out_channels=128, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer1_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[12][1]).permute(3, 2, 0, 1)
+        )
         self.discriminator_autocorr_layer1_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[13][1]).squeeze())
         self.discriminator_autocorr_layer1_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer2_conv_conv = torch.nn.Conv2d(in_channels=128, out_channels=256, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer2_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[14][1]).permute(3, 2, 0, 1))
+        self.discriminator_autocorr_layer2_conv_conv = torch.nn.Conv2d(
+            in_channels=128, out_channels=256, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer2_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[14][1]).permute(3, 2, 0, 1)
+        )
         self.discriminator_autocorr_layer2_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[15][1]).squeeze())
         self.discriminator_autocorr_layer2_conv_relu = torch.nn.LeakyReLU(0.2)
-        self.discriminator_autocorr_layer3_conv_conv = torch.nn.Conv2d(in_channels=256, out_channels=1, kernel_size=(1,3), stride=1, padding=(0,1), dilation=1)
-        self.discriminator_autocorr_layer3_conv_conv.weight = torch.nn.Parameter(torch.tensor(params[16][1]).unsqueeze(3).permute(3, 2, 0, 1))
+        self.discriminator_autocorr_layer3_conv_conv = torch.nn.Conv2d(
+            in_channels=256, out_channels=1, kernel_size=(1, 3), stride=1, padding=(0, 1), dilation=1
+        )
+        self.discriminator_autocorr_layer3_conv_conv.weight = torch.nn.Parameter(
+            torch.tensor(params[16][1]).unsqueeze(3).permute(3, 2, 0, 1)
+        )
         self.discriminator_autocorr_layer3_conv_conv.bias = torch.nn.Parameter(torch.tensor(params[17][1]).squeeze(1))
         self.discriminator_autocorr_layer3_conv_relu = torch.nn.LeakyReLU(0.2)
         self.discriminator_psdmed_reshape = Reshape((100, 1, 1))
@@ -87,7 +117,9 @@ class ICLabelNet(torch.nn.Module):
         self.discriminator_autocorr_concat1 = Concatenate(dim=2)
         self.discriminator_autocorr_concat2 = Concatenate(dim=3)
         self.discriminator_concat = Concatenate(dim=1)
-        self.discriminator_conv = torch.nn.Conv2d(in_channels=712, out_channels=7, kernel_size=4, stride=1, padding=0, dilation=1)
+        self.discriminator_conv = torch.nn.Conv2d(
+            in_channels=712, out_channels=7, kernel_size=4, stride=1, padding=0, dilation=1
+        )
         self.discriminator_conv.weight = torch.nn.Parameter(torch.tensor(params[18][1]).permute(3, 2, 0, 1))
         self.discriminator_conv.bias = torch.nn.Parameter(torch.tensor(params[19][1]).squeeze())
         self.discriminator_softmax = torch.nn.Softmax(dim=1)
@@ -109,8 +141,8 @@ class ICLabelNet(torch.nn.Module):
         x_psdmed = self.discriminator_psdmed_layer3_conv_conv(x_psdmed)
         x_psdmed = self.discriminator_psdmed_layer3_conv_relu(x_psdmed)
         x_psdmed = self.discriminator_psdmed_reshape(x_psdmed)
-        x_psdmed = self.discriminator_psdmed_concat1([x_psdmed]*4)
-        x_psdmed = self.discriminator_psdmed_concat2([x_psdmed]*4)
+        x_psdmed = self.discriminator_psdmed_concat1([x_psdmed] * 4)
+        x_psdmed = self.discriminator_psdmed_concat2([x_psdmed] * 4)
         print('x_psdmed', x_psdmed.shape)
 
         x_autocorr = self.discriminator_autocorr_layer1_conv_conv(autocorr)
@@ -120,8 +152,8 @@ class ICLabelNet(torch.nn.Module):
         x_autocorr = self.discriminator_autocorr_layer3_conv_conv(x_autocorr)
         x_autocorr = self.discriminator_autocorr_layer3_conv_relu(x_autocorr)
         x_autocorr = self.discriminator_autocorr_reshape(x_autocorr)
-        x_autocorr = self.discriminator_autocorr_concat1([x_autocorr]*4)
-        x_autocorr = self.discriminator_autocorr_concat2([x_autocorr]*4)
+        x_autocorr = self.discriminator_autocorr_concat1([x_autocorr] * 4)
+        x_autocorr = self.discriminator_autocorr_concat2([x_autocorr] * 4)
         print('x_autocorr', x_autocorr.shape)
 
         x = self.discriminator_concat([x_image, x_psdmed, x_autocorr])
@@ -133,11 +165,12 @@ class ICLabelNet(torch.nn.Module):
 
         return x
 
+
 if __name__ == "__main__":
     model = ICLabelNet(Path(__file__).with_name("netICL.mat"))
     data = scipy.io.loadmat('python_temp_reformated.mat')
-    image_mat    = data['grid'][0][0]
-    psdmed_mat   = data['grid'][0][1]
+    image_mat = data['grid'][0][0]
+    psdmed_mat = data['grid'][0][1]
     autocorr_mat = data['grid'][0][2]
     # assuming third dimension is trivial and last dimension is channel. First two dimensions (32 x 32) are size of topoplot
     image = torch.tensor(image_mat).permute(-1, 2, 0, 1)

--- a/src/eegprep/plugins/ICLabel/menu.py
+++ b/src/eegprep/plugins/ICLabel/menu.py
@@ -12,9 +12,21 @@ def iclabel_menu() -> MenuItemSpec:
         userdata="startup:off;study:on;ica:on;roi:off",
         origin="ICLabel",
         children=[
-            menu_item("Label components", action="pop_iclabel", userdata="startup:off;study:on;ica:on", origin="ICLabel"),
-            menu_item("Flag components as artifacts", action="pop_icflag", userdata="startup:off;study:on;ica:on", origin="ICLabel"),
-            menu_item("View extended component properties", action="pop_viewprops:components", userdata="startup:off;ica:on", origin="ICLabel"),
+            menu_item(
+                "Label components", action="pop_iclabel", userdata="startup:off;study:on;ica:on", origin="ICLabel"
+            ),
+            menu_item(
+                "Flag components as artifacts",
+                action="pop_icflag",
+                userdata="startup:off;study:on;ica:on",
+                origin="ICLabel",
+            ),
+            menu_item(
+                "View extended component properties",
+                action="pop_viewprops:components",
+                userdata="startup:off;ica:on",
+                origin="ICLabel",
+            ),
         ],
     )
 

--- a/src/eegprep/plugins/__init__.py
+++ b/src/eegprep/plugins/__init__.py
@@ -1,2 +1,1 @@
 """EEGLAB-style plugin modules."""
-

--- a/src/eegprep/plugins/clean_rawdata/__init__.py
+++ b/src/eegprep/plugins/clean_rawdata/__init__.py
@@ -1,2 +1,1 @@
 """clean_rawdata plugin ports."""
-

--- a/src/eegprep/plugins/clean_rawdata/asr_calibrate.py
+++ b/src/eegprep/plugins/clean_rawdata/asr_calibrate.py
@@ -13,9 +13,21 @@ from .private.stats import fit_eeg_distribution, geometric_median
 logger = logging.getLogger(__name__)
 
 
-def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
-                  window_len=None, window_overlap=None, max_dropout_fraction=None,
-                  min_clean_fraction=None, maxmem=None, useriemannian=None, compatibility=None):
+def asr_calibrate(
+    X,
+    srate,
+    cutoff=None,
+    blocksize=None,
+    B=None,
+    A=None,
+    window_len=None,
+    window_overlap=None,
+    max_dropout_fraction=None,
+    min_clean_fraction=None,
+    maxmem=None,
+    useriemannian=None,
+    compatibility=None,
+):
     """Calibration function for the Artifact Subspace Reconstruction (ASR) method.
 
     State = asr_calibrate(Data, SamplingRate, Cutoff, BlockSize, FilterB, FilterA, WindowLength, WindowOverlap, MaxDropoutFraction, MinCleanFraction, MaxMemory)
@@ -86,54 +98,271 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
     srate = float(srate)
 
     # Parameter defaults
-    if cutoff is None: cutoff = 5.0
-    if blocksize is None: blocksize = 10
-    if maxmem is None: maxmem = 64  # in MB
-    if window_len is None: window_len = 0.5
-    if window_overlap is None: window_overlap = 0.66
-    if max_dropout_fraction is None: max_dropout_fraction = 0.1
-    if min_clean_fraction is None: min_clean_fraction = 0.25
-    if compatibility is None: compatibility = 'standard'
+    if cutoff is None:
+        cutoff = 5.0
+    if blocksize is None:
+        blocksize = 10
+    if maxmem is None:
+        maxmem = 64  # in MB
+    if window_len is None:
+        window_len = 0.5
+    if window_overlap is None:
+        window_overlap = 0.66
+    if max_dropout_fraction is None:
+        max_dropout_fraction = 0.1
+    if min_clean_fraction is None:
+        min_clean_fraction = 0.25
+    if compatibility is None:
+        compatibility = 'standard'
 
     # there's no record of when or how this formula crept into the MATLAB code, but
     # to match it, we'll have to use it here as well
-    blocksize = max(blocksize, math.ceil((C*C*S*8*3*2)/(maxmem*(2**21))))
+    blocksize = max(blocksize, math.ceil((C * C * S * 8 * 3 * 2) / (maxmem * (2**21))))
 
     # Default IIR filter coefficients (approximating MATLAB's yulewalk defaults)
     # Based on artifact_removal_legacy.py and asr_calibrate.m logic
     if B is None or A is None:
         sr_round = int(round_mat(srate))
         if sr_round == 100:
-            B = np.array([0.9314233528641650, -1.0023683814963549, -0.4125359862018213, 0.7631567476327510, 0.4160430392910331, -0.6549131038692215, -0.0372583518046807, 0.1916268458752655, 0.0462411971592346], dtype=np.float64)
-            A = np.array([1.0000000000000000, -0.4544220180303844, -1.0007038682936749, 0.5374925521337940, 0.4905013360991340, -0.4861062879351137, -0.1995986490699414, 0.1830048420730026, 0.0457678549234644], dtype=np.float64)
+            B = np.array(
+                [
+                    0.9314233528641650,
+                    -1.0023683814963549,
+                    -0.4125359862018213,
+                    0.7631567476327510,
+                    0.4160430392910331,
+                    -0.6549131038692215,
+                    -0.0372583518046807,
+                    0.1916268458752655,
+                    0.0462411971592346,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -0.4544220180303844,
+                    -1.0007038682936749,
+                    0.5374925521337940,
+                    0.4905013360991340,
+                    -0.4861062879351137,
+                    -0.1995986490699414,
+                    0.1830048420730026,
+                    0.0457678549234644,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 128:
-            B = np.array([1.1027301639165037, -2.0025621813611867, 0.8942119516481342, 0.1549979524226999, 0.0192366904488084, 0.1782897770278735, -0.5280306696498717, 0.2913540603407520, -0.0262209802526358], dtype=np.float64)
-            A = np.array([1.0000000000000000, -1.1042042046423233, -0.3319558528606542, 0.5802946221107337, -0.0010360013915635, 0.0382167091925086, -0.2609928034425362, 0.0298719057761086, 0.0935044692959187], dtype=np.float64)
+            B = np.array(
+                [
+                    1.1027301639165037,
+                    -2.0025621813611867,
+                    0.8942119516481342,
+                    0.1549979524226999,
+                    0.0192366904488084,
+                    0.1782897770278735,
+                    -0.5280306696498717,
+                    0.2913540603407520,
+                    -0.0262209802526358,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -1.1042042046423233,
+                    -0.3319558528606542,
+                    0.5802946221107337,
+                    -0.0010360013915635,
+                    0.0382167091925086,
+                    -0.2609928034425362,
+                    0.0298719057761086,
+                    0.0935044692959187,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 200:
-            B = np.array([1.4489483325802353, -2.6692514764802775, 2.0813970620731115, -0.9736678877049534, 0.1054605060352928, -0.1889101692314626, 0.6111331636592364, -0.3616483013075088, 0.1834313060776763], dtype=np.float64)
-            A = np.array([1.0000000000000000, -0.9913236099393967, 0.3159563145469344, -0.0708347481677557, -0.0558793822071149, -0.2539619026478943, 0.2473056615251193, -0.0420478437473110, 0.0077455718334464], dtype=np.float64)
+            B = np.array(
+                [
+                    1.4489483325802353,
+                    -2.6692514764802775,
+                    2.0813970620731115,
+                    -0.9736678877049534,
+                    0.1054605060352928,
+                    -0.1889101692314626,
+                    0.6111331636592364,
+                    -0.3616483013075088,
+                    0.1834313060776763,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -0.9913236099393967,
+                    0.3159563145469344,
+                    -0.0708347481677557,
+                    -0.0558793822071149,
+                    -0.2539619026478943,
+                    0.2473056615251193,
+                    -0.0420478437473110,
+                    0.0077455718334464,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 250:
-            B = np.array([1.7313331085426, -4.168133532957, 5.37379900844173, -5.57212564343886, 4.70122651316513, -3.34208799655246, 1.95045488724908, -0.766909658912065, 0.233281060974837], dtype=np.float64)
-            A = np.array([1.0, -1.6384949276666, 1.73987814299055, -1.83638657883456, 1.3924177536798, -0.953780426622198, 0.505158779550745, -0.159504514603055, 0.0545278399847978], dtype=np.float64)
+            B = np.array(
+                [
+                    1.7313331085426,
+                    -4.168133532957,
+                    5.37379900844173,
+                    -5.57212564343886,
+                    4.70122651316513,
+                    -3.34208799655246,
+                    1.95045488724908,
+                    -0.766909658912065,
+                    0.233281060974837,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0,
+                    -1.6384949276666,
+                    1.73987814299055,
+                    -1.83638657883456,
+                    1.3924177536798,
+                    -0.953780426622198,
+                    0.505158779550745,
+                    -0.159504514603055,
+                    0.0545278399847978,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 256:
-            B = np.array([1.7587013141770287, -4.3267624394458641, 5.7999880031015953, -6.2396625463547508, 5.3768079046882207, -3.7938218893374835, 2.1649108095226470, -0.8591392569863763, 0.2569361125627988], dtype=np.float64)
-            A = np.array([1.0000000000000000, -1.7008039639301735, 1.9232830391058724, -2.0826929726929797, 1.5982638742557307, -1.0735854183930011, 0.5679719225652651, -0.1886181499768189, 0.0572954115997261], dtype=np.float64)
+            B = np.array(
+                [
+                    1.7587013141770287,
+                    -4.3267624394458641,
+                    5.7999880031015953,
+                    -6.2396625463547508,
+                    5.3768079046882207,
+                    -3.7938218893374835,
+                    2.1649108095226470,
+                    -0.8591392569863763,
+                    0.2569361125627988,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -1.7008039639301735,
+                    1.9232830391058724,
+                    -2.0826929726929797,
+                    1.5982638742557307,
+                    -1.0735854183930011,
+                    0.5679719225652651,
+                    -0.1886181499768189,
+                    0.0572954115997261,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 300:
-             B = np.array([1.9153920676433143, -5.7748421104926795, 9.1864764859103936, -10.7350356619363630, 9.6423672437729007, -6.6181939699544277, 3.4219421494177711, -1.2622976569994351, 0.2968423019363821], dtype=np.float64)
-             A = np.array([1.0000000000000000, -2.3143703322055491, 3.2222567327379434, -3.6030527704320621, 2.9645154844073698, -1.8842615840684735, 0.9222455868758080, -0.3103251703648485, 0.0634586449896364], dtype=np.float64)
+            B = np.array(
+                [
+                    1.9153920676433143,
+                    -5.7748421104926795,
+                    9.1864764859103936,
+                    -10.7350356619363630,
+                    9.6423672437729007,
+                    -6.6181939699544277,
+                    3.4219421494177711,
+                    -1.2622976569994351,
+                    0.2968423019363821,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -2.3143703322055491,
+                    3.2222567327379434,
+                    -3.6030527704320621,
+                    2.9645154844073698,
+                    -1.8842615840684735,
+                    0.9222455868758080,
+                    -0.3103251703648485,
+                    0.0634586449896364,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 500:
-            B = np.array([2.3133520086975823, -11.9471223009159130, 29.1067166493384340, -43.7550171007238190, 44.3385767452216370, -30.9965523846388000, 14.6209883020737190, -4.2743412400311449, 0.5982553583777899], dtype=np.float64)
-            A = np.array([1.0000000000000000, -4.6893329084452580, 10.5989986701080210, -14.9691518101365230, 14.3320358399731820, -9.4924317069169977, 4.2425899618982656, -1.1715600975178280, 0.1538048427717476], dtype=np.float64)
+            B = np.array(
+                [
+                    2.3133520086975823,
+                    -11.9471223009159130,
+                    29.1067166493384340,
+                    -43.7550171007238190,
+                    44.3385767452216370,
+                    -30.9965523846388000,
+                    14.6209883020737190,
+                    -4.2743412400311449,
+                    0.5982553583777899,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -4.6893329084452580,
+                    10.5989986701080210,
+                    -14.9691518101365230,
+                    14.3320358399731820,
+                    -9.4924317069169977,
+                    4.2425899618982656,
+                    -1.1715600975178280,
+                    0.1538048427717476,
+                ],
+                dtype=np.float64,
+            )
         elif sr_round == 512:
-             B = np.array([2.3275475636130865, -12.2166478485960430, 30.1632789058248850, -45.8009842020820410, 46.7261263011068880, -32.7796858196767220, 15.4623349612560630, -4.5019779685307473, 0.6242733481676324], dtype=np.float64)
-             A = np.array([1.0000000000000000, -4.7827378944258703, 10.9780696236622980, -15.6795187888195360, 15.1281978667576310, -10.0632079834518220, 4.5014690636505614, -1.2394100873286753, 0.1614727510688058], dtype=np.float64)
+            B = np.array(
+                [
+                    2.3275475636130865,
+                    -12.2166478485960430,
+                    30.1632789058248850,
+                    -45.8009842020820410,
+                    46.7261263011068880,
+                    -32.7796858196767220,
+                    15.4623349612560630,
+                    -4.5019779685307473,
+                    0.6242733481676324,
+                ],
+                dtype=np.float64,
+            )
+            A = np.array(
+                [
+                    1.0000000000000000,
+                    -4.7827378944258703,
+                    10.9780696236622980,
+                    -15.6795187888195360,
+                    15.1281978667576310,
+                    -10.0632079834518220,
+                    4.5014690636505614,
+                    -1.2394100873286753,
+                    0.1614727510688058,
+                ],
+                dtype=np.float64,
+            )
         else:
             # Fallback if no precomputed filter matches or yulewalk is unavailable
             # Consider adding a call to a yulewalk implementation if available,
             # or raising a more specific error/warning.
-            logger.warning(f"No pre-computed spectral filter for srate {srate}. "
-                 f"Using a simple default (may be suboptimal).")
-            B = np.array([1.0, -1.0]) # Simple high-pass/difference filter as a basic fallback
+            logger.warning(
+                f"No pre-computed spectral filter for srate {srate}. Using a simple default (may be suboptimal)."
+            )
+            B = np.array([1.0, -1.0])  # Simple high-pass/difference filter as a basic fallback
             A = np.array([1.0])
             # Original MATLAB error:
             # error('asr_calibrate:NoYulewalk','The yulewalk() function was not found and there is no pre-computed spectral filter for your sampling rate...');
@@ -158,8 +387,10 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
         Xf, iir_state = scipy.signal.sosfilt(sos, X, axis=1, zi=zi)
 
     if np.any(~np.isfinite(Xf)):
-        raise RuntimeError('The IIR filter diverged on your data. Please try using either '
-                           'a more conservative filter or removing some bad sections/channels from the calibration data.')
+        raise RuntimeError(
+            'The IIR filter diverged on your data. Please try using either '
+            'a more conservative filter or removing some bad sections/channels from the calibration data.'
+        )
 
     # Calculate the sample covariance matrices U (averaged in blocks of blocksize successive samples)
     # U will be shape (C, C, num_blocks)
@@ -174,7 +405,8 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
     for k in range(blocksize):
         # Calculate indices for this step, avoiding going past the end
         range_indices = np.minimum(block_starts + k, S - 1)
-        if range_indices.size == 0: continue # Skip if no indices
+        if range_indices.size == 0:
+            continue  # Skip if no indices
 
         # Extract data for these indices
         X_k = Xf[:, range_indices]
@@ -184,7 +416,7 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
 
         # Add to U, ensuring shape alignment
         if outer_products.shape[2] < U.shape[2]:
-            U[:, :, :outer_products.shape[2]] += outer_products
+            U[:, :, : outer_products.shape[2]] += outer_products
         else:
             U += outer_products
 
@@ -201,13 +433,13 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
         med = cov_mean(U, robust=True)
     if med is None or np.any(np.isnan(med)):
         if med is not None:
-            logger.warning("Riemannian geometric median calculation resulted in "
-                           "NaNs. Using standard geometric median as fallback.")
+            logger.warning(
+                "Riemannian geometric median calculation resulted in NaNs. Using standard geometric median as fallback."
+            )
         logger.info("Calculating robust geometric median covariance...")
         med = geometric_median(U.reshape(C * C, -1).T)
     if np.any(np.isnan(med)):
-        logger.warning("Geometric median calculation resulted in NaNs. "
-                       "Using standard median as fallback.")
+        logger.warning("Geometric median calculation resulted in NaNs. Using standard median as fallback.")
         med = np.median(U, axis=-1)
 
     # make sure median is reshaped back to matrix form
@@ -253,7 +485,7 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
 
     # Calculate thresholds for each component
     for c in reversed(range(C)):
-        comp_data = X_transformed[:, c]**2
+        comp_data = X_transformed[:, c] ** 2
 
         # Calculate RMS amplitude for each window
         rms_windows = np.sqrt(np.mean(comp_data[window_indices], axis=1))
@@ -261,9 +493,7 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
         # Fit a distribution to the clean part
         try:
             mu_c, sig_c, _, _ = fit_eeg_distribution(
-                rms_windows,
-                min_clean_fraction=min_clean_fraction,
-                max_dropout_fraction=max_dropout_fraction
+                rms_windows, min_clean_fraction=min_clean_fraction, max_dropout_fraction=max_dropout_fraction
             )
             mu[c] = mu_c
             sig[c] = sig_c
@@ -289,17 +519,17 @@ def asr_calibrate(X, srate, cutoff=None, blocksize=None, B=None, A=None,
 
     # Return the state dictionary
     state = {
-        'M': M,                 # Mixing matrix
-        'T': T,                 # Threshold matrix
-        'B': B,                 # Original filter coefficients (for reference)
+        'M': M,  # Mixing matrix
+        'T': T,  # Threshold matrix
+        'B': B,  # Original filter coefficients (for reference)
         'A': A,
-        'sos': sos,             # SOS filter representation for processing (None if compatibility='max')
-        'iir_state': iir_state, # Initial filter state
-        'cov': None,            # Initial covariance buffer (will be set in process)
-        'carry': None,          # Initial carry buffer (will be set in process)
-        'last_R': None,         # Initial reconstruction matrix (will be set in process)
-        'last_trivial': True,   # Initial trivial flag
-        'useriemannian': useriemannian, # Riemannian ASR variant option
+        'sos': sos,  # SOS filter representation for processing (None if compatibility='max')
+        'iir_state': iir_state,  # Initial filter state
+        'cov': None,  # Initial covariance buffer (will be set in process)
+        'carry': None,  # Initial carry buffer (will be set in process)
+        'last_R': None,  # Initial reconstruction matrix (will be set in process)
+        'last_trivial': True,  # Initial trivial flag
+        'useriemannian': useriemannian,  # Riemannian ASR variant option
         'compatibility': compatibility,  # Compatibility mode for IIR filtering
     }
 

--- a/src/eegprep/plugins/clean_rawdata/asr_process.py
+++ b/src/eegprep/plugins/clean_rawdata/asr_process.py
@@ -11,7 +11,9 @@ from .private.sigproc import moving_average
 logger = logging.getLogger(__name__)
 
 
-def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32, max_dims=0.66, max_mem=None, use_gpu=False):
+def asr_process(
+    data, srate, state, window_len=0.5, lookahead=None, step_size=32, max_dims=0.66, max_mem=None, use_gpu=False
+):
     """Process data using the Artifact Subspace Reconstruction (ASR) method.
 
     CleanedData, State = asr_process(Data, SamplingRate, State, WindowLength, LookAhead, StepSize, MaxDimensions, MaxMemory, UseGPU)
@@ -60,6 +62,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
     if max_mem is None:
         # use at most half of available memory
         import psutil
+
         max_mem = psutil.virtual_memory().free / 1024**2 / 2
 
     # Ensure window length is adequate
@@ -79,19 +82,19 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
     data[~np.isfinite(data)] = 0
 
     # Extract state variables
-    M = state['M']                  # Mixing matrix
-    T = state['T']                  # Threshold matrix
-    sos = state.get('sos')          # SOS filter representation (None if compatibility='max')
-    b = state.get('B')              # Filter numerator coefficients
-    a = state.get('A')              # Filter denominator coefficients
+    M = state['M']  # Mixing matrix
+    T = state['T']  # Threshold matrix
+    sos = state.get('sos')  # SOS filter representation (None if compatibility='max')
+    b = state.get('B')  # Filter numerator coefficients
+    a = state.get('A')  # Filter denominator coefficients
     compatibility = state.get('compatibility', 'standard')  # Compatibility mode
     iir_state = state.get('iir_state')  # Filter state
-    carry = state.get('carry')      # Carry buffer (previous lookahead data)
-    cov = state.get('cov')          # Covariance state (MovAvgState or None)
+    carry = state.get('carry')  # Carry buffer (previous lookahead data)
+    cov = state.get('cov')  # Covariance state (MovAvgState or None)
     # If cov is from an older run and is not a MovAvgState, reset it
     if cov is not None and not hasattr(cov, 'buf'):
         cov = None
-    last_R = state.get('last_R')    # Last reconstruction matrix
+    last_R = state.get('last_R')  # Last reconstruction matrix
     last_trivial = state.get('last_trivial', True)  # Was last step trivial (no artifacts)
 
     # Initialize prior filter state by extrapolating available data into the past
@@ -104,19 +107,19 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
 
     # Calculate number of splits for memory management
 
-    if max_mem*1024*1024 - C*C*P*8*3 < 0:
-        logger.warning("Memory too low, increasing it (rejection block size now "
-             "depends on available memory so it might not be fully reproducible)...")
+    if max_mem * 1024 * 1024 - C * C * P * 8 * 3 < 0:
+        logger.warning(
+            "Memory too low, increasing it (rejection block size now "
+            "depends on available memory so it might not be fully reproducible)..."
+        )
         import psutil
+
         max_mem = psutil.virtual_memory().free / 1024**2 / 2
-        if max_mem*1024*1024 - C*C*P*8*3 < 0:
+        if max_mem * 1024 * 1024 - C * C * P * 8 * 3 < 0:
             raise RuntimeError('Not enough memory')
 
     # Calculate memory bytes needed (following reference implementation formula)
-    bytes_needed = (C * C * S * 8 * 8 +
-                    C * C * 8 * S / step_size +
-                    C * S * 8 * 2 +
-                    S * 8 * 5)
+    bytes_needed = C * C * S * 8 * 8 + C * C * 8 * S / step_size + C * S * 8 * 2 + S * 8 * 5
 
     # Available memory in bytes (subtract fixed overhead)
     mem_available = max_mem * 1024**2 - C * C * P * 8 * 3
@@ -156,10 +159,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
         # replicates MATLAB's `moving_average` helper. This yields a smoothed
         # covariance estimate for *every* sample and updates the internal
         # circular buffer/state stored in `cov`.
-        Xcov_sample = np.reshape(
-            np.reshape(Xfilt, (C, 1, -1)) * np.reshape(Xfilt, (1, C, -1)),
-            (C * C, -1)
-        )
+        Xcov_sample = np.reshape(np.reshape(Xfilt, (C, 1, -1)) * np.reshape(Xfilt, (1, C, -1)), (C * C, -1))
 
         # Running mean over a window of N samples (along the last / time axis)
         Xcov_filtered, cov = moving_average(Xcov_sample, N=N, axis=1, Z=cov, init=0)
@@ -173,7 +173,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
             update_at = np.insert(update_at, 0, 1)
             last_R = np.eye(C)
 
-        update_at -= 1 # prepare for 0-based indexing
+        update_at -= 1  # prepare for 0-based indexing
 
         # Extract the covariance matrices at our update points (already
         # averaged by the moving window) and reshape to C × C × #updates.
@@ -194,7 +194,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
 
             # Determine which components to keep (variance below threshold or not admissible for rejection)
             try:
-                thresholds = np.sum(finite_matmul(T, V)**2, axis=0)
+                thresholds = np.sum(finite_matmul(T, V) ** 2, axis=0)
                 keep = (D < thresholds) | (np.arange(1, C + 1) < (C - max_dims_num))
                 trivial = np.all(keep)
             except Exception as e:
@@ -235,10 +235,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
                     segment = X[:, idx_in_X]
 
                     # Apply blended reconstruction
-                    X[:, idx_in_X] = (
-                        blend * finite_matmul(R, segment)
-                        + (1 - blend) * finite_matmul(last_R, segment)
-                    )
+                    X[:, idx_in_X] = blend * finite_matmul(R, segment) + (1 - blend) * finite_matmul(last_R, segment)
 
             # Update state for next iteration
             last_n = n
@@ -246,7 +243,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
             last_trivial = trivial
 
         if splits > 1 and k % 10 == 0:
-            logger.debug(f'Processing block {k+1}/{splits}')
+            logger.debug(f'Processing block {k + 1}/{splits}')
 
     if splits > 1:
         logger.info('Finished cleaning.')
@@ -255,7 +252,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
     new_carry = X[:, -P:] if X.shape[1] >= P else X
 
     # Return cleaned data (without the lookahead portion)
-    outdata = X[:, P:P+S]
+    outdata = X[:, P : P + S]
 
     # Update state dictionary
     outstate = {
@@ -271,7 +268,7 @@ def asr_process(data, srate, state, window_len=0.5, lookahead=None, step_size=32
         'B': b,
         'A': a,
         'compatibility': compatibility,
-        'useriemannian': state.get('useriemannian')
+        'useriemannian': state.get('useriemannian'),
     }
 
     return outdata, outstate

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -1,7 +1,7 @@
 """EEG artifact cleaning functions."""
 
-from typing import *
 import logging
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 #                               Public API
 # -----------------------------------------------------------------------------
+
 
 def clean_artifacts(
     EEG: Dict[str, Any],
@@ -138,19 +139,14 @@ def clean_artifacts(
     if 'etc' not in EEG:
         EEG['etc'] = {}
 
-    # Keep an untouched copy if we need to re‑insert channels later.
-    oriEEG = None
-    oriEEG_without_ignored_channels = None
-
     # ------------------------------------------------------------------
     #             Optional: restrict to / ignore certain channels
     # ------------------------------------------------------------------
     if Channels is not None and len(Channels):
-        # copy original
-        oriEEG = EEG.copy()
         # Attempt pop_select based on labels; fall back to manual
         try:
-            from eegprep import pop_select  # type: ignore
+            from eegprep import pop_select
+
             EEG = pop_select(EEG, channel=list(Channels))
         except Exception:
             # Manual selection on labels
@@ -159,12 +155,11 @@ def clean_artifacts(
             EEG['data'] = EEG['data'][keep_idx, :]
             EEG['chanlocs'] = [EEG['chanlocs'][i] for i in keep_idx]
             EEG['nbchan'] = len(keep_idx)
-        oriEEG_without_ignored_channels = EEG.copy()
         EEG['event'] = []  # will be restored later
     elif Channels_ignore is not None and len(Channels_ignore):
-        oriEEG = EEG.copy()
         try:
-            from eegprep import pop_select  # type: ignore
+            from eegprep import pop_select
+
             EEG = pop_select(EEG, nochannel=list(Channels_ignore))
         except Exception:
             lbl_to_idx = {ch['labels']: idx for idx, ch in enumerate(EEG['chanlocs'])}
@@ -173,7 +168,6 @@ def clean_artifacts(
             EEG['data'] = EEG['data'][keep_idx, :]
             EEG['chanlocs'] = [EEG['chanlocs'][i] for i in keep_idx]
             EEG['nbchan'] = len(keep_idx)
-        oriEEG_without_ignored_channels = EEG.copy()
         EEG['event'] = []
 
     # ------------------------------------------------------------------
@@ -218,9 +212,7 @@ def clean_artifacts(
             removed_channels = ~EEG['etc']['clean_channel_mask']
         except Exception as e:
             # Fall back to "no‑locs" version if location dependent failure
-            logger.warning(
-                f'clean_channels failed ({e}); falling back to clean_channels_nolocs.'
-            )
+            logger.warning(f'clean_channels failed ({e}); falling back to clean_channels_nolocs.')
             EEG, removed_channels = clean_channels_nolocs(
                 EEG,
                 min_corr=float(NoLocsChannelCriterion),
@@ -274,7 +266,7 @@ def clean_artifacts(
                 lengths = retain_intervals[:, 1] - retain_intervals[:, 0]
                 small = lengths < 5
                 for s, e in retain_intervals[small]:
-                    sample_mask[s:e + 1] = False
+                    sample_mask[s : e + 1] = False
                 retain_intervals = retain_intervals[~small]
 
             rejected_intervals = mask_to_intervals(sample_mask, value=False)

--- a/src/eegprep/plugins/clean_rawdata/clean_asr.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_asr.py
@@ -5,7 +5,7 @@ on EEG data to remove artifacts.
 """
 
 import logging
-from typing import Dict, Any, Optional, Union, Tuple, Optional
+from typing import Dict, Any, Union, Tuple, Optional
 from copy import deepcopy
 
 import math
@@ -31,7 +31,7 @@ def clean_asr(
     ref_wndlen: Union[float, str, None] = 1.0,
     use_gpu: bool = False,
     useriemannian: Optional[str] = None,
-    maxmem: Optional[int] = 64
+    maxmem: Optional[int] = 64,
 ) -> Dict[str, Any]:
     """Run the Artifact Subspace Reconstruction (ASR) method on EEG data.
 
@@ -87,8 +87,8 @@ def clean_asr(
     C, S = data.shape
 
     if C != nbchan:
-         logger.warning(f"Mismatch between EEG['nbchan'] ({nbchan}) and EEG['data'].shape[0] ({C}). Using shape[0].")
-         nbchan = C # Use the actual dimension from data
+        logger.warning(f"Mismatch between EEG['nbchan'] ({nbchan}) and EEG['data'].shape[0] ({C}). Using shape[0].")
+        nbchan = C  # Use the actual dimension from data
 
     # --- Handle Defaults ---
     if window_len is None:
@@ -99,24 +99,32 @@ def clean_asr(
 
     # --- Determine Reference/Calibration Data ---
     ref_section_data = None
-    if isinstance(ref_maxbadchannels, (int, float)) and isinstance(ref_tolerances, (tuple, list)) and isinstance(ref_wndlen, (int, float)):
+    if (
+        isinstance(ref_maxbadchannels, (int, float))
+        and isinstance(ref_tolerances, (tuple, list))
+        and isinstance(ref_wndlen, (int, float))
+    ):
         logger.info('Finding a clean section of the data for calibration...')
         try:
             # clean_windows is assumed to return the selected data array (C x S_clean)
             # It needs the EEG dict structure, similar to other clean_* funcs
             temp_EEG_for_cleanwin = deepcopy(EEG)
-            temp_EEG_for_cleanwin['data'] = data # ensure it has the float64 data
+            temp_EEG_for_cleanwin['data'] = data  # ensure it has the float64 data
             cleaned_EEG, _ = clean_windows(temp_EEG_for_cleanwin, ref_maxbadchannels, ref_tolerances, ref_wndlen)
             ref_section_data = np.asarray(cleaned_EEG['data'], dtype=np.float64)
             if ref_section_data.size == 0 or ref_section_data.shape[1] == 0:
                 logger.warning("clean_windows returned no data. Falling back to using all data for calibration.")
                 ref_section_data = data
             elif ref_section_data.shape[1] < 64:
-                logger.warning("clean_windows returned insufficient data. Falling back to using all data for calibration.")
+                logger.warning(
+                    "clean_windows returned insufficient data. Falling back to using all data for calibration."
+                )
                 ref_section_data = data
         except Exception as e:
             logger.error(f"An error occurred during clean_windows: {e}")
-            logger.warning("Could not automatically identify clean calibration data. Falling back to using the entire data for calibration.")
+            logger.warning(
+                "Could not automatically identify clean calibration data. Falling back to using the entire data for calibration."
+            )
             ref_section_data = data
     elif (isinstance(ref_maxbadchannels, str) and ref_maxbadchannels.lower() == 'off') or ref_maxbadchannels is None:
         logger.info(f"Using the entire data for calibration ('ref_maxbadchannels' set to {ref_maxbadchannels!r}).")
@@ -131,9 +139,11 @@ def clean_asr(
         logger.info("Using user-supplied data array for calibration.")
         ref_section_data = np.asarray(ref_maxbadchannels, dtype=np.float64)
         if ref_section_data.ndim != 2 or ref_section_data.shape[0] != C:
-             raise ValueError(f"User-supplied calibration data must be a 2D array with shape ({C}, n_samples).")
+            raise ValueError(f"User-supplied calibration data must be a 2D array with shape ({C}, n_samples).")
     else:
-        raise ValueError(f"Unsupported value or type for 'ref_maxbadchannels': {ref_maxbadchannels}. Must be float, None/'off', or numpy array.")
+        raise ValueError(
+            f"Unsupported value or type for 'ref_maxbadchannels': {ref_maxbadchannels}. Must be float, None/'off', or numpy array."
+        )
 
     # --- Calibrate ASR ---
     logger.info('Estimating ASR calibration statistics...')
@@ -142,25 +152,25 @@ def clean_asr(
     try:
         state = asr_calibrate(ref_section_data, srate, cutoff=cutoff, maxmem=maxmem, useriemannian=useriemannian)
     except ValueError as e:
-         # Catch specific errors like not enough calibration data
-         raise ValueError(f"ASR calibration failed: {e}")
+        # Catch specific errors like not enough calibration data
+        raise ValueError(f"ASR calibration failed: {e}")
     # except Exception as e:
     #      # Catch unexpected errors during calibration
     #      logger.exception("An unexpected error occurred during ASR calibration.")
     #      raise RuntimeError(f"ASR calibration failed unexpectedly: {e}")
 
-    del ref_section_data # Free memory
+    del ref_section_data  # Free memory
 
     # --- Prepare for Processing ---
     if step_size is None:
-        step_size = int(math.floor(srate * window_len / 2)) # Samples
+        step_size = int(math.floor(srate * window_len / 2))  # Samples
 
     # --- Extrapolate Signal End ---
     # Required because asr_process needs lookahead data beyond the signal end
     # Based on: sig = [signal.data bsxfun(@minus,2*signal.data(:,end),signal.data(:,(end-1):-1:end-round(windowlen/2*signal.srate)))];
     N_extrap = int(round_mat(window_len / 2 * srate))
     if N_extrap > 0:
-         # Calculate indices for reflection, handling edge case where N_extrap >= S-1
+        # Calculate indices for reflection, handling edge case where N_extrap >= S-1
         extrap_len = min(N_extrap, S - 1 if S > 1 else 0)
         if extrap_len > 0:
             # Indices from second-to-last sample back 'extrap_len' steps
@@ -168,15 +178,14 @@ def clean_asr(
             # Reflect around the last sample: 2*last_sample - samples_before_last
             extrap_part = 2 * data[:, [-1]] - data[:, extrap_indices]
             sig = np.concatenate((data, extrap_part), axis=1)
-        else: # Not enough data to extrapolate
-             sig = data
-    else: # No extrapolation needed
+        else:  # Not enough data to extrapolate
+            sig = data
+    else:  # No extrapolation needed
         sig = data
-
 
     # --- Process Signal using ASR ---
     logger.info('Applying ASR processing...')
-    lookahead_sec = window_len / 2.0 # asr_process expects lookahead in seconds
+    lookahead_sec = window_len / 2.0  # asr_process expects lookahead in seconds
     outdata, _ = asr_process(
         sig,
         srate,
@@ -186,7 +195,7 @@ def clean_asr(
         step_size=step_size,
         max_dims=max_dims,
         max_mem=maxmem,
-        use_gpu=use_gpu # Passed but ignored in current Python port
+        use_gpu=use_gpu,  # Passed but ignored in current Python port
     )
 
     # --- Finalize ---

--- a/src/eegprep/plugins/clean_rawdata/clean_channels.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_channels.py
@@ -1,8 +1,7 @@
 """EEG channel cleaning utilities."""
 
-from typing import *
 import logging
-import traceback
+from typing import Any, Dict
 
 import numpy as np
 
@@ -15,13 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 def clean_channels(
-        EEG: Dict[str, Any],
-        corr_threshold: float = 0.8,
-        noise_threshold: float = 5.0,
-        window_len: float = 5,
-        max_broken_time: float = 0.4,
-        num_samples: int = 50,
-        subset_size: float = 0.25,
+    EEG: Dict[str, Any],
+    corr_threshold: float = 0.8,
+    noise_threshold: float = 5.0,
+    window_len: float = 5,
+    max_broken_time: float = 0.4,
+    num_samples: int = 50,
+    subset_size: float = 0.25,
 ) -> Dict[str, Any]:
     """Remove channels with problematic data from a continuous data set.
 
@@ -80,7 +79,7 @@ def clean_channels(
 
     if Fs > 100:
         # remove signal content above 50Hz
-        B = design_fir(100, 2 * np.array([0, 45, 50, Fs/2]) / Fs, [1, 1, 0, 0])
+        B = design_fir(100, 2 * np.array([0, 45, 50, Fs / 2]) / Fs, [1, 1, 0, 0])
         X = np.zeros((S, C))
         for c in range(C):
             X[:, c] = filtfilt_fast(B, 1, EEG['data'][c, :])
@@ -96,14 +95,11 @@ def clean_channels(
         noise_mask = np.zeros(C, dtype=bool)  # transpose added in MATLAB comment
 
     # get the matrix of all channel locations [3xN]
-    xyz = [
-        [ch.get(coord, np.nan) for ch in EEG['chanlocs']]
-        for coord in ['X', 'Y', 'Z']]
+    xyz = [[ch.get(coord, np.nan) for ch in EEG['chanlocs']] for coord in ['X', 'Y', 'Z']]
     xyz = [[x if not (isinstance(x, np.ndarray) and x.size == 0) else np.nan for x in xyz_sub] for xyz_sub in xyz]
     xyz = np.asarray([np.asarray([np.nan if x is None else x for x in row], dtype=float) for row in xyz])
     if np.mean(np.any(np.isnan(xyz), axis=0)) > 0.5:
-        raise ValueError(
-            'To use this function most of your channels should have X,Y,Z location measurements.')
+        raise ValueError('To use this function most of your channels should have X,Y,Z location measurements.')
     usable_channels = np.where(~np.any(np.isnan(xyz), axis=0))[0]
 
     locs = xyz[:, usable_channels].T
@@ -118,6 +114,7 @@ def clean_channels(
     time_passed_list = np.zeros(W)
     for o in range(W):
         import time
+
         start_time = time.time()
 
         XX = X[offsets[o] + wnd, :]
@@ -127,13 +124,13 @@ def clean_channels(
         # Calculate correlation for each channel
         for c in range(len(usable_channels)):
             numerator = np.sum(XX[:, c] * YY[:, c])
-            denominator = np.sqrt(np.sum(XX[:, c]**2)) * np.sqrt(np.sum(YY[:, c]**2))
+            denominator = np.sqrt(np.sum(XX[:, c] ** 2)) * np.sqrt(np.sum(YY[:, c] ** 2))
             corrs[c, o] = numerator / denominator
 
         time_passed_list[o] = time.time() - start_time
-        median_time_passed = np.median(time_passed_list[:o+1])
+        median_time_passed = np.median(time_passed_list[: o + 1])
         if o % 50 == 0:
-            logger.info(f'{o+1:3d}/{W} blocks, {median_time_passed*(W-o-1)/60:.1f} minutes remaining.')
+            logger.info(f'{o + 1:3d}/{W} blocks, {median_time_passed * (W - o - 1) / 60:.1f} minutes remaining.')
 
     flagged = corrs < corr_threshold
 
@@ -145,10 +142,13 @@ def clean_channels(
 
     # apply removal
     if np.mean(removed_channels) > 0.75:
-        raise ValueError('More than 75% of your channels were removed -- this is probably caused by incorrect channel location measurements (e.g., wrong cap design).')
+        raise ValueError(
+            'More than 75% of your channels were removed -- this is probably caused by incorrect channel location measurements (e.g., wrong cap design).'
+        )
     elif np.any(removed_channels):
         try:
             from eegprep import pop_select
+
             EEG = pop_select(EEG, nochannel=list(np.where(removed_channels)[0]))
         except Exception as e:
             if isinstance(e, ImportError):

--- a/src/eegprep/plugins/clean_rawdata/clean_channels_nolocs.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_channels_nolocs.py
@@ -1,25 +1,22 @@
 """EEG channel cleaning utilities without locations."""
 
-from typing import *
 import logging
-import traceback
+from typing import Any, Dict, Tuple
 
 import numpy as np
-from scipy.signal import filtfilt
 
 from .private.sigproc import design_fir, design_kaiser, filtfilt_fast
 
 logger = logging.getLogger(__name__)
 
 
-
 def clean_channels_nolocs(
-        EEG: Dict[str, Any],
-        min_corr: float = 0.45,
-        ignored_quantile: float = 0.1,
-        window_len: float = 2.0,
-        max_broken_time: float = 0.5,
-        linenoise_aware: bool = True
+    EEG: Dict[str, Any],
+    min_corr: float = 0.45,
+    ignored_quantile: float = 0.1,
+    window_len: float = 2.0,
+    max_broken_time: float = 0.5,
+    linenoise_aware: bool = True,
 ) -> Tuple[Dict[str, Any], np.ndarray]:
     """Remove channels with abnormal data from a continuous data set.
 
@@ -78,18 +75,10 @@ def clean_channels_nolocs(
         if Fs <= 110:
             raise ValueError('Sampling rate must be above 110 Hz')
         elif Fs <= 130:
-            B = design_fir(
-                len(Bwnd) - 1,
-                2 * np.array([0, 45, 50, 55, Fs/2]) / Fs,
-                [1, 1, 0, 1, 1],
-                w=Bwnd
-            )
+            B = design_fir(len(Bwnd) - 1, 2 * np.array([0, 45, 50, 55, Fs / 2]) / Fs, [1, 1, 0, 1, 1], w=Bwnd)
         else:
             B = design_fir(
-                len(Bwnd) - 1,
-                2 * np.array([0, 45, 50, 55, 60, 65, Fs/2]) / Fs,
-                [1, 1, 0, 1, 0, 1, 1],
-                w=Bwnd
+                len(Bwnd) - 1, 2 * np.array([0, 45, 50, 55, 60, 65, Fs / 2]) / Fs, [1, 1, 0, 1, 0, 1, 1], w=Bwnd
             )
 
         X = np.zeros((S, C))
@@ -117,6 +106,7 @@ def clean_channels_nolocs(
         try:
             # Try to use pop_select if available
             from eegprep import pop_select
+
             EEG = pop_select(EEG, nochannel=list(np.where(removed_channels)[0]))
         except Exception as e:
             if isinstance(e, ImportError):
@@ -140,7 +130,11 @@ def clean_channels_nolocs(
                     EEG[field] = np.array([])
 
         # Update clean_channel_mask
-        if 'etc' in EEG and 'clean_channel_mask' in EEG['etc'] and sum(EEG['etc']['clean_channel_mask']) == len(removed_channels):
+        if (
+            'etc' in EEG
+            and 'clean_channel_mask' in EEG['etc']
+            and sum(EEG['etc']['clean_channel_mask']) == len(removed_channels)
+        ):
             mask = EEG['etc']['clean_channel_mask']
             EEG['etc']['clean_channel_mask'] = np.logical_and(mask, ~removed_channels[mask])
         else:

--- a/src/eegprep/plugins/clean_rawdata/clean_drifts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_drifts.py
@@ -1,7 +1,7 @@
 """EEG drift removal utilities."""
 
-from typing import *
 import logging
+from typing import Any, Dict, Sequence
 
 import numpy as np
 from scipy.signal import filtfilt
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 def clean_drifts(
-        EEG: Dict[str, Any],
-        transition: Sequence[float] = (0.5, 1),
-        attenuation: float = 80.0,
-        method: str = 'fft',
+    EEG: Dict[str, Any],
+    transition: Sequence[float] = (0.5, 1),
+    attenuation: float = 80.0,
+    method: str = 'fft',
 ) -> Dict[str, Any]:
     """Remove drifts from the data using a forward-backward high-pass filter.
 
@@ -36,13 +36,9 @@ def clean_drifts(
     EEG['data'] = np.asarray(EEG['data'], dtype=np.float64)
 
     # design highpass FIR filter
-    transition = 2*np.asarray(transition) / EEG['srate']
+    transition = 2 * np.asarray(transition) / EEG['srate']
     wnd = design_kaiser(transition[0], transition[1], attenuation, True)
-    B = design_fir(
-        len(wnd)-1,
-        np.concatenate(([0], transition, [1])),
-        [0, 0, 1, 1],
-        w=wnd)
+    B = design_fir(len(wnd) - 1, np.concatenate(([0], transition, [1])), [0, 0, 1, 1], w=wnd)
 
     op = filtfilt if method == 'fir' else filtfilt_fast
 

--- a/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
@@ -1,7 +1,6 @@
 """EEG flatline channel removal utilities."""
 
-import traceback
-from typing import *
+from typing import Any, Dict
 import logging
 
 import numpy as np
@@ -51,6 +50,7 @@ def clean_flatlines(EEG: Dict[str, Any], max_flatline_duration: float = 5.0, max
         try:
             # noinspection PyUnresolvedReferences
             from eegprep import pop_select
+
             EEG = pop_select(EEG, nochannel=list(np.where(removed_channels)[0]))
         except Exception as e:
             if isinstance(e, ImportError):

--- a/src/eegprep/plugins/clean_rawdata/clean_windows.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_windows.py
@@ -5,7 +5,7 @@ from continuous EEG data.
 """
 
 import logging
-from typing import *
+from typing import Any, Dict, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -16,17 +16,18 @@ from .private.stats import fit_eeg_distribution
 
 logger = logging.getLogger(__name__)
 
+
 def clean_windows(
-        EEG: Dict[str, Any],
-        max_bad_channels: Union[int, float] = 0.2,
-        zthresholds: Tuple[float, float] = (-3.5, 5),
-        window_len: float = 1.0,
-        window_overlap: float = 0.66,
-        max_dropout_fraction: float = 0.1,
-        min_clean_fraction: float = 0.25,
-        truncate_quant: Tuple[float, float] = (0.022, 0.6),
-        step_sizes: Tuple[float, float] = (0.01, 0.01),
-        shape_range: Union[np.ndarray, Sequence[float]] = np.arange(1.7, 3.6, 0.15),
+    EEG: Dict[str, Any],
+    max_bad_channels: Union[int, float] = 0.2,
+    zthresholds: Tuple[float, float] = (-3.5, 5),
+    window_len: float = 1.0,
+    window_overlap: float = 0.66,
+    max_dropout_fraction: float = 0.1,
+    min_clean_fraction: float = 0.25,
+    truncate_quant: Tuple[float, float] = (0.022, 0.6),
+    step_sizes: Tuple[float, float] = (0.01, 0.01),
+    shape_range: Union[np.ndarray, Sequence[float]] = np.arange(1.7, 3.6, 0.15),
 ) -> Tuple[Dict[str, Any], np.ndarray]:
     """Remove periods with abnormally high-power content from continuous data.
 
@@ -174,7 +175,7 @@ def clean_windows(
     sample_mask = np.ones(S, dtype=bool)
     for w in removed_windows:
         start = offsets[w]
-        sample_mask[start:start + N] = False
+        sample_mask[start : start + N] = False
 
     kept_pct = 100.0 * np.mean(sample_mask)
     kept_seconds = np.count_nonzero(sample_mask) / Fs

--- a/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
+++ b/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
@@ -150,10 +150,14 @@ def pop_clean_rawdata_dialog_spec(EEG) -> DialogSpec:
             ControlSpec("text", f"Max acceptable {winsize:1.1f} second window std dev"),
             ControlSpec("edit", tag="asrstdval", value="20"),
             ControlSpec("spacer"),
-            ControlSpec("checkbox", "Use Riemanian distance metric (not Euclidean) - beta", tag="distance", value=False),
+            ControlSpec(
+                "checkbox", "Use Riemanian distance metric (not Euclidean) - beta", tag="distance", value=False
+            ),
             ControlSpec("spacer"),
             ControlSpec("spacer"),
-            ControlSpec("checkbox", "Remove bad data periods (when uncheck, correct using ASR)", tag="asrrej", value=True),
+            ControlSpec(
+                "checkbox", "Remove bad data periods (when uncheck, correct using ASR)", tag="asrrej", value=True
+            ),
             ControlSpec("spacer"),
             ControlSpec("spacer"),
             ControlSpec(
@@ -170,7 +174,9 @@ def pop_clean_rawdata_dialog_spec(EEG) -> DialogSpec:
             ControlSpec("text", "Maximum out-of-bound channels (%)"),
             ControlSpec("edit", tag="rejwinval2", value="25"),
             ControlSpec("spacer"),
-            ControlSpec("checkbox", "Pop up scrolling data window with rejected data highlighted", tag="vis", value=False),
+            ControlSpec(
+                "checkbox", "Pop up scrolling data window with rejected data highlighted", tag="vis", value=False
+            ),
         ),
     )
 

--- a/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
+++ b/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
@@ -288,4 +288,4 @@ def _notify_vis_artifacts_unavailable():
     if app is None:
         logger.warning(message)
         return
-    QtWidgets.QMessageBox.information(app.activeWindow(), "EEGPrep", message)
+    QtWidgets.QMessageBox.information(QtWidgets.QApplication.activeWindow(), "EEGPrep", message)

--- a/src/eegprep/plugins/clean_rawdata/private/__init__.py
+++ b/src/eegprep/plugins/clean_rawdata/private/__init__.py
@@ -1,2 +1,1 @@
 """Private clean_rawdata helper ports."""
-

--- a/src/eegprep/plugins/clean_rawdata/private/covariance.py
+++ b/src/eegprep/plugins/clean_rawdata/private/covariance.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
 import logging
 
 import numpy as np
@@ -69,7 +68,7 @@ def cov_sqrtm(C):
 def cov_rsqrtm(C):
     """Calculate the matrix reciprocal square root of a covariance matrix or ...,N,N array."""
     D, V = np.linalg.eigh(C)
-    return finite_matmul(finite_matmul(V, diag_nd(1./np.sqrt(D))), V.swapaxes(-2, -1))
+    return finite_matmul(finite_matmul(V, diag_nd(1.0 / np.sqrt(D))), V.swapaxes(-2, -1))
 
 
 def cov_sqrtm2(C):
@@ -78,12 +77,11 @@ def cov_sqrtm2(C):
     sqrtD = np.sqrt(D)
     return (
         finite_matmul(finite_matmul(V, diag_nd(sqrtD)), V.swapaxes(-2, -1)),
-        finite_matmul(finite_matmul(V, diag_nd(1./sqrtD)), V.swapaxes(-2, -1)),
+        finite_matmul(finite_matmul(V, diag_nd(1.0 / sqrtD)), V.swapaxes(-2, -1)),
     )
 
 
-def cov_mean(X, *, weights=None, robust=False, iters=50, tol=1e-5, huber=0,
-             nancheck=False, verbose=False):
+def cov_mean(X, *, weights=None, robust=False, iters=50, tol=1e-5, huber=0, nancheck=False, verbose=False):
     """Calculate the (weighted) average of a set of covariance matrices on the manifold of SPD matrices, optionally robustly using the geometric median or Huber mean.
 
     Args:
@@ -111,7 +109,7 @@ def cov_mean(X, *, weights=None, robust=False, iters=50, tol=1e-5, huber=0,
     weights = np.ones(len(X)) if weights is None else np.asarray(weights)
     scales = weights
 
-    mu = np.sum(X * weights[:, None, None], axis=0)/np.sum(weights)
+    mu = np.sum(X * weights[:, None, None], axis=0) / np.sum(weights)
     # step size and divergence check threshold
     step, thresh = 1.0, 1e20
     for i in range(iters):
@@ -136,7 +134,7 @@ def cov_mean(X, *, weights=None, robust=False, iters=50, tol=1e-5, huber=0,
                 w = np.where(d <= huber, 1, huber / d)
                 scales = weights * w
         # get update Jacobian (np.average takes care of renormalization)
-        J = np.sum(Xt * scales[:, None, None], axis=0)/np.sum(scales)
+        J = np.sum(Xt * scales[:, None, None], axis=0) / np.sum(scales)
         # apply update on manifold
         mu = finite_matmul(finite_matmul(mu_sqrt, cov_expm(step * J)), mu_sqrt)
         # convergence checks

--- a/src/eegprep/plugins/clean_rawdata/private/ransac.py
+++ b/src/eegprep/plugins/clean_rawdata/private/ransac.py
@@ -1,6 +1,6 @@
 """RANSAC utilities for EEG data processing."""
 
-from typing import *
+from typing import Optional
 
 import numpy as np
 
@@ -8,11 +8,8 @@ from ....functions.adminfunc.eeglabcompat import get_eeglab
 from ....functions.miscfunc.misc import round_mat
 from .sphericalSplineInterpolate import sphericalSplineInterpolate
 
-def rand_sample(
-        n: int,
-        m: int,
-        stream: np.random.RandomState
-) -> np.ndarray:
+
+def rand_sample(n: int, m: int, stream: np.random.RandomState) -> np.ndarray:
     """Random sampling without replacement using Fisher-Yates shuffle.
 
     Optimized O(n) implementation using swap-based Fisher-Yates instead of
@@ -53,10 +50,7 @@ def rand_sample(
     return pool[:m].copy()
 
 
-def rand_permutation(
-        n: int,
-        stream: np.random.RandomState
-) -> np.ndarray:
+def rand_permutation(n: int, stream: np.random.RandomState) -> np.ndarray:
     """Random permutation with MATLAB parity using Fisher-Yates shuffle.
 
     This function produces the SAME permutation sequence as MATLAB's
@@ -104,11 +98,11 @@ def rand_permutation(
 
 
 def calc_projector(
-        locs: np.ndarray,
-        num_samples: int,
-        subset_size: int,
-        stream: Optional[np.random.RandomState] = None,
-        subroutine: str = 'sphericalSplineInterpolate'
+    locs: np.ndarray,
+    num_samples: int,
+    subset_size: int,
+    stream: Optional[np.random.RandomState] = None,
+    subroutine: str = 'sphericalSplineInterpolate',
 ) -> np.ndarray:
     """Calculate a bag of reconstruction matrices from random channel subsets.
 
@@ -131,13 +125,22 @@ def calc_projector(
     rand_samples = np.zeros((locs.shape[0], num_samples, locs.shape[0]))
 
     if subroutine == 'sphericalSplineInterpolate':
-        op = lambda src, dest: sphericalSplineInterpolate(src.T, dest.T)[0]
+
+        def op(src, dest):
+            return sphericalSplineInterpolate(src.T, dest.T)[0]
+
     elif subroutine == 'matlab':
         matlab = get_eeglab('MAT')
-        op = lambda src, dest: matlab.sphericalSplineInterpolate(src.T, dest.T)[0]
+
+        def op(src, dest):
+            return matlab.sphericalSplineInterpolate(src.T, dest.T)[0]
+
     elif subroutine == 'octave':
         octave = get_eeglab('OCT')
-        op = lambda src, dest: octave.sphericalSplineInterpolate(src.T, dest.T)[0]
+
+        def op(src, dest):
+            return octave.sphericalSplineInterpolate(src.T, dest.T)[0]
+
     else:
         raise ValueError(f'Unknown subroutine: {subroutine}')
 

--- a/src/eegprep/plugins/clean_rawdata/private/sigproc.py
+++ b/src/eegprep/plugins/clean_rawdata/private/sigproc.py
@@ -1,6 +1,6 @@
 """Signal processing utilities."""
 
-from typing import *
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 from scipy.signal import fftconvolve
@@ -9,13 +9,7 @@ from ....functions.miscfunc.misc import round_mat
 __all__ = ['design_kaiser', 'design_fir', 'filtfilt_fast', 'firwsord', 'firws']
 
 
-def design_kaiser(
-        lo: float,
-        hi: float,
-        atten: float,
-        want_odd: bool,
-        use_scipy: bool = False
-) -> np.ndarray:
+def design_kaiser(lo: float, hi: float, atten: float, want_odd: bool, use_scipy: bool = False) -> np.ndarray:
     """Design a Kaiser window for a low-pass FIR filter.
 
     Parameters
@@ -45,9 +39,9 @@ def design_kaiser(
         if atten < 21:
             beta = 0
         elif atten < 50:
-            beta = 0.5842*(atten-21)**0.4 + 0.07886*(atten-21)
+            beta = 0.5842 * (atten - 21) ** 0.4 + 0.07886 * (atten - 21)
         else:
-            beta = 0.1102*(atten-8.7)
+            beta = 0.1102 * (atten - 8.7)
 
         #  determine the number of points
         N = int(round_mat((atten - 7.95) / (2 * np.pi * 2.285 * (hi - lo))) + 1)
@@ -61,13 +55,13 @@ def design_kaiser(
 
 
 def design_fir(
-        n: int,
-        f: Union[np.ndarray, Sequence[float]],
-        a: Union[np.ndarray, Sequence[float]],
-        *,
-        nfft: Optional[int] = None,
-        w: Optional[np.ndarray] = None,
-        compat: bool = True,
+    n: int,
+    f: Union[np.ndarray, Sequence[float]],
+    a: Union[np.ndarray, Sequence[float]],
+    *,
+    nfft: Optional[int] = None,
+    w: Optional[np.ndarray] = None,
+    compat: bool = True,
 ) -> np.ndarray:
     """Design an FIR filter using the frequency-sampling method.
 
@@ -97,14 +91,16 @@ def design_fir(
         The filter coefficients.
     """
     from scipy.interpolate import PchipInterpolator
+
     f, a = np.asarray(f), np.asarray(a)
     if nfft is None:
-        nfft = max([512, 2**np.ceil(np.log(n) / np.log(2))])
+        nfft = max([512, 2 ** np.ceil(np.log(n) / np.log(2))])
     if w is None:
         if compat:
-            w = 0.54 - 0.46*np.cos(2*np.pi*np.arange(n+1)/n)
+            w = 0.54 - 0.46 * np.cos(2 * np.pi * np.arange(n + 1) / n)
         else:
             from scipy.signal.windows import hamming
+
             w = hamming(n)
 
     # calculate interpolated frequency response
@@ -116,13 +112,13 @@ def design_fir(
     b = np.real(np.fft.ifft(np.concatenate((f, np.conj(f[::-1][1:-1])))))
 
     # apply window to kernel
-    return b[:len(w)] * w
+    return b[: len(w)] * w
 
 
 def filtfilt_fast(
-        b: np.ndarray,
-        a: Union[float, np.ndarray],
-        x: np.ndarray,
+    b: np.ndarray,
+    a: Union[float, np.ndarray],
+    x: np.ndarray,
 ) -> np.ndarray:
     """Apply a zero-phase forward-backward filter to a signal using FFTs.
 
@@ -153,7 +149,7 @@ def filtfilt_fast(
     y_filtered = fftconvolve(y_forward, b, mode='full')[::-1]
     # trim off padding
     excess = len(y_filtered) - len(x)
-    y_depadded = y_filtered[excess//2:-excess//2]
+    y_depadded = y_filtered[excess // 2 : -excess // 2]
     return y_depadded
 
 
@@ -215,6 +211,7 @@ def moving_average(X, *, N=3, axis=-1, Z=None, inplace=False, transform=None, in
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
     """
+
     class MovAvgState:
         """State representation for moving_average() filter function."""
 
@@ -224,7 +221,9 @@ def moving_average(X, *, N=3, axis=-1, Z=None, inplace=False, transform=None, in
     if transform and inplace:
         raise ValueError("You cannot use inplace and transform at the same time.")
     if transform is None:
-        def transform(x): return x
+
+        def transform(x):
+            return x
     # we're doing some extra homework here to be able to buffer and transform the data
     # without swizzling axes (which creates temporaries that can exceed the memory),
     # so we have to be able to do all operations on input and output along the desired axis,
@@ -232,7 +231,7 @@ def moving_average(X, *, N=3, axis=-1, Z=None, inplace=False, transform=None, in
 
     def slice_at(x, k):
         """Generate an index slice that will slice x at the desired axis."""
-        slices = [slice(None)]*x.ndim
+        slices = [slice(None)] * x.ndim
         slices[axis] = k
         return tuple(slices)
 
@@ -251,8 +250,9 @@ def moving_average(X, *, N=3, axis=-1, Z=None, inplace=False, transform=None, in
             init_n = N
         else:
             raise ValueError("init must be 0 or None")
-        Z = MovAvgState(p=0, buf=np.zeros_like(X[slice_at(X, [0]*N)]),
-                        acc=np.zeros_like(transform(X[slice_at(X, 0)])), n=init_n)
+        Z = MovAvgState(
+            p=0, buf=np.zeros_like(X[slice_at(X, [0] * N)]), acc=np.zeros_like(transform(X[slice_at(X, 0)])), n=init_n
+        )
 
     for k in range(X.shape[axis]):
         # this is basically the buffered moving average trick (updating/downdating
@@ -272,7 +272,9 @@ def moving_average(X, *, N=3, axis=-1, Z=None, inplace=False, transform=None, in
     return (X if inplace else Y), Z
 
 
-def firws(m: int, f: Union[float, Sequence[float]], t: Optional[str] = None, w: Optional[np.ndarray] = None) -> Tuple[np.ndarray, float]:
+def firws(
+    m: int, f: Union[float, Sequence[float]], t: Optional[str] = None, w: Optional[np.ndarray] = None
+) -> Tuple[np.ndarray, float]:
     """Designs windowed sinc type I linear phase FIR filter.
 
     Parameters
@@ -364,17 +366,17 @@ def _fkernel(m: int, f: float, w: np.ndarray) -> np.ndarray:
         Filter kernel.
     """
     # Create range -m/2 : m/2
-    n = np.arange(-m//2, m//2 + 1, dtype=float)
+    n = np.arange(-m // 2, m // 2 + 1, dtype=float)
 
     # Compute sinc function
     b = np.zeros_like(n)
 
     # Handle n == 0 case (no division by zero)
-    zero_idx = (n == 0)
+    zero_idx = n == 0
     b[zero_idx] = 2 * np.pi * f
 
     # Handle n != 0 case
-    nonzero_idx = (n != 0)
+    nonzero_idx = n != 0
     b[nonzero_idx] = np.sin(2 * np.pi * f * n[nonzero_idx]) / n[nonzero_idx]
 
     # Apply window

--- a/src/eegprep/plugins/clean_rawdata/private/sigproc.py
+++ b/src/eegprep/plugins/clean_rawdata/private/sigproc.py
@@ -313,10 +313,10 @@ def firws(
         raise ValueError('Filter order must be a real, even, positive integer.')
 
     # Convert f to array and normalize
-    f = np.asarray(f, dtype=float)
-    if f.ndim == 0:
-        f = f.reshape(1)
-    f = f / 2.0
+    f_arr = np.asarray(f, dtype=float)
+    if f_arr.ndim == 0:
+        f_arr = f_arr.reshape(1)
+    f = f_arr / 2.0
 
     if np.any(f <= 0) or np.any(f >= 0.5):
         raise ValueError('Frequencies must fall in range between 0 and 1.')

--- a/src/eegprep/plugins/clean_rawdata/private/sphericalSplineInterpolate.py
+++ b/src/eegprep/plugins/clean_rawdata/private/sphericalSplineInterpolate.py
@@ -1,6 +1,5 @@
 """Spatial interpolation utilities."""
 
-from typing import *
 import numpy as np
 
 from eegprep.functions.miscfunc.misc import finite_matmul, finite_pinv
@@ -21,20 +20,20 @@ def _interpMx(cosEE, order, tol):
     -------
         tuple[np.ndarray, np.ndarray]: G and H matrices.
     """
-    x = np.asarray(cosEE) # Ensure input is a numpy array
+    x = np.asarray(cosEE)  # Ensure input is a numpy array
 
     # Initialize variables for Legendre polynomial recurrence (vectorized)
     # Using float for n even for integers to ensure float division later
     n = 1.0
     Pns1 = np.ones_like(x)
-    Pn = x.copy() # Use a copy to avoid modifying input if it was passed by reference
+    Pn = x.copy()  # Use a copy to avoid modifying input if it was passed by reference
 
     # Calculate initial terms for G and H sums
-    nn_plus_n = n * n + n # = 2.0 when n=1
+    nn_plus_n = n * n + n  # = 2.0 when n=1
     # Ensure float exponentiation/division
-    tmp = ((2.0 * n + 1.0) * Pn) / (nn_plus_n**float(order))
-    G = tmp.copy() # Start sum for G
-    H = nn_plus_n * tmp # Start sum for H
+    tmp = ((2.0 * n + 1.0) * Pn) / (nn_plus_n ** float(order))
+    G = tmp.copy()  # Start sum for G
+    H = nn_plus_n * tmp  # Start sum for H
 
     # Initialize convergence tracking variables
     # Initialize dG/dH with the magnitude of the first term; avoids issues if G/H start near zero
@@ -44,7 +43,7 @@ def _interpMx(cosEE, order, tol):
     # Summation loop for Legendre polynomial series (vectorized)
     # Max iterations set to 500 as in the MATLAB code
     for n_int in range(2, 501):
-        n = float(n_int) # Use float n for calculations
+        n = float(n_int)  # Use float n for calculations
 
         # Legendre polynomial recurrence relation (vectorized)
         Pns2 = Pns1
@@ -58,11 +57,11 @@ def _interpMx(cosEE, order, tol):
         # Calculate update term 'tmp' (vectorized)
         nn_plus_n = n * n + n
         # Ensure float exponentiation/division
-        tmp = ((2.0 * n + 1.0) * Pn) / (nn_plus_n**float(order))
+        tmp = ((2.0 * n + 1.0) * Pn) / (nn_plus_n ** float(order))
 
         # Update G and H sums (vectorized)
-        G += tmp        # update function estimate, spline interp
-        H += nn_plus_n * tmp # update function estimate, SLAP
+        G += tmp  # update function estimate, spline interp
+        H += nn_plus_n * tmp  # update function estimate, SLAP
 
         # Update moving average gradient estimate for convergence (vectorized)
         # Add small epsilon to denominator to prevent potential division by zero if dG/dH were zero?
@@ -76,10 +75,11 @@ def _interpMx(cosEE, order, tol):
             break
 
     # Final scaling
-    G /= (4.0 * np.pi)
-    H /= (4.0 * np.pi)
+    G /= 4.0 * np.pi
+    H /= 4.0 * np.pi
 
     return G, H
+
 
 # Main function mirroring the MATLAB sphericalSplineInterpolate
 def sphericalSplineInterpolate(src, dest, lambda_reg=1e-5, order=4, type='spline', tol=np.finfo(float).eps):
@@ -148,7 +148,7 @@ def sphericalSplineInterpolate(src, dest, lambda_reg=1e-5, order=4, type='spline
     # If the vectors are on top of each other, the result is 1.
     # Transpose src_norm (N, 3) and dest_norm (M, 3) for matrix multiplication
     cosSS = finite_matmul(src_norm.T, src_norm)  # angles between source positions [N x N]
-    cosDS = finite_matmul(dest_norm.T, src_norm) # angles between destination positions [M x N]
+    cosDS = finite_matmul(dest_norm.T, src_norm)  # angles between destination positions [M x N]
 
     # Ensure cosines are within [-1, 1] due to potential floating point errors
     cosSS = np.clip(cosSS, -1.0, 1.0)
@@ -165,32 +165,32 @@ def sphericalSplineInterpolate(src, dest, lambda_reg=1e-5, order=4, type='spline
 
     # Compute the mapping to the polynomial coefficients space
     # N.B. this can be numerically unstable so use the PINV to solve..
-    muGss = 1.0 # Fixed value as in the MATLAB code (comment mentioned median(diag(Gss)))
+    muGss = 1.0  # Fixed value as in the MATLAB code (comment mentioned median(diag(Gss)))
 
     # Construct matrix C
     # C = [ Gss    muGss*ones(N,1) ]
     #     [ muGss*ones(1,N)    0   ]
     C = np.zeros((n_src + 1, n_src + 1))
     C[:n_src, :n_src] = Gss
-    C[:n_src, n_src] = muGss # Column of ones * muGss
-    C[n_src, :n_src] = muGss # Row of ones * muGss
+    C[:n_src, n_src] = muGss  # Column of ones * muGss
+    C[n_src, :n_src] = muGss  # Row of ones * muGss
     # C[n_src, n_src] remains 0
 
     # Calculate the pseudoinverse of C
-    iC = finite_pinv(C) # [N+1 x N+1]
+    iC = finite_pinv(C)  # [N+1 x N+1]
 
     # Compute the final mapping matrix W based on the specified type
     type_lower = type.lower()
     if type_lower == 'spline':
         # W = [Gds ones(M,1)*muGss] * iC[:, :-1]
         # Construct the [Gds ones(M,1)*muGss] matrix part
-        Gds_augmented = np.hstack((Gds, muGss * np.ones((n_dest, 1)))) # [M x N+1]
+        Gds_augmented = np.hstack((Gds, muGss * np.ones((n_dest, 1))))  # [M x N+1]
         # Multiply by the relevant part of iC
-        W = finite_matmul(Gds_augmented, iC[:, :n_src]) # [M x N+1] @ [N+1 x N] = [M x N]
+        W = finite_matmul(Gds_augmented, iC[:, :n_src])  # [M x N+1] @ [N+1 x N] = [M x N]
 
     elif type_lower == 'slap':
         # W = Hds * iC[:-1, :-1]
-        W = finite_matmul(Hds, iC[:n_src, :n_src]) # [M x N] @ [N x N] = [M x N]
+        W = finite_matmul(Hds, iC[:n_src, :n_src])  # [M x N] @ [N x N] = [M x N]
 
     else:
         raise ValueError(f"Unknown interpolation type specified: '{type}'. Must be 'spline' or 'slap'.")

--- a/src/eegprep/plugins/clean_rawdata/private/stats.py
+++ b/src/eegprep/plugins/clean_rawdata/private/stats.py
@@ -10,8 +10,9 @@ from ....functions.miscfunc.misc import round_mat
 logger = logging.getLogger(__name__)
 
 
-def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
-                         quants=None, step_sizes=None, beta=None):
+def fit_eeg_distribution(
+    X, min_clean_fraction=None, max_dropout_fraction=None, quants=None, step_sizes=None, beta=None
+):
     """Estimate the mean and standard deviation of clean EEG from contaminated data.
 
     Mu,Sigma,Alpha,Beta = fit_eeg_distribution(X,MinCleanFraction,MaxDropoutFraction,FitQuantiles,StepSizes,ShapeRange)
@@ -72,7 +73,7 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
           - beta (float): estimated shape parameter of the generalized Gaussian
                           clean EEG distribution.
     """
-# --- Assign defaults ---
+    # --- Assign defaults ---
     if min_clean_fraction is None:
         min_clean_fraction = 0.25
     if max_dropout_fraction is None:
@@ -109,8 +110,8 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
     n = len(X)
 
     # --- Calc z bounds for the truncated standard generalized Gaussian pdf and pdf rescaler ---
-    zbounds = [] # Use a list to store bounds for each beta
-    rescale = np.zeros_like(beta, dtype=float) # Pre-allocate rescale array
+    zbounds = []  # Use a list to store bounds for each beta
+    rescale = np.zeros_like(beta, dtype=float)  # Pre-allocate rescale array
     for i, b_val in enumerate(beta):
         # Calculate bounds using gammaincinv
         # Note: MATLAB's gammaincinv(A,X) finds y where gammainc(y,A,'lower') = X.
@@ -131,16 +132,16 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
         rescale[i] = b_val / (2.0 * gamma(1.0 / b_val))
 
     # --- Determine the quantile-dependent limits for the grid search ---
-    lower_min = np.min(quants)                  # we can generally skip the tail below the lower quantile
-    max_width = np.diff(quants)[0]              # maximum width is the fit interval if all data is clean
+    lower_min = np.min(quants)  # we can generally skip the tail below the lower quantile
+    max_width = np.diff(quants)[0]  # maximum width is the fit interval if all data is clean
     min_width = min_clean_fraction * max_width  # minimum width of the fit interval, as fraction of data
 
     # --- Get matrix of shifted data ranges ---
     # Generate start indices based on lower quantile, dropout fraction, and step size
     # Use np.arange; add a small fraction of step_sizes[0] to ensure the endpoint is included if it's a multiple of the step
-    start_indices = round_mat(n * np.arange(lower_min,
-                                            lower_min + max_dropout_fraction + 0.99 * step_sizes[0],
-                                            step_sizes[0])).astype(int)
+    start_indices = round_mat(
+        n * np.arange(lower_min, lower_min + max_dropout_fraction + 0.99 * step_sizes[0], step_sizes[0])
+    ).astype(int)
 
     # Generate indices within each window based on max_width
     max_window_len = int(round_mat(n * max_width))
@@ -154,29 +155,28 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
     X_windows = X[all_indices]
 
     # Get the first element (lower bound) of each window
-    X1 = X_windows[:, 0].copy() # Use .copy() to avoid potential view issues
+    X1 = X_windows[:, 0].copy()  # Use .copy() to avoid potential view issues
 
     # Subtract the lower bound from each element in its respective window (equivalent to bsxfun(@minus, X, X1))
-    X_shifted = X_windows - X1[:, None] # Broadcasting subtraction
+    X_shifted = X_windows - X1[:, None]  # Broadcasting subtraction
 
     # --- Grid search ---
     opt_val = np.inf
     opt_beta = np.nan
     opt_bounds = np.array([np.nan, np.nan])
-    opt_lu = np.array([np.nan, np.nan]) # Lower and Upper data values of the optimal interval
+    opt_lu = np.array([np.nan, np.nan])  # Lower and Upper data values of the optimal interval
 
     # Iterate through possible interval widths 'm' exactly as in-house
     m_steps = np.int32(round_mat(n * np.arange(max_width, min_width, -step_sizes[1])))
 
     for m in m_steps:
-        if m <= 0: continue # Skip if width is non-positive
+        if m <= 0:
+            continue  # Skip if width is non-positive
 
         # --- Scale and bin the data in the intervals ---
         nbins = int(round_mat(3 * math.log2(1 + m / 2)))
-        if nbins <= 0: continue # Skip if nbins is non-positive
-
-        # Get the endpoint of the interval for scaling (width m means index m-1)
-        X_m = X_shifted[:, m - 1]
+        if nbins <= 0:
+            continue  # Skip if nbins is non-positive
 
         # scale and bin the data in the intervals exactly as in the MATLAB code
         with np.errstate(invalid="ignore", divide="ignore"):
@@ -193,7 +193,7 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
         for b in range(len(beta)):
             bounds = zbounds[b]
             x_vals = bounds[0] + (0.5 + np.arange(nbins)) / nbins * np.diff(bounds)
-            p = np.exp(-np.abs(x_vals)**beta[b]) * rescale[b]
+            p = np.exp(-(np.abs(x_vals) ** beta[b])) * rescale[b]
             p /= np.sum(p)
             kl = np.sum(p * (np.log(p) - logq), axis=1) + np.log(m)
             min_val = np.min(kl)
@@ -228,12 +228,12 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
     try:
         gamma_3_over_beta = gamma(3.0 / final_beta)
         gamma_1_over_beta = gamma(1.0 / final_beta)
-        if gamma_1_over_beta < 1e-9: # Avoid division by near-zero
-             sig = np.nan
-             logger.warning("gamma(1/beta) is close to zero; std dev calculation failed.")
+        if gamma_1_over_beta < 1e-9:  # Avoid division by near-zero
+            sig = np.nan
+            logger.warning("gamma(1/beta) is close to zero; std dev calculation failed.")
         else:
-             sig = np.sqrt((alpha**2) * gamma_3_over_beta / gamma_1_over_beta)
-    except ValueError: # Catches potential issues with gamma function inputs (e.g., non-positive)
+            sig = np.sqrt((alpha**2) * gamma_3_over_beta / gamma_1_over_beta)
+    except ValueError:  # Catches potential issues with gamma function inputs (e.g., non-positive)
         sig = np.nan
         logger.warning("Could not calculate std dev due to invalid gamma function input.")
 
@@ -246,7 +246,7 @@ def fit_eeg_distribution(X, min_clean_fraction=None, max_dropout_fraction=None,
     return mu, sig, alpha, final_beta
 
 
-def geometric_median(X, tol=1.e-5, y=None, max_iter=500):
+def geometric_median(X, tol=1.0e-5, y=None, max_iter=500):
     """Calculate the geometric median for a set of observations.
 
     This is the mean under a Laplacian noise distribution, using
@@ -274,7 +274,7 @@ def geometric_median(X, tol=1.e-5, y=None, max_iter=500):
     else:
         y = np.asarray(y)
         if y.shape != (X.shape[1],):
-             raise ValueError(f"Initial guess y must have shape ({X.shape[1]},) matching the number of features in X.")
+            raise ValueError(f"Initial guess y must have shape ({X.shape[1]},) matching the number of features in X.")
 
     # Small constant to prevent division by zero if a point coincides with the median
     epsilon = 1e-9
@@ -283,10 +283,10 @@ def geometric_median(X, tol=1.e-5, y=None, max_iter=500):
         # Calculate squared distances from each point in X to the current median y
         # X shape: (n_samples, n_features), y shape: (n_features,)
         # Broadcasting makes (X - y) shape (n_samples, n_features)
-        squared_distances = np.sum((X - y)**2, axis=1)
+        squared_distances = np.sum((X - y) ** 2, axis=1)
 
         # Calculate inverse norms (distances). Add epsilon for numerical stability.
-        invnorms = 1. / np.sqrt(squared_distances + epsilon)
+        invnorms = 1.0 / np.sqrt(squared_distances + epsilon)
 
         # Check for exact matches (where distance is near zero)
         # If a data point coincides with the current estimate, its weight should be handled carefully.
@@ -308,9 +308,9 @@ def geometric_median(X, tol=1.e-5, y=None, max_iter=500):
         # Check for convergence: relative change in norm
         # Use np.linalg.norm for vector norm
         norm_y = np_norm(y)
-        if norm_y == 0: # Avoid division by zero if the median is the zero vector
-             if np_norm(y - oldy) < tol: # Check absolute difference if norm is zero
-                 break
+        if norm_y == 0:  # Avoid division by zero if the median is the zero vector
+            if np_norm(y - oldy) < tol:  # Check absolute difference if norm is zero
+                break
         elif np_norm(y - oldy) / norm_y < tol:
             break
 
@@ -322,7 +322,7 @@ def geometric_median(X, tol=1.e-5, y=None, max_iter=500):
 
 
 # Helper function ported from asr_calibrate.m
-def block_geometric_median(X, blocksize=1, tol=1.e-5, y=None, max_iter=500):
+def block_geometric_median(X, blocksize=1, tol=1.0e-5, y=None, max_iter=500):
     """Calculate a blockwise geometric median.
 
     Faster and less memory-intensive than the regular geom_median function.
@@ -355,7 +355,7 @@ def block_geometric_median(X, blocksize=1, tol=1.e-5, y=None, max_iter=500):
 
     o, v = X.shape  # #observations & #variables
     if o == 0:
-         # Handle empty input case
+        # Handle empty input case
         return np.full((v,), np.nan)
 
     r = o % blocksize  # #remainder in last block
@@ -364,10 +364,10 @@ def block_geometric_median(X, blocksize=1, tol=1.e-5, y=None, max_iter=500):
     if b > 0:
         # Process full blocks
         # Reshape to (num_blocks, blocksize, num_variables) and sum along axis 1
-        X_blocks = X[:o - r, :].reshape(b, blocksize, v).sum(axis=1)
+        X_blocks = X[: o - r, :].reshape(b, blocksize, v).sum(axis=1)
         if r > 0:
             # Process remainder block if it exists
-            X_rem = X[o - r:, :].sum(axis=0, keepdims=True) * (blocksize / r)
+            X_rem = X[o - r :, :].sum(axis=0, keepdims=True) * (blocksize / r)
             # Combine full blocks and scaled remainder
             X_processed = np.vstack((X_blocks, X_rem))
         else:
@@ -375,11 +375,10 @@ def block_geometric_median(X, blocksize=1, tol=1.e-5, y=None, max_iter=500):
             X_processed = X_blocks
     elif r > 0:
         # Only a remainder block exists
-        X_processed = X[o - r:, :].sum(axis=0, keepdims=True) * (blocksize / r)
+        X_processed = X[o - r :, :].sum(axis=0, keepdims=True) * (blocksize / r)
     else:
         # This case should ideally not be reached if o > 0, but handle defensively
-         return np.full((v,), np.nan)
-
+        return np.full((v,), np.nan)
 
     # Call the standard geometric median function on the processed data
     median_val = geometric_median(X_processed, tol=tol, y=y, max_iter=max_iter)

--- a/src/eegprep/plugins/dipfit/menu.py
+++ b/src/eegprep/plugins/dipfit/menu.py
@@ -17,13 +17,44 @@ def dipfit_menu() -> MenuItemSpec:
         separator=True,
         origin="dipfit",
         children=[
-            menu_item("Head model and settings", action="pop_dipfit_settings", userdata="startup:off;study:on", origin="dipfit"),
-            menu_item("Create a head model from an MRI", action="pop_dipfit_headmodel", userdata="startup:off;study:off", origin="dipfit"),
-            menu_item("Component dipole coarse fit", action="pop_dipfit_gridsearch", userdata="startup:off", separator=True, origin="dipfit"),
-            menu_item("Component dipole fine fit", action="pop_dipfit_nonlinear", userdata="startup:off", origin="dipfit"),
+            menu_item(
+                "Head model and settings",
+                action="pop_dipfit_settings",
+                userdata="startup:off;study:on",
+                origin="dipfit",
+            ),
+            menu_item(
+                "Create a head model from an MRI",
+                action="pop_dipfit_headmodel",
+                userdata="startup:off;study:off",
+                origin="dipfit",
+            ),
+            menu_item(
+                "Component dipole coarse fit",
+                action="pop_dipfit_gridsearch",
+                userdata="startup:off",
+                separator=True,
+                origin="dipfit",
+            ),
+            menu_item(
+                "Component dipole fine fit", action="pop_dipfit_nonlinear", userdata="startup:off", origin="dipfit"
+            ),
             menu_item("Component dipole plot ", action="pop_dipplot", userdata="startup:off", origin="dipfit"),
-            menu_item("Component dipole autofit", action="pop_multifit", userdata="startup:off;study:on", origin="dipfit"),
-            menu_item("Distributed source Leadfield matrix", action="pop_leadfield", userdata="startup:off;study:on", separator=True, origin="dipfit"),
-            menu_item("Distributed source component modelling", action="pop_dipfit_loreta", userdata="startup:off", origin="dipfit"),
+            menu_item(
+                "Component dipole autofit", action="pop_multifit", userdata="startup:off;study:on", origin="dipfit"
+            ),
+            menu_item(
+                "Distributed source Leadfield matrix",
+                action="pop_leadfield",
+                userdata="startup:off;study:on",
+                separator=True,
+                origin="dipfit",
+            ),
+            menu_item(
+                "Distributed source component modelling",
+                action="pop_dipfit_loreta",
+                userdata="startup:off",
+                origin="dipfit",
+            ),
         ],
     )

--- a/src/eegprep/plugins/firfilt/firws.py
+++ b/src/eegprep/plugins/firfilt/firws.py
@@ -3,4 +3,3 @@
 from ..clean_rawdata.private.sigproc import firws
 
 __all__ = ["firws"]
-

--- a/src/eegprep/plugins/firfilt/firwsord.py
+++ b/src/eegprep/plugins/firfilt/firwsord.py
@@ -3,4 +3,3 @@
 from ..clean_rawdata.private.sigproc import firwsord
 
 __all__ = ["firwsord"]
-

--- a/src/eegprep/utils/testing.py
+++ b/src/eegprep/utils/testing.py
@@ -1,7 +1,6 @@
 """Testing utilities."""
 
 import importlib.util
-import os
 import shutil
 import sys
 import unittest
@@ -28,6 +27,7 @@ default_32_bit = True
 # works around an issue where pop_loadset can at times read back a 2d array@
 # as 3d
 flatten_to_2d = True
+
 
 def compare_eeg(a, b, rtol=0, atol=1e-7, use_32_bit=default_32_bit, err_msg=''):
     """Compare EEG time series data, with optional 32-bit precision.
@@ -76,7 +76,7 @@ def compare_eeg(a, b, rtol=0, atol=1e-7, use_32_bit=default_32_bit, err_msg=''):
 
     # Build summary string
     summary_lines = [
-        f"Comparison Summary:",
+        "Comparison Summary:",
         f"  Shape: {original_shape}",
         f"  Total elements: {total_elements:,}",
         f"  Mismatched elements (> {atol}): {mismatched:,} ({mismatch_pct:.2f}%)",
@@ -118,6 +118,7 @@ class DebuggableTestCase(unittest.TestCase):
         loader = unittest.defaultTestLoader
         testSuite = loader.loadTestsFromTestCase(cls)
         testSuite.debug()
+
 
 def is_debug():
     """Determine whether Python is running in debug mode."""
@@ -189,8 +190,7 @@ def use_64bit_eeg_options():
                 backup_path.unlink()  # Remove the backup file
             else:
                 warnings.warn(
-                    f"Backup file {backup_path} went missing, could not restore original eeg_options.m",
-                    UserWarning
+                    f"Backup file {backup_path} went missing, could not restore original eeg_options.m", UserWarning
                 )
         else:
             # Delete the file since it didn't exist before

--- a/src/eegprep/utils/testing.py
+++ b/src/eegprep/utils/testing.py
@@ -122,7 +122,7 @@ class DebuggableTestCase(unittest.TestCase):
 
 def is_debug():
     """Determine whether Python is running in debug mode."""
-    return getattr(sys, 'gettrace', None)() is not None
+    return sys.gettrace() is not None
 
 
 def has_optional_dependency(name: str) -> bool:

--- a/tests/compare_iclabel_engines.py
+++ b/tests/compare_iclabel_engines.py
@@ -32,6 +32,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'
 
 from eegprep import pop_loadset, pop_saveset, iclabel
 
+
 def compare_iclabel_engines(input_file, output_dir=None, engines=None, algorithm='default'):
     """
     Compare the results of applying ICLabel with different engines.
@@ -84,6 +85,7 @@ def compare_iclabel_engines(input_file, output_dir=None, engines=None, algorithm
 
     return results
 
+
 def compare_classifications(results):
     """
     Compare the classifications from different engines.
@@ -105,7 +107,7 @@ def compare_classifications(results):
 
     # Compare each pair of engines
     for i in range(n_engines):
-        for j in range(i+1, n_engines):
+        for j in range(i + 1, n_engines):
             engine1 = engines[i]
             engine2 = engines[j]
 
@@ -126,10 +128,11 @@ def compare_classifications(results):
             comparisons[(engine1, engine2)] = {
                 'correlations': correlations,
                 'mean_correlation': np.mean(correlations),
-                'mean_abs_diff': mean_abs_diff
+                'mean_abs_diff': mean_abs_diff,
             }
 
     return comparisons
+
 
 def plot_comparisons(results, comparisons, output_dir=None, algorithm='default'):
     """
@@ -153,7 +156,7 @@ def plot_comparisons(results, comparisons, output_dir=None, algorithm='default')
     plt.figure(figsize=(15, 5 * n_engines))
 
     for i, engine in enumerate(engines):
-        plt.subplot(n_engines, 1, i+1)
+        plt.subplot(n_engines, 1, i + 1)
         classifications = results[engine]['etc']['ic_classification']['ICLabel']['classifications']
         classes = results[engine]['etc']['ic_classification']['ICLabel']['classes']
 
@@ -172,9 +175,11 @@ def plot_comparisons(results, comparisons, output_dir=None, algorithm='default')
     plt.figure(figsize=(15, 5 * len(comparisons)))
 
     for i, ((engine1, engine2), metrics) in enumerate(comparisons.items()):
-        plt.subplot(len(comparisons), 1, i+1)
+        plt.subplot(len(comparisons), 1, i + 1)
         plt.bar(range(len(metrics['correlations'])), metrics['correlations'])
-        plt.axhline(metrics['mean_correlation'], color='r', linestyle='--', label=f"Mean: {metrics['mean_correlation']:.3f}")
+        plt.axhline(
+            metrics['mean_correlation'], color='r', linestyle='--', label=f"Mean: {metrics['mean_correlation']:.3f}"
+        )
         plt.title(f"Correlation between {engine1} and {engine2}")
         plt.xlabel('Component')
         plt.ylabel('Correlation')
@@ -184,6 +189,7 @@ def plot_comparisons(results, comparisons, output_dir=None, algorithm='default')
 
     if output_dir is not None:
         plt.savefig(os.path.join(output_dir, f'iclabel_correlations_{algorithm}.png'))
+
 
 def main():
     """
@@ -220,6 +226,7 @@ def main():
             print(f"  Mean absolute difference: {metrics['mean_abs_diff']:.3f}")
     else:
         print("Not enough results to compare.")
+
 
 if __name__ == '__main__':
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,7 @@ SLOW_NODEID_PARTS = (
     "tests/test_runamica.py::TestRunamicaIntegration::",
 )
 
-VISUAL_FILE_SUFFIXES = (
-    "tests/test_visual_parity.py",
-)
+VISUAL_FILE_SUFFIXES = ("tests/test_visual_parity.py",)
 
 GUI_FILE_SUFFIXES = (
     "tests/test_gui_pop_adjustevents.py",
@@ -49,9 +47,7 @@ GUI_FILE_SUFFIXES = (
     "tests/test_gui_pop_select.py",
     "tests/test_gui_main_window.py",
 )
-GUI_NODEID_PARTS = (
-    "::test_gui_",
-)
+GUI_NODEID_PARTS = ("::test_gui_",)
 
 MATLAB_FILE_SUFFIXES = (
     "tests/test_ICL_feature_extractor_parity.py",
@@ -101,9 +97,7 @@ MATLAB_NODEID_PARTS = (
     "tests/test_topoplot.py::TestTopoplotParity::",
 )
 
-OCTAVE_NODEID_PARTS = (
-    "tests/test_matlab_path.py::TestMatlabPath::test_get_eeglab_oct",
-)
+OCTAVE_NODEID_PARTS = ("tests/test_matlab_path.py::TestMatlabPath::test_get_eeglab_oct",)
 
 
 def _path_has_suffix(path: str, suffixes: tuple[str, ...]) -> bool:
@@ -128,17 +122,13 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         if _path_has_suffix(path, VISUAL_FILE_SUFFIXES):
             item.add_marker(pytest.mark.visual)
 
-        if _path_has_suffix(path, GUI_FILE_SUFFIXES) or _nodeid_has_part(
-            lower_nodeid, GUI_NODEID_PARTS
-        ):
+        if _path_has_suffix(path, GUI_FILE_SUFFIXES) or _nodeid_has_part(lower_nodeid, GUI_NODEID_PARTS):
             item.add_marker(pytest.mark.gui)
 
         if "parity" in lower_nodeid:
             item.add_marker(pytest.mark.parity)
 
-        requires_matlab = _path_has_suffix(path, MATLAB_FILE_SUFFIXES) or _nodeid_has_part(
-            nodeid, MATLAB_NODEID_PARTS
-        )
+        requires_matlab = _path_has_suffix(path, MATLAB_FILE_SUFFIXES) or _nodeid_has_part(nodeid, MATLAB_NODEID_PARTS)
         if requires_matlab:
             item.add_marker(pytest.mark.matlab)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,6 +6,7 @@ across different test modules.
 
 import os
 import unittest
+import importlib.util
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
@@ -21,11 +22,7 @@ def matlab_engine_available():
     if os.environ.get('EEGPREP_SKIP_MATLAB', '0') == '1':
         return False
 
-    try:
-        import matlab.engine
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("matlab.engine") is not None
 
 
 def skip_without_matlab(test_func):
@@ -37,10 +34,7 @@ def skip_without_matlab(test_func):
             # Test code that requires MATLAB
             pass
     """
-    return unittest.skipUnless(
-        matlab_engine_available(),
-        "MATLAB engine not available or skipped"
-    )(test_func)
+    return unittest.skipUnless(matlab_engine_available(), "MATLAB engine not available or skipped")(test_func)
 
 
 def mpl_use_agg():
@@ -84,36 +78,35 @@ def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
     if n_trials > 1:
         # Create one event per epoch
         for i in range(n_trials):
-            events.append({
-                'type': 'epoch',
-                'latency': i * n_samples + 1,  # 1-based indexing for EEGLAB
-                'duration': 0,
-                'urevent': i + 1
-            })
-            epochs.append({
-                'event': [i],
-                'eventtype': ['epoch'],
-                'eventlatency': [0],
-                'eventduration': [0]
-            })
+            events.append(
+                {
+                    'type': 'epoch',
+                    'latency': i * n_samples + 1,  # 1-based indexing for EEGLAB
+                    'duration': 0,
+                    'urevent': i + 1,
+                }
+            )
+            epochs.append({'event': [i], 'eventtype': ['epoch'], 'eventlatency': [0], 'eventduration': [0]})
 
     # Create basic channel locations
     chanlocs = []
     for i in range(n_channels):
-        chanlocs.append({
-            'labels': f'Ch{i+1}',
-            'type': 'EEG',
-            'theta': i * (360 / n_channels),
-            'radius': 0.5,
-            'X': 0.5 * np.cos(np.radians(i * (360 / n_channels))),
-            'Y': 0.5 * np.sin(np.radians(i * (360 / n_channels))),
-            'Z': 0.0,
-            'sph_theta': i * (360 / n_channels),
-            'sph_phi': 0.0,
-            'sph_radius': 1.0,
-            'urchan': i + 1,
-            'ref': ''
-        })
+        chanlocs.append(
+            {
+                'labels': f'Ch{i + 1}',
+                'type': 'EEG',
+                'theta': i * (360 / n_channels),
+                'radius': 0.5,
+                'X': 0.5 * np.cos(np.radians(i * (360 / n_channels))),
+                'Y': 0.5 * np.sin(np.radians(i * (360 / n_channels))),
+                'Z': 0.0,
+                'sph_theta': i * (360 / n_channels),
+                'sph_phi': 0.0,
+                'sph_radius': 1.0,
+                'urchan': i + 1,
+                'ref': '',
+            }
+        )
 
     # Create basic EEG structure
     eeg = {
@@ -142,13 +135,7 @@ def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
         'icachansind': None,
         'chanlocs': chanlocs,
         'urchanlocs': [],
-        'chaninfo': {
-            'filename': '',
-            'plotrad': [],
-            'shrink': [],
-            'nosedir': '+X',
-            'nodatchans': []
-        },
+        'chaninfo': {'filename': '', 'plotrad': [], 'shrink': [], 'nosedir': '+X', 'nodatchans': []},
         'urevent': [],
         'eventdescription': {},
         'epoch': epochs,
@@ -165,14 +152,13 @@ def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
         'etc': {},
         'datfile': '',
         'run': [],
-        'roi': {}
+        'roi': {},
     }
 
     return eeg
 
 
-def create_test_eeg_with_ica(n_channels=32, n_samples=1000, srate=250.0,
-                           n_components=None, n_trials=1):
+def create_test_eeg_with_ica(n_channels=32, n_samples=1000, srate=250.0, n_components=None, n_trials=1):
     """Create a synthetic EEG structure with ICA decomposition for testing.
 
     Args:
@@ -209,15 +195,17 @@ def create_test_eeg_with_ica(n_channels=32, n_samples=1000, srate=250.0,
     # Add basic channel locations
     eeg['chanlocs'] = []
     for i in range(n_channels):
-        eeg['chanlocs'].append({
-            'theta': i * (360 / n_channels),  # Distribute evenly around head
-            'radius': 0.3,
-            'X': 0.3 * np.cos(np.radians(i * (360 / n_channels))),
-            'Y': 0.3 * np.sin(np.radians(i * (360 / n_channels))),
-            'Z': 0.0,
-            'labels': f'Ch{i+1}',
-            'type': 'EEG'
-        })
+        eeg['chanlocs'].append(
+            {
+                'theta': i * (360 / n_channels),  # Distribute evenly around head
+                'radius': 0.3,
+                'X': 0.3 * np.cos(np.radians(i * (360 / n_channels))),
+                'Y': 0.3 * np.sin(np.radians(i * (360 / n_channels))),
+                'Z': 0.0,
+                'labels': f'Ch{i + 1}',
+                'type': 'EEG',
+            }
+        )
 
     return eeg
 
@@ -241,17 +229,19 @@ def create_test_events(n_events=10, max_latency=1000, event_types=None):
 
     for i, latency in enumerate(latencies):
         event_type = event_types[i % len(event_types)]
-        events.append({
-            'type': event_type,
-            'latency': float(latency),
-            'duration': 0.0,
-            'channel': 0,
-            'bvtime': [],
-            'bvmknum': 1,
-            'visible': [1],
-            'code': event_type,
-            'urevent': i + 1
-        })
+        events.append(
+            {
+                'type': event_type,
+                'latency': float(latency),
+                'duration': 0.0,
+                'channel': 0,
+                'bvtime': [],
+                'bvmknum': 1,
+                'visible': [1],
+                'code': event_type,
+                'urevent': i + 1,
+            }
+        )
 
     return events
 
@@ -325,6 +315,11 @@ class TestFixturesContextManager:
 # Backward compatibility alias for legacy references.
 EEGContext = TestFixturesContextManager
 
+
 # Legacy functions for backward compatibility
-small_eeg = lambda: create_test_eeg(n_channels=8, n_samples=250)  # Small EEG for quick tests
+def small_eeg():
+    """Create a small EEG fixture for quick legacy tests."""
+    return create_test_eeg(n_channels=8, n_samples=250)
+
+
 TestFixtures = EEGContext  # Backward compatibility alias

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,7 +22,10 @@ def matlab_engine_available():
     if os.environ.get('EEGPREP_SKIP_MATLAB', '0') == '1':
         return False
 
-    return importlib.util.find_spec("matlab.engine") is not None
+    try:
+        return importlib.util.find_spec("matlab.engine") is not None
+    except ModuleNotFoundError:
+        return False
 
 
 def skip_without_matlab(test_func):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,7 +24,7 @@ def matlab_engine_available():
 
     try:
         return importlib.util.find_spec("matlab.engine") is not None
-    except ModuleNotFoundError:
+    except (ImportError, ValueError):
         return False
 
 

--- a/tests/matlab/ICL_feature_extractor_compare_helper.py
+++ b/tests/matlab/ICL_feature_extractor_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import pop_loadset
@@ -18,5 +19,6 @@ res = ICL_feature_extractor(EEG, True)
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('python_temp.mat', {'grid': res})
 print('Saved python_temp.mat')

--- a/tests/matlab/eeg_autocorr_compare_helper.py
+++ b/tests/matlab/eeg_autocorr_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import pop_loadset
@@ -13,5 +14,6 @@ res = eeg_autocorr(EEG, 100)
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('eeg_autocorr_data.mat', {'grid': res})
 print('Saved eeg_autocorr_data.mat')

--- a/tests/matlab/eeg_autocorr_fftw_compare_helper.py
+++ b/tests/matlab/eeg_autocorr_fftw_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import pop_loadset
@@ -19,5 +20,6 @@ res = eeg_autocorr_fftw(EEG, 100)
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('eeg_autocorr_data.mat', {'grid': res})
 print('Saved eeg_autocorr_data.mat')

--- a/tests/matlab/eeg_autocorr_welch_compare_helper.py
+++ b/tests/matlab/eeg_autocorr_welch_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import pop_loadset
@@ -13,5 +14,6 @@ res = eeg_autocorr_welch(EEG, 100)
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('eeg_autocorr_welch_data.mat', {'grid': res})
 print('Saved eeg_autocorr_welch_data.mat')

--- a/tests/matlab/eeg_rpsd_compare_helper.py
+++ b/tests/matlab/eeg_rpsd_compare_helper.py
@@ -1,5 +1,6 @@
 import sys
 import os
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import eeg_rpsd
@@ -16,5 +17,6 @@ res = eeg_rpsd(EEG, 100)
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('eeg_rpsd_data.mat', {'grid': res})
 print('Saved eeg_rpsd_data.mat')

--- a/tests/matlab/iclabel_compare_helper.py
+++ b/tests/matlab/iclabel_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import iclabel
@@ -11,7 +12,7 @@ if len(sys.argv) != 3:
     raise ValueError('Please provide the input and output file paths as command line arguments')
 
 # get first command line argument
-eeglab_file_path_in  = sys.argv[1]
+eeglab_file_path_in = sys.argv[1]
 eeglab_file_path_out = sys.argv[2]
 
 EEG = pop_loadset(eeglab_file_path_in)

--- a/tests/matlab/pop_reref_compare_helper.py
+++ b/tests/matlab/pop_reref_compare_helper.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import pop_reref
@@ -8,21 +9,20 @@ from eegprep import pop_saveset
 
 import sys
 import os
-import scipy.io
 
 # Check if a parameter was provided
 if len(sys.argv) > 1:
     # The first element in sys.argv is the script name, so we access the second one for the argument
     file_name = sys.argv[1]
     print(f"The EEG file is: {file_name}")
-    print(f"Output will be in python_temp.mat (result field)")
+    print("Output will be in python_temp.mat (result field)")
 else:
     file_name = '../../sample_data/eeglab_data_with_ica_tmp.set'
     # raise("Provide the name of a file containing EEG (full path) as the first parameter.")
 
 # check if file name exists on disk
 if not os.path.isfile(file_name):
-    raise(f"File {file_name} does not exist.")
+    raise (f"File {file_name} does not exist.")
 
 EEG = pop_loadset(file_name)
 EEG = pop_reref(EEG, None)

--- a/tests/matlab/simple_test_octave.py
+++ b/tests/matlab/simple_test_octave.py
@@ -1,4 +1,3 @@
-
 if __name__ == '__main__':
     from eegprep import pop_resample, pop_loadset
 
@@ -12,11 +11,11 @@ if __name__ == '__main__':
 
 
 if 0:
-    from oct2py import Oct2Py, get_log
+    from oct2py import get_log
     from oct2py import octave as octave_engine
     import logging
-    import os
-    #engine = Oct2Py(logger=get_log())
+
+    # engine = Oct2Py(logger=get_log())
     octave_engine.logger = get_log("new_log")
     octave_engine.logger.setLevel(logging.WARNING)
     octave_engine.warning('off', 'backtrace')
@@ -29,7 +28,6 @@ if 0:
     octave_engine.addpath(path2eeglab + '/functions/sigprocfunc')
     octave_engine.addpath(path2eeglab + '/functions/miscfunc')
     octave_engine.addpath(path2eeglab + '/plugins/dipfit')
-
 
     EEG = octave_engine.pop_loadset('tmp.set')
     EEG = octave_engine.pop_resample(EEG, 100)

--- a/tests/matlab/topoplot_compare_helper.py
+++ b/tests/matlab/topoplot_compare_helper.py
@@ -1,6 +1,7 @@
 # get relative path
 import os
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'src'))
 
 from eegprep import topoplot
@@ -29,5 +30,6 @@ grid = res[1]
 
 # save in a matlab file
 import scipy.io
+
 scipy.io.savemat('topoplot_data.mat', {'grid': grid})
 print('Saved topoplot_data.mat')

--- a/tests/test_ICL_feature_extractor.py
+++ b/tests/test_ICL_feature_extractor.py
@@ -10,7 +10,6 @@ import numpy as np
 import os
 import tempfile
 import scipy.io
-from copy import deepcopy
 
 from eegprep.plugins.ICLabel.ICL_feature_extractor import ICL_feature_extractor
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
@@ -36,7 +35,7 @@ def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
         'xmax': (n_samples - 1) / srate,
         'times': np.arange(n_samples) / srate,
         'event': [],
-        'ref': 'unknown'
+        'ref': 'unknown',
     }
 
 
@@ -55,10 +54,7 @@ class TestICLFeatureExtractorBasic(unittest.TestCase):
 
         # Create base EEG structure
         self.test_eeg = create_test_eeg(
-            n_channels=self.n_channels,
-            n_samples=self.n_samples,
-            srate=self.srate,
-            n_trials=1
+            n_channels=self.n_channels, n_samples=self.n_samples, srate=self.srate, n_trials=1
         )
 
         # Add required ICA fields
@@ -70,14 +66,19 @@ class TestICLFeatureExtractorBasic(unittest.TestCase):
         self.test_eeg['ref'] = 'averef'
 
         # Add channel locations (simplified) - create numpy array format
-        self.test_eeg['chanlocs'] = np.array([{
-            'theta': 45 * i,  # Use fixed positions to avoid randomness issues
-            'radius': 0.3,
-            'X': 0.3 * np.cos(np.radians(45 * i)),
-            'Y': 0.3 * np.sin(np.radians(45 * i)),
-            'Z': 0.0,
-            'labels': f'Ch{i+1}'
-        } for i in range(self.n_channels)])
+        self.test_eeg['chanlocs'] = np.array(
+            [
+                {
+                    'theta': 45 * i,  # Use fixed positions to avoid randomness issues
+                    'radius': 0.3,
+                    'X': 0.3 * np.cos(np.radians(45 * i)),
+                    'Y': 0.3 * np.sin(np.radians(45 * i)),
+                    'Z': 0.0,
+                    'labels': f'Ch{i + 1}',
+                }
+                for i in range(self.n_channels)
+            ]
+        )
 
     def test_icl_feature_extractor_missing_ica_winv(self):
         """Test ICL_feature_extractor with missing icawinv."""
@@ -171,10 +172,7 @@ class TestICLFeatureExtractorDataTypes(unittest.TestCase):
         self.srate = 250.0
 
         self.base_eeg = create_test_eeg(
-            n_channels=self.n_channels,
-            n_samples=self.n_samples,
-            srate=self.srate,
-            n_trials=1
+            n_channels=self.n_channels, n_samples=self.n_samples, srate=self.srate, n_trials=1
         )
 
         self.base_eeg['icawinv'] = np.random.randn(self.n_channels, self.n_components) * 0.5
@@ -187,14 +185,16 @@ class TestICLFeatureExtractorDataTypes(unittest.TestCase):
         # Add channel locations
         self.base_eeg['chanlocs'] = []
         for i in range(self.n_channels):
-            self.base_eeg['chanlocs'].append({
-                'theta': np.random.uniform(0, 360),
-                'radius': np.random.uniform(0.1, 0.5),
-                'X': np.random.uniform(-1, 1),
-                'Y': np.random.uniform(-1, 1),
-                'Z': np.random.uniform(-1, 1),
-                'labels': f'Ch{i+1}'
-            })
+            self.base_eeg['chanlocs'].append(
+                {
+                    'theta': np.random.uniform(0, 360),
+                    'radius': np.random.uniform(0.1, 0.5),
+                    'X': np.random.uniform(-1, 1),
+                    'Y': np.random.uniform(-1, 1),
+                    'Z': np.random.uniform(-1, 1),
+                    'labels': f'Ch{i + 1}',
+                }
+            )
 
     def test_icl_feature_extractor_float32_data(self):
         """Test ICL_feature_extractor with float32 input data."""
@@ -228,6 +228,7 @@ class TestICLFeatureExtractorDataTypes(unittest.TestCase):
         except Exception as e:
             self.skipTest(f"ICL_feature_extractor float64 test not available: {e}")
 
+
 class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
     """Test ICL_feature_extractor edge cases."""
 
@@ -241,10 +242,7 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         self.srate = 250.0
 
         self.base_eeg = create_test_eeg(
-            n_channels=self.n_channels,
-            n_samples=self.n_samples,
-            srate=self.srate,
-            n_trials=1
+            n_channels=self.n_channels, n_samples=self.n_samples, srate=self.srate, n_trials=1
         )
 
         self.base_eeg['icawinv'] = np.random.randn(self.n_channels, self.n_components) * 0.5
@@ -257,14 +255,16 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         # Add minimal channel locations
         self.base_eeg['chanlocs'] = []
         for i in range(self.n_channels):
-            self.base_eeg['chanlocs'].append({
-                'theta': i * 45,  # Spread evenly
-                'radius': 0.3,
-                'X': 0.3 * np.cos(np.radians(i * 45)),
-                'Y': 0.3 * np.sin(np.radians(i * 45)),
-                'Z': 0.0,
-                'labels': f'Ch{i+1}'
-            })
+            self.base_eeg['chanlocs'].append(
+                {
+                    'theta': i * 45,  # Spread evenly
+                    'radius': 0.3,
+                    'X': 0.3 * np.cos(np.radians(i * 45)),
+                    'Y': 0.3 * np.sin(np.radians(i * 45)),
+                    'Z': 0.0,
+                    'labels': f'Ch{i + 1}',
+                }
+            )
 
     def test_icl_feature_extractor_small_eeg_data(self):
         """Test ICL_feature_extractor with small EEG data."""
@@ -429,10 +429,7 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
         self.srate = 250.0
 
         self.base_eeg = create_test_eeg(
-            n_channels=self.n_channels,
-            n_samples=self.n_samples,
-            srate=self.srate,
-            n_trials=1
+            n_channels=self.n_channels, n_samples=self.n_samples, srate=self.srate, n_trials=1
         )
 
         self.base_eeg['icawinv'] = np.random.randn(self.n_channels, self.n_components) * 0.5
@@ -445,14 +442,16 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
         # Add channel locations
         self.base_eeg['chanlocs'] = []
         for i in range(self.n_channels):
-            self.base_eeg['chanlocs'].append({
-                'theta': i * 45,
-                'radius': 0.3,
-                'X': 0.3 * np.cos(np.radians(i * 45)),
-                'Y': 0.3 * np.sin(np.radians(i * 45)),
-                'Z': 0.0,
-                'labels': f'Ch{i+1}'
-            })
+            self.base_eeg['chanlocs'].append(
+                {
+                    'theta': i * 45,
+                    'radius': 0.3,
+                    'X': 0.3 * np.cos(np.radians(i * 45)),
+                    'Y': 0.3 * np.sin(np.radians(i * 45)),
+                    'Z': 0.0,
+                    'labels': f'Ch{i + 1}',
+                }
+            )
 
     def test_icl_feature_extractor_no_inf_nan_in_features(self):
         """Test ICL_feature_extractor produces no inf/nan values in features."""
@@ -461,8 +460,7 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
 
             # Check that no features contain inf or nan
             for i, feature in enumerate(features):
-                self.assertTrue(np.all(np.isfinite(feature)),
-                              f"Feature {i} contains inf or nan values")
+                self.assertTrue(np.all(np.isfinite(feature)), f"Feature {i} contains inf or nan values")
 
         except Exception as e:
             self.skipTest(f"ICL_feature_extractor inf/nan test not available: {e}")
@@ -513,7 +511,7 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
             features = ICL_feature_extractor(EEG, flag_autocorr=False)
             if features:
                 self.assertEqual(len(features), 2)
-        except (ValueError, IndexError) as e:
+        except (ValueError, IndexError):
             # Expected behavior for mismatched indices
             pass
         except Exception as e:
@@ -527,8 +525,7 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
             # All features should be scaled by 0.99 (max absolute value <= 0.99)
             for i, feature in enumerate(features):
                 max_abs_val = np.max(np.abs(feature))
-                self.assertLessEqual(max_abs_val, 0.99 + 1e-6,
-                                   f"Feature {i} not properly scaled by 0.99")
+                self.assertLessEqual(max_abs_val, 0.99 + 1e-6, f"Feature {i} not properly scaled by 0.99")
 
         except Exception as e:
             self.skipTest(f"ICL_feature_extractor scaling test not available: {e}")
@@ -586,11 +583,7 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Load MATLAB features
         mat_data = scipy.io.loadmat(temp_file + '.mat')
-        features_ml = [
-            mat_data['features'][0, 0],
-            mat_data['features'][0, 1],
-            mat_data['features'][0, 2]
-        ]
+        features_ml = [mat_data['features'][0, 0], mat_data['features'][0, 1], mat_data['features'][0, 2]]
 
         # Clean up
         os.remove(temp_file)
@@ -606,13 +599,15 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
             ml_feat = features_ml[i]
 
             # Verify shapes match
-            self.assertEqual(py_feat.shape, ml_feat.shape,
-                           f"{name} feature shape mismatch: {py_feat.shape} vs {ml_feat.shape}")
+            self.assertEqual(
+                py_feat.shape, ml_feat.shape, f"{name} feature shape mismatch: {py_feat.shape} vs {ml_feat.shape}"
+            )
 
             # Compare values
             # Max absolute diff: ~6e-8 (float32 precision)
-            np.testing.assert_allclose(py_feat, ml_feat, rtol=1e-5, atol=1e-6,
-                                       err_msg=f"{name} feature differs beyond tolerance")
+            np.testing.assert_allclose(
+                py_feat, ml_feat, rtol=1e-5, atol=1e-6, err_msg=f"{name} feature differs beyond tolerance"
+            )
 
     def test_parity_topo_feature_only(self):
         """Test parity specifically for topography feature."""
@@ -647,8 +642,9 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Compare
         # Max absolute diff: ~6e-8 (float32 precision)
-        np.testing.assert_allclose(topo_py, topo_ml, rtol=1e-5, atol=1e-6,
-                                   err_msg="Topo feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            topo_py, topo_ml, rtol=1e-5, atol=1e-6, err_msg="Topo feature differs beyond tolerance"
+        )
 
     def test_parity_psd_feature_only(self):
         """Test parity specifically for PSD feature."""
@@ -683,8 +679,7 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Compare
         # Max absolute diff: ~6e-8 (float32 precision)
-        np.testing.assert_allclose(psd_py, psd_ml, rtol=1e-5, atol=1e-6,
-                                   err_msg="PSD feature differs beyond tolerance")
+        np.testing.assert_allclose(psd_py, psd_ml, rtol=1e-5, atol=1e-6, err_msg="PSD feature differs beyond tolerance")
 
     def test_parity_autocorr_feature_only(self):
         """Test parity specifically for autocorrelation feature."""
@@ -719,8 +714,9 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Compare
         # Max absolute diff: ~6e-8 (float32 precision)
-        np.testing.assert_allclose(autocorr_py, autocorr_ml, rtol=1e-5, atol=1e-6,
-                                   err_msg="Autocorr feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            autocorr_py, autocorr_ml, rtol=1e-5, atol=1e-6, err_msg="Autocorr feature differs beyond tolerance"
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_ICL_feature_extractor_parity.py
+++ b/tests/test_ICL_feature_extractor_parity.py
@@ -7,6 +7,7 @@ Multithreading is disabled for deterministic numerical results.
 
 # Disable multithreading for deterministic numerical results
 import os
+
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
@@ -79,7 +80,7 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Compare topo feature
         py_topo = py_features[0]
-        print(f"\nTopo comparison:")
+        print("\nTopo comparison:")
         print(f"  Python shape: {py_topo.shape}")
         print(f"  MATLAB shape: {ml_topo.shape}")
         print(f"  Max absolute diff: {np.max(np.abs(py_topo - ml_topo)):.6f}")
@@ -88,18 +89,23 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
         mismatch_mask = ~np.isclose(py_topo, ml_topo, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL)
         n_mismatch = np.sum(mismatch_mask)
         n_total = py_topo.size
-        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100*n_mismatch/n_total:.2f}%)")
+        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100 * n_mismatch / n_total:.2f}%)")
 
         if n_mismatch > 0:
             max_rel_diff = np.max(np.abs((py_topo - ml_topo) / (ml_topo + 1e-10)))
             print(f"  Max relative diff: {max_rel_diff:.6f}")
 
-        np.testing.assert_allclose(py_topo, ml_topo, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL,
-                                   err_msg="Topo feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_topo,
+            ml_topo,
+            rtol=ICLABEL_PARITY_RTOL,
+            atol=ICLABEL_PARITY_ATOL,
+            err_msg="Topo feature differs beyond tolerance",
+        )
 
         # Compare psd feature
         py_psd = py_features[1]
-        print(f"\nPSD comparison:")
+        print("\nPSD comparison:")
         print(f"  Python shape: {py_psd.shape}")
         print(f"  MATLAB shape: {ml_psd.shape}")
         print(f"  Max absolute diff: {np.max(np.abs(py_psd - ml_psd)):.6f}")
@@ -108,14 +114,19 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
         mismatch_mask = ~np.isclose(py_psd, ml_psd, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PSD_PARITY_ATOL)
         n_mismatch = np.sum(mismatch_mask)
         n_total = py_psd.size
-        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100*n_mismatch/n_total:.2f}%)")
+        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100 * n_mismatch / n_total:.2f}%)")
 
         if n_mismatch > 0:
             max_rel_diff = np.max(np.abs((py_psd - ml_psd) / (ml_psd + 1e-10)))
             print(f"  Max relative diff: {max_rel_diff:.6f}")
 
-        np.testing.assert_allclose(py_psd, ml_psd, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PSD_PARITY_ATOL,
-                                   err_msg="PSD feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_psd,
+            ml_psd,
+            rtol=ICLABEL_PARITY_RTOL,
+            atol=ICLABEL_PSD_PARITY_ATOL,
+            err_msg="PSD feature differs beyond tolerance",
+        )
 
     def test_parity_with_autocorr(self):
         """Test parity with MATLAB with autocorrelation (flag_autocorr=True)."""
@@ -153,7 +164,7 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
 
         # Compare topo feature
         py_topo = py_features[0]
-        print(f"\nTopo comparison:")
+        print("\nTopo comparison:")
         print(f"  Python shape: {py_topo.shape}")
         print(f"  MATLAB shape: {ml_topo.shape}")
         print(f"  Max absolute diff: {np.max(np.abs(py_topo - ml_topo)):.6f}")
@@ -162,18 +173,23 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
         mismatch_mask = ~np.isclose(py_topo, ml_topo, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL)
         n_mismatch = np.sum(mismatch_mask)
         n_total = py_topo.size
-        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100*n_mismatch/n_total:.2f}%)")
+        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100 * n_mismatch / n_total:.2f}%)")
 
         if n_mismatch > 0:
             max_rel_diff = np.max(np.abs((py_topo - ml_topo) / (ml_topo + 1e-10)))
             print(f"  Max relative diff: {max_rel_diff:.6f}")
 
-        np.testing.assert_allclose(py_topo, ml_topo, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL,
-                                   err_msg="Topo feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_topo,
+            ml_topo,
+            rtol=ICLABEL_PARITY_RTOL,
+            atol=ICLABEL_PARITY_ATOL,
+            err_msg="Topo feature differs beyond tolerance",
+        )
 
         # Compare psd feature
         py_psd = py_features[1]
-        print(f"\nPSD comparison:")
+        print("\nPSD comparison:")
         print(f"  Python shape: {py_psd.shape}")
         print(f"  MATLAB shape: {ml_psd.shape}")
         print(f"  Max absolute diff: {np.max(np.abs(py_psd - ml_psd)):.6f}")
@@ -182,18 +198,23 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
         mismatch_mask = ~np.isclose(py_psd, ml_psd, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PSD_PARITY_ATOL)
         n_mismatch = np.sum(mismatch_mask)
         n_total = py_psd.size
-        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100*n_mismatch/n_total:.2f}%)")
+        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100 * n_mismatch / n_total:.2f}%)")
 
         if n_mismatch > 0:
             max_rel_diff = np.max(np.abs((py_psd - ml_psd) / (ml_psd + 1e-10)))
             print(f"  Max relative diff: {max_rel_diff:.6f}")
 
-        np.testing.assert_allclose(py_psd, ml_psd, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PSD_PARITY_ATOL,
-                                   err_msg="PSD feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_psd,
+            ml_psd,
+            rtol=ICLABEL_PARITY_RTOL,
+            atol=ICLABEL_PSD_PARITY_ATOL,
+            err_msg="PSD feature differs beyond tolerance",
+        )
 
         # Compare autocorr feature
         py_autocorr = py_features[2]
-        print(f"\nAutocorr comparison:")
+        print("\nAutocorr comparison:")
         print(f"  Python shape: {py_autocorr.shape}")
         print(f"  MATLAB shape: {ml_autocorr.shape}")
         print(f"  Max absolute diff: {np.max(np.abs(py_autocorr - ml_autocorr)):.6f}")
@@ -202,14 +223,19 @@ class TestICLFeatureExtractorParity(unittest.TestCase):
         mismatch_mask = ~np.isclose(py_autocorr, ml_autocorr, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL)
         n_mismatch = np.sum(mismatch_mask)
         n_total = py_autocorr.size
-        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100*n_mismatch/n_total:.2f}%)")
+        print(f"  Mismatched elements: {n_mismatch} / {n_total} ({100 * n_mismatch / n_total:.2f}%)")
 
         if n_mismatch > 0:
             max_rel_diff = np.max(np.abs((py_autocorr - ml_autocorr) / (ml_autocorr + 1e-10)))
             print(f"  Max relative diff: {max_rel_diff:.6f}")
 
-        np.testing.assert_allclose(py_autocorr, ml_autocorr, rtol=ICLABEL_PARITY_RTOL, atol=ICLABEL_PARITY_ATOL,
-                                   err_msg="Autocorr feature differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_autocorr,
+            ml_autocorr,
+            rtol=ICLABEL_PARITY_RTOL,
+            atol=ICLABEL_PARITY_ATOL,
+            err_msg="Autocorr feature differs beyond tolerance",
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_bids_preproc.py
+++ b/tests/test_bids_preproc.py
@@ -3,26 +3,30 @@ Test suite for bids_preproc.py
 """
 
 import logging
-import unittest
 import os
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
-import sys
 import socket
+import unittest
+
 import numpy as np
-import os
+
+from eegprep.utils.testing import DebuggableTestCase
 
 logger = logging.getLogger(__name__)
 
-# Add src to path for imports
-sys.path.insert(0, 'src')
-from eegprep.utils.testing import DebuggableTestCase
+if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
+    raise unittest.SkipTest("MATLAB not available")
 
 curhost = socket.gethostname()
 
 # add your host to this list if you want to run the (very) slow tests
-slow_tests_hosts_only = ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'sccn-delorme.ucsd.edu','jamming', 'DESKTOP-TGLFTPM']
+slow_tests_hosts_only = [
+    'ck-carbon',
+    'MacBook-Pro-10.local',
+    'MacBook-Pro-10.lan',
+    'sccn-delorme.ucsd.edu',
+    'jamming',
+    'DESKTOP-TGLFTPM',
+]
 
 # add your host to this list if you want to run things in parallel
 if curhost in ['ck-carbon', 'MacBook-Pro-10.local', 'MacBook-Pro-10.lan', 'jamming', 'sccn-delorme.ucsd.edu']:
@@ -46,22 +50,24 @@ class TestBidsPreproc(DebuggableTestCase):
             self.root_path = os.path.abspath(os.path.expanduser('data'))
         else:
             self.root_path = None
-            logger.warning(f"Skipping test TestBidsPreproc on unknown test host {curhost}; "
-                           f"please add support for your hostname to the above list to "
-                           f"enable this test.")
+            logger.warning(
+                f"Skipping test TestBidsPreproc on unknown test host {curhost}; "
+                f"please add support for your hostname to the above list to "
+                f"enable this test."
+            )
 
         # list of studies to run end-to-end tests on (set to run first 2 recordings in each)
         self.studies = [
             {
                 'studyname': 'ds002680',
                 'subjects': ['002'],  # first subject, has 2 sessions
-                'runs': [], # needs to be >= 10 otherwise MATLAB-side filtering by run fails
+                'runs': [],  # needs to be >= 10 otherwise MATLAB-side filtering by run fails
             },
             {
                 'studyname': 'ds003061',
-                'subjects': ['001'], #, '002'],
+                'subjects': ['001'],  # , '002'],
                 'runs': [2],  # using run 2 to avoid ICA shape issues with cached run 1 files
-            }
+            },
         ]
 
     def test_end2end(self):
@@ -106,11 +112,15 @@ class TestBidsPreproc(DebuggableTestCase):
                 study_path,
                 ReservePerJob=reservation,
                 # just the first few subjects of the main task
-                Subjects=subjects, Runs=runs,
+                Subjects=subjects,
+                Runs=runs,
                 # reuse results for for quicker re-runs
-                SkipIfPresent=True, UseHashes=True, MinimizeDiskUsage=False,
+                SkipIfPresent=True,
+                UseHashes=True,
+                MinimizeDiskUsage=False,
                 # parse events from BIDS, use value column
-                ApplyEvents=True, EventColumn='value', # <- needed for this study to match pop_importbids() in MATLAB
+                ApplyEvents=True,
+                EventColumn='value',  # <- needed for this study to match pop_importbids() in MATLAB
                 # channel selection - match MATLAB's default behavior
                 OnlyModalities=['EEG'],  # <- filter to EEG channels only, matching MATLAB
                 # resample
@@ -118,13 +128,19 @@ class TestBidsPreproc(DebuggableTestCase):
                 # reinterpolate
                 WithInterp=True,
                 # epoch around all events; short limits to reduce disk space
-                EpochEvents=[], EpochLimits=[-0.2, 0.5], EpochBaseline=[-0.2, 0],
+                EpochEvents=[],
+                EpochLimits=[-0.2, 0.5],
+                EpochBaseline=[-0.2, 0],
                 # temporarily disabled for quicker runs
-                WithICA=True, ICAAlgorithm='picard', WithICLabel=True,
+                WithICA=True,
+                ICAAlgorithm='picard',
+                WithICLabel=True,
                 # save intermediate stages for comparison
-                SaveIntermediateStages=True, IntermediateDir=stage_dir,
+                SaveIntermediateStages=True,
+                IntermediateDir=stage_dir,
                 # return so we can compare things
-                ReturnData=True)
+                ReturnData=True,
+            )
 
             print(f"Running bids_pipeline() on {study_path}...")
             eeglab = get_eeglab('MATLAB')
@@ -133,8 +149,11 @@ class TestBidsPreproc(DebuggableTestCase):
                 [f'sub-{s}' for s in subjects],
                 [f'{r}' for r in runs],
                 100,
-                'SaveIntermediateStages', True,
-                'IntermediateDir', stage_dir)
+                'SaveIntermediateStages',
+                True,
+                'IntermediateDir',
+                stage_dir,
+            )
 
             with eeg_checkset_strict_mode(False):
                 ALLEEG_mat = [pop_loadset(p.item()) for p in result_paths.flatten()]
@@ -145,7 +164,7 @@ class TestBidsPreproc(DebuggableTestCase):
 
             # testing up to here because pop_select occasionally retains events on py that
             # are dropped by the MATLAB code, so things go out of sync at that point
-            print(f"Comparing Python vs MATLAB results...")
+            print("Comparing Python vs MATLAB results...")
             print(f"Python returned: {type(ALLEEG_py)}, length: {len(ALLEEG_py) if ALLEEG_py else 'N/A'}")
             print(f"MATLAB returned: {type(ALLEEG_mat)}, length: {len(ALLEEG_mat)}")
             for k in range(min(len(ALLEEG_py) if ALLEEG_py else 0, len(ALLEEG_mat))):
@@ -159,15 +178,13 @@ class TestBidsPreproc(DebuggableTestCase):
                 print(f"  MATLAB: {EEG_mat['data'].shape} (epochs={EEG_mat.get('trials', 'N/A')})")
                 if 'epoch' in EEG_py and 'epoch' in EEG_mat:
                     print(f"  Python epochs: {len(EEG_py['epoch'])}, MATLAB epochs: {len(EEG_mat['epoch'])}")
-                np.testing.assert_allclose(EEG_py['data'][:, :, :],
-                                           EEG_mat['data'][:, :, :],
-                                           rtol=0, atol=abstol)
+                np.testing.assert_allclose(EEG_py['data'][:, :, :], EEG_mat['data'][:, :, :], rtol=0, atol=abstol)
                 # PICARD currently doesn't pass its unit test vs MATLAB, so disabling for now
                 # np.testing.assert_allclose(EEG_py['icaweights'], EEG_mat['icaweights'], rtol=0, atol=1e-5)
                 print("passed.")
 
             # Generate and save stage-by-stage comparison report
-            print("\n" + "="*80)
+            print("\n" + "=" * 80)
             print("Generating stage-by-stage comparison report...")
             try:
                 comparison_table = generate_comparison_table(stage_dir)
@@ -177,14 +194,18 @@ class TestBidsPreproc(DebuggableTestCase):
                 print(f"Report saved to: {os.path.join(stage_dir, 'comparison_report.md')}")
             except Exception as e:
                 print(f"Could not generate comparison report: {e}")
-            print("="*80 + "\n")
+            print("=" * 80 + "\n")
 
-    @unittest.skipIf(curhost not in slow_tests_hosts_only, f"Slow stress test skipped by default on hosts other than {slow_tests_hosts_only}")
+    @unittest.skipIf(
+        curhost not in slow_tests_hosts_only,
+        f"Slow stress test skipped by default on hosts other than {slow_tests_hosts_only}",
+    )
     def test_crashability_slow(self):
         """Test whether bids_preproc chokes on any of the studies in a given
         repository of BIDS-compliant studies (relative to root_path).
         """
         from eegprep import bids_preproc
+
         if self.root_path is None:
             self.skipTest("Skipping test_crashability_slow on unknown host")
 
@@ -198,11 +219,17 @@ class TestBidsPreproc(DebuggableTestCase):
                 os.path.join(self.root_path, p),
                 ReservePerJob=reservation,
                 # process just the first few subjects/sessions/runs, across all tasks
-                subjects=[0,1], sessions=[0,1], runs=[0,1,2],
-                SkipIfPresent=True, # <- for quicker re-runs
+                subjects=[0, 1],
+                sessions=[0, 1],
+                runs=[0, 1, 2],
+                SkipIfPresent=True,  # <- for quicker re-runs
                 # maximal settings enabled to test everything that could go wrong
                 # (except ICA/IClabel, which are too slow for a test)
                 bidsevent=True,
                 SamplingRate=128,
-                WithInterp=True, EpochEvents=[], EpochLimits=[-0.2, 0.5], EpochBaseline=[None, 0],
-                MinimizeDiskUsage=False)
+                WithInterp=True,
+                EpochEvents=[],
+                EpochLimits=[-0.2, 0.5],
+                EpochBaseline=[None, 0],
+                MinimizeDiskUsage=False,
+            )

--- a/tests/test_bids_preproc_old.py
+++ b/tests/test_bids_preproc_old.py
@@ -1,10 +1,5 @@
-
-
 if __name__ == "__main__":
-    import os
-    import sys
-    from eegprep import pop_load_frombids, bids_list_eeg_files, pop_loadset, bids_preproc
-
+    from eegprep import bids_list_eeg_files, bids_preproc
 
     if True:
         # no events
@@ -14,19 +9,18 @@ if __name__ == "__main__":
         fn = '/home/christian/data/OpenNeuro/ds006018-download/sub-002/eeg/sub-002_task-visualoddball_eeg.vhdr'
 
         # giant files that need to be resampled
-        #fn = '/home/christian/data/OpenNeuro/ds004517-download/sub-01/eeg/sub-01_task-eeg_eeg.bdf'
+        # fn = '/home/christian/data/OpenNeuro/ds004517-download/sub-01/eeg/sub-01_task-eeg_eeg.bdf'
 
         # file with associated electrode locations (but very large file!)
-        #fn = '/Users/arno/Python/eegprep/src/eegprep/eeglab/sample_data/test_data/BIDS_test/sub-S1/ses-01/eeg/sub-S1_ses-01_task-Experiment_run-01_eeg.edf'
+        # fn = '/Users/arno/Python/eegprep/src/eegprep/eeglab/sample_data/test_data/BIDS_test/sub-S1/ses-01/eeg/sub-S1_ses-01_task-Experiment_run-01_eeg.edf'
         # EEG = pop_load_frombids(fn, bidsevent=True)
 
     if True:
-
         # good test case for coord import
         # rt = '/home/christian/data/OpenNeuro/ds004324-download'
 
         # good test case for coord inference
-        #rt = '/System/Volumes/Data/data/data/STUDIES/ds003061'
+        # rt = '/System/Volumes/Data/data/data/STUDIES/ds003061'
         rt = '/home/christian/data/OpenNeuro/ds003061-download'
 
         print(f'parsing BIDS files in {rt}...')
@@ -34,7 +28,14 @@ if __name__ == "__main__":
         for fn in filelist:
             print(' - ' + fn)
 
-        reserve = '' #'1CPU,4GB-5GB,1max' # ''
-        bids_preproc(rt, ReservePerJob=reserve, WithICLabel=False, SkipIfPresent=True,
-                     WithInterp=True,
-                     bidsevent=True, EpochEvents=['stimulus', 'response'], EpochBaseline=(-0.2, 0))
+        reserve = ''  #'1CPU,4GB-5GB,1max' # ''
+        bids_preproc(
+            rt,
+            ReservePerJob=reserve,
+            WithICLabel=False,
+            SkipIfPresent=True,
+            WithInterp=True,
+            bidsevent=True,
+            EpochEvents=['stimulus', 'response'],
+            EpochBaseline=(-0.2, 0),
+        )

--- a/tests/test_clean_artifacts.py
+++ b/tests/test_clean_artifacts.py
@@ -8,9 +8,6 @@ artifact removal including flatline channels, drifts, noisy channels, bursts, an
 import unittest
 import sys
 import numpy as np
-import tempfile
-import os
-import shutil
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
@@ -51,7 +48,7 @@ def create_test_eeg():
                 'sph_phi': np.random.uniform(-90, 90),
                 'sph_radius': np.random.uniform(0, 1),
                 'urchan': i + 1,
-                'ref': ''
+                'ref': '',
             }
             for i in range(32)
         ],
@@ -71,7 +68,7 @@ def create_test_eeg():
         'reject': [],
         'stats': [],
         'dipfit': [],
-        'roi': []
+        'roi': [],
     }
 
 
@@ -117,7 +114,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # With all criteria off, data should be unchanged
@@ -168,7 +165,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
                 LineNoiseCriterion='off',
                 BurstCriterion='off',
                 WindowCriterion='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
             # Should work - list is acceptable
             self.assertIsInstance(EEG, dict)
@@ -178,11 +175,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
     def test_clean_artifacts_mutually_exclusive_channels(self):
         """Test clean_artifacts with mutually exclusive channel parameters."""
         with self.assertRaises(ValueError) as cm:
-            clean_artifacts(
-                self.test_eeg,
-                Channels=['EEG001', 'EEG002'],
-                Channels_ignore=['EEG003']
-            )
+            clean_artifacts(self.test_eeg, Channels=['EEG001', 'EEG002'], Channels_ignore=['EEG003'])
         self.assertIn('mutually exclusive', str(cm.exception))
 
     def test_clean_artifacts_mutually_exclusive_channels_both_empty(self):
@@ -197,7 +190,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
             # Should work - empty lists are not mutually exclusive
             self.assertIsInstance(EEG, dict)
@@ -216,7 +209,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
             # Should work - None and list is not mutually exclusive
             self.assertIsInstance(EEG, dict)
@@ -235,7 +228,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
             # Should work - both None is not mutually exclusive
             self.assertIsInstance(EEG, dict)
@@ -248,7 +241,7 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
             clean_artifacts(
                 self.test_eeg,
                 Channels=['EEG001', 'EEG002', 'EEG003'],
-                Channels_ignore=['EEG002', 'EEG004']  # EEG002 overlaps
+                Channels_ignore=['EEG002', 'EEG004'],  # EEG002 overlaps
             )
         self.assertIn('mutually exclusive', str(cm.exception))
 
@@ -277,7 +270,7 @@ class TestCleanArtifactsFlatline(DebuggableTestCase):
                 LineNoiseCriterion='off',
                 BurstCriterion='off',
                 WindowCriterion='off',
-                Highpass='off'
+                Highpass='off',
             )
 
             # Should have removed some channels
@@ -301,7 +294,7 @@ class TestCleanArtifactsFlatline(DebuggableTestCase):
                 LineNoiseCriterion='off',
                 BurstCriterion='off',
                 WindowCriterion='off',
-                Highpass='off'
+                Highpass='off',
             )
 
             # Should not have removed any channels
@@ -330,7 +323,7 @@ class TestCleanArtifactsHighpass(DebuggableTestCase):
                 LineNoiseCriterion='off',
                 BurstCriterion='off',
                 WindowCriterion='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # HP should contain the highpass filtered data
@@ -353,7 +346,7 @@ class TestCleanArtifactsHighpass(DebuggableTestCase):
                 LineNoiseCriterion='off',
                 BurstCriterion='off',
                 WindowCriterion='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Data should be unchanged
@@ -380,7 +373,7 @@ class TestCleanArtifactsChannelCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have removed some channels with high threshold
@@ -399,7 +392,7 @@ class TestCleanArtifactsChannelCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have removed some channels with low threshold
@@ -418,7 +411,7 @@ class TestCleanArtifactsChannelCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have removed some channels
@@ -445,7 +438,7 @@ class TestCleanArtifactsBurstCleaning(DebuggableTestCase):
                 BurstCriterion=5.0,
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # BUR should contain the burst repaired data
@@ -466,7 +459,7 @@ class TestCleanArtifactsBurstCleaning(DebuggableTestCase):
                 BurstRejection='on',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have removed some samples
@@ -485,7 +478,7 @@ class TestCleanArtifactsBurstCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Data should be unchanged
@@ -512,7 +505,7 @@ class TestCleanArtifactsWindowCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion=0.5,  # Allow 50% bad channels per window
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have removed some samples
@@ -531,7 +524,7 @@ class TestCleanArtifactsWindowCleaning(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Data should be unchanged
@@ -561,7 +554,7 @@ class TestCleanArtifactsChannelSelection(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have only the specified channels
@@ -584,7 +577,7 @@ class TestCleanArtifactsChannelSelection(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should have fewer channels
@@ -606,12 +599,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept numeric values and 'off'
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion=0.8,
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion=0.8,
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts channel criterion validation not available: {e}")
 
@@ -620,12 +625,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept numeric values and 'off'
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion=4.0, BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion=4.0,
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts line noise criterion validation not available: {e}")
 
@@ -634,12 +651,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept numeric values and 'off'
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion=5.0,
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion=5.0,
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts burst criterion validation not available: {e}")
 
@@ -648,12 +677,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept numeric values and 'off'
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion=0.25, Highpass='off', FlatlineCriterion='off')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion=0.25,
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts window criterion validation not available: {e}")
 
@@ -662,12 +703,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept numeric values and 'off'
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion=5.0)
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion=5.0,
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts flatline criterion validation not available: {e}")
 
@@ -676,14 +729,26 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept 'on' and 'off' strings
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off',
-                          BurstRejection='on')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off',
-                          BurstRejection='off')
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                BurstRejection='on',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                BurstRejection='off',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts burst rejection validation not available: {e}")
 
@@ -692,14 +757,26 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         # Should accept 'euclidian' and other distance metrics
         try:
             # Valid cases
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off',
-                          Distance='euclidian')
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off',
-                          Distance='riemann')  # Should trigger riemannian mode
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                Distance='euclidian',
+            )
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                Distance='riemann',
+            )  # Should trigger riemannian mode
         except Exception as e:
             self.skipTest(f"clean_artifacts distance metric validation not available: {e}")
 
@@ -707,29 +784,47 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         """Test clean_artifacts with negative parameter values."""
         # Some parameters should handle negative values gracefully
         try:
-            clean_artifacts(self.test_eeg, ChannelCriterion='off',
-                          LineNoiseCriterion='off', BurstCriterion='off',
-                          WindowCriterion='off', Highpass='off', FlatlineCriterion='off',
-                          MaxMem=-1)  # Negative MaxMem should be handled
-        except Exception as e:
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                MaxMem=-1,
+            )  # Negative MaxMem should be handled
+        except Exception:
             # Negative values may cause errors - this is acceptable
             pass
 
     def test_clean_artifacts_zero_values(self):
         """Test clean_artifacts with zero parameter values."""
         try:
-            clean_artifacts(self.test_eeg, ChannelCriterion=0.0,  # Zero correlation threshold
-                          LineNoiseCriterion=0.0, BurstCriterion='off',
-                          WindowCriterion=0.0, Highpass='off', FlatlineCriterion=0.0)
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion=0.0,  # Zero correlation threshold
+                LineNoiseCriterion=0.0,
+                BurstCriterion='off',
+                WindowCriterion=0.0,
+                Highpass='off',
+                FlatlineCriterion=0.0,
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts zero values not available: {e}")
 
     def test_clean_artifacts_extreme_values(self):
         """Test clean_artifacts with extreme parameter values."""
         try:
-            clean_artifacts(self.test_eeg, ChannelCriterion=1.0,  # Perfect correlation required
-                          LineNoiseCriterion=100.0, BurstCriterion='off',
-                          WindowCriterion=1.0, Highpass='off', FlatlineCriterion=1000.0)
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion=1.0,  # Perfect correlation required
+                LineNoiseCriterion=100.0,
+                BurstCriterion='off',
+                WindowCriterion=1.0,
+                Highpass='off',
+                FlatlineCriterion=1000.0,
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts extreme values not available: {e}")
 
@@ -752,7 +847,7 @@ class TestCleanArtifactsParameters(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should complete without error
@@ -772,7 +867,7 @@ class TestCleanArtifactsParameters(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should complete without error
@@ -792,7 +887,7 @@ class TestCleanArtifactsParameters(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Should complete without error
@@ -819,7 +914,7 @@ class TestCleanArtifactsIntegration(DebuggableTestCase):
                 ChannelCriterion=0.8,
                 LineNoiseCriterion=4.0,
                 BurstCriterion=5.0,
-                WindowCriterion=0.25
+                WindowCriterion=0.25,
             )
 
             # Check all return values
@@ -850,7 +945,7 @@ class TestCleanArtifactsIntegration(DebuggableTestCase):
                 BurstCriterion='off',
                 WindowCriterion='off',
                 Highpass='off',
-                FlatlineCriterion='off'
+                FlatlineCriterion='off',
             )
 
             # Check EEG structure

--- a/tests/test_clean_asr.py
+++ b/tests/test_clean_asr.py
@@ -6,9 +6,7 @@ processing switches.
 """
 
 import unittest
-from unittest.mock import patch, MagicMock
 import numpy as np
-import logging
 
 from eegprep.plugins.clean_rawdata.clean_asr import clean_asr
 
@@ -32,7 +30,7 @@ class TestCleanASRBasic(unittest.TestCase):
             'pnts': self.n_samples,
             'trials': 1,
             'xmin': 0.0,
-            'xmax': (self.n_samples - 1) / self.srate
+            'xmax': (self.n_samples - 1) / self.srate,
         }
 
     def test_clean_asr_missing_required_fields(self):
@@ -100,7 +98,7 @@ class TestCleanASRParameters(unittest.TestCase):
             'srate': self.srate,
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
     def test_clean_asr_parameter_acceptance(self):
@@ -140,7 +138,7 @@ class TestCleanASRCalibrationData(unittest.TestCase):
             'srate': self.srate,
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
     def test_clean_asr_ref_maxbadchannels_off(self):
@@ -232,7 +230,7 @@ class TestCleanASRCalibrationFailure(unittest.TestCase):
             'srate': self.srate,
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
     def test_clean_asr_insufficient_calibration_data(self):
@@ -257,7 +255,7 @@ class TestCleanASRCalibrationFailure(unittest.TestCase):
                     ref_maxbadchannels=0.1,
                     ref_tolerances=(-3.0, 5.0),
                     ref_wndlen=1.0,
-                    cutoff=20.0  # Conservative
+                    cutoff=20.0,  # Conservative
                 )
 
             # Should attempt to find clean calibration data
@@ -286,7 +284,7 @@ class TestCleanASRSignalExtrapolation(unittest.TestCase):
             'srate': self.srate,
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
     def test_clean_asr_with_different_window_lengths(self):
@@ -340,7 +338,7 @@ class TestCleanASREdgeCases(unittest.TestCase):
             'srate': self.srate,
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
     def test_clean_asr_single_channel_data(self):
@@ -350,7 +348,7 @@ class TestCleanASREdgeCases(unittest.TestCase):
             'srate': self.srate,
             'nbchan': 1,
             'pnts': self.n_samples,
-            'trials': 1
+            'trials': 1,
         }
 
         try:

--- a/tests/test_clean_drifts.py
+++ b/tests/test_clean_drifts.py
@@ -8,8 +8,6 @@ drifts from EEG data using high-pass filtering.
 import unittest
 import sys
 import numpy as np
-import tempfile
-import os
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
@@ -50,7 +48,7 @@ def create_test_eeg():
                 'sph_phi': np.random.uniform(-90, 90),
                 'sph_radius': np.random.uniform(0, 1),
                 'urchan': i + 1,
-                'ref': ''
+                'ref': '',
             }
             for i in range(32)
         ],
@@ -64,7 +62,7 @@ def create_test_eeg():
         'epoch': [],
         'setname': 'test_dataset',
         'filename': 'test.set',
-        'filepath': '/tmp'
+        'filepath': '/tmp',
     }
 
 

--- a/tests/test_clean_flatlines.py
+++ b/tests/test_clean_flatlines.py
@@ -8,8 +8,6 @@ prolonged flatline periods from EEG data.
 import unittest
 import sys
 import numpy as np
-import tempfile
-import os
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
@@ -46,7 +44,7 @@ def create_test_eeg():
                 'sph_phi': np.random.uniform(-90, 90),
                 'sph_radius': np.random.uniform(0, 1),
                 'urchan': i + 1,
-                'ref': ''
+                'ref': '',
             }
             for i in range(32)
         ],
@@ -60,7 +58,7 @@ def create_test_eeg():
         'epoch': [],
         'setname': 'test_dataset',
         'filename': 'test.set',
-        'filepath': '/tmp'
+        'filepath': '/tmp',
     }
 
 

--- a/tests/test_clean_rawdata.py
+++ b/tests/test_clean_rawdata.py
@@ -4,14 +4,22 @@ import unittest
 
 if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
     raise unittest.SkipTest("MATLAB not available")
-import psutil
 from copy import deepcopy
 
 import numpy as np
 
-from eegprep import *
+from eegprep import (
+    clean_artifacts,
+    clean_asr,
+    clean_channels,
+    clean_channels_nolocs,
+    clean_drifts,
+    clean_flatlines,
+    clean_windows,
+    pop_loadset,
+)
 from eegprep.functions.adminfunc import eeglabcompat
-from eegprep.utils.testing import *
+from eegprep.utils.testing import DebuggableTestCase, compare_eeg, is_debug, use_64bit_eeg_options
 
 logger = logging.getLogger(__name__)
 
@@ -26,13 +34,13 @@ def ensure_file(fname: str) -> str:
     local_file = os.path.abspath(f"{local_url}{fname}")
     if not os.path.exists(local_file):
         from urllib.request import urlretrieve
+
         urlretrieve(full_url, local_file)
     return local_file
 
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestMATLABAccess(unittest.TestCase):
-
     def setUp(self):
         try:
             self.eeglab = eeglabcompat.get_eeglab('MAT')
@@ -41,23 +49,20 @@ class TestMATLABAccess(unittest.TestCase):
             self.skipTest(f"MATLAB not available: {e}")
 
     def test_basic(self):
-        result = self.eeglab.sqrt(4.0)
-        self.assertEqual(result, 2.0, 'MATLAB sqrt() failed')
+        self.assertEqual(self.eeglab.sqrt(4.0), 2.0, 'MATLAB sqrt() failed')
 
     def test_eeglab_presence(self):
-        result = eeglabcompat.eeg_checkset(self.EEG, eeglab=self.eeglab)
-        pass
+        eeglabcompat.eeg_checkset(self.EEG, eeglab=self.eeglab)
 
 
 class TestCleanFlatlines(unittest.TestCase):
-
     def setUp(self):
         # download file
         self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
         self.EEG['data'][5, 1000:2000] = 3.5  # this should trigger
         self.EEG['data'][7, 2000:2100] = 4.5  # this should not (too short)
         self.EEG['data'][9, 3000:4000] = 5.5  # should trigger too
-        self.EEG['data'][15, 5000:10000] = np.random.randn(5000)*1e-10  # should not trigger (too large amplitude)
+        self.EEG['data'][15, 5000:10000] = np.random.randn(5000) * 1e-10  # should not trigger (too large amplitude)
         self.expected = self.EEG['data'][~np.isin(np.arange(self.EEG['nbchan']), [5, 9]), :]
 
     def test_clean_flatlines(self):
@@ -67,35 +72,44 @@ class TestCleanFlatlines(unittest.TestCase):
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestUtilFuncs(DebuggableTestCase):
-
     def setUp(self):
         self.eeglab = eeglabcompat.get_eeglab('MAT')
 
     def test_design_kaiser(self):
         from eegprep.plugins.clean_rawdata.private.sigproc import design_kaiser
+
         observed = design_kaiser(0.06, 0.08, 75, True)
         expected = np.asarray(self.eeglab.design_kaiser(0.06, 0.08, 75.0, True))
-        np.testing.assert_almost_equal(observed.flatten(), expected.flatten(),
-                                       err_msg='design_kaiser() test failed')
+        np.testing.assert_almost_equal(observed.flatten(), expected.flatten(), err_msg='design_kaiser() test failed')
 
     def test_design_fir_default_wnd(self):
         from eegprep.plugins.clean_rawdata.private.sigproc import design_fir
+
         observed = design_fir(234, [0.0, 0.06, 0.08, 1.0], [0, 0, 1, 1])
-        expected = np.asarray(self.eeglab.design_fir(234.0, np.asarray([0.0, 0.06, 0.08, 1.0]), np.asarray([0.0, 0.0, 1.0, 1.0])))
-        np.testing.assert_almost_equal(observed.flatten(), expected.flatten(),
-                                       err_msg='test_design_fir_default_wnd() test failed')
+        expected = np.asarray(
+            self.eeglab.design_fir(234.0, np.asarray([0.0, 0.06, 0.08, 1.0]), np.asarray([0.0, 0.0, 1.0, 1.0]))
+        )
+        np.testing.assert_almost_equal(
+            observed.flatten(), expected.flatten(), err_msg='test_design_fir_default_wnd() test failed'
+        )
 
     def test_design_fir_custom_wnd(self):
         from eegprep.plugins.clean_rawdata.private.sigproc import design_fir, design_kaiser
+
         wnd = design_kaiser(0.06, 0.08, 75.0, True)
         observed = design_fir(234, [0.0, 0.06, 0.08, 1.0], [0, 0, 1.0, 1.0], w=wnd)
-        expected = np.asarray(self.eeglab.design_fir(234.0, np.asarray([0.0, 0.06, 0.08, 1.0]),
-                                                     np.asarray([0, 0, 1.0, 1.0]), np.asarray([]), wnd))
-        np.testing.assert_almost_equal(observed.flatten(), expected.flatten(),
-                                       err_msg='test_design_fir_custom_wnd() test failed')
+        expected = np.asarray(
+            self.eeglab.design_fir(
+                234.0, np.asarray([0.0, 0.06, 0.08, 1.0]), np.asarray([0, 0, 1.0, 1.0]), np.asarray([]), wnd
+            )
+        )
+        np.testing.assert_almost_equal(
+            observed.flatten(), expected.flatten(), err_msg='test_design_fir_custom_wnd() test failed'
+        )
 
     def test_block_geometric_median(self):
         from eegprep.plugins.clean_rawdata.private.stats import block_geometric_median
+
         np.random.seed(42)
         # generate heavy-tailed data with non-zero centroid and apply random rotation
         df = 3  # degrees of freedom for t-distribution
@@ -106,21 +120,22 @@ class TestUtilFuncs(DebuggableTestCase):
         X = noise.dot(R) + center
         observed = block_geometric_median(X, 10)
         expected = np.asarray(self.eeglab.block_geometric_median(X, 10.0))
-        np.testing.assert_almost_equal(observed.flatten(), expected.flatten(),
-                                       err_msg='block_geometric_median() test failed')
+        np.testing.assert_almost_equal(
+            observed.flatten(), expected.flatten(), err_msg='block_geometric_median() test failed'
+        )
 
     def test_fit_eeg_distribution(self):
         from eegprep.plugins.clean_rawdata.private.stats import fit_eeg_distribution
         from scipy.stats import genextreme
+
         x = genextreme.rvs(0.1, size=5007)
         observed, *_ = fit_eeg_distribution(x)  # returns 4 values, for now we check only the first
         expected = self.eeglab.fit_eeg_distribution(x)
         # compare numbers
-        np.testing.assert_almost_equal(observed, expected,
-                                       err_msg='fit_eeg_distribution() test failed')
+        np.testing.assert_almost_equal(observed, expected, err_msg='fit_eeg_distribution() test failed')
+
 
 class TestCleanDrifts(DebuggableTestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
 
@@ -130,17 +145,14 @@ class TestCleanDrifts(DebuggableTestCase):
         # compare vs MATLAB
         expected = eeglab.clean_drifts(self.EEG, [3, 4], 75)
         cleaned1 = clean_drifts(deepcopy(self.EEG), [3, 4], 75, method='fir')
-        compare_eeg(cleaned1['data'], expected['data'],
-                    err_msg='clean_drifts() failed')
+        compare_eeg(cleaned1['data'], expected['data'], err_msg='clean_drifts() failed')
 
         # compare FFT vs FIR
         cleaned2 = clean_drifts(deepcopy(self.EEG), [3, 4], 75, method='fft')
-        compare_eeg(cleaned1['data'], cleaned2['data'],
-                    err_msg='clean_drifts() FFT mode test failed',atol=2e-7)
+        compare_eeg(cleaned1['data'], cleaned2['data'], err_msg='clean_drifts() FFT mode test failed', atol=2e-7)
 
 
 class TestCleanChannels(DebuggableTestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(ensure_file('EmotionValence.set'))
 
@@ -148,39 +160,39 @@ class TestCleanChannels(DebuggableTestCase):
         eeglab = eeglabcompat.get_eeglab('MAT')
         cleaned, _ = clean_channels_nolocs(deepcopy(self.EEG), 0.9)
         expected = eeglab.clean_channels_nolocs(self.EEG, 0.9)
-        compare_eeg(cleaned['data'], expected['data'],
-                    err_msg='clean_channels_nolocs() failed')
+        compare_eeg(cleaned['data'], expected['data'], err_msg='clean_channels_nolocs() failed')
 
     def test_clean_channels_locs(self):
         cleaned = clean_channels(deepcopy(self.EEG), 0.9)
         eeglab = eeglabcompat.get_eeglab('MAT')
         expected = eeglab.clean_channels(self.EEG, 0.9)
-        compare_eeg(cleaned['data'], expected['data'],
-                    err_msg='clean_channels() failed')
+        compare_eeg(cleaned['data'], expected['data'], err_msg='clean_channels() failed')
 
 
 class TestCleanASR(DebuggableTestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(ensure_file('EmotionValence.set'))
 
     def test_clean_asr_nowindow(self):
         cleaned = clean_asr(deepcopy(self.EEG), ref_maxbadchannels='off')
         eeglab = eeglabcompat.get_eeglab('MAT')
-        expected = eeglab.clean_asr(self.EEG, [],[],[],[], 'off')
-        compare_eeg(cleaned['data'], expected['data'],
-                    atol=0, rtol=1e-6, # because of eigh() precision differences
-                    err_msg='clean_asr() failed vs MATLAB')
+        expected = eeglab.clean_asr(self.EEG, [], [], [], [], 'off')
+        compare_eeg(
+            cleaned['data'],
+            expected['data'],
+            atol=0,
+            rtol=1e-6,  # because of eigh() precision differences
+            err_msg='clean_asr() failed vs MATLAB',
+        )
 
     def test_riemannian(self):
         """Test the Riemannian mode."""
         # for now this is just checking that it does not crash since we don't have
         # MATLAB reference code for this
-        cleaned_py = clean_asr(deepcopy(self.EEG), useriemannian='calib')
+        clean_asr(deepcopy(self.EEG), useriemannian='calib')
 
 
 class TestCleanWindows(DebuggableTestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(ensure_file('EmotionValence.set'))
 
@@ -224,8 +236,7 @@ class TestCleanWindows(DebuggableTestCase):
         cleaned, _ = clean_windows(deepcopy(self.EEG))
         eeglab = eeglabcompat.get_eeglab('MAT')
         expected = eeglab.clean_windows(self.EEG)
-        compare_eeg(cleaned['data'], expected['data'],
-                    err_msg='clean_windows() failed vs MATLAB')
+        compare_eeg(cleaned['data'], expected['data'], err_msg='clean_windows() failed vs MATLAB')
 
     def test_clean_windows_preserves_float64(self):
         cleaned, _ = clean_windows(deepcopy(self.EEG))
@@ -238,14 +249,12 @@ class TestCleanWindows(DebuggableTestCase):
 
 
 class TestCleanArtifacts(DebuggableTestCase):
-
     def setUp(self):
         # Use the same dataset as other heavy‑duty tests
         self.EEG = pop_loadset(ensure_file('EmotionValence.set'))
 
     def test_clean_artifacts_defaults(self):
-        """Compare Python clean_artifacts against MATLAB implementation (default params).
-        """
+        """Compare Python clean_artifacts against MATLAB implementation (default params)."""
         with use_64bit_eeg_options():
             # --- Python version ---
             cleaned_py, _, _, _ = clean_artifacts(deepcopy(self.EEG))
@@ -260,39 +269,40 @@ class TestCleanArtifacts(DebuggableTestCase):
                 expected_mat['data'],
                 rtol=0,
                 atol=1e-5,  # limit to 1e-5 uV likely due to solver differences
-                err_msg='clean_artifacts() failed vs MATLAB'
+                err_msg='clean_artifacts() failed vs MATLAB',
             )
 
-class TestCleanArtifactsAdvanced(DebuggableTestCase):
 
+class TestCleanArtifactsAdvanced(DebuggableTestCase):
     def setUp(self):
         # Use the same dataset as other heavy‑duty tests
         self.EEG = pop_loadset(ensure_file('eeglab_data_with_ica_tmp.set'))
 
     def test_clean_artifacts_alt_defaults(self):
-        """Compare Python clean_artifacts against MATLAB implementation (alt parameters).
-        """
+        """Compare Python clean_artifacts against MATLAB implementation (alt parameters)."""
         kwargs = dict(
-            FlatlineCriterion=5, ChannelCriterion=0.87, LineNoiseCriterion=4,
-            Highpass=[0.25, 0.75], BurstCriterion=20, WindowCriterion=0.25,
-            WindowCriterionTolerances=[float('-inf'), 7]
+            FlatlineCriterion=5,
+            ChannelCriterion=0.87,
+            LineNoiseCriterion=4,
+            Highpass=[0.25, 0.75],
+            BurstCriterion=20,
+            WindowCriterion=0.25,
+            WindowCriterionTolerances=[float('-inf'), 7],
         )
 
         # --- Python version ---
-        cleaned_py, _, _, _ = clean_artifacts(
-            deepcopy(self.EEG), **kwargs)
+        cleaned_py, _, _, _ = clean_artifacts(deepcopy(self.EEG), **kwargs)
 
         # --- MATLAB reference ---
         eeglab = eeglabcompat.get_eeglab('MAT')
-        expected_mat = eeglab.clean_artifacts(
-            self.EEG, **kwargs)
+        expected_mat = eeglab.clean_artifacts(self.EEG, **kwargs)
 
         compare_eeg(
             cleaned_py['data'],
             expected_mat['data'],
             rtol=0,
             atol=2e-5,  # limit to 2e-5 uV due to solver and floating point differences
-            err_msg='clean_artifacts() failed vs MATLAB'
+            err_msg='clean_artifacts() failed vs MATLAB',
         )
 
 

--- a/tests/test_clean_windows.py
+++ b/tests/test_clean_windows.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
-import warnings
-from unittest.mock import patch, MagicMock
-import logging
+from unittest.mock import patch
 
 from eegprep.plugins.clean_rawdata.clean_windows import clean_windows
 
@@ -41,7 +39,7 @@ class TestCleanWindows(unittest.TestCase):
             'pnts': self.n_samples,
             'nbchan': self.n_channels,
             'xmin': 0.0,
-            'xmax': (self.n_samples - 1) / self.srate
+            'xmax': (self.n_samples - 1) / self.srate,
         }
 
         self.EEG_artifacts = {
@@ -50,7 +48,7 @@ class TestCleanWindows(unittest.TestCase):
             'pnts': self.n_samples,
             'nbchan': self.n_channels,
             'xmin': 0.0,
-            'xmax': (self.n_samples - 1) / self.srate
+            'xmax': (self.n_samples - 1) / self.srate,
         }
 
     def test_basic_functionality(self):
@@ -79,10 +77,7 @@ class TestCleanWindows(unittest.TestCase):
         results = []
         for zthresh in test_thresholds:
             with self.subTest(zthresholds=zthresh):
-                EEG_out, sample_mask = clean_windows(
-                    self.EEG_artifacts.copy(),
-                    zthresholds=zthresh
-                )
+                EEG_out, sample_mask = clean_windows(self.EEG_artifacts.copy(), zthresholds=zthresh)
                 results.append((EEG_out, sample_mask))
 
                 # More lenient thresholds should retain more data
@@ -101,13 +96,13 @@ class TestCleanWindows(unittest.TestCase):
         # Test as fraction
         EEG_out1, mask1 = clean_windows(
             self.EEG_artifacts.copy(),
-            max_bad_channels=0.25  # 25% of channels
+            max_bad_channels=0.25,  # 25% of channels
         )
 
         # Test as absolute count
         EEG_out2, mask2 = clean_windows(
             self.EEG_artifacts.copy(),
-            max_bad_channels=2  # 2 channels
+            max_bad_channels=2,  # 2 channels
         )
 
         # Both should work and produce valid results
@@ -123,15 +118,12 @@ class TestCleanWindows(unittest.TestCase):
         test_params = [
             {'window_len': 0.5, 'window_overlap': 0.5},
             {'window_len': 1.0, 'window_overlap': 0.66},
-            {'window_len': 2.0, 'window_overlap': 0.8}
+            {'window_len': 2.0, 'window_overlap': 0.8},
         ]
 
         for params in test_params:
             with self.subTest(**params):
-                EEG_out, sample_mask = clean_windows(
-                    self.EEG_artifacts.copy(),
-                    **params
-                )
+                EEG_out, sample_mask = clean_windows(self.EEG_artifacts.copy(), **params)
 
                 # Should complete without errors
                 self.assertIsInstance(EEG_out, dict)
@@ -146,7 +138,7 @@ class TestCleanWindows(unittest.TestCase):
             min_clean_fraction=0.3,
             truncate_quant=(0.05, 0.7),
             step_sizes=(0.02, 0.02),
-            shape_range=np.arange(1.5, 4.0, 0.2)
+            shape_range=np.arange(1.5, 4.0, 0.2),
         )
 
         # Should complete successfully
@@ -173,7 +165,7 @@ class TestCleanWindows(unittest.TestCase):
         EEG_out, sample_mask = clean_windows(
             self.EEG_clean.copy(),
             zthresholds=(-10, 10),  # Very lenient
-            max_bad_channels=self.n_channels  # Allow all channels to be bad
+            max_bad_channels=self.n_channels,  # Allow all channels to be bad
         )
 
         # Should keep most/all data
@@ -196,7 +188,7 @@ class TestCleanWindows(unittest.TestCase):
         EEG_out, sample_mask = clean_windows(
             EEG_extreme,
             zthresholds=(-0.1, 0.1),  # Very strict
-            max_bad_channels=0  # No bad channels allowed
+            max_bad_channels=0,  # No bad channels allowed
         )
 
         # Should remove most data
@@ -210,18 +202,11 @@ class TestCleanWindows(unittest.TestCase):
     def test_tolerances_array_shape_range(self):
         """Test different shape_range (beta parameter) arrays."""
         # Test different shape ranges for the generalized Gaussian
-        shape_ranges = [
-            np.arange(1.0, 2.5, 0.1),
-            np.arange(2.0, 4.0, 0.2),
-            np.array([1.5, 2.0, 2.5, 3.0])
-        ]
+        shape_ranges = [np.arange(1.0, 2.5, 0.1), np.arange(2.0, 4.0, 0.2), np.array([1.5, 2.0, 2.5, 3.0])]
 
         for shape_range in shape_ranges:
             with self.subTest(shape_range=shape_range):
-                EEG_out, sample_mask = clean_windows(
-                    self.EEG_artifacts.copy(),
-                    shape_range=shape_range
-                )
+                EEG_out, sample_mask = clean_windows(self.EEG_artifacts.copy(), shape_range=shape_range)
 
                 # Should complete successfully
                 self.assertIsInstance(EEG_out, dict)
@@ -229,12 +214,7 @@ class TestCleanWindows(unittest.TestCase):
 
     def test_edge_case_empty_data(self):
         """Test error handling with empty data."""
-        empty_EEG = {
-            'data': np.empty((0, 0)),
-            'srate': 250.0,
-            'pnts': 0,
-            'nbchan': 0
-        }
+        empty_EEG = {'data': np.empty((0, 0)), 'srate': 250.0, 'pnts': 0, 'nbchan': 0}
 
         with self.assertRaises(ValueError) as cm:
             clean_windows(empty_EEG)
@@ -250,7 +230,7 @@ class TestCleanWindows(unittest.TestCase):
             'pnts': self.n_samples,
             'nbchan': 1,
             'xmin': 0.0,
-            'xmax': (self.n_samples - 1) / self.srate
+            'xmax': (self.n_samples - 1) / self.srate,
         }
 
         EEG_out, sample_mask = clean_windows(single_ch_EEG)
@@ -268,7 +248,7 @@ class TestCleanWindows(unittest.TestCase):
             'pnts': 100,
             'nbchan': self.n_channels,
             'xmin': 0.0,
-            'xmax': 99 / self.srate
+            'xmax': 99 / self.srate,
         }
 
         # With default window_len=1.0s (250 samples), this should raise an error
@@ -299,7 +279,7 @@ class TestCleanWindows(unittest.TestCase):
         # Test overlap >= 1 (should be handled gracefully)
         EEG_out, sample_mask = clean_windows(
             self.EEG_artifacts.copy(),
-            window_overlap=1.0  # 100% overlap
+            window_overlap=1.0,  # 100% overlap
         )
 
         # Should work (function sets step=1 to avoid infinite loop)
@@ -309,7 +289,7 @@ class TestCleanWindows(unittest.TestCase):
         # Test overlap > 1
         EEG_out2, sample_mask2 = clean_windows(
             self.EEG_artifacts.copy(),
-            window_overlap=1.5  # 150% overlap
+            window_overlap=1.5,  # 150% overlap
         )
 
         # Should also work
@@ -321,14 +301,7 @@ class TestCleanWindows(unittest.TestCase):
         # The function has built-in fallback logic for when sigma=0 or NaN
         # We can test this by creating data that might cause fitting issues
         constant_data = np.ones((4, 1000)) * 0.5  # Constant data might cause sigma=0
-        constant_EEG = {
-            'data': constant_data,
-            'srate': 250.0,
-            'pnts': 1000,
-            'nbchan': 4,
-            'xmin': 0.0,
-            'xmax': 3.996
-        }
+        constant_EEG = {'data': constant_data, 'srate': 250.0, 'pnts': 1000, 'nbchan': 4, 'xmin': 0.0, 'xmax': 3.996}
 
         # Should complete using MAD fallback if distribution fitting fails
         EEG_out, sample_mask = clean_windows(constant_EEG)
@@ -431,7 +404,7 @@ class TestCleanWindows(unittest.TestCase):
         # artifact so we can verify post-cut latency shifting.
         EEG_in['event'] = [
             {'type': 'S1', 'latency': 100.0, 'duration': 0.0},
-            {'type': 'S2', 'latency': 600.0, 'duration': 0.0},   # inside first artifact (500:750)
+            {'type': 'S2', 'latency': 600.0, 'duration': 0.0},  # inside first artifact (500:750)
             {'type': 'S3', 'latency': 1000.0, 'duration': 0.0},
             {'type': 'S4', 'latency': 2000.0, 'duration': 0.0},
         ]

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -117,12 +117,16 @@ def test_nested_workspace_gui_buffers_restore_previous_buffer():
     second_stream = io.StringIO()
     first_workspace = EEGPrepConsoleWorkspace(
         first_session,
-        command_echo=lambda command: console_module._terminal_write(f"In [1]: {command}\n", stream=first_stream, sync=True),
+        command_echo=lambda command: console_module._terminal_write(
+            f"In [1]: {command}\n", stream=first_stream, sync=True
+        ),
         exports={},
     )
     second_workspace = EEGPrepConsoleWorkspace(
         second_session,
-        command_echo=lambda command: console_module._terminal_write(f"In [1]: {command}\n", stream=second_stream, sync=True),
+        command_echo=lambda command: console_module._terminal_write(
+            f"In [1]: {command}\n", stream=second_stream, sync=True
+        ),
         exports={},
     )
 
@@ -752,11 +756,14 @@ def test_run_console_forwards_cli_options_to_gui_launcher():
         captured["gui_kwargs"] = kwargs
         return SimpleNamespace(refresh=mock.Mock())
 
-    assert console_module.run_console(
-        ["--full", "--no-plugins", "--window-menu-bar"],
-        shell_factory=shell_factory,
-        gui_launcher=gui_launcher,
-    ) == 0
+    assert (
+        console_module.run_console(
+            ["--full", "--no-plugins", "--window-menu-bar"],
+            shell_factory=shell_factory,
+            gui_launcher=gui_launcher,
+        )
+        == 0
+    )
 
     assert captured["gui_args"] == ("full",)
     assert captured["gui_kwargs"]["include_plugins"] is False
@@ -779,11 +786,14 @@ def test_run_console_native_file_dialogs_are_explicit_opt_in():
         captured["gui_kwargs"] = kwargs
         return SimpleNamespace(refresh=mock.Mock())
 
-    assert console_module.run_console(
-        ["--native-file-dialogs"],
-        shell_factory=shell_factory,
-        gui_launcher=gui_launcher,
-    ) == 0
+    assert (
+        console_module.run_console(
+            ["--native-file-dialogs"],
+            shell_factory=shell_factory,
+            gui_launcher=gui_launcher,
+        )
+        == 0
+    )
 
     assert captured["gui_kwargs"]["native_file_dialogs"] is True
 

--- a/tests/test_eeg_amica.py
+++ b/tests/test_eeg_amica.py
@@ -20,8 +20,7 @@ from eegprep.functions.popfunc.eeg_amica import eeg_amica, load_amica_model
 from eegprep.functions.sigprocfunc.runamica import is_amica_available
 
 
-def _make_test_eeg(n_channels=4, n_samples=2000, n_trials=1, srate=250.0,
-                   seed=42):
+def _make_test_eeg(n_channels=4, n_samples=2000, n_trials=1, srate=250.0, seed=42):
     """Create a minimal EEG dict with mixed sinusoidal sources.
 
     The data is constructed as mixing @ sources so that ICA can recover
@@ -65,9 +64,13 @@ def _make_test_eeg(n_channels=4, n_samples=2000, n_trials=1, srate=250.0,
         'xmax': (n_samples - 1) / srate,
         'times': np.arange(n_samples) / srate,
         'chanlocs': [
-            {'labels': f'Ch{i+1}', 'type': 'EEG',
-             'X': rng.uniform(-1, 1), 'Y': rng.uniform(-1, 1),
-             'Z': rng.uniform(-1, 1)}
+            {
+                'labels': f'Ch{i + 1}',
+                'type': 'EEG',
+                'X': rng.uniform(-1, 1),
+                'Y': rng.uniform(-1, 1),
+                'Z': rng.uniform(-1, 1),
+            }
             for i in range(n_channels)
         ],
         'event': [],
@@ -84,8 +87,7 @@ def _make_test_eeg(n_channels=4, n_samples=2000, n_trials=1, srate=250.0,
     return EEG
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaBasic(unittest.TestCase):
     """Basic eeg_amica tests with continuous data."""
 
@@ -129,8 +131,7 @@ class TestEegAmicaBasic(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(result['icaact'])))
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaOutputShapes(unittest.TestCase):
     """Test output shapes with 3D (epoched) data."""
 
@@ -149,8 +150,7 @@ class TestEegAmicaOutputShapes(unittest.TestCase):
         self.assertEqual(result['icawinv'].shape[1], ncomps)
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaReconstruction(unittest.TestCase):
     """Test data reconstruction from ICA decomposition."""
 
@@ -173,13 +173,11 @@ class TestEegAmicaReconstruction(unittest.TestCase):
         # W@S extracts components, A maps back to channels
         reconstructed = A @ (W @ S) @ data
         np.testing.assert_allclose(
-            reconstructed, data, atol=0.01,
-            err_msg="ICA reconstruction should approximate original data"
+            reconstructed, data, atol=0.01, err_msg="ICA reconstruction should approximate original data"
         )
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaEtcStored(unittest.TestCase):
     """Test that full AMICA output is stored in EEG['etc']['amica']."""
 
@@ -194,8 +192,22 @@ class TestEegAmicaEtcStored(unittest.TestCase):
         self.assertIsInstance(mods, dict)
 
         # Key outputs from _load_amica_output
-        for key in ('W', 'S', 'A', 'mean', 'gm', 'alpha', 'mu', 'sbeta',
-                     'rho', 'LL', 'svar', 'origord', 'num_pcs', 'num_models'):
+        for key in (
+            'W',
+            'S',
+            'A',
+            'mean',
+            'gm',
+            'alpha',
+            'mu',
+            'sbeta',
+            'rho',
+            'LL',
+            'svar',
+            'origord',
+            'num_pcs',
+            'num_models',
+        ):
             self.assertIn(key, mods, f"Missing key in mods: {key}")
 
         # num_models and num_pcs should be correct
@@ -203,8 +215,7 @@ class TestEegAmicaEtcStored(unittest.TestCase):
         self.assertEqual(mods['num_pcs'], 4)
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaSortcomps(unittest.TestCase):
     """Test component sorting by variance."""
 
@@ -215,22 +226,18 @@ class TestEegAmicaSortcomps(unittest.TestCase):
 
         # Compute variance metric: sum(icawinv^2, axis=0) * sum(icaact^2, axis=1)
         icaact_2d = result['icaact'].reshape(result['icaact'].shape[0], -1)
-        variance_metric = (
-            np.sum(result['icawinv'] ** 2, axis=0)
-            * np.sum(icaact_2d ** 2, axis=1)
-        )
+        variance_metric = np.sum(result['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
 
         # Should be in descending order
         for i in range(len(variance_metric) - 1):
             self.assertGreaterEqual(
-                variance_metric[i], variance_metric[i + 1],
-                f"Variance metric not descending at index {i}: "
-                f"{variance_metric[i]} < {variance_metric[i + 1]}"
+                variance_metric[i],
+                variance_metric[i + 1],
+                f"Variance metric not descending at index {i}: {variance_metric[i]} < {variance_metric[i + 1]}",
             )
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestEegAmicaPosact(unittest.TestCase):
     """Test positive activation sign normalization."""
 
@@ -244,14 +251,10 @@ class TestEegAmicaPosact(unittest.TestCase):
 
         for r in range(ncomps):
             ix = np.argmax(np.abs(icaact_2d[r, :]))
-            self.assertGreaterEqual(
-                icaact_2d[r, ix], 0,
-                f"Component {r}: max abs activation value should be positive"
-            )
+            self.assertGreaterEqual(icaact_2d[r, ix], 0, f"Component {r}: max abs activation value should be positive")
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestLoadAmicaModel(unittest.TestCase):
     """Test load_amica_model() for model switching."""
 
@@ -269,20 +272,16 @@ class TestLoadAmicaModel(unittest.TestCase):
 
         # Fields should match the original
         np.testing.assert_array_equal(
-            EEG2['icaweights'], result['icaweights'],
-            err_msg="icaweights should match after reloading model 0"
+            EEG2['icaweights'], result['icaweights'], err_msg="icaweights should match after reloading model 0"
         )
         np.testing.assert_array_equal(
-            EEG2['icasphere'], result['icasphere'],
-            err_msg="icasphere should match after reloading model 0"
+            EEG2['icasphere'], result['icasphere'], err_msg="icasphere should match after reloading model 0"
         )
         np.testing.assert_array_equal(
-            EEG2['icawinv'], result['icawinv'],
-            err_msg="icawinv should match after reloading model 0"
+            EEG2['icawinv'], result['icawinv'], err_msg="icawinv should match after reloading model 0"
         )
         np.testing.assert_allclose(
-            EEG2['icaact'], result['icaact'], atol=1e-10,
-            err_msg="icaact should match after reloading model 0"
+            EEG2['icaact'], result['icaact'], atol=1e-10, err_msg="icaact should match after reloading model 0"
         )
 
     def test_load_amica_model_invalid(self):

--- a/tests/test_eeg_autocorr.py
+++ b/tests/test_eeg_autocorr.py
@@ -7,6 +7,7 @@ of ICA components for EEG data.
 
 # Disable multithreading for deterministic numerical results
 import os
+
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
@@ -53,9 +54,12 @@ class TestEegAutocorr(DebuggableTestCase):
             data = np.random.randn(nbchan, pnts, trials).astype(np.float64)
 
         # Create channel locations
-        chanlocs = np.array([{'labels': f'E{i+1}', 'X': 0.0, 'Y': 0.0, 'Z': 0.0,
-                             'theta': 0.0, 'radius': 0.0, 'type': 'EEG'}
-                            for i in range(nbchan)])
+        chanlocs = np.array(
+            [
+                {'labels': f'E{i + 1}', 'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'theta': 0.0, 'radius': 0.0, 'type': 'EEG'}
+                for i in range(nbchan)
+            ]
+        )
 
         # ICA matrices - consistent dimensions for MATLAB compatibility
         # icaweights: (ncomp, nbchan), icasphere: (nbchan, nbchan)
@@ -133,7 +137,7 @@ class TestEegAutocorr(DebuggableTestCase):
             {'srate': 128, 'expected_samples': 100},
             {'srate': 256, 'expected_samples': 100},
             {'srate': 500, 'expected_samples': 100},
-            {'srate': 1000, 'expected_samples': 100}
+            {'srate': 1000, 'expected_samples': 100},
         ]
 
         for case in test_cases:
@@ -220,10 +224,10 @@ class TestEegAutocorr(DebuggableTestCase):
         """Test that FFT size is calculated correctly."""
         # Test with different data lengths to verify nfft calculation
         test_cases = [
-            {'pnts': 100, 'expected_nfft_min': 128},   # 2^7
-            {'pnts': 256, 'expected_nfft_min': 512},   # 2^9
+            {'pnts': 100, 'expected_nfft_min': 128},  # 2^7
+            {'pnts': 256, 'expected_nfft_min': 512},  # 2^9
             {'pnts': 500, 'expected_nfft_min': 1024},  # 2^10
-            {'pnts': 1000, 'expected_nfft_min': 2048}, # 2^11
+            {'pnts': 1000, 'expected_nfft_min': 2048},  # 2^11
         ]
 
         for case in test_cases:
@@ -343,7 +347,7 @@ class TestEegAutocorr(DebuggableTestCase):
         EEG = self.create_test_eeg(ncomp=3, pnts=256, srate=128)
         original_dtype = EEG['icaact'].dtype
 
-        result = eeg_autocorr(EEG)
+        eeg_autocorr(EEG)
 
         # Function should modify icaact dtype to float32
         self.assertEqual(EEG['icaact'].dtype, np.float32)
@@ -355,10 +359,8 @@ class TestEegAutocorr(DebuggableTestCase):
         EEG = self.create_test_eeg(ncomp=3, pnts=256, srate=128)
 
         # Make copies to avoid modification effects
-        EEG1 = {key: value.copy() if isinstance(value, np.ndarray) else value
-                for key, value in EEG.items()}
-        EEG2 = {key: value.copy() if isinstance(value, np.ndarray) else value
-                for key, value in EEG.items()}
+        EEG1 = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
+        EEG2 = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
 
         result1 = eeg_autocorr(EEG1)
         result2 = eeg_autocorr(EEG2)

--- a/tests/test_eeg_autocorr_fftw.py
+++ b/tests/test_eeg_autocorr_fftw.py
@@ -7,6 +7,7 @@ of ICA components using FFTW-optimized FFT operations.
 
 # Disable multithreading for deterministic numerical results
 import os
+
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
@@ -41,7 +42,9 @@ class TestEegAutocorrFftw(DebuggableTestCase):
         """Create a test EEG structure with ICA data."""
         # Create realistic ICA activations
         np.random.seed(42)  # For reproducible tests
-        icaact = np.random.randn(ncomp, pnts, trials).astype(np.float64)  # Use float64 to match MATLAB default precision
+        icaact = np.random.randn(ncomp, pnts, trials).astype(
+            np.float64
+        )  # Use float64 to match MATLAB default precision
 
         return {
             'icaact': icaact,
@@ -98,7 +101,7 @@ class TestEegAutocorrFftw(DebuggableTestCase):
             {'srate': 128, 'expected_samples': 100},
             {'srate': 256, 'expected_samples': 100},
             {'srate': 500, 'expected_samples': 100},
-            {'srate': 1000, 'expected_samples': 100}
+            {'srate': 1000, 'expected_samples': 100},
         ]
 
         for case in test_cases:
@@ -268,10 +271,8 @@ class TestEegAutocorrFftw(DebuggableTestCase):
         EEG = self.create_test_eeg(ncomp=3, pnts=256, srate=128)
 
         # Make copies to avoid modification effects
-        EEG1 = {key: value.copy() if isinstance(value, np.ndarray) else value
-                for key, value in EEG.items()}
-        EEG2 = {key: value.copy() if isinstance(value, np.ndarray) else value
-                for key, value in EEG.items()}
+        EEG1 = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
+        EEG2 = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
 
         result1 = eeg_autocorr_fftw(EEG1)
         result2 = eeg_autocorr_fftw(EEG2)
@@ -301,10 +302,8 @@ class TestEegAutocorrFftw(DebuggableTestCase):
         EEG = self.create_test_eeg(ncomp=3, pnts=256, srate=128)
 
         # Make copies to avoid modification effects
-        EEG_fftw = {key: value.copy() if isinstance(value, np.ndarray) else value
-                   for key, value in EEG.items()}
-        EEG_regular = {key: value.copy() if isinstance(value, np.ndarray) else value
-                      for key, value in EEG.items()}
+        EEG_fftw = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
+        EEG_regular = {key: value.copy() if isinstance(value, np.ndarray) else value for key, value in EEG.items()}
 
         result_fftw = eeg_autocorr_fftw(EEG_fftw)
         result_regular = eeg_autocorr(EEG_regular)

--- a/tests/test_eeg_autocorr_welch.py
+++ b/tests/test_eeg_autocorr_welch.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
-import warnings
 import os
-from unittest.mock import patch, MagicMock
 
 from eegprep.plugins.ICLabel.eeg_autocorr_welch import eeg_autocorr_welch
 
@@ -21,6 +19,7 @@ class TestEegAutocorrWelch(unittest.TestCase):
         cls.eeglab = None
         try:
             from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+
             cls.eeglab = get_eeglab()
             cls.matlab_available = True
         except Exception as e:
@@ -35,7 +34,7 @@ class TestEegAutocorrWelch(unittest.TestCase):
         self.n_channels = 8
         # Use data that creates exactly one segment to avoid the reshape issue
         self.n_points = 750  # Exactly 3 seconds at 250 Hz - creates single segment
-        self.n_trials = 1    # Single trial to avoid the axis issue in the function
+        self.n_trials = 1  # Single trial to avoid the axis issue in the function
         self.srate = 250.0
 
         # Create synthetic ICA activations
@@ -57,7 +56,7 @@ class TestEegAutocorrWelch(unittest.TestCase):
             'icaweights': self.icaweights,
             'pnts': self.n_points,
             'trials': self.n_trials,
-            'srate': self.srate
+            'srate': self.srate,
         }
 
     def test_basic_functionality(self):
@@ -321,7 +320,7 @@ class TestEegAutocorrWelch(unittest.TestCase):
             'icaact': np.random.randn(10, 750, 1) * 0.5,  # Large data, single trial
             'pnts': 750,
             'trials': 1,
-            'srate': 250
+            'srate': 250,
         }
 
         # This should complete without memory errors

--- a/tests/test_eeg_checkset.py
+++ b/tests/test_eeg_checkset.py
@@ -8,8 +8,6 @@ EEG data structures, ensuring required fields exist and have correct types.
 import unittest
 import sys
 import numpy as np
-import tempfile
-import os
 import logging
 
 # Add src to path for imports
@@ -51,7 +49,7 @@ def create_complete_eeg():
         'condition': '',
         'session': 1,
         'comments': np.array([]),
-        'chanlocs': np.array([{'labels': f'Ch{i+1}'} for i in range(n_channels)]),
+        'chanlocs': np.array([{'labels': f'Ch{i + 1}'} for i in range(n_channels)]),
         'urchanlocs': np.array([]),
         'chaninfo': {},
         'ref': 'common',
@@ -77,7 +75,7 @@ def create_complete_eeg():
         'icawinv': np.array([]),
         'icasphere': np.array([]),
         'icaweights': np.array([]),
-        'icachansind': np.array([])
+        'icachansind': np.array([]),
     }
 
 
@@ -286,10 +284,7 @@ class TestEegChecksetEventHandling(DebuggableTestCase):
     def test_event_list_to_array(self):
         """Test that event list is converted to numpy array."""
         eeg = create_minimal_eeg()
-        eeg['event'] = [
-            {'type': 'stimulus', 'latency': 100},
-            {'type': 'response', 'latency': 200}
-        ]
+        eeg['event'] = [{'type': 'stimulus', 'latency': 100}, {'type': 'response', 'latency': 200}]
 
         result = eeg_checkset(eeg)
 
@@ -326,10 +321,7 @@ class TestEegChecksetChanlocsHandling(DebuggableTestCase):
     def test_chanlocs_list_to_array(self):
         """Test that chanlocs list is converted to numpy array."""
         eeg = create_minimal_eeg()
-        eeg['chanlocs'] = [
-            {'labels': 'Ch1', 'theta': 0},
-            {'labels': 'Ch2', 'theta': 45}
-        ]
+        eeg['chanlocs'] = [{'labels': 'Ch1', 'theta': 0}, {'labels': 'Ch2', 'theta': 45}]
 
         result = eeg_checkset(eeg)
 
@@ -612,11 +604,8 @@ class TestEegChecksetIntegration(DebuggableTestCase):
             'xmin': -0.5,
             'xmax': 3.5,
             'setname': 'Subject01_Session01',
-            'event': [
-                {'type': 'stimulus', 'latency': 250},
-                {'type': 'response', 'latency': 500}
-            ],
-            'chanlocs': [{'labels': f'EEG{i:03d}'} for i in range(1, 65)]
+            'event': [{'type': 'stimulus', 'latency': 250}, {'type': 'response', 'latency': 500}],
+            'chanlocs': [{'labels': f'EEG{i:03d}'} for i in range(1, 65)],
         }
 
         result = eeg_checkset(eeg)
@@ -639,9 +628,20 @@ class TestEegChecksetIntegration(DebuggableTestCase):
 
         # All standard fields should be present
         required_fields = [
-            'data', 'srate', 'nbchan', 'pnts', 'trials',
-            'xmin', 'xmax', 'setname', 'filename', 'filepath',
-            'event', 'chanlocs', 'chaninfo', 'reject'
+            'data',
+            'srate',
+            'nbchan',
+            'pnts',
+            'trials',
+            'xmin',
+            'xmax',
+            'setname',
+            'filename',
+            'filepath',
+            'event',
+            'chanlocs',
+            'chaninfo',
+            'reject',
         ]
 
         for field in required_fields:

--- a/tests/test_eeg_checkset_eventconsistency.py
+++ b/tests/test_eeg_checkset_eventconsistency.py
@@ -28,9 +28,9 @@ class TestEventconsistencyOperations:
     def test_removes_out_of_bounds_events(self):
         EEG = {
             'event': [
-                {'type': 'stim', 'latency': 0.3},   # < 0.5 -> remove
-                {'type': 'stim', 'latency': 0.5},   # == 0.5 -> keep
-                {'type': 'stim', 'latency': 500},   # ok
+                {'type': 'stim', 'latency': 0.3},  # < 0.5 -> remove
+                {'type': 'stim', 'latency': 0.5},  # == 0.5 -> keep
+                {'type': 'stim', 'latency': 500},  # ok
                 {'type': 'stim', 'latency': 1001},  # == pnts*trials+1 -> keep
                 {'type': 'stim', 'latency': 1002},  # > pnts*trials+1 -> remove
             ],
@@ -49,9 +49,9 @@ class TestEventconsistencyOperations:
         EEG = {
             'event': [
                 {'type': 'stim', 'latency': 10, 'epoch': 1},
-                {'type': 'stim', 'latency': 20, 'epoch': 0},    # invalid
+                {'type': 'stim', 'latency': 20, 'epoch': 0},  # invalid
                 {'type': 'stim', 'latency': 30, 'epoch': 3},
-                {'type': 'stim', 'latency': 40, 'epoch': 4},    # invalid (> trials)
+                {'type': 'stim', 'latency': 40, 'epoch': 4},  # invalid (> trials)
             ],
             'pnts': 100,
             'trials': 3,
@@ -135,24 +135,22 @@ class TestEventconsistencyOperations:
 
 @pytest.mark.skipif(
     not os.path.exists('partity_analysis/all_steps/python_eegprep/sub-002_run-1_step5.set'),
-    reason="Sub-002 parity data not available"
+    reason="Sub-002 parity data not available",
 )
 class TestPopEpochSubject002Parity:
     """Integration test using real sub-002 step-5 data."""
 
     def _load_step5(self):
         from eegprep import pop_loadset, eeg_checkset_strict_mode
+
         with eeg_checkset_strict_mode(False):
-            return pop_loadset(
-                'partity_analysis/all_steps/python_eegprep/sub-002_run-1_step5.set'
-            )
+            return pop_loadset('partity_analysis/all_steps/python_eegprep/sub-002_run-1_step5.set')
 
     def _load_compat_step6(self):
         from eegprep import pop_loadset, eeg_checkset_strict_mode
+
         with eeg_checkset_strict_mode(False):
-            return pop_loadset(
-                'partity_analysis/all_steps/matlab_eeglabcompat/sub-002_run-1_step6.set'
-            )
+            return pop_loadset('partity_analysis/all_steps/matlab_eeglabcompat/sub-002_run-1_step6.set')
 
     def test_trial_count_matches_matlab(self):
         """Python pop_epoch trial count must match MATLAB eeglabcompat.
@@ -170,6 +168,5 @@ class TestPopEpochSubject002Parity:
         )
 
         assert eeg_out['trials'] == eeg_matlab6['trials'], (
-            f"Trial count mismatch: Python={eeg_out['trials']}, "
-            f"MATLAB={eeg_matlab6['trials']}"
+            f"Trial count mismatch: Python={eeg_out['trials']}, MATLAB={eeg_matlab6['trials']}"
         )

--- a/tests/test_eeg_compare.py
+++ b/tests/test_eeg_compare.py
@@ -12,7 +12,6 @@ import io
 import numpy as np
 import math
 from contextlib import redirect_stderr, redirect_stdout
-from unittest.mock import patch
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
@@ -68,7 +67,7 @@ class TestEegCompare(DebuggableTestCase):
             'icachansind': np.array([]),
             'chanlocs': [
                 {
-                    'labels': f'Ch{i+1}',
+                    'labels': f'Ch{i + 1}',
                     'X': np.cos(2 * np.pi * i / nbchan),
                     'Y': np.sin(2 * np.pi * i / nbchan),
                     'Z': 0.0,
@@ -76,8 +75,9 @@ class TestEegCompare(DebuggableTestCase):
                     'radius': 0.5,
                     'sph_theta': 0.0,
                     'sph_phi': 0.0,
-                    'sph_radius': 1.0
-                } for i in range(nbchan)
+                    'sph_radius': 1.0,
+                }
+                for i in range(nbchan)
             ],
             'urchanlocs': np.array([]),
             'chaninfo': {'plotrad': [], 'shrink': [], 'nosedir': '+X'},
@@ -85,7 +85,7 @@ class TestEegCompare(DebuggableTestCase):
             'event': [
                 {'type': 'stimulus', 'latency': 250, 'duration': 0, 'epoch': 1},
                 {'type': 'response', 'latency': 500, 'duration': 0, 'epoch': 1},
-                {'type': 'boundary', 'latency': 750, 'duration': 0, 'epoch': 1}
+                {'type': 'boundary', 'latency': 750, 'duration': 0, 'epoch': 1},
             ],
             'urevent': np.array([]),
             'eventdescription': ['stimulus', 'response', 'boundary'],
@@ -102,7 +102,7 @@ class TestEegCompare(DebuggableTestCase):
             'saved': 'no',
             'etc': {},
             'datfile': '',
-            'comments': 'Test dataset for eeg_compare'
+            'comments': 'Test dataset for eeg_compare',
         }
 
     def test_identical_datasets(self):
@@ -118,7 +118,6 @@ class TestEegCompare(DebuggableTestCase):
         self.assertTrue(result)
 
         # Check output indicates no differences
-        stderr_output = stderr_capture.getvalue()
         stdout_output = stdout_capture.getvalue()
 
         # Should have minimal output for identical datasets
@@ -184,7 +183,7 @@ class TestEegCompare(DebuggableTestCase):
         """Test detection of xmin/xmax differences."""
         eeg2 = self.create_test_eeg()
         eeg2['xmin'] = -0.1  # Different from -0.2
-        eeg2['xmax'] = 4.0   # Different from original
+        eeg2['xmax'] = 4.0  # Different from original
 
         stderr_capture = io.StringIO()
         stdout_capture = io.StringIO()
@@ -353,6 +352,7 @@ class TestEegCompare(DebuggableTestCase):
 
     def test_object_with_dict_interface(self):
         """Test comparison of objects with __dict__ interface."""
+
         class EegObject:
             def __init__(self, eeg_dict):
                 for key, value in eeg_dict.items():
@@ -463,13 +463,13 @@ class TestEegCompare(DebuggableTestCase):
 
         self.assertTrue(result)
 
+
 class TestIsequaln(unittest.TestCase):
     """Test cases for the internal isequaln function."""
 
     def setUp(self):
         """Import the isequaln function for testing."""
         # We need to access the internal function for thorough testing
-        from eegprep.functions.popfunc.eeg_compare import eeg_compare
 
         # Create a dummy function to access isequaln
         def dummy_compare(a, b):
@@ -490,24 +490,24 @@ class TestIsequaln(unittest.TestCase):
                 if isinstance(x, np.ndarray) or isinstance(y, np.ndarray):
                     try:
                         return bool(np.array_equal(np.array(x), np.array(y), equal_nan=True))
-                    except:
+                    except Exception:
                         pass
                 # Handle numpy arrays in general comparison
                 if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
                     try:
                         return bool(np.array_equal(x, y, equal_nan=True))
-                    except:
+                    except Exception:
                         pass
                 # Handle scalar vs array comparisons
                 if isinstance(x, np.ndarray) and np.isscalar(y):
                     try:
                         return bool(np.all(x == y))
-                    except:
+                    except Exception:
                         pass
                 if isinstance(y, np.ndarray) and np.isscalar(x):
                     try:
                         return bool(np.all(y == x))
-                    except:
+                    except Exception:
                         pass
                 # Final comparison - ensure we return a boolean
                 try:
@@ -515,8 +515,9 @@ class TestIsequaln(unittest.TestCase):
                     if isinstance(result, np.ndarray):
                         return bool(result.all())
                     return bool(result)
-                except:
+                except Exception:
                     return False
+
             return isequaln(a, b)
 
         self.isequaln = dummy_compare

--- a/tests/test_eeg_decodechan.py
+++ b/tests/test_eeg_decodechan.py
@@ -4,6 +4,7 @@ import unittest
 # Bring in the function under test
 from eegprep import eeg_decodechan
 
+
 class TestEEGDecodeChan(unittest.TestCase):
     def setUp(self):
         self.chanlocs = [

--- a/tests/test_eeg_eeg2mne.py
+++ b/tests/test_eeg_eeg2mne.py
@@ -6,35 +6,28 @@ This module tests the eeg_eeg2mne function that converts EEGLAB datasets to MNE 
 
 import unittest
 import os
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
-
-import sys
 import numpy as np
 import tempfile
-import os
 import shutil
 
-# Ensure tests dir is in path for unittest discovery
-test_dir = os.path.dirname(os.path.abspath(__file__))
-if test_dir not in sys.path:
-    sys.path.insert(0, test_dir)
+from eegprep.functions.miscfunc.eeg_eeg2mne import eeg_eeg2mne
 
 try:
     import mne
     from mne.io.base import BaseRaw
+
     MNE_AVAILABLE = True
 except ImportError:
     MNE_AVAILABLE = False
     BaseRaw = None
 
-from eegprep.functions.miscfunc.eeg_eeg2mne import eeg_eeg2mne
-from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 try:
     from .fixtures import create_test_eeg
 except (ImportError, ValueError):
     from fixtures import create_test_eeg
+
+if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
+    raise unittest.SkipTest("MATLAB not available")
 
 
 class TestEEGEEG2MNE(unittest.TestCase):
@@ -179,11 +172,13 @@ class TestEEGEEG2MNE(unittest.TestCase):
         eeg_with_events['data'] = np.random.randn(32, 100, 5)
 
         # Add some additional events (already has epoch events from fixture)
-        eeg_with_events['event'].extend([
-            {'latency': 1, 'type': 'event1', 'duration': 0, 'urevent': 100},
-            {'latency': 50, 'type': 'event2', 'duration': 0, 'urevent': 101},
-            {'latency': 100, 'type': 'event3', 'duration': 0, 'urevent': 102},
-        ])
+        eeg_with_events['event'].extend(
+            [
+                {'latency': 1, 'type': 'event1', 'duration': 0, 'urevent': 100},
+                {'latency': 50, 'type': 'event2', 'duration': 0, 'urevent': 101},
+                {'latency': 100, 'type': 'event3', 'duration': 0, 'urevent': 102},
+            ]
+        )
 
         try:
             result = eeg_eeg2mne(eeg_with_events)
@@ -262,10 +257,12 @@ class TestEEGEEG2MNE(unittest.TestCase):
         realistic_eeg = create_test_eeg(n_samples=1000, n_trials=10, srate=500.0)
 
         # Add some additional events (already has epoch events from fixture)
-        realistic_eeg['event'].extend([
-            {'latency': 1, 'type': 'stimulus', 'duration': 0, 'urevent': 100},
-            {'latency': 500, 'type': 'response', 'duration': 0, 'urevent': 101},
-        ])
+        realistic_eeg['event'].extend(
+            [
+                {'latency': 1, 'type': 'stimulus', 'duration': 0, 'urevent': 100},
+                {'latency': 500, 'type': 'response', 'duration': 0, 'urevent': 101},
+            ]
+        )
 
         try:
             result = eeg_eeg2mne(realistic_eeg)

--- a/tests/test_eeg_eegrej.py
+++ b/tests/test_eeg_eegrej.py
@@ -14,14 +14,17 @@ from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
 web_root = 'https://sccntestdatasets.s3.us-east-2.amazonaws.com/'
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
-def ensure_file(fname: str) -> str: # duplicate of test_clean_rawdata.py
+
+def ensure_file(fname: str) -> str:  # duplicate of test_clean_rawdata.py
     """Download a file if it does not exist and return the local path."""
     full_url = f"{web_root}{fname}"
     local_file = os.path.abspath(f"{local_url}{fname}")
     if not os.path.exists(local_file):
         from urllib.request import urlretrieve
+
         urlretrieve(full_url, local_file)
     return local_file
+
 
 def _make_continuous_eeg():
     # 2 channels × 20 samples, 1-based event latencies
@@ -42,40 +45,45 @@ def _make_continuous_eeg():
     }
     return EEG
 
+
 def _make_continuous_eeg2():
     # 2 channels × 20 samples, 1-based event latencies
-    data     = np.arange(75350*4, dtype=float).reshape(4, 75350)
-    timevals = np.array(range(data.shape[1]))/100
-    EEG = dict({
-        "data": data,
-        "xmin": 0.0,
-        "xmax": 753.4900,
-        "pnts": data.shape[1],
-        "srate": 100,
-        "nbchan": 4,
-        "trials": 1,
-        "times": timevals,
-        "event": [
-            {"type": "stim", "latency": 3.0},
-            {"type": "boundary", "latency": 6.0, "duration": 0.0},
-            {"type": "stim", "latency": 7.0},
-            {"type": "resp", "latency": 12.0},
-        ],
-    })
+    data = np.arange(75350 * 4, dtype=float).reshape(4, 75350)
+    timevals = np.array(range(data.shape[1])) / 100
+    EEG = dict(
+        {
+            "data": data,
+            "xmin": 0.0,
+            "xmax": 753.4900,
+            "pnts": data.shape[1],
+            "srate": 100,
+            "nbchan": 4,
+            "trials": 1,
+            "times": timevals,
+            "event": [
+                {"type": "stim", "latency": 3.0},
+                {"type": "boundary", "latency": 6.0, "duration": 0.0},
+                {"type": "stim", "latency": 7.0},
+                {"type": "resp", "latency": 12.0},
+            ],
+        }
+    )
     EEG = eeg_checkset(EEG)
     return EEG
+
 
 def _save_eeg(path, EEG):
     # Save as a single file object array for simplicity
     np.save(path, EEG, allow_pickle=True)
 
+
 def _load_eeg(path):
     return np.load(path, allow_pickle=True).item()
+
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestEEGEegrej(unittest.TestCase):
     def setUp(self):
-        EEG = _make_continuous_eeg2()
         self.tmpdir = tempfile.TemporaryDirectory()
         self.fpath = os.path.join(self.tmpdir.name, "eeg.npy")
         self.fpath_eeglab = ensure_file('FlankerTest.set')
@@ -151,7 +159,7 @@ class TestEEGEegrej(unittest.TestCase):
 
     def test_rmtime_continuous2(self):
         EEG = pop_loadset(self.fpath_eeglab)
-        rm_seg = np.array([[7535.900000,15070.800000]], dtype=float)
+        rm_seg = np.array([[7535.900000, 15070.800000]], dtype=float)
         EEG_py = eeg_eegrej(EEG, rm_seg)
 
         EEG_mat = self.eeglab.eeg_eegrej(EEG, rm_seg)
@@ -206,10 +214,13 @@ class TestEEGEegrejExtended(unittest.TestCase):
         self.assertEqual(result['data'].shape[1], 16)
 
         # Check that data is correctly concatenated
-        expected_data = np.concatenate([
-            EEG['data'][:, :4],   # samples 1-4 (0-3 in 0-based)
-            EEG['data'][:, 8:]    # samples 9-20 (8-19 in 0-based)
-        ], axis=1)
+        expected_data = np.concatenate(
+            [
+                EEG['data'][:, :4],  # samples 1-4 (0-3 in 0-based)
+                EEG['data'][:, 8:],  # samples 9-20 (8-19 in 0-based)
+            ],
+            axis=1,
+        )
         np.testing.assert_array_equal(result['data'], expected_data)
 
     def test_eeg_eegrej_multiple_regions(self):
@@ -225,11 +236,14 @@ class TestEEGEegrejExtended(unittest.TestCase):
         self.assertEqual(result['data'].shape[1], 14)
 
         # Check that data is correctly concatenated
-        expected_data = np.concatenate([
-            EEG['data'][:, :2],    # samples 1-2 (0-1 in 0-based)
-            EEG['data'][:, 5:14],  # samples 6-14 (5-13 in 0-based)
-            EEG['data'][:, 17:]    # samples 18-20 (17-19 in 0-based)
-        ], axis=1)
+        expected_data = np.concatenate(
+            [
+                EEG['data'][:, :2],  # samples 1-2 (0-1 in 0-based)
+                EEG['data'][:, 5:14],  # samples 6-14 (5-13 in 0-based)
+                EEG['data'][:, 17:],  # samples 18-20 (17-19 in 0-based)
+            ],
+            axis=1,
+        )
         np.testing.assert_array_equal(result['data'], expected_data)
 
     def test_eeg_eegrej_overlapping_regions(self):
@@ -306,8 +320,8 @@ class TestEEGEegrejExtended(unittest.TestCase):
 
         # Add more events for comprehensive testing
         EEG['event'] = [
-            {"type": "stim", "latency": 2.0},   # Before rejection region
-            {"type": "resp", "latency": 9.0},   # Inside rejection region (should be removed)
+            {"type": "stim", "latency": 2.0},  # Before rejection region
+            {"type": "resp", "latency": 9.0},  # Inside rejection region (should be removed)
             {"type": "stim", "latency": 15.0},  # After rejection region (should shift)
         ]
 
@@ -355,9 +369,9 @@ class TestEEGEegrejExtended(unittest.TestCase):
 
         # Add problematic events that should be cleaned up
         EEG['event'] = [
-            {"type": "boundary", "latency": 0.0},    # Should be removed (latency 0)
+            {"type": "boundary", "latency": 0.0},  # Should be removed (latency 0)
             {"type": "stim", "latency": 5.0},
-            {"type": "boundary", "latency": 20.0},   # Should be removed (latency == pnts)
+            {"type": "boundary", "latency": 20.0},  # Should be removed (latency == pnts)
         ]
 
         regions = np.array([[10, 12]])
@@ -439,20 +453,26 @@ class TestEEGEegrejExtended(unittest.TestCase):
         EEG = self.base_eeg.copy()
 
         # Use specific data pattern to verify integrity
-        EEG['data'] = np.array([
-            [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-            [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
-        ], dtype=float)
+        EEG['data'] = np.array(
+            [
+                [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+                [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+            ],
+            dtype=float,
+        )
 
         # Remove samples 6-10 (1-based) = indices 5-9 (0-based)
         regions = np.array([[6, 10]])
         result = eeg_eegrej(EEG, regions)
 
         # Expected result: keep samples 1-5 and 11-20 (0-based: 0-4 and 10-19)
-        expected_data = np.array([
-            [10, 11, 12, 13, 14, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-            [30, 31, 32, 33, 34, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
-        ], dtype=float)
+        expected_data = np.array(
+            [
+                [10, 11, 12, 13, 14, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+                [30, 31, 32, 33, 34, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+            ],
+            dtype=float,
+        )
 
         np.testing.assert_array_equal(result['data'], expected_data)
 
@@ -469,7 +489,7 @@ class TestEEGEegrejExtended(unittest.TestCase):
 
         # Core fields should be updated
         self.assertEqual(result['pnts'], 16)
-        self.assertAlmostEqual(result['xmax'], EEG['xmin'] + (EEG['xmax'] - EEG['xmin']) * (16/20))
+        self.assertAlmostEqual(result['xmax'], EEG['xmin'] + (EEG['xmax'] - EEG['xmin']) * (16 / 20))
 
         # Other fields should be preserved
         self.assertEqual(result['srate'], 250.0)

--- a/tests/test_eeg_interp.py
+++ b/tests/test_eeg_interp.py
@@ -2,8 +2,6 @@ import copy
 import os
 import unittest
 import numpy as np
-from scipy.io import loadmat, savemat
-from unittest.mock import patch, MagicMock
 
 from eegprep.functions.popfunc.eeg_interp import eeg_interp, spheric_spline, computeg
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
@@ -98,13 +96,13 @@ class TestEegInterpParity(unittest.TestCase):
             'ref': 'common',
             'history': '',
             'saved': 'no',
-            'etc': {}
+            'etc': {},
         }
 
         # Create realistic channel locations on unit sphere
         for i in range(n_channels):
             theta = 2 * np.pi * i / n_channels
-            phi = np.pi/6 + (np.pi/3) * (i % 8) / 8
+            phi = np.pi / 6 + (np.pi / 3) * (i % 8) / 8
 
             x = np.cos(phi) * np.cos(theta)
             y = np.cos(phi) * np.sin(theta)
@@ -120,22 +118,24 @@ class TestEegInterpParity(unittest.TestCase):
             elif i == 3:
                 label = 'F3'
             else:
-                label = f'Ch{i+1}'
+                label = f'Ch{i + 1}'
 
-            self.test_EEG['chanlocs'].append({
-                'labels': label,
-                'X': x,
-                'Y': y,
-                'Z': z,
-                'theta': np.arctan2(y, x),
-                'radius': np.sqrt(x**2 + y**2),
-                'sph_theta': theta,
-                'sph_phi': phi,
-                'sph_radius': 1.0,  # Unit sphere
-                'type': 'EEG',
-                'urchan': i,  # 0-based original channel index
-                'ref': ''
-            })
+            self.test_EEG['chanlocs'].append(
+                {
+                    'labels': label,
+                    'X': x,
+                    'Y': y,
+                    'Z': z,
+                    'theta': np.arctan2(y, x),
+                    'radius': np.sqrt(x**2 + y**2),
+                    'sph_theta': theta,
+                    'sph_phi': phi,
+                    'sph_radius': 1.0,  # Unit sphere
+                    'type': 'EEG',
+                    'urchan': i,  # 0-based original channel index
+                    'ref': '',
+                }
+            )
 
     def _compare_eeg_results(self, py_result, ml_result):
         """Helper method to compare Python and MATLAB EEG results"""
@@ -308,9 +308,7 @@ class TestSphericalSplineParity(unittest.TestCase):
         """Test parity for basic spherical spline interpolation"""
         # Python computation
         py_result = spheric_spline(
-            self.xelec, self.yelec, self.zelec,
-            self.xbad, self.ybad, self.zbad,
-            self.values, self.params
+            self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, self.params
         )
 
         # Convert tuple to numpy array for MATLAB
@@ -318,9 +316,7 @@ class TestSphericalSplineParity(unittest.TestCase):
 
         # MATLAB computation (call the internal function)
         ml_result = self.eeglab.spheric_spline(
-            self.xelec, self.yelec, self.zelec,
-            self.xbad, self.ybad, self.zbad,
-            self.values, params_array
+            self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, params_array
         )
 
         # Extract the actual interpolated values (4th output from MATLAB)
@@ -335,25 +331,21 @@ class TestSphericalSplineParity(unittest.TestCase):
     def test_parity_spheric_spline_different_params(self):
         """Test parity with different parameter sets"""
         param_sets = [
-            (0, 4, 7),      # spherical
+            (0, 4, 7),  # spherical
             (1e-8, 3, 50),  # sphericalKang
-            (1e-5, 4, 100)  # sphericalCRD (reduced iterations for speed)
+            (1e-5, 4, 100),  # sphericalCRD (reduced iterations for speed)
         ]
 
         for params in param_sets:
             with self.subTest(params=params):
                 py_result = spheric_spline(
-                    self.xelec, self.yelec, self.zelec,
-                    self.xbad, self.ybad, self.zbad,
-                    self.values, params
+                    self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, params
                 )
 
                 # Convert tuple to numpy array for MATLAB
                 params_array = np.array(params)
                 ml_result = self.eeglab.spheric_spline(
-                    self.xelec, self.yelec, self.zelec,
-                    self.xbad, self.ybad, self.zbad,
-                    self.values, params_array
+                    self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, params_array
                 )
 
                 # Extract interpolated values (4th output from MATLAB)
@@ -384,19 +376,11 @@ class TestComputeGParity(unittest.TestCase):
 
     def test_parity_computeg_basic(self):
         """Test parity for basic computeg function"""
-        py_result = computeg(
-            self.x, self.y, self.z,
-            self.xelec, self.yelec, self.zelec,
-            self.params
-        )
+        py_result = computeg(self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, self.params)
 
         # Convert tuple to numpy array for MATLAB
         params_array = np.array(self.params)
-        ml_result = self.eeglab.computeg(
-            self.x, self.y, self.z,
-            self.xelec, self.yelec, self.zelec,
-            params_array
-        )
+        ml_result = self.eeglab.computeg(self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, params_array)
 
         self.assertEqual(py_result.shape, ml_result.shape)
         self.assertTrue(np.allclose(py_result, ml_result, atol=1e-10))
@@ -406,23 +390,17 @@ class TestComputeGParity(unittest.TestCase):
         param_sets = [
             (0, 2, 5),
             (0, 4, 7),
-            (1e-8, 3, 20)  # Reduced iterations for speed
+            (1e-8, 3, 20),  # Reduced iterations for speed
         ]
 
         for params in param_sets:
             with self.subTest(params=params):
-                py_result = computeg(
-                    self.x, self.y, self.z,
-                    self.xelec, self.yelec, self.zelec,
-                    params
-                )
+                py_result = computeg(self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, params)
 
                 # Convert tuple to numpy array for MATLAB
                 params_array = np.array(params)
                 ml_result = self.eeglab.computeg(
-                    self.x, self.y, self.z,
-                    self.xelec, self.yelec, self.zelec,
-                    params_array
+                    self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, params_array
                 )
 
                 self.assertEqual(py_result.shape, ml_result.shape)
@@ -430,7 +408,6 @@ class TestComputeGParity(unittest.TestCase):
 
 
 class TestEegInterp(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures with mock EEG data structure"""
         # Create a minimal EEG structure for testing
@@ -441,7 +418,7 @@ class TestEegInterp(unittest.TestCase):
             'trials': 1,
             'xmin': -0.5,
             'xmax': 1.5,
-            'chanlocs': []
+            'chanlocs': [],
         }
 
         # Create mock channel locations
@@ -453,12 +430,7 @@ class TestEegInterp(unittest.TestCase):
             y = np.cos(phi) * np.sin(theta)
             z = np.sin(phi)
 
-            self.mock_EEG['chanlocs'].append({
-                'labels': f'Ch{i+1}',
-                'X': x,
-                'Y': y,
-                'Z': z
-            })
+            self.mock_EEG['chanlocs'].append({'labels': f'Ch{i + 1}', 'X': x, 'Y': y, 'Z': z})
 
         # Add some named channels for testing
         self.mock_EEG['chanlocs'][0]['labels'] = 'Fp1'
@@ -536,12 +508,7 @@ class TestEegInterp(unittest.TestCase):
         # Add a channel with NaN coordinates
         eeg_with_nan = self.mock_EEG.copy()
         eeg_with_nan['chanlocs'] = self.mock_EEG['chanlocs'].copy()
-        eeg_with_nan['chanlocs'].append({
-            'labels': 'NaN_ch',
-            'X': np.nan,
-            'Y': np.nan,
-            'Z': np.nan
-        })
+        eeg_with_nan['chanlocs'].append({'labels': 'NaN_ch', 'X': np.nan, 'Y': np.nan, 'Z': np.nan})
         eeg_with_nan['nbchan'] = 33
         eeg_with_nan['data'] = np.random.randn(33, 1000, 1)
 
@@ -569,7 +536,6 @@ class TestEegInterp(unittest.TestCase):
 
 
 class TestSphericSpline(unittest.TestCase):
-
     def setUp(self):
         """Set up test data for spheric spline"""
         np.random.seed(42)  # For reproducible tests
@@ -592,9 +558,7 @@ class TestSphericSpline(unittest.TestCase):
     def test_spheric_spline_basic(self):
         """Test basic spheric spline functionality"""
         result = spheric_spline(
-            self.xelec, self.yelec, self.zelec,
-            self.xbad, self.ybad, self.zbad,
-            self.values, self.params
+            self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, self.params
         )
 
         # Check output shape
@@ -606,17 +570,15 @@ class TestSphericSpline(unittest.TestCase):
     def test_spheric_spline_different_params(self):
         """Test spheric spline with different parameter sets"""
         params_sets = [
-            (0, 4, 7),      # spherical
+            (0, 4, 7),  # spherical
             (1e-8, 3, 50),  # sphericalKang
-            (1e-5, 4, 500)  # sphericalCRD
+            (1e-5, 4, 500),  # sphericalCRD
         ]
 
         for params in params_sets:
             with self.subTest(params=params):
                 result = spheric_spline(
-                    self.xelec, self.yelec, self.zelec,
-                    self.xbad, self.ybad, self.zbad,
-                    self.values, params
+                    self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, self.values, params
                 )
                 self.assertEqual(result.shape, (self.n_bad, self.n_points))
                 self.assertTrue(np.all(np.isfinite(result)))
@@ -625,9 +587,7 @@ class TestSphericSpline(unittest.TestCase):
         """Test spheric spline with single time point"""
         values_single = self.values[:, :1]  # Single time point
         result = spheric_spline(
-            self.xelec, self.yelec, self.zelec,
-            self.xbad, self.ybad, self.zbad,
-            values_single, self.params
+            self.xelec, self.yelec, self.zelec, self.xbad, self.ybad, self.zbad, values_single, self.params
         )
 
         self.assertEqual(result.shape, (self.n_bad, 1))
@@ -635,7 +595,6 @@ class TestSphericSpline(unittest.TestCase):
 
 
 class TestComputeG(unittest.TestCase):
-
     def setUp(self):
         """Set up test data for computeg function"""
         self.x = np.array([0.1, 0.2, 0.3])
@@ -648,9 +607,7 @@ class TestComputeG(unittest.TestCase):
 
     def test_computeg_basic(self):
         """Test basic computeg functionality"""
-        result = computeg(self.x, self.y, self.z,
-                         self.xelec, self.yelec, self.zelec,
-                         self.params)
+        result = computeg(self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, self.params)
 
         # Check output shape
         expected_shape = (len(self.x), len(self.xelec))
@@ -661,17 +618,11 @@ class TestComputeG(unittest.TestCase):
 
     def test_computeg_different_params(self):
         """Test computeg with different parameter values"""
-        params_list = [
-            (0, 2, 5),
-            (0, 4, 7),
-            (0, 6, 10)
-        ]
+        params_list = [(0, 2, 5), (0, 4, 7), (0, 6, 10)]
 
         for params in params_list:
             with self.subTest(params=params):
-                result = computeg(self.x, self.y, self.z,
-                                 self.xelec, self.yelec, self.zelec,
-                                 params)
+                result = computeg(self.x, self.y, self.z, self.xelec, self.yelec, self.zelec, params)
                 self.assertEqual(result.shape, (len(self.x), len(self.xelec)))
                 self.assertTrue(np.all(np.isfinite(result)))
 
@@ -681,9 +632,7 @@ class TestComputeG(unittest.TestCase):
         y_single = np.array([0.2])
         z_single = np.array([0.3])
 
-        result = computeg(x_single, y_single, z_single,
-                         self.xelec, self.yelec, self.zelec,
-                         self.params)
+        result = computeg(x_single, y_single, z_single, self.xelec, self.yelec, self.zelec, self.params)
 
         self.assertEqual(result.shape, (1, len(self.xelec)))
         self.assertTrue(np.all(np.isfinite(result)))
@@ -695,9 +644,7 @@ class TestComputeG(unittest.TestCase):
         y_same = np.array([0.0])
         z_same = np.array([1.0])
 
-        result = computeg(x_same, y_same, z_same,
-                         self.xelec, self.yelec, self.zelec,
-                         self.params)
+        result = computeg(x_same, y_same, z_same, self.xelec, self.yelec, self.zelec, self.params)
 
         self.assertEqual(result.shape, (1, len(self.xelec)))
         # Note: Some values might be NaN or Inf for identical points, that's expected
@@ -721,25 +668,20 @@ class TestEegInterpIntegration(unittest.TestCase):
             'srate': 500,  # 500 Hz sampling rate
             'xmin': -1.0,
             'xmax': 3.0,
-            'chanlocs': []
+            'chanlocs': [],
         }
 
         # Create realistic channel locations (10-20 system approximation)
         for i in range(n_channels):
             # Distribute channels on sphere
             theta = 2 * np.pi * i / n_channels
-            phi = np.pi/6 + (np.pi/3) * (i % 8) / 8  # Vary elevation
+            phi = np.pi / 6 + (np.pi / 3) * (i % 8) / 8  # Vary elevation
 
             x = np.cos(phi) * np.cos(theta)
             y = np.cos(phi) * np.sin(theta)
             z = np.sin(phi)
 
-            self.eeg_data['chanlocs'].append({
-                'labels': f'Ch{i+1}',
-                'X': x,
-                'Y': y,
-                'Z': z
-            })
+            self.eeg_data['chanlocs'].append({'labels': f'Ch{i + 1}', 'X': x, 'Y': y, 'Z': z})
 
     def test_interpolation_preserves_good_channels(self):
         """Test that interpolation doesn't change good channels"""
@@ -753,10 +695,7 @@ class TestEegInterpIntegration(unittest.TestCase):
         result = eeg_interp(self.eeg_data, bad_channels, method='spherical')
 
         # Check that good channels are unchanged
-        np.testing.assert_array_equal(
-            result['data'][good_channels, :, :],
-            original_good_data
-        )
+        np.testing.assert_array_equal(result['data'][good_channels, :, :], original_good_data)
 
     def test_interpolation_changes_bad_channels(self):
         """Test that interpolation actually changes bad channels"""
@@ -770,10 +709,7 @@ class TestEegInterpIntegration(unittest.TestCase):
 
         # Check that bad channels have changed
         with self.assertRaises(AssertionError):
-            np.testing.assert_array_equal(
-                result['data'][bad_channels, :, :],
-                original_bad_data
-            )
+            np.testing.assert_array_equal(result['data'][bad_channels, :, :], original_bad_data)
 
     def test_interpolation_reasonable_values(self):
         """Test that interpolated values are reasonable"""
@@ -791,7 +727,7 @@ class TestEegInterpIntegration(unittest.TestCase):
         # Should be within reasonable amplitude range (not too extreme)
         # Assuming original data has std around 50, interpolated should be similar
         self.assertTrue(np.std(interpolated_data) < 200)  # Not too large
-        self.assertTrue(np.std(interpolated_data) > 1)    # Not too small
+        self.assertTrue(np.std(interpolated_data) > 1)  # Not too small
 
 
 class TestEegInterpFileOperations(unittest.TestCase):
@@ -816,9 +752,14 @@ class TestEegInterpFileOperations(unittest.TestCase):
 
         # Test that spheric spline computation works
         result = spheric_spline(
-            xelec=xyz[0], yelec=xyz[1], zelec=xyz[2],
-            xbad=xbad[0], ybad=xbad[1], zbad=xbad[2],
-            values=values, params=(0, 4, 7)
+            xelec=xyz[0],
+            yelec=xyz[1],
+            zelec=xyz[2],
+            xbad=xbad[0],
+            ybad=xbad[1],
+            zbad=xbad[2],
+            values=values,
+            params=(0, 4, 7),
         )
 
         self.assertEqual(result.shape, (n_bad, n_pts))
@@ -828,8 +769,8 @@ class TestEegInterpFileOperations(unittest.TestCase):
         """Test that computeg can handle different input configurations"""
         # Test computeg with various input sizes
         test_cases = [
-            (10, 5),    # 10 interpolation points, 5 electrodes
-            (50, 10),   # 50 interpolation points, 10 electrodes
+            (10, 5),  # 10 interpolation points, 5 electrodes
+            (50, 10),  # 50 interpolation points, 10 electrodes
             (100, 20),  # 100 interpolation points, 20 electrodes
         ]
 
@@ -850,6 +791,7 @@ class TestEegInterpFileOperations(unittest.TestCase):
                 self.assertEqual(g.shape, (n_points, n_elec))
                 self.assertTrue(np.all(np.isfinite(g)))
 
+
 class TestEegInterpChanlocs(unittest.TestCase):
     """Test the new chanloc structure functionality in eeg_interp"""
 
@@ -869,7 +811,7 @@ class TestEegInterpChanlocs(unittest.TestCase):
                 {'labels': 'Fp2', 'X': -0.1, 'Y': 0.8, 'Z': 0.6},
                 {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},
                 {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},
-            ]
+            ],
         }
 
         # Store original data for comparison
@@ -886,8 +828,7 @@ class TestEegInterpChanlocs(unittest.TestCase):
         np.testing.assert_array_equal(result['data'], self.original_data)
         self.assertEqual(result['nbchan'], 4)
         self.assertEqual(len(result['chanlocs']), 4)
-        self.assertEqual([ch['labels'] for ch in result['chanlocs']],
-                        ['Fp1', 'Fp2', 'F3', 'F4'])
+        self.assertEqual([ch['labels'] for ch in result['chanlocs']], ['Fp1', 'Fp2', 'F3', 'F4'])
 
     def test_chanloc_no_overlap_appends_channels(self):
         """Test Case 2: No overlap should append new channels"""
@@ -920,12 +861,12 @@ class TestEegInterpChanlocs(unittest.TestCase):
         """Test Case 3: Existing channels as proper subset should remap to new structure"""
         # Create superset that includes existing channels plus new ones
         superset_chanlocs = [
-            {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},    # existing
-            {'labels': 'C3', 'X': 0.6, 'Y': 0.0, 'Z': 0.8},     # new
-            {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},     # existing
-            {'labels': 'C4', 'X': -0.6, 'Y': 0.0, 'Z': 0.8},    # new
-            {'labels': 'Fp2', 'X': -0.1, 'Y': 0.8, 'Z': 0.6},   # existing
-            {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},    # existing
+            {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},  # existing
+            {'labels': 'C3', 'X': 0.6, 'Y': 0.0, 'Z': 0.8},  # new
+            {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},  # existing
+            {'labels': 'C4', 'X': -0.6, 'Y': 0.0, 'Z': 0.8},  # new
+            {'labels': 'Fp2', 'X': -0.1, 'Y': 0.8, 'Z': 0.6},  # existing
+            {'labels': 'F4', 'X': -0.4, 'Y': 0.6, 'Z': 0.7},  # existing
         ]
 
         result = eeg_interp(self.test_EEG.copy(), superset_chanlocs)
@@ -966,9 +907,9 @@ class TestEegInterpChanlocs(unittest.TestCase):
         """Test partial overlap case (not subset, not disjoint)"""
         # Create chanlocs with partial overlap
         partial_overlap_chanlocs = [
-            {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},    # exists
-            {'labels': 'T7', 'X': 0.8, 'Y': 0.0, 'Z': 0.6},     # new
-            {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},     # exists
+            {'labels': 'Fp1', 'X': 0.1, 'Y': 0.8, 'Z': 0.6},  # exists
+            {'labels': 'T7', 'X': 0.8, 'Y': 0.0, 'Z': 0.6},  # new
+            {'labels': 'F3', 'X': 0.4, 'Y': 0.6, 'Z': 0.7},  # exists
         ]
 
         result = eeg_interp(self.test_EEG.copy(), partial_overlap_chanlocs)
@@ -994,8 +935,8 @@ class TestEegInterpChanlocs(unittest.TestCase):
         # Same labels but different coordinates
         different_coords_chanlocs = [
             {'labels': 'Fp1', 'X': 0.2, 'Y': 0.9, 'Z': 0.5},  # Different coords
-            {'labels': 'Fp2', 'X': -0.2, 'Y': 0.9, 'Z': 0.5}, # Different coords
-            {'labels': 'F3', 'X': 0.5, 'Y': 0.7, 'Z': 0.6},   # Different coords
+            {'labels': 'Fp2', 'X': -0.2, 'Y': 0.9, 'Z': 0.5},  # Different coords
+            {'labels': 'F3', 'X': 0.5, 'Y': 0.7, 'Z': 0.6},  # Different coords
             {'labels': 'F4', 'X': -0.5, 'Y': 0.7, 'Z': 0.6},  # Different coords
         ]
 
@@ -1008,11 +949,6 @@ class TestEegInterpChanlocs(unittest.TestCase):
 
     def test_chanloc_invalid_structure(self):
         """Test error handling for invalid chanloc structures"""
-        # Test missing required fields
-        invalid_chanlocs = [
-            {'labels': 'T7', 'X': 0.8, 'Y': 0.0},  # Missing Z
-        ]
-
         # Should fall back to treating as regular channel names and fail appropriately
         with self.assertRaises(ValueError):
             eeg_interp(self.test_EEG.copy(), ['NonexistentChannel'])

--- a/tests/test_eeg_lat2point.py
+++ b/tests/test_eeg_lat2point.py
@@ -9,7 +9,6 @@ from eegprep.functions.popfunc.eeg_lat2point import eeg_lat2point
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestEegLat2PointParity(unittest.TestCase):
-
     def setUp(self):
         self.eeglab = get_eeglab('MAT')
 
@@ -60,7 +59,6 @@ class TestEegLat2PointParity(unittest.TestCase):
 
 
 class TestEegLat2PointFunctional(unittest.TestCase):
-
     def test_eeg_lat2point_continuous(self):
         # 100 Hz, epoch 0–1 s → 101 points; 0,0.5,1.0 s map to 1,51,101 (1-based)
         srate = 100

--- a/tests/test_eeg_mne2eeg.py
+++ b/tests/test_eeg_mne2eeg.py
@@ -16,6 +16,7 @@ sys.path.insert(0, 'src')
 
 try:
     import mne
+
     MNE_AVAILABLE = True
 except ImportError:
     MNE_AVAILABLE = False
@@ -29,6 +30,7 @@ try:
 except (ImportError, ValueError):
     # Fallback for unittest: add tests dir to path if needed
     import os
+
     test_dir = os.path.dirname(os.path.abspath(__file__))
     if test_dir not in sys.path:
         sys.path.insert(0, test_dir)
@@ -152,9 +154,7 @@ class TestEEGMNE2EEG(unittest.TestCase):
 
         # Add annotations using set_annotations method
         annotations = mne.Annotations(
-            onset=[0.1, 0.5, 0.9],
-            duration=[0.05, 0.05, 0.05],
-            description=['event1', 'event2', 'event3']
+            onset=[0.1, 0.5, 0.9], duration=[0.05, 0.05, 0.05], description=['event1', 'event2', 'event3']
         )
         raw.set_annotations(annotations)
 
@@ -195,13 +195,15 @@ class TestEEGMNE2EEG(unittest.TestCase):
         data = np.random.randn(n_epochs, n_channels, n_times)
 
         # Create events with different types
-        events = np.array([
-            [0, 0, 1],  # event type 1
-            [1, 0, 2],  # event type 2
-            [2, 0, 1],  # event type 1
-            [3, 0, 3],  # event type 3
-            [4, 0, 2],  # event type 2
-        ])
+        events = np.array(
+            [
+                [0, 0, 1],  # event type 1
+                [1, 0, 2],  # event type 2
+                [2, 0, 1],  # event type 1
+                [3, 0, 3],  # event type 3
+                [4, 0, 2],  # event type 2
+            ]
+        )
         event_id = {'stimulus': 1, 'response': 2, 'feedback': 3}
 
         epochs = mne.EpochsArray(data, info, events, tmin=0, event_id=event_id)
@@ -419,7 +421,7 @@ class TestEEGMNE2EEG(unittest.TestCase):
         annotations = mne.Annotations(
             onset=[0.1, 0.5, 1.0, 1.5, 2.0],
             duration=[0.05, 0.05, 0.05, 0.05, 0.05],
-            description=['stimulus', 'response', 'stimulus', 'response', 'stimulus']
+            description=['stimulus', 'response', 'stimulus', 'response', 'stimulus'],
         )
         raw.set_annotations(annotations)
 
@@ -456,9 +458,7 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
         """Test conversion of MNE annotations to EEGLAB events."""
         # Create MNE annotations
         annotations = mne.Annotations(
-            onset=[0.1, 0.5, 1.0],
-            duration=[0.05, 0.05, 0.05],
-            description=['event1', 'event2', 'event3']
+            onset=[0.1, 0.5, 1.0], duration=[0.05, 0.05, 0.05], description=['event1', 'event2', 'event3']
         )
 
         # Create a mock raw object with annotations
@@ -495,11 +495,13 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
     def test_mne_events_to_eeglab_events_events_array(self):
         """Test conversion of MNE events array to EEGLAB events."""
         # Create MNE events array
-        events = np.array([
-            [0, 0, 1],   # sample 0, event type 1
-            [100, 0, 2], # sample 100, event type 2
-            [200, 0, 1], # sample 200, event type 1
-        ])
+        events = np.array(
+            [
+                [0, 0, 1],  # sample 0, event type 1
+                [100, 0, 2],  # sample 100, event type 2
+                [200, 0, 1],  # sample 200, event type 1
+            ]
+        )
 
         # Create a mock epochs object with events and event_id
         class MockEpochs:
@@ -542,10 +544,12 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
     def test_mne_events_to_eeglab_events_no_event_id(self):
         """Test conversion when event_id is not available."""
         # Create MNE events array
-        events = np.array([
-            [0, 0, 1],
-            [100, 0, 2],
-        ])
+        events = np.array(
+            [
+                [0, 0, 1],
+                [100, 0, 2],
+            ]
+        )
 
         # Create a mock epochs object without event_id
         class MockEpochs:

--- a/tests/test_eeg_mne2eeg_epochs.py
+++ b/tests/test_eeg_mne2eeg_epochs.py
@@ -6,35 +6,27 @@ This module tests the eeg_mne2eeg_epochs function that converts MNE Epochs with 
 
 import unittest
 import os
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
-import sys
 import numpy as np
 import tempfile
-import os
 import shutil
-import math
 
-# Add src to path for imports
-sys.path.insert(0, 'src')
-# Ensure tests dir is in path for unittest discovery
-test_dir = os.path.dirname(os.path.abspath(__file__))
-if test_dir not in sys.path:
-    sys.path.insert(0, test_dir)
+from eegprep.functions.miscfunc.eeg_mne2eeg_epochs import eeg_mne2eeg_epochs
 
 try:
     import mne
     from mne.preprocessing import ICA
+
     MNE_AVAILABLE = True
 except ImportError:
     MNE_AVAILABLE = False
 
-from eegprep.functions.miscfunc.eeg_mne2eeg_epochs import eeg_mne2eeg_epochs
 try:
     from .fixtures import create_test_eeg
 except (ImportError, ValueError):
     from fixtures import create_test_eeg
+
+if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
+    raise unittest.SkipTest("MATLAB not available")
 
 
 class TestEEGMNE2EEGEpochs(unittest.TestCase):
@@ -148,12 +140,22 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
 
         # Add channel locations (MNE requires exactly 12 elements)
         for i, ch in enumerate(info['chs']):
-            ch['loc'] = np.array([
-                np.cos(i * np.pi / 4) * 0.1,  # x
-                np.sin(i * np.pi / 4) * 0.1,  # y
-                0.0,  # z
-                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  # other fields (12 total)
-            ])
+            ch['loc'] = np.array(
+                [
+                    np.cos(i * np.pi / 4) * 0.1,  # x
+                    np.sin(i * np.pi / 4) * 0.1,  # y
+                    0.0,  # z
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,  # other fields (12 total)
+                ]
+            )
 
         data = np.random.randn(n_epochs, n_channels, n_times)
         events = np.array([[i, 0, 1] for i in range(n_epochs)])
@@ -445,12 +447,22 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
 
         # Add realistic channel locations (MNE requires exactly 12 elements)
         for i, ch in enumerate(info['chs']):
-            ch['loc'] = np.array([
-                np.cos(i * np.pi / 16) * 0.1,  # x
-                np.sin(i * np.pi / 16) * 0.1,  # y
-                0.0,  # z
-                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  # other fields (12 total)
-            ])
+            ch['loc'] = np.array(
+                [
+                    np.cos(i * np.pi / 16) * 0.1,  # x
+                    np.sin(i * np.pi / 16) * 0.1,  # y
+                    0.0,  # z
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,  # other fields (12 total)
+                ]
+            )
 
         data = np.random.randn(n_epochs, n_channels, n_times)
         events = np.array([[i, 0, 1] for i in range(n_epochs)])

--- a/tests/test_eeg_picard.py
+++ b/tests/test_eeg_picard.py
@@ -4,7 +4,6 @@ import numpy as np
 from eegprep import pop_loadset, eeg_picard, pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.utils.testing import DebuggableTestCase, matlab_function_exists
-from eegprep.functions.miscfunc.pinv import pinv
 
 
 def compare_ica_components(weights1, weights2, rtol=0.01, atol=0.05):
@@ -54,6 +53,7 @@ def compare_ica_components(weights1, weights2, rtol=0.01, atol=0.05):
 
     return matched, max_correlations, best_matches, corr_matrix
 
+
 # ASSESSMENT OF THE TEST RESULTS
 # -----------------------------
 # The current conclusion is that while MATLAB and Octave are not exactly the same, they are close enough.
@@ -94,7 +94,7 @@ def create_test_eeg():
                 'sph_phi': np.random.uniform(-90, 90),
                 'sph_radius': np.random.uniform(0, 1),
                 'urchan': i + 1,
-                'ref': ''
+                'ref': '',
             }
             for i in range(32)
         ],
@@ -108,7 +108,7 @@ def create_test_eeg():
         'epoch': [],
         'setname': 'test_dataset',
         'filename': 'test.set',
-        'filepath': '/tmp'
+        'filepath': '/tmp',
     }
 
 
@@ -159,7 +159,7 @@ class TestEegPicardSimple(DebuggableTestCase):
                 self.test_eeg.copy(),
                 max_iter=10,  # picard uses max_iter, not maxiter
                 verbose=False,
-                random_state=42
+                random_state=42,
             )
 
             # Check that all ICA fields are present
@@ -325,7 +325,6 @@ class TestEegPicardSimple(DebuggableTestCase):
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestEegPicard(unittest.TestCase):
-
     def setUp(self):
         # Using a standard test file.
         # Even if it has ICA data, picard should overwrite it.
@@ -360,7 +359,7 @@ class TestEegPicard(unittest.TestCase):
         # --- Assertions ---
 
         # Check that all results have the necessary ICA fields
-        for eeg_result, engine_name in [(EEG_python, 'Python'), (EEG_matlab, 'MATLAB')]: #, (EEG_octave, 'Octave')]:
+        for eeg_result, engine_name in [(EEG_python, 'Python'), (EEG_matlab, 'MATLAB')]:  # , (EEG_octave, 'Octave')]:
             with self.subTest(engine=engine_name):
                 self.assertIn('icaweights', eeg_result)
                 self.assertIn('icasphere', eeg_result)
@@ -407,6 +406,7 @@ class TestEegPicard(unittest.TestCase):
         # plot the difference between each 2-D array and the difference between the 2-D arrays and save the figure
         if False:
             import matplotlib.pyplot as plt
+
             fig, axes = plt.subplots(1, 3, figsize=(18, 5))
             im1 = axes[0].imshow(EEG_python['icaweights'], aspect='auto', cmap='viridis')
             axes[0].set_title('Python icaweights')
@@ -425,7 +425,11 @@ class TestEegPicard(unittest.TestCase):
 
         # save weights to MATLAB file
         import scipy.io
-        scipy.io.savemat(os.path.join(local_url, 'icaweights_comparison.mat'), {'pArray': EEG_python['icaweights'], 'mArray': EEG_matlab['icaweights']}) #, 'oArray': EEG_octave['icaweights']})
+
+        scipy.io.savemat(
+            os.path.join(local_url, 'icaweights_comparison.mat'),
+            {'pArray': EEG_python['icaweights'], 'mArray': EEG_matlab['icaweights']},
+        )  # , 'oArray': EEG_octave['icaweights']})
 
         # Compare Python and MATLAB results using correlation-based comparison
         # ICA solutions are unique only up to permutation and sign of components
@@ -434,9 +438,11 @@ class TestEegPicard(unittest.TestCase):
 
         # icasphere should be identity for both (exact match expected)
         np.testing.assert_allclose(
-            EEG_python['icasphere'], EEG_matlab['icasphere'],
-            rtol=0.005, atol=1e-5,
-            err_msg='Python and Matlab icasphere differ beyond tolerance'
+            EEG_python['icasphere'],
+            EEG_matlab['icasphere'],
+            rtol=0.005,
+            atol=1e-5,
+            err_msg='Python and Matlab icasphere differ beyond tolerance',
         )
 
         # Compare icaweights using correlation (handles permutation and sign ambiguity)
@@ -463,7 +469,7 @@ class TestEegPicard(unittest.TestCase):
         self.assertTrue(
             matched,
             f"ICA components do not match well. Min correlation: {np.min(max_corrs):.4f}. "
-            f"Expected >= 0.65 for all components. Mean: {np.mean(max_corrs):.4f}"
+            f"Expected >= 0.65 for all components. Mean: {np.mean(max_corrs):.4f}",
         )
 
         # Note: icawinv = pinv(icaweights), so if icaweights match, icawinv is
@@ -472,6 +478,7 @@ class TestEegPicard(unittest.TestCase):
         # would be redundant with the icaweights check above.
 
         print("Python and MATLAB ICA results match (accounting for permutation/sign).")
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='TestEegPicard.test_picard_engines')

--- a/tests/test_eeg_point2lat.py
+++ b/tests/test_eeg_point2lat.py
@@ -4,6 +4,7 @@ from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.functions.popfunc.eeg_point2lat import eeg_point2lat
 import unittest
 
+
 def _matlab_row(x):
     """Convert a 1D numpy array or list into a MATLAB 1xN double."""
     x = np.asarray(x, dtype=float).ravel().tolist()
@@ -12,7 +13,6 @@ def _matlab_row(x):
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestEegPoint2LatParity(unittest.TestCase):
-
     def setUp(self):
         self.eeglab = get_eeglab('MAT')
 
@@ -55,7 +55,7 @@ class TestEegPoint2LatParity(unittest.TestCase):
     def test_eeg_point2lat_continuous(self):
         # Continuous data: 100 Hz, 0–1 s
         srate = 100
-        timewin = [0, 1]   # seconds
+        timewin = [0, 1]  # seconds
         lat_array = [1, 51, 101]  # 1-based samples
         # Expected latencies in seconds: [0.0, 0.5, 1.0]
         out = eeg_point2lat(lat_array, [], srate, timewin, 1)
@@ -77,11 +77,12 @@ class TestEegPoint2LatParity(unittest.TestCase):
     def test_eeg_point2lat_milliseconds(self):
         # Output in ms instead of seconds
         srate = 1000
-        timewin = [0, 1]   # sec
+        timewin = [0, 1]  # sec
         lat_array = [1, 1001]
         out = eeg_point2lat(lat_array, [], srate, timewin, 1e-3)  # ms
         expected = np.array([0.0, 1000.0])  # ms
         assert np.allclose(out, expected, atol=1e-9)
+
 
 class TestEegPoint2LatEdgeCases(unittest.TestCase):
     """Test edge cases and error conditions for eeg_point2lat."""

--- a/tests/test_eeg_rpsd_parity.py
+++ b/tests/test_eeg_rpsd_parity.py
@@ -7,6 +7,7 @@ Multithreading is disabled for deterministic numerical results.
 
 # Disable multithreading for deterministic numerical results
 import os
+
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
@@ -72,8 +73,13 @@ class TestEegRpsdParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: 0.00017, Mismatched: 1/2048 (0.05%)
         # Max relative diff: 1.14e-05
-        np.testing.assert_allclose(py_result, ml_result, rtol=2e-5, atol=1e-8,
-                                   err_msg="eeg_rpsd results differ beyond tolerance (default nfreqs)")
+        np.testing.assert_allclose(
+            py_result,
+            ml_result,
+            rtol=2e-5,
+            atol=1e-8,
+            err_msg="eeg_rpsd results differ beyond tolerance (default nfreqs)",
+        )
 
     def test_parity_custom_nfreqs_100(self):
         """Test parity with MATLAB using nfreqs=100."""
@@ -107,8 +113,9 @@ class TestEegRpsdParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: 0.00017, Mismatched: 1/2048 (0.05%)
         # Max relative diff: 1.14e-05
-        np.testing.assert_allclose(py_result, ml_result, rtol=2e-5, atol=1e-8,
-                                   err_msg="eeg_rpsd results differ beyond tolerance (nfreqs=100)")
+        np.testing.assert_allclose(
+            py_result, ml_result, rtol=2e-5, atol=1e-8, err_msg="eeg_rpsd results differ beyond tolerance (nfreqs=100)"
+        )
 
     def test_parity_custom_nfreqs_50(self):
         """Test parity with MATLAB using nfreqs=50."""
@@ -142,8 +149,9 @@ class TestEegRpsdParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: ~0.0002, Mismatched: ~1/1024 (0.1%)
         # Max relative diff: ~1.14e-05
-        np.testing.assert_allclose(py_result, ml_result, rtol=2e-5, atol=1e-8,
-                                   err_msg="eeg_rpsd results differ beyond tolerance (nfreqs=50)")
+        np.testing.assert_allclose(
+            py_result, ml_result, rtol=2e-5, atol=1e-8, err_msg="eeg_rpsd results differ beyond tolerance (nfreqs=50)"
+        )
 
     def test_parity_with_icl_processing(self):
         """Test parity with MATLAB including ICL processing (notch undo + normalization)."""
@@ -215,8 +223,9 @@ class TestEegRpsdParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: TBD
         # Max relative diff: TBD
-        np.testing.assert_allclose(py_result, ml_result, rtol=2e-5, atol=1e-8,
-                                   err_msg="eeg_rpsd with ICL processing differs beyond tolerance")
+        np.testing.assert_allclose(
+            py_result, ml_result, rtol=2e-5, atol=1e-8, err_msg="eeg_rpsd with ICL processing differs beyond tolerance"
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_eegfindboundaries.py
+++ b/tests/test_eegfindboundaries.py
@@ -11,7 +11,6 @@ from eegprep.functions.popfunc.eeg_findboundaries import eeg_findboundaries
 
 
 class TestEegFindBoundariesParity(unittest.TestCase):
-
     def setUp(self):
         self.eeglab = get_eeglab('MAT')
 
@@ -23,12 +22,12 @@ class TestEegFindBoundariesParity(unittest.TestCase):
                 {'type': 'stim', 'latency': 20},
                 {'type': 'boundary123', 'latency': 30},
                 {'type': 'resp', 'latency': 40},
-            ]
+            ],
         }
         py_out = eeg_findboundaries(EEG=EEG)
         ml_out = self.eeglab.eeg_findboundaries(EEG)
         # MATLAB returns column vector, Python returns list - compare flattened versions
-        self.assertTrue(np.array_equal(np.array(py_out), ml_out.flatten()-1))
+        self.assertTrue(np.array_equal(np.array(py_out), ml_out.flatten() - 1))
 
     def test_parity_string_types_eventlist(self):
         tmpevent = [
@@ -40,11 +39,10 @@ class TestEegFindBoundariesParity(unittest.TestCase):
         py_out = eeg_findboundaries(EEG=tmpevent)
         ml_out = self.eeglab.eeg_findboundaries(tmpevent)
         # MATLAB returns column vector, Python returns list - compare flattened versions
-        self.assertTrue(np.array_equal(np.array(py_out), ml_out.flatten()-1))
+        self.assertTrue(np.array_equal(np.array(py_out), ml_out.flatten() - 1))
 
 
 class TestEegFindBoundariesFunctional(unittest.TestCase):
-
     def test_returns_empty_on_empty_input(self):
         self.assertEqual(eeg_findboundaries(EEG={}), [])
         self.assertEqual(eeg_findboundaries(EEG=[]), [])
@@ -66,6 +64,7 @@ class TestEegFindBoundariesFunctional(unittest.TestCase):
     def test_numeric_option_boundary99_true(self):
         # Toggle the EEG_OPTIONS option_boundary99 for this test
         from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
+
         old = EEG_OPTIONS['option_boundary99']
         EEG_OPTIONS['option_boundary99'] = 1  # Use 1 to match MATLAB convention
         try:
@@ -78,6 +77,7 @@ class TestEegFindBoundariesFunctional(unittest.TestCase):
     def test_numeric_option_boundary99_false(self):
         # Toggle the EEG_OPTIONS option_boundary99 for this test
         from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
+
         old = EEG_OPTIONS['option_boundary99']
         EEG_OPTIONS['option_boundary99'] = 0  # Use 0 to match MATLAB convention
         try:
@@ -88,10 +88,7 @@ class TestEegFindBoundariesFunctional(unittest.TestCase):
             EEG_OPTIONS['option_boundary99'] = old
 
     def test_struct_vs_eventlist_path(self):
-        EEG = {
-            'setname': 'test',
-            'event': [{'type': 'stim'}, {'type': 'boundary'}]
-        }
+        EEG = {'setname': 'test', 'event': [{'type': 'stim'}, {'type': 'boundary'}]}
         out_struct = eeg_findboundaries(EEG=EEG)
         out_list = eeg_findboundaries(EEG=EEG['event'])
         self.assertEqual(out_struct, out_list)
@@ -145,7 +142,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
         events = [
             {'latency': 100},  # No type field
             {'type': 'boundary', 'latency': 200},
-            {'latency': 300}   # No type field
+            {'latency': 300},  # No type field
         ]
         result = eeg_findboundaries(EEG=events)
         self.assertEqual(result, [])  # Should return empty due to missing type in first event
@@ -155,7 +152,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
         events = [
             {'type': 'boundary', 'latency': 100},
             {'type': 1, 'latency': 200},  # Numeric type
-            {'type': 'boundary_end', 'latency': 300}
+            {'type': 'boundary_end', 'latency': 300},
         ]
         result = eeg_findboundaries(EEG=events)
         # Should find string boundaries at indices 0 and 2
@@ -181,7 +178,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
         events = [
             {'type': 'stimulus', 'latency': 100},
             {'type': 'response', 'latency': 200},
-            {'type': 'target', 'latency': 300}
+            {'type': 'target', 'latency': 300},
         ]
         result = eeg_findboundaries(EEG=events)
         self.assertEqual(result, [])
@@ -193,7 +190,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
             {'type': 'boundary', 'latency': 101},
             {'type': 'boundary', 'latency': 102},
             {'type': 'stimulus', 'latency': 200},
-            {'type': 'boundary', 'latency': 300}
+            {'type': 'boundary', 'latency': 300},
         ]
         result = eeg_findboundaries(EEG=events)
         self.assertEqual(result, [0, 1, 2, 4])
@@ -201,21 +198,18 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_correct_indexing(self):
         """Test that correct 0-based indices are returned."""
         events = [
-            {'type': 'start', 'latency': 0},      # Index 0
-            {'type': 'boundary', 'latency': 100}, # Index 1 - should be found
-            {'type': 'stimulus', 'latency': 200}, # Index 2
-            {'type': 'boundary', 'latency': 300}, # Index 3 - should be found
-            {'type': 'end', 'latency': 400}       # Index 4
+            {'type': 'start', 'latency': 0},  # Index 0
+            {'type': 'boundary', 'latency': 100},  # Index 1 - should be found
+            {'type': 'stimulus', 'latency': 200},  # Index 2
+            {'type': 'boundary', 'latency': 300},  # Index 3 - should be found
+            {'type': 'end', 'latency': 400},  # Index 4
         ]
         result = eeg_findboundaries(EEG=events)
         self.assertEqual(result, [1, 3])
 
     def test_boundary_labels_preserved(self):
         """Test that function correctly identifies boundaries without modifying input."""
-        events = [
-            {'type': 'boundary', 'latency': 100, 'duration': 0},
-            {'type': 'stimulus', 'latency': 200, 'code': 1}
-        ]
+        events = [{'type': 'boundary', 'latency': 100, 'duration': 0}, {'type': 'stimulus', 'latency': 200, 'code': 1}]
         original_events = [ev.copy() for ev in events]  # Deep copy
 
         result = eeg_findboundaries(EEG=events)
@@ -228,15 +222,16 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_numeric_boundary99_enabled(self):
         """Test numeric boundary detection with option_boundary99 enabled."""
         from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
+
         old_value = EEG_OPTIONS['option_boundary99']
         EEG_OPTIONS['option_boundary99'] = 1
 
         try:
             events = [
-                {'type': -99, 'latency': 100},   # Should be found
-                {'type': 1, 'latency': 200},     # Should not be found
-                {'type': -99, 'latency': 300},   # Should be found
-                {'type': 'boundary', 'latency': 400}  # Should not be found (numeric mode)
+                {'type': -99, 'latency': 100},  # Should be found
+                {'type': 1, 'latency': 200},  # Should not be found
+                {'type': -99, 'latency': 300},  # Should be found
+                {'type': 'boundary', 'latency': 400},  # Should not be found (numeric mode)
             ]
             result = eeg_findboundaries(EEG=events)
             self.assertEqual(result, [0, 2])
@@ -246,14 +241,15 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_numeric_boundary99_disabled(self):
         """Test numeric boundary detection with option_boundary99 disabled."""
         from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
+
         old_value = EEG_OPTIONS['option_boundary99']
         EEG_OPTIONS['option_boundary99'] = 0
 
         try:
             events = [
-                {'type': -99, 'latency': 100},   # Should not be found
-                {'type': 1, 'latency': 200},     # Should not be found
-                {'type': -99, 'latency': 300},   # Should not be found
+                {'type': -99, 'latency': 100},  # Should not be found
+                {'type': 1, 'latency': 200},  # Should not be found
+                {'type': -99, 'latency': 300},  # Should not be found
             ]
             result = eeg_findboundaries(EEG=events)
             self.assertEqual(result, [])
@@ -263,6 +259,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_mixed_string_numeric_types_with_boundary99(self):
         """Test mixed string and numeric types with boundary99 option."""
         from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
+
         old_value = EEG_OPTIONS['option_boundary99']
         EEG_OPTIONS['option_boundary99'] = 1
 
@@ -270,17 +267,17 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
             # When first event has string type, function uses string matching mode
             events = [
                 {'type': 'boundary', 'latency': 100},  # String type - will be found (string mode)
-                {'type': -99, 'latency': 200},          # Numeric type - not found in string mode
-                {'type': 'stimulus', 'latency': 300}    # String type - not found
+                {'type': -99, 'latency': 200},  # Numeric type - not found in string mode
+                {'type': 'stimulus', 'latency': 300},  # String type - not found
             ]
             result = eeg_findboundaries(EEG=events)
             self.assertEqual(result, [0])  # String 'boundary' found in string mode
 
             # When first event has numeric type, function uses numeric mode
             events_numeric_first = [
-                {'type': -99, 'latency': 100},          # Numeric type - will be found (numeric mode)
-                {'type': 'boundary', 'latency': 200},   # String type - not found in numeric mode
-                {'type': -99, 'latency': 300}           # Numeric type - will be found
+                {'type': -99, 'latency': 100},  # Numeric type - will be found (numeric mode)
+                {'type': 'boundary', 'latency': 200},  # String type - not found in numeric mode
+                {'type': -99, 'latency': 300},  # Numeric type - will be found
             ]
             result = eeg_findboundaries(EEG=events_numeric_first)
             self.assertEqual(result, [0, 2])  # Numeric -99s found in numeric mode
@@ -304,10 +301,7 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_eeg_struct_without_setname(self):
         """Test EEG dict that has events but no setname field."""
         EEG = {
-            'event': [
-                {'type': 'boundary', 'latency': 100},
-                {'type': 'stimulus', 'latency': 200}
-            ]
+            'event': [{'type': 'boundary', 'latency': 100}, {'type': 'stimulus', 'latency': 200}]
             # Missing 'setname' field - should still be treated as event list
         }
         result = eeg_findboundaries(EEG=EEG)
@@ -318,17 +312,12 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
     def test_eeg_struct_identification(self):
         """Test proper identification of EEG struct vs event list."""
         # Valid EEG struct (has both 'event' and 'setname')
-        EEG_struct = {
-            'setname': 'test',
-            'event': [{'type': 'boundary', 'latency': 100}]
-        }
+        EEG_struct = {'setname': 'test', 'event': [{'type': 'boundary', 'latency': 100}]}
         result = eeg_findboundaries(EEG=EEG_struct)
         self.assertEqual(result, [0])
 
         # Dict with only 'event' (treated as event list)
-        event_dict = {
-            'event': [{'type': 'boundary', 'latency': 100}]
-        }
+        event_dict = {'event': [{'type': 'boundary', 'latency': 100}]}
         result = eeg_findboundaries(EEG=event_dict)
         self.assertEqual(result, [])  # No 'type' field at top level
 
@@ -357,13 +346,9 @@ class TestEegFindBoundariesEdgeCases(unittest.TestCase):
                 'latency': 100,
                 'duration': 0,
                 'code': 'boundary_marker',
-                'description': 'Data discontinuity'
+                'description': 'Data discontinuity',
             },
-            {
-                'type': 'stimulus',
-                'latency': 200,
-                'code': 'S1'
-            }
+            {'type': 'stimulus', 'latency': 200, 'code': 'S1'},
         ]
         result = eeg_findboundaries(EEG=events)
         self.assertEqual(result, [0])

--- a/tests/test_eeglabcompat.py
+++ b/tests/test_eeglabcompat.py
@@ -10,8 +10,11 @@ import unittest
 from copy import deepcopy
 
 from eegprep.functions.adminfunc.eeglabcompat import (
-    MatlabWrapper, get_eeglab, clean_drifts, pop_eegfiltnew,
-    eeg_checkset as eeglab_eeg_checkset
+    MatlabWrapper,
+    get_eeglab,
+    clean_drifts,
+    pop_eegfiltnew,
+    eeg_checkset as eeglab_eeg_checkset,
 )
 from eegprep import clean_artifacts, pop_loadset
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
@@ -50,6 +53,7 @@ class TestMatlabWrapper(DebuggableTestCase):
 
     def test_wrapper_creation(self):
         """Test MatlabWrapper creation with mock engine."""
+
         class MockEngine:
             def eval(self, cmd, nargout=0):
                 pass
@@ -61,6 +65,7 @@ class TestMatlabWrapper(DebuggableTestCase):
 
     def test_getattr_returns_wrapper_function(self):
         """Test that __getattr__ returns a callable wrapper function."""
+
         class MockEngine:
             def eval(self, cmd, nargout=0):
                 pass
@@ -271,7 +276,7 @@ class TestCleanArtifacts(DebuggableTestCase):
             LineNoiseCriterion='off',
             FlatlineCriterion='off',
             BurstCriterion='off',
-            Highpass='off'
+            Highpass='off',
         )
         self.assertIsNotNone(result)
         self.assertIn('data', result)
@@ -287,21 +292,20 @@ class TestEeglabCompatIntegration(DebuggableTestCase):
 
         # Test MATLAB runtime
         try:
-            eeglab = get_eeglab('MAT')
+            get_eeglab('MAT')
             runtimes_available.append('MAT')
         except Exception:
             pass
 
         # Test Octave runtime
         try:
-            eeglab = get_eeglab('OCT')
+            get_eeglab('OCT')
             runtimes_available.append('OCT')
         except Exception:
             pass
 
         # At least one runtime should be available for testing
-        self.assertGreater(len(runtimes_available), 0,
-                          "No EEGLAB runtime available for testing")
+        self.assertGreater(len(runtimes_available), 0, "No EEGLAB runtime available for testing")
 
 
 if __name__ == '__main__':

--- a/tests/test_eegobj.py
+++ b/tests/test_eegobj.py
@@ -4,9 +4,8 @@ import os
 import tempfile
 import shutil
 from eegprep.functions.eegobj.eegobj import EEGobj
-from eegprep.functions.popfunc.pop_select import pop_select # Import pop_select for direct testing if needed
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
-import copy
+
 
 # Helper function to create a dummy EEG dictionary
 def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
@@ -22,21 +21,21 @@ def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
         'filename': 'test.set',
         'filepath': '/tmp',
         'event': [],
-        'chanlocs': [{'labels': f'Ch{i+1}', 'type': 'EEG'} for i in range(n_channels)],
+        'chanlocs': [{'labels': f'Ch{i + 1}', 'type': 'EEG'} for i in range(n_channels)],
         'icaact': [],  # Add missing field
         'icawinv': [],
         'icasphere': [],
         'icaweights': [],
         'icachansind': [],
-        'chaninfo': {}  # Add missing chaninfo field
+        'chaninfo': {},  # Add missing chaninfo field
     }
     eeg = eeg_checkset(eeg)
     return eeg
 
-class TestEEGobj(unittest.TestCase):
 
+class TestEEGobj(unittest.TestCase):
     def setUp(self):
-        self.test_file_path = 'sample_data/eeglab_data.set' # Assuming this file exists for path-based init
+        self.test_file_path = 'sample_data/eeglab_data.set'  # Assuming this file exists for path-based init
         self.temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -60,7 +59,7 @@ class TestEEGobj(unittest.TestCase):
         obj = EEGobj(self.test_file_path)
         self.assertIsInstance(obj.EEG, dict)
         self.assertGreater(obj.nbchan, 0)
-        self.assertIn("EEG |", repr(obj)) # Check for header
+        self.assertIn("EEG |", repr(obj))  # Check for header
 
     def test_init_invalid_type(self):
         """Test initialization with invalid type."""
@@ -82,7 +81,7 @@ class TestEEGobj(unittest.TestCase):
         self.assertEqual(out['trials'], 3)
         self.assertEqual(out['data'].shape[2], 3)
         # Ensure original object is not modified
-        self.assertEqual(obj.EEG['trials'], 3) # obj.EEG should be updated
+        self.assertEqual(obj.EEG['trials'], 3)  # obj.EEG should be updated
         self.assertEqual(obj.EEG['data'].shape[2], 3)
 
     def test_forward_pop_select_keyval(self):
@@ -92,7 +91,7 @@ class TestEEGobj(unittest.TestCase):
         self.assertEqual(out['nbchan'], 2)
         self.assertEqual(out['data'].shape[0], 2)
         # Ensure original object is not modified
-        self.assertEqual(obj.EEG['nbchan'], 2) # obj.EEG should be updated
+        self.assertEqual(obj.EEG['nbchan'], 2)  # obj.EEG should be updated
         self.assertEqual(obj.EEG['data'].shape[0], 2)
 
     def test_forward_pop_select_normalized_keys(self):
@@ -152,8 +151,6 @@ class TestEEGobj(unittest.TestCase):
 
         # Test with a function that actually returns a tuple
         # We'll use a simple test that doesn't interfere with pop_select
-        original_eeg = copy.deepcopy(eeg)
-
         # The test verifies that tuple return values are handled correctly
         # by checking that the object is updated properly
         result = obj.pop_select(channel=[0, 1])
@@ -167,8 +164,6 @@ class TestEEGobj(unittest.TestCase):
 
         # Test with a function that returns None
         # We'll use a simple test that doesn't interfere with pop_select
-        original_eeg = copy.deepcopy(eeg)
-
         # The test verifies that None return values are handled correctly
         # by checking that the object is updated properly
         result = obj.pop_select(channel=[0, 1])
@@ -217,7 +212,7 @@ class TestEEGobj(unittest.TestCase):
             'nbchan': 16,
             'pnts': 100,
             'trials': 1,
-            'srate': 250.0
+            'srate': 250.0,
             # Missing setname, filename, filepath, event, chanlocs
         }
         obj = EEGobj(eeg)
@@ -233,16 +228,10 @@ class TestEEGobj(unittest.TestCase):
         eeg = create_test_eeg()
 
         # Add numpy array events
-        eeg['event'] = np.array([
-            {'latency': 1, 'type': 'event1'},
-            {'latency': 50, 'type': 'event2'}
-        ])
+        eeg['event'] = np.array([{'latency': 1, 'type': 'event1'}, {'latency': 50, 'type': 'event2'}])
 
         # Add numpy array chanlocs
-        eeg['chanlocs'] = np.array([
-            {'labels': 'Ch1', 'type': 'EEG'},
-            {'labels': 'Ch2', 'type': 'EEG'}
-        ])
+        eeg['chanlocs'] = np.array([{'labels': 'Ch1', 'type': 'EEG'}, {'labels': 'Ch2', 'type': 'EEG'}])
 
         obj = EEGobj(eeg)
         repr_str = repr(obj)
@@ -256,15 +245,9 @@ class TestEEGobj(unittest.TestCase):
         eeg = create_test_eeg()
 
         # Add bytes strings
-        eeg['event'] = [
-            {'latency': 1, 'type': b'event1'},
-            {'latency': 50, 'type': b'event2'}
-        ]
+        eeg['event'] = [{'latency': 1, 'type': b'event1'}, {'latency': 50, 'type': b'event2'}]
 
-        eeg['chanlocs'] = [
-            {'labels': b'Ch1', 'type': b'EEG'},
-            {'labels': b'Ch2', 'type': b'EEG'}
-        ]
+        eeg['chanlocs'] = [{'labels': b'Ch1', 'type': b'EEG'}, {'labels': b'Ch2', 'type': b'EEG'}]
 
         obj = EEGobj(eeg)
         repr_str = repr(obj)
@@ -311,11 +294,9 @@ class TestEEGobj(unittest.TestCase):
         eeg['event'] = [
             {'latency': 1, 'type': 'stimulus'},
             {'latency': 100, 'type': 'response'},
-            {'latency': 200, 'type': 'feedback'}
+            {'latency': 200, 'type': 'feedback'},
         ]
-        eeg['chanlocs'] = [
-            {'labels': f'EEG{i:03d}', 'type': 'EEG'} for i in range(64)
-        ]
+        eeg['chanlocs'] = [{'labels': f'EEG{i:03d}', 'type': 'EEG'} for i in range(64)]
 
         obj = EEGobj(eeg)
         repr_str = repr(obj)
@@ -345,9 +326,6 @@ class TestEEGobj(unittest.TestCase):
         obj = EEGobj(eeg)
 
         # Store original data
-        original_data = obj.EEG['data'].copy()
-        original_nbchan = obj.EEG['nbchan']
-
         # Call a method that modifies data
         result = obj.pop_select(channel=[0, 1])
 
@@ -388,6 +366,6 @@ class TestEEGobj(unittest.TestCase):
             # This is expected if pop_select is not available
             pass
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_eegrej.py
+++ b/tests/test_eegrej.py
@@ -5,6 +5,7 @@ import numpy as np
 from eegprep.functions.popfunc.eeg_eegrej import _eegrej  # replace with the actual module name
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 
+
 class TestEEGRej(unittest.TestCase):
     def setUp(self):
         # 2 channels, 20 samples with simple increasing values
@@ -77,6 +78,7 @@ class TestEEGRej(unittest.TestCase):
         eeglab = get_eeglab()
         eeglab_outdata = eeglab.eegrej(self.data, np.array([[5, 8]]), self.timelength, events)
         np.testing.assert_array_equal(outdata, eeglab_outdata)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -30,7 +30,6 @@ def _ml_list_of_arrays_to_0_based(list_of_arrays):
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestEpochParity(unittest.TestCase):
-
     def setUp(self):
         np.random.seed(0)
         self.eeglab = get_eeglab('MAT')
@@ -99,19 +98,9 @@ class TestEpochParity(unittest.TestCase):
         allevents = np.array([4.7, 4.9, 5.1, 5.6, 9.1, 9.85, 10.05], dtype=float)
         alleventrange = np.array([-0.1, 0.3], dtype=float)
 
-        py = epoch(
-            data, events, lim,
-            srate=srate,
-            allevents=allevents,
-            alleventrange=alleventrange,
-            verbose='off'
-        )
+        py = epoch(data, events, lim, srate=srate, allevents=allevents, alleventrange=alleventrange, verbose='off')
         ml = self.eeglab.epoch(
-            data, events, lim,
-            'srate', srate,
-            'allevents', allevents,
-            'alleventrange', alleventrange,
-            'verbose', 'off'
+            data, events, lim, 'srate', srate, 'allevents', allevents, 'alleventrange', alleventrange, 'verbose', 'off'
         )
 
         py_epochdat, py_newtime, py_indexes, py_alleventout, py_alllatencyout, py_reallim = py
@@ -165,7 +154,6 @@ class TestEpochParity(unittest.TestCase):
 
 
 class TestEpochFunctional(unittest.TestCase):
-
     def test_functional_3d_epoched_input_same_epoch_constraint(self):
         # data shaped (chan, frames, epochs) = (1, 100, 3)
         # time window must remain within the same pre-existing epoch
@@ -191,18 +179,18 @@ class TestEpochFunctional(unittest.TestCase):
         reallim0 = int(np.round(lim[0] * srate))  # -20
         reallim1 = int(np.round(lim[1] * srate - 1))  # 29
         posinit = pos0 + reallim0  # 100 (0-based)
-        posend = pos0 + reallim1   # 149 (0-based)
+        posend = pos0 + reallim1  # 149 (0-based)
 
         # MATLAB slicing: posinit:posend (1-based) becomes [posinit-1:posend] (0-based)
         start_global = posinit - 1  # 99 (Python 0-based)
-        end_global = posend         # 149 (Python 0-based exclusive)
+        end_global = posend  # 149 (Python 0-based exclusive)
 
         # Extract the expected slice from linearized data (Fortran order)
         data_linearized = data.reshape(1, -1, order='F')
         expected = data_linearized[0, start_global:end_global]
         self.assertTrue(np.allclose(ep[0, :, 0], expected, atol=1e-12))
         # newtime should reflect limits divided by srate with the -1 sample convention
-        self.assertTrue(np.allclose(newtime, np.array([lim[0], np.round(lim[1]*srate-1)/srate]), atol=1e-12))
+        self.assertTrue(np.allclose(newtime, np.array([lim[0], np.round(lim[1] * srate - 1) / srate]), atol=1e-12))
 
     def test_functional_valuelim_pass_all(self):
         srate = 200.0

--- a/tests/test_file_menu_pop_functions.py
+++ b/tests/test_file_menu_pop_functions.py
@@ -300,7 +300,9 @@ def test_pop_importbids_escapes_history_path(monkeypatch, tmp_path):
         "eegprep.plugins.EEG_BIDS.pop_importbids.bids_list_eeg_files",
         lambda _path: [str(source / "sub-01_task-test_eeg.set")],
     )
-    monkeypatch.setattr("eegprep.plugins.EEG_BIDS.pop_importbids.pop_load_frombids", lambda _filename, **_kwargs: _eeg())
+    monkeypatch.setattr(
+        "eegprep.plugins.EEG_BIDS.pop_importbids.pop_load_frombids", lambda _filename, **_kwargs: _eeg()
+    )
 
     eeg, command = pop_importbids(source, return_com=True)
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -3,6 +3,8 @@
 import unittest
 import sys
 import os
+from unittest import mock
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
@@ -14,8 +16,10 @@ if test_dir not in sys.path:
 
 try:
     # Try pytest-style relative import first
+    from . import fixtures as fixtures_module
     from .fixtures import (
         mpl_use_agg,
+        matlab_engine_available,
         rng_seed,
         create_test_eeg,
         create_test_eeg_with_ica,
@@ -26,8 +30,10 @@ try:
     )
 except (ImportError, ValueError):
     # Fallback for unittest discovery
+    import fixtures as fixtures_module
     from fixtures import (
         mpl_use_agg,
+        matlab_engine_available,
         rng_seed,
         create_test_eeg,
         create_test_eeg_with_ica,
@@ -165,6 +171,18 @@ class TestFixturesFunctions(unittest.TestCase):
         self.assertEqual(eeg['nbchan'], 8)
         self.assertEqual(eeg['pnts'], 250)
         self.assertEqual(eeg['data'].shape, (8, 250))
+
+    def test_matlab_engine_available_returns_false_when_parent_package_missing(self):
+        """Missing MATLAB package should skip tests instead of failing collection."""
+        with (
+            mock.patch.dict(os.environ, {'EEGPREP_SKIP_MATLAB': '0'}),
+            mock.patch.object(
+                fixtures_module.importlib.util,
+                "find_spec",
+                side_effect=ModuleNotFoundError("No module named 'matlab'"),
+            ),
+        ):
+            self.assertFalse(matlab_engine_available())
 
 
 class TestContextManager(unittest.TestCase):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -4,8 +4,6 @@ import unittest
 import sys
 import os
 import numpy as np
-import os
-import sys
 import matplotlib
 import matplotlib.pyplot as plt
 
@@ -16,17 +14,27 @@ if test_dir not in sys.path:
 
 try:
     # Try pytest-style relative import first
-    from . import fixtures
     from .fixtures import (
-        mpl_use_agg, rng_seed, create_test_eeg, create_test_eeg_with_ica,
-        create_test_events, cleanup_matplotlib, TestFixturesContextManager, small_eeg
+        mpl_use_agg,
+        rng_seed,
+        create_test_eeg,
+        create_test_eeg_with_ica,
+        create_test_events,
+        cleanup_matplotlib,
+        TestFixturesContextManager,
+        small_eeg,
     )
 except (ImportError, ValueError):
     # Fallback for unittest discovery
-    import fixtures
     from fixtures import (
-        mpl_use_agg, rng_seed, create_test_eeg, create_test_eeg_with_ica,
-        create_test_events, cleanup_matplotlib, TestFixturesContextManager, small_eeg
+        mpl_use_agg,
+        rng_seed,
+        create_test_eeg,
+        create_test_eeg_with_ica,
+        create_test_events,
+        cleanup_matplotlib,
+        TestFixturesContextManager,
+        small_eeg,
     )
 
 
@@ -111,7 +119,7 @@ class TestFixturesFunctions(unittest.TestCase):
         self.assertEqual(len(eeg['chanlocs']), 16)
         for i, ch in enumerate(eeg['chanlocs']):
             self.assertIn('labels', ch)
-            self.assertEqual(ch['labels'], f'Ch{i+1}')
+            self.assertEqual(ch['labels'], f'Ch{i + 1}')
 
     def test_create_test_events(self):
         """Test event creation."""
@@ -242,7 +250,7 @@ class TestFixturesIntegration(unittest.TestCase):
 
         for i in range(5):
             with TestFixturesContextManager() as fixtures:
-                eeg = fixtures.create_eeg(n_channels=2, n_samples=10)
+                fixtures.create_eeg(n_channels=2, n_samples=10)
                 plt.figure()  # Create figure that should be cleaned up
 
         # Should not accumulate figures

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -172,17 +172,14 @@ class TestFixturesFunctions(unittest.TestCase):
         self.assertEqual(eeg['pnts'], 250)
         self.assertEqual(eeg['data'].shape, (8, 250))
 
-    def test_matlab_engine_available_returns_false_when_parent_package_missing(self):
-        """Missing MATLAB package should skip tests instead of failing collection."""
-        with (
-            mock.patch.dict(os.environ, {'EEGPREP_SKIP_MATLAB': '0'}),
-            mock.patch.object(
-                fixtures_module.importlib.util,
-                "find_spec",
-                side_effect=ModuleNotFoundError("No module named 'matlab'"),
-            ),
-        ):
-            self.assertFalse(matlab_engine_available())
+    def test_matlab_engine_available_returns_false_when_discovery_fails(self):
+        """Missing or broken MATLAB package should skip tests instead of failing collection."""
+        for error in (ModuleNotFoundError("No module named 'matlab'"), ValueError("broken package path")):
+            with (
+                mock.patch.dict(os.environ, {'EEGPREP_SKIP_MATLAB': '0'}),
+                mock.patch.object(fixtures_module.importlib.util, "find_spec", side_effect=error),
+            ):
+                self.assertFalse(matlab_engine_available())
 
 
 class TestContextManager(unittest.TestCase):

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -92,7 +92,9 @@ def _fake_qt_widgets(*, open_file="", save_file="", directory="", double_value=1
         def information(*_args, **_kwargs):
             return None
 
-    return type("FakeQtWidgets", (), {"QFileDialog": QFileDialog, "QInputDialog": QInputDialog, "QMessageBox": QMessageBox})
+    return type(
+        "FakeQtWidgets", (), {"QFileDialog": QFileDialog, "QInputDialog": QInputDialog, "QMessageBox": QMessageBox}
+    )
 
 
 def _demo_eeg(*, epoched=False, chanlocs=True, ica=True):
@@ -893,7 +895,9 @@ class QtMainWindowTests(unittest.TestCase):
         session.retrieve(2)
         window = build_main_window(session, all_menus=False)
         datasets = next(action.menu() for action in window.window.menuBar().actions() if action.text() == "Datasets")
-        dataset_actions = {action.text(): action for action in datasets.actions() if action.text().startswith("Dataset")}
+        dataset_actions = {
+            action.text(): action for action in datasets.actions() if action.text().startswith("Dataset")
+        }
 
         self.assertFalse(dataset_actions["Dataset 1:demo"].isChecked())
         self.assertTrue(dataset_actions["Dataset 2:second"].isCheckable())
@@ -908,7 +912,9 @@ class QtMainWindowTests(unittest.TestCase):
         session = EEGPrepSession()
         session.store_current(_demo_eeg(), new=True)
         window = build_main_window(session, all_menus=False)
-        actions_by_data = {action.data(): action for action in _qt_actions(window.window.menuBar().actions()) if action.data()}
+        actions_by_data = {
+            action.data(): action for action in _qt_actions(window.window.menuBar().actions()) if action.data()
+        }
         placeholder = actions_by_data["pop_eegplot:data"]
         implemented = actions_by_data["pop_resample"]
 

--- a/tests/test_gui_pop_clean_rawdata.py
+++ b/tests/test_gui_pop_clean_rawdata.py
@@ -35,7 +35,9 @@ class PopCleanRawdataGuiTests(unittest.TestCase):
         labels = [(control.style, control.string, control.tag) for control in spec.controls]
         self.assertIn(("checkbox", "Remove channel drift (data not already high-pass filtered)", "filter"), labels)
         self.assertIn(("checkbox", "Process/remove channels", "chanrm"), labels)
-        self.assertIn(("checkbox", "Perform Artifact Subspace Reconstruction bad burst correction/rejection", "asr"), labels)
+        self.assertIn(
+            ("checkbox", "Perform Artifact Subspace Reconstruction bad burst correction/rejection", "asr"), labels
+        )
         self.assertIn(("checkbox", "Additional removal of bad data periods", "rejwin"), labels)
         controls = controls_by_tag(spec)
         self.assertEqual(controls["filter"].font_weight, "bold")

--- a/tests/test_gui_pop_iclabel.py
+++ b/tests/test_gui_pop_iclabel.py
@@ -28,10 +28,13 @@ class PopIclabelGuiTests(unittest.TestCase):
         self.assertEqual(spec.title, "ICLabel")
         self.assertEqual(spec.function_name, "pop_iclabel")
         self.assertEqual(spec.eeglab_source, "plugins/ICLabel/pop_iclabel.m")
-        self.assertEqual([(control.style, control.string, control.tag) for control in spec.controls], [
-            ("text", "Select which icversion of ICLabel to use:", None),
-            ("popupmenu", "Default (recommended)|Lite|Beta", "icversion"),
-        ])
+        self.assertEqual(
+            [(control.style, control.string, control.tag) for control in spec.controls],
+            [
+                ("text", "Select which icversion of ICLabel to use:", None),
+                ("popupmenu", "Default (recommended)|Lite|Beta", "icversion"),
+            ],
+        )
 
     def test_gui_result_runs_iclabel_and_returns_history(self):
         class Renderer:

--- a/tests/test_gui_pop_resample.py
+++ b/tests/test_gui_pop_resample.py
@@ -28,10 +28,13 @@ class PopResampleGuiTests(unittest.TestCase):
         self.assertEqual(spec.title, "Resample current dataset -- pop_resample()")
         self.assertEqual(spec.function_name, "pop_resample")
         self.assertEqual(spec.eeglab_source, "functions/popfunc/pop_resample.m")
-        self.assertEqual([(control.style, control.string, control.tag) for control in spec.controls], [
-            ("text", "New sampling rate", None),
-            ("edit", "", "freq"),
-        ])
+        self.assertEqual(
+            [(control.style, control.string, control.tag) for control in spec.controls],
+            [
+                ("text", "New sampling rate", None),
+                ("edit", "", "freq"),
+            ],
+        )
 
     def test_gui_result_resamples_and_returns_history(self):
         class Renderer:

--- a/tests/test_gui_pop_runica.py
+++ b/tests/test_gui_pop_runica.py
@@ -271,7 +271,9 @@ class PopRunicaGuiTests(unittest.TestCase):
 
         first = dict(_eeg(), setname="first")
         second = dict(_eeg(), setname="second")
-        updated = dict(second, icaweights=np.eye(4), icasphere=np.eye(4), icawinv=np.eye(4), icaact=np.zeros((4, 20, 1)))
+        updated = dict(
+            second, icaweights=np.eye(4), icasphere=np.eye(4), icawinv=np.eye(4), icaact=np.zeros((4, 20, 1))
+        )
 
         with mock.patch("eegprep.functions.popfunc.pop_runica.eeg_runica", return_value=updated) as runica:
             out, com = pop_runica([first, second], gui=True, renderer=Renderer(), return_com=True)
@@ -365,7 +367,9 @@ class PopRunicaGuiTests(unittest.TestCase):
             icachansind=np.arange(4),
             etc={"ic_classification": {"ICLabel": {"version": "default"}}},
         )
-        updated = dict(eeg, icaweights=np.eye(4) * 2, icasphere=np.eye(4), icawinv=np.eye(4), icaact=np.zeros((4, 20, 1)))
+        updated = dict(
+            eeg, icaweights=np.eye(4) * 2, icasphere=np.eye(4), icawinv=np.eye(4), icaact=np.zeros((4, 20, 1))
+        )
 
         with mock.patch("eegprep.functions.popfunc.pop_runica.eeg_runica", return_value=updated):
             out = pop_runica(eeg, options={"extended": 1})

--- a/tests/test_guifunc_pophelp_chansel.py
+++ b/tests/test_guifunc_pophelp_chansel.py
@@ -4,13 +4,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 from eegprep.functions.guifunc.pophelp import pophelp_text
-pophelp_module = importlib.import_module("eegprep.functions.guifunc.pophelp")
 from eegprep.functions.popfunc.pop_interp import pop_interp_dialog_spec
 from eegprep.functions.popfunc.pop_chansel import (
     pop_chansel_display_values,
     pop_chansel_selected_string,
 )
 from eegprep.functions.popfunc.pop_reref import pop_reref_dialog_spec
+
+pophelp_module = importlib.import_module("eegprep.functions.guifunc.pophelp")
 
 
 class PopHelpAndChanSelTests(unittest.TestCase):

--- a/tests/test_iclabel.py
+++ b/tests/test_iclabel.py
@@ -1,18 +1,15 @@
 import os
 import unittest
-from copy import deepcopy
 import numpy as np
-from eegprep import *
-import tempfile
-import scipy.io
+from eegprep import ICL_feature_extractor, iclabel, pop_loadset
 from eegprep.utils.testing import has_optional_dependency
 
 # where the test resources
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
+
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestICLabelEngines(unittest.TestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(os.path.join(local_url, 'eeglab_data_with_ica_tmp.set'))
 
@@ -20,19 +17,17 @@ class TestICLabelEngines(unittest.TestCase):
         if not has_optional_dependency('torch'):
             self.skipTest("PyTorch is not installed; install eegprep[torch] to run ICLabel parity")
 
-        # First, extract features separately to compare
-        from eegprep import ICL_feature_extractor
         features_python = ICL_feature_extractor(self.EEG, True)
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("FEATURE EXTRACTION COMPARISON")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Python features[0] (topo) shape: {features_python[0].shape}, dtype: {features_python[0].dtype}")
         print(f"Python features[1] (psd) shape: {features_python[1].shape}, dtype: {features_python[1].dtype}")
         print(f"Python features[2] (autocorr) shape: {features_python[2].shape}, dtype: {features_python[2].dtype}")
         print(f"Python topo max: {np.max(features_python[0]):.6f}, min: {np.min(features_python[0]):.6f}")
         print(f"Python psd max: {np.max(features_python[1]):.6f}, min: {np.min(features_python[1]):.6f}")
         print(f"Python autocorr max: {np.max(features_python[2]):.6f}, min: {np.min(features_python[2]):.6f}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
 
         EEG_python = iclabel(self.EEG, algorithm='default', engine=None)
         EEG_matlab = iclabel(self.EEG, algorithm='default', engine='matlab')
@@ -41,9 +36,9 @@ class TestICLabelEngines(unittest.TestCase):
         res2 = EEG_matlab['etc']['ic_classification']['ICLabel']['classifications'].flatten()
 
         # Diagnostic output
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC OUTPUT")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Python result dtype: {res1.dtype}")
         print(f"MATLAB result dtype: {res2.dtype}")
         print(f"Python result shape: {res1.shape}")
@@ -66,11 +61,11 @@ class TestICLabelEngines(unittest.TestCase):
         print(f"\nValues exceeding absolute tolerance (1e-8): {np.sum(exceeds_abs)}/{len(res1)}")
         print(f"Values exceeding relative tolerance (1e-5): {np.sum(exceeds_rel)}/{len(res1)}")
         print(f"Values exceeding BOTH tolerances: {np.sum(exceeds_both)}/{len(res1)}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
 
         # Max abs diff: 3.37e-06, Max rel diff: 4.25e-05
-        self.assertTrue(np.allclose(res1, res2, rtol=1e-4, atol=1e-5),
-                       'ICLabel results differ beyond tolerance')
+        self.assertTrue(np.allclose(res1, res2, rtol=1e-4, atol=1e-5), 'ICLabel results differ beyond tolerance')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_iclabel_features.py
+++ b/tests/test_iclabel_features.py
@@ -2,6 +2,7 @@
 Test to compare ICLabel features between Python and MATLAB implementations.
 Tests both float32 and float64 precision.
 """
+
 import os
 import unittest
 import numpy as np
@@ -12,17 +13,17 @@ import scipy.io
 
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
+
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestICLabelFeatureComparison(unittest.TestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(os.path.join(local_url, 'eeglab_data_with_ica_tmp.set'))
 
     def test_feature_comparison_float32(self):
         """Compare Python vs MATLAB features in float32."""
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print("FEATURE COMPARISON: FLOAT32 (Default)")
-        print(f"{'='*70}")
+        print(f"{'=' * 70}")
 
         # Extract Python features (float32)
         features_py = ICL_feature_extractor(self.EEG, True)
@@ -32,6 +33,7 @@ class TestICLabelFeatureComparison(unittest.TestCase):
 
         # Save EEG to temp file for MATLAB
         from eegprep import pop_saveset
+
         temp_file = tempfile.mktemp(suffix='.set')
         pop_saveset(self.EEG, temp_file)
 
@@ -45,11 +47,7 @@ class TestICLabelFeatureComparison(unittest.TestCase):
 
         # Load MATLAB features
         mat_data = scipy.io.loadmat(temp_file + '.mat')
-        features_mat = [
-            mat_data['features'][0, 0],
-            mat_data['features'][0, 1],
-            mat_data['features'][0, 2]
-        ]
+        features_mat = [mat_data['features'][0, 0], mat_data['features'][0, 1], mat_data['features'][0, 2]]
 
         # Clean up
         os.remove(temp_file)
@@ -61,16 +59,16 @@ class TestICLabelFeatureComparison(unittest.TestCase):
 
     def test_feature_comparison_float64(self):
         """Compare Python vs MATLAB features in float64."""
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print("FEATURE COMPARISON: FLOAT64 (Modified)")
-        print(f"{'='*70}")
+        print(f"{'=' * 70}")
 
         # Extract Python features and convert to float64
         features_py32 = ICL_feature_extractor(self.EEG, True)
         features_py = [
             features_py32[0].astype(np.float64),
             features_py32[1].astype(np.float64),
-            features_py32[2].astype(np.float64)
+            features_py32[2].astype(np.float64),
         ]
 
         # Extract MATLAB features
@@ -78,6 +76,7 @@ class TestICLabelFeatureComparison(unittest.TestCase):
 
         # Save EEG to temp file
         from eegprep import pop_saveset
+
         temp_file = tempfile.mktemp(suffix='.set')
         pop_saveset(self.EEG, temp_file)
 
@@ -94,7 +93,7 @@ class TestICLabelFeatureComparison(unittest.TestCase):
         features_mat = [
             mat_data['features'][0, 0].astype(np.float64),
             mat_data['features'][0, 1].astype(np.float64),
-            mat_data['features'][0, 2].astype(np.float64)
+            mat_data['features'][0, 2].astype(np.float64),
         ]
 
         # Clean up
@@ -113,9 +112,9 @@ class TestICLabelFeatureComparison(unittest.TestCase):
             py_feat = features_py[i]
             mat_feat = features_mat[i]
 
-            print(f"\n{'-'*70}")
+            print(f"\n{'-' * 70}")
             print(f"{name} Feature ({precision})")
-            print(f"{'-'*70}")
+            print(f"{'-' * 70}")
 
             # Shape and dtype
             print(f"Python shape: {py_feat.shape}, dtype: {py_feat.dtype}")
@@ -126,13 +125,13 @@ class TestICLabelFeatureComparison(unittest.TestCase):
             print(f"MATLAB  - min: {np.min(mat_feat):+.10f}, max: {np.max(mat_feat):+.10f}")
 
             # Explain min/max
-            print(f"\nMin/Max Explanation:")
-            print(f"  - Features are scaled by 0.99 in ICL_feature_extractor")
-            print(f"  - Expected range: [-0.99, +0.99] for topo, [0, 0.99] for others")
+            print("\nMin/Max Explanation:")
+            print("  - Features are scaled by 0.99 in ICL_feature_extractor")
+            print("  - Expected range: [-0.99, +0.99] for topo, [0, 0.99] for others")
             if np.min(py_feat) < -0.99 or np.max(py_feat) > 0.99:
-                print(f"  ⚠️  Python feature EXCEEDS expected range!")
+                print("  ⚠️  Python feature EXCEEDS expected range!")
             if np.min(mat_feat) < -0.99 or np.max(mat_feat) > 0.99:
-                print(f"  ⚠️  MATLAB feature EXCEEDS expected range!")
+                print("  ⚠️  MATLAB feature EXCEEDS expected range!")
 
             # Statistics
             print(f"\nPython  - mean: {np.mean(py_feat):+.10f}, std: {np.std(py_feat):.10f}")
@@ -144,7 +143,7 @@ class TestICLabelFeatureComparison(unittest.TestCase):
                 abs_diff = np.abs(diff)
                 rel_diff = np.abs(diff) / (np.abs(mat_feat) + 1e-10)
 
-                print(f"\nDifference Statistics:")
+                print("\nDifference Statistics:")
                 print(f"  Max absolute diff:  {np.max(abs_diff):.2e}")
                 print(f"  Mean absolute diff: {np.mean(abs_diff):.2e}")
                 print(f"  Max relative diff:  {np.max(rel_diff):.2e}")
@@ -156,24 +155,25 @@ class TestICLabelFeatureComparison(unittest.TestCase):
                 exceeds_rel_1e5 = np.sum(rel_diff > 1e-5)
                 total = py_feat.size
 
-                print(f"\nValues exceeding tolerances:")
-                print(f"  |diff| > 1e-8:  {exceeds_abs_1e8:6d}/{total} ({100*exceeds_abs_1e8/total:.1f}%)")
-                print(f"  |diff| > 1e-6:  {exceeds_abs_1e6:6d}/{total} ({100*exceeds_abs_1e6/total:.1f}%)")
-                print(f"  rel diff > 1e-5: {exceeds_rel_1e5:6d}/{total} ({100*exceeds_rel_1e5/total:.1f}%)")
+                print("\nValues exceeding tolerances:")
+                print(f"  |diff| > 1e-8:  {exceeds_abs_1e8:6d}/{total} ({100 * exceeds_abs_1e8 / total:.1f}%)")
+                print(f"  |diff| > 1e-6:  {exceeds_abs_1e6:6d}/{total} ({100 * exceeds_abs_1e6 / total:.1f}%)")
+                print(f"  rel diff > 1e-5: {exceeds_rel_1e5:6d}/{total} ({100 * exceeds_rel_1e5 / total:.1f}%)")
 
                 # Are they close?
                 is_close_1e5 = np.allclose(py_feat, mat_feat, rtol=1e-5, atol=1e-8)
                 is_close_1e4 = np.allclose(py_feat, mat_feat, rtol=1e-4, atol=1e-6)
                 is_close_1e3 = np.allclose(py_feat, mat_feat, rtol=1e-3, atol=1e-5)
 
-                print(f"\nallclose() results:")
+                print("\nallclose() results:")
                 print(f"  rtol=1e-5, atol=1e-8: {is_close_1e5}")
                 print(f"  rtol=1e-4, atol=1e-6: {is_close_1e4}")
                 print(f"  rtol=1e-3, atol=1e-5: {is_close_1e3}")
             else:
-                print(f"\n⚠️  Shape mismatch! Cannot compare values.")
+                print("\n⚠️  Shape mismatch! Cannot compare values.")
 
-        print(f"\n{'='*70}\n")
+        print(f"\n{'=' * 70}\n")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_import_edf.py
+++ b/tests/test_import_edf.py
@@ -1,8 +1,4 @@
-
-
 if __name__ == "__main__":
-    import os
-    import sys
     from eegprep import pop_load_frombids, pop_biosig
 
     fn = '/Users/arno/Python/eegprep/sample_data/test_file.edf'
@@ -13,5 +9,5 @@ if __name__ == "__main__":
 
     # compare using eeg_compare
     from eegprep import eeg_compare
-    eeg_compare(EEG1, EEG2, verbose_level=1)
 
+    eeg_compare(EEG1, EEG2, verbose_level=1)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -2,7 +2,6 @@ import logging
 import unittest
 import contextlib
 import io
-import sys
 import warnings
 from unittest.mock import patch
 
@@ -10,7 +9,6 @@ from eegprep.functions.adminfunc.logs import setup_logging, ColoredWarningFormat
 
 
 class TestLogs(unittest.TestCase):
-
     @contextlib.contextmanager
     def _preserve_root_logger(self):
         root_logger = logging.getLogger()
@@ -121,5 +119,3 @@ class TestLogs(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/tests/test_matlab_path.py
+++ b/tests/test_matlab_path.py
@@ -4,8 +4,8 @@ Note: This project uses matlab.engine Python API, not the matlab CLI.
 The matlab.engine finds MATLAB through its own mechanism and doesn't
 require 'matlab' to be in PATH.
 """
+
 import os
-import subprocess
 import unittest
 
 
@@ -18,6 +18,7 @@ class TestMatlabPath(unittest.TestCase):
             self.skipTest("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
         try:
             import matlab.engine
+
             print(f"MATLAB engine module found at: {matlab.engine.__file__}")
         except ImportError as e:
             self.skipTest(f"matlab.engine not installed: {e}")
@@ -42,6 +43,7 @@ class TestMatlabPath(unittest.TestCase):
         """Test get_eeglab with Octave runtime (informational)."""
         try:
             from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+
             print("Attempting to get EEGLAB with Octave runtime...")
             eeglab = get_eeglab('OCT')
             print(f"EEGLAB (Octave) loaded successfully: {type(eeglab)}")
@@ -54,6 +56,7 @@ class TestMatlabPath(unittest.TestCase):
             self.skipTest("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
         try:
             from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+
             print("Attempting to get EEGLAB with MATLAB runtime...")
             eeglab = get_eeglab('MAT')
             print(f"EEGLAB (MATLAB) loaded successfully: {type(eeglab)}")

--- a/tests/test_parity_rng.py
+++ b/tests/test_parity_rng.py
@@ -63,13 +63,14 @@ class TestRNGParity(unittest.TestCase):
         os.remove(temp_file)
 
         # Compare rand (uniform distribution) - THIS SHOULD MATCH for 1D
-        print(f"\nrand() 1D uniform comparison:")
+        print("\nrand() 1D uniform comparison:")
         print(f"  Python first 5 values: {py_rand[:5]}")
         print(f"  MATLAB first 5 values: {ml_rand[:5]}")
         print(f"  Max absolute diff: {np.max(np.abs(py_rand - ml_rand)):.2e}")
 
-        np.testing.assert_allclose(py_rand, ml_rand, rtol=1e-15, atol=1e-15,
-                                   err_msg="rand() 1D uniform should produce identical sequences")
+        np.testing.assert_allclose(
+            py_rand, ml_rand, rtol=1e-15, atol=1e-15, err_msg="rand() 1D uniform should produce identical sequences"
+        )
 
     def test_rng_normal_incompatibility(self):
         """Test that randn() (normal) produces DIFFERENT sequences (known incompatibility)."""
@@ -99,15 +100,16 @@ class TestRNGParity(unittest.TestCase):
         os.remove(temp_file)
 
         # Compare randn (normal distribution) - THIS SHOULD DIFFER
-        print(f"\nrandn() normal comparison (EXPECTED TO DIFFER):")
+        print("\nrandn() normal comparison (EXPECTED TO DIFFER):")
         print(f"  Python first 3 values: {py_randn.flatten()[:3]}")
         print(f"  MATLAB first 3 values: {ml_randn.flatten()[:3]}")
         print(f"  Max absolute diff: {np.max(np.abs(py_randn - ml_randn)):.2e}")
 
         are_different = not np.allclose(py_randn, ml_randn, rtol=1e-10, atol=1e-10)
-        self.assertTrue(are_different,
-                       "randn() normal distribution differs between Python and MATLAB "
-                       "(this is expected - use rand() for parity)")
+        self.assertTrue(
+            are_different,
+            "randn() normal distribution differs between Python and MATLAB (this is expected - use rand() for parity)",
+        )
 
     def test_rand_sample_mechanism(self):
         """Test the rand_sample mechanism that provides MATLAB parity."""
@@ -116,7 +118,7 @@ class TestRNGParity(unittest.TestCase):
 
         seed = 5489
         n = 20  # sample from 20 items
-        m = 5   # select 5 items
+        m = 5  # select 5 items
 
         # Python rand_sample (from ransac.py)
         rng_py = np.random.RandomState(seed)
@@ -156,12 +158,11 @@ class TestRNGParity(unittest.TestCase):
         os.remove(temp_file)
 
         # Compare
-        print(f"\nrand_sample comparison:")
+        print("\nrand_sample comparison:")
         print(f"  Python sample: {py_sample}")
         print(f"  MATLAB sample: {ml_sample}")
 
-        np.testing.assert_array_equal(py_sample, ml_sample,
-                                     err_msg="rand_sample should produce identical results")
+        np.testing.assert_array_equal(py_sample, ml_sample, err_msg="rand_sample should produce identical results")
 
     def test_round_mat_parity(self):
         """Test that round_mat matches MATLAB's round() behavior."""
@@ -191,13 +192,12 @@ class TestRNGParity(unittest.TestCase):
         os.remove(temp_file)
 
         # Compare
-        print(f"\nround_mat comparison:")
+        print("\nround_mat comparison:")
         print(f"  Test values:  {test_values}")
         print(f"  Python round: {py_rounded}")
         print(f"  MATLAB round: {ml_rounded}")
 
-        np.testing.assert_array_equal(py_rounded, ml_rounded,
-                                     err_msg="round_mat should match MATLAB round()")
+        np.testing.assert_array_equal(py_rounded, ml_rounded, err_msg="round_mat should match MATLAB round()")
 
     def test_rng_permutation_compatibility(self):
         """Test that permutation differs (known incompatibility)."""
@@ -230,15 +230,17 @@ class TestRNGParity(unittest.TestCase):
         # Check if they differ (they should - different algorithms)
         are_different = not np.array_equal(py_perm, ml_perm)
 
-        print(f"\nPermutation comparison (EXPECTED TO DIFFER):")
+        print("\nPermutation comparison (EXPECTED TO DIFFER):")
         print(f"  Python permutation: {py_perm[:5]}...")
         print(f"  MATLAB permutation: {ml_perm[:5]}...")
         print(f"  Are different: {are_different}")
 
         # Document this known incompatibility
-        self.assertTrue(are_different,
-                       "Permutation algorithms differ between Python and MATLAB "
-                       "(this is expected - randperm uses different algorithm than permutation)")
+        self.assertTrue(
+            are_different,
+            "Permutation algorithms differ between Python and MATLAB "
+            "(this is expected - randperm uses different algorithm than permutation)",
+        )
 
 
 class TestRNGIsolation(unittest.TestCase):
@@ -257,8 +259,7 @@ class TestRNGIsolation(unittest.TestCase):
         seq2 = rng2.rand(100)
 
         # Should be identical
-        np.testing.assert_array_equal(seq1, seq2,
-                                     err_msg="Same seed should produce identical sequence")
+        np.testing.assert_array_equal(seq1, seq2, err_msg="Same seed should produce identical sequence")
 
     def test_python_rng_different_seeds(self):
         """Test that different seeds produce different sequences."""
@@ -269,8 +270,7 @@ class TestRNGIsolation(unittest.TestCase):
         seq2 = rng2.rand(100)
 
         # Should be different
-        self.assertFalse(np.array_equal(seq1, seq2),
-                        "Different seeds should produce different sequences")
+        self.assertFalse(np.array_equal(seq1, seq2), "Different seeds should produce different sequences")
 
     def test_matlab_default_seed_value(self):
         """Document that 5489 is MATLAB's default seed."""
@@ -288,13 +288,18 @@ class TestRNGIsolation(unittest.TestCase):
         # Expected first value when using seed 5489
         # (Verified against MATLAB: rng(5489,'twister'); rand)
         expected_first_uniform_value = 0.8147236863931789  # Matches MATLAB output
+        self.assertAlmostEqual(first_uniform_value, expected_first_uniform_value)
 
         # Reset and check
         rng = np.random.RandomState(matlab_default_seed)
         actual_first_uniform_value = rng.rand()
 
-        self.assertAlmostEqual(actual_first_uniform_value, expected_first_uniform_value, places=15,
-                              msg="MATLAB default seed (5489) should produce expected first uniform value")
+        self.assertAlmostEqual(
+            actual_first_uniform_value,
+            expected_first_uniform_value,
+            places=15,
+            msg="MATLAB default seed (5489) should produce expected first uniform value",
+        )
 
     def test_rand_sample_deterministic(self):
         """Test that rand_sample is deterministic."""
@@ -311,8 +316,7 @@ class TestRNGIsolation(unittest.TestCase):
         sample2 = rand_sample(n, m, rng2)
 
         # Should be identical
-        np.testing.assert_array_equal(sample1, sample2,
-                                     err_msg="rand_sample with same seed should be deterministic")
+        np.testing.assert_array_equal(sample1, sample2, err_msg="rand_sample with same seed should be deterministic")
 
     def test_round_mat_tie_breaking(self):
         """Test round_mat's tie-breaking behavior (rounds away from zero)."""
@@ -320,11 +324,11 @@ class TestRNGIsolation(unittest.TestCase):
         # Python's round() rounds ties to even (banker's rounding)
         # round_mat should match MATLAB
 
-        self.assertEqual(round_mat(0.5), 1.0)   # Round up
+        self.assertEqual(round_mat(0.5), 1.0)  # Round up
         self.assertEqual(round_mat(-0.5), -1.0)  # Round down (away from zero)
-        self.assertEqual(round_mat(1.5), 2.0)   # Round up
+        self.assertEqual(round_mat(1.5), 2.0)  # Round up
         self.assertEqual(round_mat(-1.5), -2.0)  # Round down (away from zero)
-        self.assertEqual(round_mat(2.5), 3.0)   # Round up
+        self.assertEqual(round_mat(2.5), 3.0)  # Round up
 
 
 if __name__ == '__main__':

--- a/tests/test_pinv.py
+++ b/tests/test_pinv.py
@@ -100,7 +100,7 @@ class TestPinvParity(unittest.TestCase):
         py_out = pinv(A)
         ml_out = self.eeglab.pinv(A)
 
-        print(f"\nLarge matrix test (64x64):")
+        print("\nLarge matrix test (64x64):")
         print(f"Python output shape: {py_out.shape}, dtype: {py_out.dtype}")
         print(f"MATLAB output shape: {ml_out.shape}, dtype: {ml_out.dtype}")
 
@@ -138,9 +138,10 @@ class TestPinvParity(unittest.TestCase):
         print(f"Adaptive tolerance ({adaptive_tol:.2e}) success: {success_adaptive}")
 
         # The test should pass with adaptive tolerance
-        self.assertTrue(success_adaptive,
-                       f"Large matrix pseudoinverse failed with max_diff={max_diff:.2e}, "
-                       f"rel_error={rel_error:.2e}")
+        self.assertTrue(
+            success_adaptive,
+            f"Large matrix pseudoinverse failed with max_diff={max_diff:.2e}, rel_error={rel_error:.2e}",
+        )
 
     def test_parity_large_matrix_rectangular(self):
         """Test pseudoinverse of a large rectangular matrix (64x32)."""
@@ -150,7 +151,7 @@ class TestPinvParity(unittest.TestCase):
         py_out = pinv(A)
         ml_out = self.eeglab.pinv(A)
 
-        print(f"\nLarge rectangular matrix test (64x32):")
+        print("\nLarge rectangular matrix test (64x32):")
         print(f"Python output shape: {py_out.shape}, dtype: {py_out.dtype}")
         print(f"MATLAB output shape: {ml_out.shape}, dtype: {ml_out.dtype}")
 
@@ -167,8 +168,7 @@ class TestPinvParity(unittest.TestCase):
         success_adaptive = np.allclose(py_out, ml_out, rtol=adaptive_tol, atol=adaptive_tol)
         print(f"Adaptive tolerance ({adaptive_tol:.2e}) success: {success_adaptive}")
 
-        self.assertTrue(success_adaptive,
-                       f"Large rectangular matrix pseudoinverse failed with max_diff={max_diff:.2e}")
+        self.assertTrue(success_adaptive, f"Large rectangular matrix pseudoinverse failed with max_diff={max_diff:.2e}")
 
     def test_parity_ill_conditioned_matrix(self):
         """Test pseudoinverse of an ill-conditioned matrix."""
@@ -183,7 +183,7 @@ class TestPinvParity(unittest.TestCase):
         py_out = pinv(A)
         ml_out = self.eeglab.pinv(A)
 
-        print(f"\nIll-conditioned matrix test (32x32):")
+        print("\nIll-conditioned matrix test (32x32):")
         print(f"Condition number: {np.linalg.cond(A):.2e}")
         print(f"Python output shape: {py_out.shape}, dtype: {py_out.dtype}")
         print(f"MATLAB output shape: {ml_out.shape}, dtype: {ml_out.dtype}")
@@ -198,8 +198,7 @@ class TestPinvParity(unittest.TestCase):
         success_adaptive = np.allclose(py_out, ml_out, rtol=adaptive_tol, atol=adaptive_tol)
         print(f"Adaptive tolerance ({adaptive_tol:.2e}) success: {success_adaptive}")
 
-        self.assertTrue(success_adaptive,
-                       f"Ill-conditioned matrix pseudoinverse failed with max_diff={max_diff:.2e}")
+        self.assertTrue(success_adaptive, f"Ill-conditioned matrix pseudoinverse failed with max_diff={max_diff:.2e}")
 
     def test_alternative_methods_for_precision(self):
         """Test different methods for computing pseudoinverse to improve precision."""
@@ -210,7 +209,7 @@ class TestPinvParity(unittest.TestCase):
         # Get MATLAB result
         ml_out = self.eeglab.pinv(A)
 
-        print(f"\nTesting alternative methods for precision:")
+        print("\nTesting alternative methods for precision:")
         print(f"Matrix condition number: {np.linalg.cond(A):.2e}")
 
         # Test different methods
@@ -257,7 +256,7 @@ class TestPinvParity(unittest.TestCase):
         U, s, Vt = np.linalg.svd(A, full_matrices=False)
         matlab_tol = max(A.shape) * np.finfo(A.dtype).eps * np.max(s)
 
-        print(f"\nMATLAB tolerance matching test:")
+        print("\nMATLAB tolerance matching test:")
         print(f"MATLAB default tolerance: {matlab_tol:.2e}")
         print(f"Max singular value: {np.max(s):.2e}")
         print(f"Min singular value: {np.min(s):.2e}")
@@ -327,8 +326,7 @@ class TestPinvFunctional(unittest.TestCase):
         result = pinv(A)
 
         # Result should be float (may be float64 or complex if needed)
-        self.assertTrue(np.issubdtype(result.dtype, np.floating) or
-                       np.issubdtype(result.dtype, np.complexfloating))
+        self.assertTrue(np.issubdtype(result.dtype, np.floating) or np.issubdtype(result.dtype, np.complexfloating))
 
 
 if __name__ == '__main__':

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,10 @@
 """
 Test suite for pipeline: clean_artifacts -> eeg_picard -> iclabel
 """
+
 import os
 import re
 import unittest
-import numpy as np
 from copy import deepcopy
 from eegprep import pop_loadset, clean_artifacts, eeg_picard, iclabel
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
@@ -15,6 +15,7 @@ from eegprep.utils.testing import (
     has_optional_dependency,
     matlab_function_exists,
 )
+
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 def test_pipeline():
@@ -30,8 +31,15 @@ def test_pipeline():
     eeglab = get_eeglab('MAT')
     EEG_mat_ch = eeglab.clean_artifacts(deepcopy(EEG), 'BurstCriterion', 'off', 'ChannelCriterion', 0.8)
     # eeg_compare(EEG_py_ch, EEG_mat_ch)
-    compare_eeg(EEG_py_ch['data'], EEG_mat_ch['data'], rtol=0.005, atol=1e-5, err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed')
+    compare_eeg(
+        EEG_py_ch['data'],
+        EEG_mat_ch['data'],
+        rtol=0.005,
+        atol=1e-5,
+        err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed',
+    )
     print("clean_artifacts() channel cleaning Python vs MATLAB passed\n\n\n")
+
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestPipeline(DebuggableTestCase):
@@ -53,18 +61,18 @@ class TestPipeline(DebuggableTestCase):
         # MATLAB also needs a fresh copy since it may modify the EEG structure
         EEG_mat_ch = self.eeglab.clean_artifacts(deepcopy(self.EEG), 'BurstCriterion', 'off', 'ChannelCriterion', 0.8)
 
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Step 1: clean_artifacts (channel cleaning only)")
-        print("="*80)
+        print("=" * 80)
         summary = compare_eeg(
             EEG_py_ch['data'],
             EEG_mat_ch['data'],
             rtol=0.005,
             atol=1e-5,
-            err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed'
+            err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed',
         )
         print(summary)
-        print("="*80 + "\n")
+        print("=" * 80 + "\n")
 
     def test_clean_artifacts_burst_cleaning(self):
         """Test clean_artifacts burst cleaning step (ChannelCriterion='off')."""
@@ -76,9 +84,9 @@ class TestPipeline(DebuggableTestCase):
         EEG_py, *_ = clean_artifacts(EEG_py_ch, ChannelCriterion='off')
         EEG_mat = self.eeglab.clean_artifacts(EEG_mat_ch, 'ChannelCriterion', 'off', 'BurstCriterion', 5.0)
 
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Step 1b: clean_artifacts (burst cleaning only)")
-        print("="*80)
+        print("=" * 80)
         eeg_summary = eeg_compare(EEG_py, EEG_mat)
         print(f"\n{eeg_summary}")
         data_summary = compare_eeg(
@@ -86,10 +94,10 @@ class TestPipeline(DebuggableTestCase):
             EEG_mat['data'],
             rtol=0.005,
             atol=1e-5,
-            err_msg='clean_artifacts() burst cleaning Python vs MATLAB failed'
+            err_msg='clean_artifacts() burst cleaning Python vs MATLAB failed',
         )
         print(f"\n{data_summary}")
-        print("="*80 + "\n")
+        print("=" * 80 + "\n")
 
     def test_eeg_picard(self):
         """Test eeg_picard ICA decomposition."""
@@ -107,9 +115,9 @@ class TestPipeline(DebuggableTestCase):
         EEG_mat_ica = eeg_picard(EEG_mat, engine=self.eeglab)
 
         # Compare ICA fields
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Step 2: eeg_picard (ICA decomposition)")
-        print("="*80)
+        print("=" * 80)
         for field in ['icaweights', 'icasphere', 'icawinv', 'icaact', 'icachansind']:
             self.assertIn(field, EEG_py_ica, f"Missing ICA field in Python: {field}")
             self.assertIn(field, EEG_mat_ica, f"Missing ICA field in MATLAB: {field}")
@@ -125,7 +133,7 @@ class TestPipeline(DebuggableTestCase):
         print("\nComparing icawinv:")
         winv_summary = eeg_compare(EEG_py_ica['icawinv'], EEG_mat_ica['icawinv'])
         print(winv_summary)
-        print("="*80 + "\n")
+        print("=" * 80 + "\n")
 
     def test_iclabel(self):
         """Test iclabel component classification."""
@@ -147,9 +155,9 @@ class TestPipeline(DebuggableTestCase):
         EEG_mat_lbl = iclabel(EEG_mat_ica, engine='matlab')
 
         # Check ICLabel output structure
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Step 3: iclabel (component classification)")
-        print("="*80)
+        print("=" * 80)
         for EEG_lbl in [EEG_py_lbl, EEG_mat_lbl]:
             self.assertIn('etc', EEG_lbl, 'Missing etc field')
             self.assertIn('ic_classification', EEG_lbl['etc'], 'Missing ic_classification field')
@@ -160,7 +168,7 @@ class TestPipeline(DebuggableTestCase):
         print("\nComparing ICLabel classifications:")
         iclabel_summary = eeg_compare(res_py, res_mat)
         print(iclabel_summary)
-        print("="*80 + "\n")
+        print("=" * 80 + "\n")
 
     def test_z_full_pipeline(self):
         """Test the complete pipeline end-to-end."""
@@ -169,9 +177,9 @@ class TestPipeline(DebuggableTestCase):
         if not has_optional_dependency('torch'):
             self.skipTest("PyTorch is not installed; install eegprep[torch] to run full pipeline parity")
 
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Full Pipeline Test: clean_artifacts -> eeg_picard -> iclabel")
-        print("="*80)
+        print("=" * 80)
 
         # Run the pipeline once and collect all eeg_compare summaries
         summaries = {}
@@ -179,16 +187,26 @@ class TestPipeline(DebuggableTestCase):
         # Step 1: Channel cleaning
         EEG_py_ch, *_ = clean_artifacts(deepcopy(self.EEG), BurstCriterion='off', ChannelCriterion=0.8)
         EEG_mat_ch = self.eeglab.clean_artifacts(deepcopy(self.EEG), 'BurstCriterion', 'off', 'ChannelCriterion', 0.8)
-        data_summary_1 = compare_eeg(EEG_py_ch['data'], EEG_mat_ch['data'], rtol=0.005, atol=1e-5,
-                                     err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed')
+        data_summary_1 = compare_eeg(
+            EEG_py_ch['data'],
+            EEG_mat_ch['data'],
+            rtol=0.005,
+            atol=1e-5,
+            err_msg='clean_artifacts() channel cleaning Python vs MATLAB failed',
+        )
         print(f"\nStep 1 - Channel cleaning data comparison:\n{data_summary_1}")
 
         # Step 1b: Burst cleaning
         EEG_py, *_ = clean_artifacts(EEG_py_ch, ChannelCriterion='off')
         EEG_mat = self.eeglab.clean_artifacts(EEG_mat_ch, 'ChannelCriterion', 'off', 'BurstCriterion', 5.0)
         summaries['burst_cleaning_eeg'] = eeg_compare(EEG_py, EEG_mat)
-        data_summary_1b = compare_eeg(EEG_py['data'], EEG_mat['data'], rtol=0.005, atol=1e-5,
-                                      err_msg='clean_artifacts() burst cleaning Python vs MATLAB failed')
+        data_summary_1b = compare_eeg(
+            EEG_py['data'],
+            EEG_mat['data'],
+            rtol=0.005,
+            atol=1e-5,
+            err_msg='clean_artifacts() burst cleaning Python vs MATLAB failed',
+        )
         print(f"\nStep 1b - Burst cleaning data comparison:\n{data_summary_1b}")
 
         # Step 2: ICA
@@ -206,9 +224,9 @@ class TestPipeline(DebuggableTestCase):
         summaries['iclabel_classifications'] = eeg_compare(res_py, res_mat)
 
         # Print consolidated eeg_compare summary as a table
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Full Pipeline Test - Consolidated eeg_compare Summary Table")
-        print("="*80)
+        print("=" * 80)
 
         # Helper function to extract metrics from summary string
         def extract_metrics(summary_str):
@@ -218,7 +236,7 @@ class TestPipeline(DebuggableTestCase):
                 'mean_abs_diff': 'N/A',
                 'rms_diff': 'N/A',
                 'max_rel_diff': 'N/A',
-                'mismatch_pct': 'N/A'
+                'mismatch_pct': 'N/A',
             }
             if 'Array Comparison Summary' in summary_str:
                 for line in summary_str.split('\n'):
@@ -263,8 +281,7 @@ class TestPipeline(DebuggableTestCase):
                     step_name = 'Step 2: eeg_picard'
                 else:
                     step_name = ''
-                step_data.append((f'  {array_name}' if idx > 0 else step_name,
-                                array_metrics, array_summary))
+                step_data.append((f'  {array_name}' if idx > 0 else step_name, array_metrics, array_summary))
 
         # Step 3: iclabel
         if 'iclabel_classifications' in summaries:
@@ -273,12 +290,16 @@ class TestPipeline(DebuggableTestCase):
             step_data.append(('Step 3: iclabel', step3_metrics, step3_summary))
 
         # Print table
-        print(f"\n{'Step':<30} {'Max Abs Diff':<18} {'Mean Abs Diff':<18} {'RMS Diff':<18} {'Max Rel Diff':<18} {'Mismatch %':<15}")
+        print(
+            f"\n{'Step':<30} {'Max Abs Diff':<18} {'Mean Abs Diff':<18} {'RMS Diff':<18} {'Max Rel Diff':<18} {'Mismatch %':<15}"
+        )
         print("-" * 120)
 
         for step_name, metrics, _ in step_data:
-            print(f"{step_name:<30} {metrics['max_abs_diff']:<18} {metrics['mean_abs_diff']:<18} "
-                  f"{metrics['rms_diff']:<18} {metrics['max_rel_diff']:<18} {metrics['mismatch_pct']:<15}")
+            print(
+                f"{step_name:<30} {metrics['max_abs_diff']:<18} {metrics['mean_abs_diff']:<18} "
+                f"{metrics['rms_diff']:<18} {metrics['max_rel_diff']:<18} {metrics['mismatch_pct']:<15}"
+            )
 
         print("-" * 120)
         print("\nDetailed summaries:")
@@ -286,9 +307,9 @@ class TestPipeline(DebuggableTestCase):
             print(f"\n{step_name}:")
             print(summary)
 
-        print("\n" + "="*80)
+        print("\n" + "=" * 80)
         print("Full pipeline test completed successfully!")
-        print("="*80 + "\n")
+        print("=" * 80 + "\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_pop_epoch.py
+++ b/tests/test_pop_epoch.py
@@ -20,7 +20,6 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch, pop_epoch_dialog_spec
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestPopEpochParity(unittest.TestCase):
-
     def setUp(self):
         np.random.seed(42)
         try:
@@ -57,7 +56,7 @@ class TestPopEpochParity(unittest.TestCase):
                 {'type': 'S2', 'latency': 350, 'duration': 0},
                 {'type': 'S1', 'latency': 550, 'duration': 0},
                 {'type': 'S3', 'latency': 750, 'duration': 0},
-                {'type': 'S2', 'latency': 850, 'duration': 0}
+                {'type': 'S2', 'latency': 850, 'duration': 0},
             ],
             'epoch': np.array([]),
             'chanlocs': np.array([]),
@@ -83,7 +82,7 @@ class TestPopEpochParity(unittest.TestCase):
             'icawinv': np.array([]),
             'icasphere': np.array([]),
             'icaweights': np.array([]),
-            'icachansind': np.array([])
+            'icachansind': np.array([]),
         }
 
     def test_parity_basic_epoching_all_events(self):
@@ -354,7 +353,7 @@ class TestPopEpochParity(unittest.TestCase):
             # Should return the original EEG and empty indices
             self.assertEqual(eeg_out, test_eeg)
             self.assertEqual(indices, [])
-        except Exception as e:
+        except Exception:
             # If it does raise an exception, that's also acceptable
             pass
 
@@ -386,7 +385,6 @@ class TestPopEpochParity(unittest.TestCase):
 
 
 class TestPopEpochEdgeCases(unittest.TestCase):
-
     def setUp(self):
         np.random.seed(42)
 
@@ -403,12 +401,12 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'xmax': 4.99,
             'setname': 'boundary_test',
             'event': [
-                {'type': 'edge', 'latency': 10},   # Near start
+                {'type': 'edge', 'latency': 10},  # Near start
                 {'type': 'edge', 'latency': 250},  # Middle
-                {'type': 'edge', 'latency': 490}   # Near end
+                {'type': 'edge', 'latency': 490},  # Near end
             ],
             'epoch': [],
-            'saved': 'no'
+            'saved': 'no',
         }
 
         # Large epoch window that should exclude boundary events
@@ -431,13 +429,9 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'xmin': 0.0,
             'xmax': 2.99,
             'setname': 'no_match_test',
-            'event': [
-                {'type': 'A', 'latency': 50},
-                {'type': 'B', 'latency': 150},
-                {'type': 'C', 'latency': 250}
-            ],
+            'event': [{'type': 'A', 'latency': 50}, {'type': 'B', 'latency': 150}, {'type': 'C', 'latency': 250}],
             'epoch': [],
-            'saved': 'no'
+            'saved': 'no',
         }
 
         # Look for event type that doesn't exist
@@ -510,7 +504,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'setname': 'single_test',
             'event': [{'type': 'test', 'latency': 100}],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         eeg_out, indices = pop_epoch([EEG], 'test', [-0.1, 0.1])
@@ -531,7 +525,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'setname': 'epoched_test',
             'event': [],  # No events
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         eeg_out, indices = pop_epoch(EEG, [], [-0.2, 0.2])
@@ -545,7 +539,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'data': np.random.randn(2, 200).astype(np.float32),
             'srate': 100.0,
             'event': [{'type': 'test'}],  # Missing latency
-            'saved': 'no'
+            'saved': 'no',
         }
 
         with self.assertRaises(ValueError):
@@ -564,7 +558,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'times': np.linspace(0, 1.99, 200),
             'event': [{'type': 'test', 'latency': 100}],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         # Test with None types and lim (should use all events)
@@ -589,7 +583,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'times': np.linspace(0, 1.99, 200),
             'event': [{'type': 'test', 'latency': 100}],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         eeg_out, indices = pop_epoch(EEG, 'test', [-0.1, 0.1], valuelim=None)
@@ -606,13 +600,9 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'xmin': 0.0,
             'xmax': 1.99,
             'times': np.linspace(0, 1.99, 200),
-            'event': [
-                {'type': 1, 'latency': 50},
-                {'type': 2, 'latency': 100},
-                {'type': 1.5, 'latency': 150}
-            ],
+            'event': [{'type': 1, 'latency': 50}, {'type': 2, 'latency': 100}, {'type': 1.5, 'latency': 150}],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         # Test numeric type matching with string.
@@ -625,7 +615,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'data': np.random.randn(2, 200).astype(np.float32),
             'srate': 100.0,
             'event': [{'type': 'test', 'latency': 100}],
-            'saved': 'no'
+            'saved': 'no',
         }
 
         with self.assertRaises(ValueError):
@@ -637,7 +627,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'data': np.random.randn(2, 200).astype(np.float32),
             'srate': 100.0,
             'event': [{'type': 'test', 'latency': 100}],
-            'saved': 'no'
+            'saved': 'no',
         }
 
         with self.assertRaises(ValueError):
@@ -657,7 +647,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'setname': 'test_dataset',
             'event': [{'type': 'test', 'latency': 100}],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         # Test with list comments
@@ -687,10 +677,10 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'event': [
                 {'type': 'stimulus', 'latency': 100},
                 {'type': 'stimulus', 'latency': 200},
-                {'type': 'stimulus', 'latency': 300}
+                {'type': 'stimulus', 'latency': 300},
             ],
             'epoch': np.array([]),
-            'saved': 'no'
+            'saved': 'no',
         }
 
         eeg_out, indices = pop_epoch(EEG, 'stimulus', [-0.2, 0.3])
@@ -701,11 +691,13 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             # Convert to list for appending
             eeg_out['event'] = list(eeg_out['event'])
             print("Converted eeg_out['event'] from numpy array to list for appending new event.")
-        eeg_out['event'].append({
-            'type': 'boundary',
-            'latency': 25,  # Within first epoch
-            'epoch': 1
-        })
+        eeg_out['event'].append(
+            {
+                'type': 'boundary',
+                'latency': 25,  # Within first epoch
+                'epoch': 1,
+            }
+        )
 
         # Test the boundary detection (this tests the code path but won't actually remove epochs
         # since pop_select would need proper implementation)
@@ -717,7 +709,7 @@ class TestPopEpochEdgeCases(unittest.TestCase):
             'data': 'filename.dat',  # String instead of array
             'srate': 100.0,
             'event': [{'type': 'test', 'latency': 100}],
-            'saved': 'no'
+            'saved': 'no',
         }
 
         with self.assertRaises(NotImplementedError):
@@ -821,7 +813,9 @@ class TestPopEpochGuiAndHistory(unittest.TestCase):
         spec = pop_epoch_dialog_spec(self.EEG)
         widgets = {"limits": _FakeWidget("0.2 -0.1"), "valuelim": _FakeWidget("")}
 
-        self.assertEqual(QtDialogRenderer._validation_message(spec, widgets), "Epoch start must be lower than epoch end")
+        self.assertEqual(
+            QtDialogRenderer._validation_message(spec, widgets), "Epoch start must be lower than epoch end"
+        )
 
     def test_multiple_datasets_return_com_uses_console_contract(self):
         eeg2 = copy.deepcopy(self.EEG)

--- a/tests/test_pop_interp.py
+++ b/tests/test_pop_interp.py
@@ -298,10 +298,13 @@ class PopInterpGuiSpecTests(unittest.TestCase):
         with patch("eegprep.functions.guifunc.qt.pop_chansel", return_value=([1, 2], "M1 M2", ["M1", "M2"])):
             QtDialogRenderer._select_interp_channels(None, target, params)
 
-        self.assertEqual(QtDialogRenderer._read_widget(target), {
-            "chans": [{"labels": "M1"}, {"labels": "M2"}],
-            "chanstr": "EEG.chaninfo.removedchans([1 2])",
-        })
+        self.assertEqual(
+            QtDialogRenderer._read_widget(target),
+            {
+                "chans": [{"labels": "M1"}, {"labels": "M2"}],
+                "chanstr": "EEG.chaninfo.removedchans([1 2])",
+            },
+        )
 
     def test_interp_selectchan_callback_uses_alleeg_subset_history_expression(self):
         target = _Target()
@@ -317,10 +320,13 @@ class PopInterpGuiSpecTests(unittest.TestCase):
         ):
             QtDialogRenderer._select_interp_channels(None, target, params)
 
-        self.assertEqual(QtDialogRenderer._read_widget(target), {
-            "chans": [{"labels": "Pz"}],
-            "chanstr": "ALLEEG(1).chanlocs([2])",
-        })
+        self.assertEqual(
+            QtDialogRenderer._read_widget(target),
+            {
+                "chans": [{"labels": "Pz"}],
+                "chanstr": "ALLEEG(1).chanlocs([2])",
+            },
+        )
 
     def test_interp_uselist_callback_uses_alleeg_full_history_expression(self):
         target = _Target()
@@ -333,10 +339,13 @@ class PopInterpGuiSpecTests(unittest.TestCase):
         with patch("eegprep.functions.guifunc.qt._require_qt", return_value=(object(), _FakeQtWidgets)):
             QtDialogRenderer._select_interp_channels(None, target, params)
 
-        self.assertEqual(QtDialogRenderer._read_widget(target), {
-            "chans": [{"labels": "Pz"}, {"labels": "Oz"}],
-            "chanstr": "ALLEEG(1).chanlocs",
-        })
+        self.assertEqual(
+            QtDialogRenderer._read_widget(target),
+            {
+                "chans": [{"labels": "Pz"}, {"labels": "Oz"}],
+                "chanstr": "ALLEEG(1).chanlocs",
+            },
+        )
 
 
 class _Target:

--- a/tests/test_pop_loadset_h5.py
+++ b/tests/test_pop_loadset_h5.py
@@ -7,7 +7,6 @@ from HDF5 format files.
 
 import os
 import unittest
-import os
 
 if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
     raise unittest.SkipTest("MATLAB not available")
@@ -24,6 +23,7 @@ from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
 from eegprep.utils.testing import DebuggableTestCase
 from eegprep.functions.popfunc.eeg_compare import eeg_compare
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
+
 
 class TestPopLoadsetH5(DebuggableTestCase):
     """Test cases for pop_loadset_h5 function."""
@@ -74,7 +74,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
             if include_chanlocs:
                 chanlocs_group = eeg_group.create_group('chanlocs')
                 # Create fields as arrays with one element per channel
-                labels_data = [f'Ch{i+1}'.encode() for i in range(32)]
+                labels_data = [f'Ch{i + 1}'.encode() for i in range(32)]
                 x_data = [np.cos(i * 2 * np.pi / 32) for i in range(32)]
                 y_data = [np.sin(i * 2 * np.pi / 32) for i in range(32)]
                 z_data = [0.0 for i in range(32)]
@@ -201,7 +201,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
         # Check individual channel properties
         for i, chan in enumerate(EEG['chanlocs']):
             # Handle both string and bytes format
-            expected_label = f'Ch{i+1}'
+            expected_label = f'Ch{i + 1}'
             actual_label = chan['labels'].decode('utf-8') if isinstance(chan['labels'], bytes) else chan['labels']
             self.assertEqual(actual_label, expected_label)
 
@@ -375,6 +375,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
         # Should handle Unicode strings (special case in the code)
         self.assertEqual(EEG['unicode_string'], 'hello 👖')
 
+
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestPopLoadsetH5Parity(unittest.TestCase):
     """Test parity between Python pop_loadset_h5 and MATLAB pop_loadset for real HDF5 files."""
@@ -383,6 +384,7 @@ class TestPopLoadsetH5Parity(unittest.TestCase):
         """Set up MATLAB connection for parity testing."""
         try:
             from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+
             self.eeglab = get_eeglab('MAT')
             self.matlab_available = True
         except Exception as e:
@@ -420,6 +422,7 @@ class TestPopLoadsetH5Parity(unittest.TestCase):
         ml_eeg = self.eeglab.pop_loadset('filename', 'eeglab_data_epochs_ica.set', 'filepath', data_dir)
 
         eeg_compare(py_eeg, ml_eeg)
+
 
 class TestPopLoadsetH5RealData(unittest.TestCase):
     """Test pop_loadset_h5 with real HDF5 files without MATLAB dependency."""
@@ -556,6 +559,7 @@ class TestPopLoadsetH5RealData(unittest.TestCase):
         EEG2 = pop_loadset_h5('sample_data/eeglab_data_epochs_ica_hdf5.set')
 
         eeg_compare(EEG1, EEG2)
+
 
 if __name__ == '__main__':
     # test test_load_epoched_data only

--- a/tests/test_pop_reref.py
+++ b/tests/test_pop_reref.py
@@ -20,6 +20,7 @@ from eegprep.functions.popfunc.pop_reref import pop_reref
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.utils.testing import DebuggableTestCase
 import importlib
+
 eeg_checkset_module = importlib.import_module('eegprep.functions.adminfunc.eeg_checkset')
 
 
@@ -86,15 +87,17 @@ class TestPopReref(DebuggableTestCase):
         # Create channel locations
         chanlocs = []
         for i in range(nbchan):
-            chanlocs.append({
-                'labels': f'Ch{i+1}',
-                'X': np.cos(2 * np.pi * i / nbchan),
-                'Y': np.sin(2 * np.pi * i / nbchan),
-                'Z': 0.0,
-                'theta': 2 * np.pi * i / nbchan,
-                'radius': 0.5,
-                'ref': 'common'  # Initial reference
-            })
+            chanlocs.append(
+                {
+                    'labels': f'Ch{i + 1}',
+                    'X': np.cos(2 * np.pi * i / nbchan),
+                    'Y': np.sin(2 * np.pi * i / nbchan),
+                    'Z': 0.0,
+                    'theta': 2 * np.pi * i / nbchan,
+                    'radius': 0.5,
+                    'ref': 'common',  # Initial reference
+                }
+            )
 
         # Create ICA components equal to number of channels
         icaweights = np.random.randn(nbchan, nbchan).astype(np.float64)
@@ -112,7 +115,7 @@ class TestPopReref(DebuggableTestCase):
             'icawinv': icawinv,
             'icasphere': icasphere,
             'icachansind': list(range(nbchan)),  # All channels used for ICA
-            'ref': 'common'
+            'ref': 'common',
         }
 
     def create_simple_eeg(self, nbchan=4, pnts=40):
@@ -127,16 +130,18 @@ class TestPopReref(DebuggableTestCase):
         chanlocs = []
         for idx in range(nbchan):
             x, y, z = coords[idx]
-            chanlocs.append({
-                'labels': f'Ch{idx + 1}',
-                'X': x,
-                'Y': y,
-                'Z': z,
-                'theta': 0.0,
-                'radius': 0.5,
-                'type': 'EEG',
-                'ref': 'common',
-            })
+            chanlocs.append(
+                {
+                    'labels': f'Ch{idx + 1}',
+                    'X': x,
+                    'Y': y,
+                    'Z': z,
+                    'theta': 0.0,
+                    'radius': 0.5,
+                    'type': 'EEG',
+                    'ref': 'common',
+                }
+            )
         data = np.arange(nbchan * pnts, dtype=np.float64).reshape(nbchan, pnts) / 10.0
         return {
             'data': data,
@@ -211,14 +216,17 @@ class TestPopReref(DebuggableTestCase):
         icachansind = np.asarray(EEG.get('icachansind', []), dtype=np.float64)
         if icachansind.size:
             icachansind = icachansind + 1
-        scipy.io.savemat(temp_input, {
-            'data_in': EEG['data'],
-            'icaweights_in': EEG.get('icaweights', np.array([])),
-            'icawinv_in': EEG.get('icawinv', np.array([])),
-            'icasphere_in': EEG.get('icasphere', np.array([])),
-            'icaact_in': EEG.get('icaact', np.array([])),
-            'icachansind_in': icachansind,
-        })
+        scipy.io.savemat(
+            temp_input,
+            {
+                'data_in': EEG['data'],
+                'icaweights_in': EEG.get('icaweights', np.array([])),
+                'icawinv_in': EEG.get('icawinv', np.array([])),
+                'icasphere_in': EEG.get('icasphere', np.array([])),
+                'icaact_in': EEG.get('icaact', np.array([])),
+                'icachansind_in': icachansind,
+            },
+        )
 
         chanlocs_code = self._matlab_locs_code('EEG.chanlocs', EEG.get('chanlocs', []))
         urchanlocs_code = self._matlab_locs_code('EEG.urchanlocs', EEG.get('urchanlocs', []))
@@ -480,16 +488,18 @@ class TestPopReref(DebuggableTestCase):
         """Test EEGLAB error path when refloc is provided without removedchans."""
         EEG = self.create_simple_eeg(nbchan=2, pnts=20)
         EEG['chaninfo'] = {
-            'nodatchans': [{
-                'labels': 'M1',
-                'X': 0.0,
-                'Y': -1.0,
-                'Z': 0.0,
-                'theta': -90.0,
-                'radius': 0.5,
-                'type': 'REF',
-                'ref': 'common',
-            }]
+            'nodatchans': [
+                {
+                    'labels': 'M1',
+                    'X': 0.0,
+                    'Y': -1.0,
+                    'Z': 0.0,
+                    'theta': -90.0,
+                    'radius': 0.5,
+                    'type': 'REF',
+                    'ref': 'common',
+                }
+            ]
         }
 
         with self.assertRaisesRegex(ValueError, "Missing reference channel information"):
@@ -529,12 +539,14 @@ class TestPopReref(DebuggableTestCase):
     def test_refica_backwardcomp_rereferences_ica_maps(self):
         """Test EEGLAB backwardcomp path still updates ICA maps."""
         EEG = self.create_simple_eeg(nbchan=4, pnts=20)
-        EEG['icawinv'] = np.array([
-            [1.0, 0.2, 0.1, 0.0],
-            [0.1, 1.0, 0.2, 0.1],
-            [0.0, 0.1, 1.0, 0.2],
-            [0.2, 0.0, 0.1, 1.0],
-        ])
+        EEG['icawinv'] = np.array(
+            [
+                [1.0, 0.2, 0.1, 0.0],
+                [0.1, 1.0, 0.2, 0.1],
+                [0.0, 0.1, 1.0, 0.2],
+                [0.2, 0.0, 0.1, 1.0],
+            ]
+        )
         EEG['icaweights'] = np.linalg.pinv(EEG['icawinv'])
         EEG['icasphere'] = np.eye(4)
         EEG['icaact'] = np.ones((4, EEG['pnts']))
@@ -561,11 +573,13 @@ class TestPopReref(DebuggableTestCase):
         }
         EEG['urchanlocs'] = EEG['chanlocs'] + [removed]
         EEG['chaninfo'] = {'removedchans': [removed]}
-        EEG['icawinv'] = np.array([
-            [1.0, 0.2, 0.1],
-            [0.1, 1.0, 0.2],
-            [0.2, 0.1, 1.0],
-        ])
+        EEG['icawinv'] = np.array(
+            [
+                [1.0, 0.2, 0.1],
+                [0.1, 1.0, 0.2],
+                [0.2, 0.1, 1.0],
+            ]
+        )
         EEG['icaweights'] = np.linalg.pinv(EEG['icawinv'])
         EEG['icasphere'] = np.eye(3)
         EEG['icaact'] = np.ones((3, EEG['pnts']))
@@ -616,7 +630,6 @@ class TestPopReref(DebuggableTestCase):
     def test_single_channel(self):
         """Test with single channel (edge case)."""
         EEG = self.create_test_eeg(nbchan=1, pnts=100)
-        original_data = EEG['data'].copy()
 
         result = pop_reref(EEG, ref=None)
 
@@ -630,14 +643,12 @@ class TestPopReref(DebuggableTestCase):
     def test_multiple_trials(self):
         """Test with multiple trials."""
         EEG = self.create_test_eeg(nbchan=8, pnts=100, trials=5)
-        original_data = EEG['data'].copy()
 
         result = pop_reref(EEG, ref=None)
 
         # Check that mean is subtracted for each time point and trial
         for trial in range(EEG['trials']):
             for time in range(EEG['pnts']):
-                original_mean = np.mean(original_data[:, time, trial])
                 new_mean = np.mean(result['data'][:, time, trial])
                 self.assertAlmostEqual(new_mean, 0, places=6)
 
@@ -671,14 +682,26 @@ class TestPopReref(DebuggableTestCase):
         EEG = self.create_test_eeg(nbchan=8, pnts=100)
 
         # Make copies to avoid modification effects
-        EEG1 = {key: value.copy() if isinstance(value, np.ndarray) else
-                ([item.copy() if isinstance(item, dict) else item for item in value]
-                 if isinstance(value, list) else value)
-                for key, value in EEG.items()}
-        EEG2 = {key: value.copy() if isinstance(value, np.ndarray) else
-                ([item.copy() if isinstance(item, dict) else item for item in value]
-                 if isinstance(value, list) else value)
-                for key, value in EEG.items()}
+        EEG1 = {
+            key: value.copy()
+            if isinstance(value, np.ndarray)
+            else (
+                [item.copy() if isinstance(item, dict) else item for item in value]
+                if isinstance(value, list)
+                else value
+            )
+            for key, value in EEG.items()
+        }
+        EEG2 = {
+            key: value.copy()
+            if isinstance(value, np.ndarray)
+            else (
+                [item.copy() if isinstance(item, dict) else item for item in value]
+                if isinstance(value, list)
+                else value
+            )
+            for key, value in EEG.items()
+        }
 
         result1 = pop_reref(EEG1, ref=None)
         result2 = pop_reref(EEG2, ref=None)
@@ -872,8 +895,9 @@ class TestPopReref(DebuggableTestCase):
 
         # Compare data (should match closely for average reference)
         # Data re-referencing: max abs diff ~1e-4 due to float32/float64 precision
-        np.testing.assert_allclose(py_result['data'], data_ml, rtol=1e-3, atol=1e-3,
-                                   err_msg="Data re-referencing differs from MATLAB")
+        np.testing.assert_allclose(
+            py_result['data'], data_ml, rtol=1e-3, atol=1e-3, err_msg="Data re-referencing differs from MATLAB"
+        )
 
     def test_parity_explicit_reference_keepref_with_matlab(self):
         """Test MATLAB parity for explicit common reference with keepref."""
@@ -964,12 +988,14 @@ class TestPopReref(DebuggableTestCase):
     def test_parity_refica_average_with_matlab(self):
         """Test MATLAB parity for average reference ICA map update."""
         EEG = self.create_simple_eeg(nbchan=4, pnts=20)
-        EEG['icawinv'] = np.array([
-            [1.0, 0.2, 0.1, 0.0],
-            [0.1, 1.0, 0.2, 0.1],
-            [0.0, 0.1, 1.0, 0.2],
-            [0.2, 0.0, 0.1, 1.0],
-        ])
+        EEG['icawinv'] = np.array(
+            [
+                [1.0, 0.2, 0.1, 0.0],
+                [0.1, 1.0, 0.2, 0.1],
+                [0.0, 0.1, 1.0, 0.2],
+                [0.2, 0.0, 0.1, 1.0],
+            ]
+        )
         EEG['icaweights'] = np.linalg.pinv(EEG['icawinv'])
         EEG['icasphere'] = np.eye(4)
         EEG['icaact'] = np.ones((4, EEG['pnts']))
@@ -984,12 +1010,14 @@ class TestPopReref(DebuggableTestCase):
     def test_parity_refica_backwardcomp_with_matlab(self):
         """Test MATLAB parity for backwardcomp ICA handling."""
         EEG = self.create_simple_eeg(nbchan=4, pnts=20)
-        EEG['icawinv'] = np.array([
-            [1.0, 0.2, 0.1, 0.0],
-            [0.1, 1.0, 0.2, 0.1],
-            [0.0, 0.1, 1.0, 0.2],
-            [0.2, 0.0, 0.1, 1.0],
-        ])
+        EEG['icawinv'] = np.array(
+            [
+                [1.0, 0.2, 0.1, 0.0],
+                [0.1, 1.0, 0.2, 0.1],
+                [0.0, 0.1, 1.0, 0.2],
+                [0.2, 0.0, 0.1, 1.0],
+            ]
+        )
         EEG['icaweights'] = np.linalg.pinv(EEG['icawinv'])
         EEG['icasphere'] = np.eye(4)
         EEG['icaact'] = np.ones((4, EEG['pnts']))

--- a/tests/test_pop_resample.py
+++ b/tests/test_pop_resample.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import os
 
 if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
     raise unittest.SkipTest("MATLAB not available")
@@ -10,8 +9,8 @@ from eegprep import pop_loadset, pop_resample, pop_saveset  # Explicitly import 
 # where the test resources
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
-class TestPopResample(unittest.TestCase):
 
+class TestPopResample(unittest.TestCase):
     def setUp(self):
         self.EEG = pop_loadset(os.path.join(local_url, 'eeglab_data_with_ica_tmp.set'))
         self.new_freq = 96  # New sampling rate in Hz
@@ -20,10 +19,14 @@ class TestPopResample(unittest.TestCase):
         """Test basic resampling functionality with different engines"""
         # Apply resampling with different engines
         EEG_python = pop_resample(self.EEG.copy(), self.new_freq, engine='poly')
-        pop_saveset(EEG_python, os.path.join(local_url, 'eeglab_data_with_ica_tmp_python.set')) # see MATLAB code to compare the results at the end of the file
+        pop_saveset(
+            EEG_python, os.path.join(local_url, 'eeglab_data_with_ica_tmp_python.set')
+        )  # see MATLAB code to compare the results at the end of the file
 
         EEG_matlab = pop_resample(self.EEG.copy(), self.new_freq, engine='matlab')
-        pop_saveset(EEG_matlab, os.path.join(local_url, 'eeglab_data_with_ica_tmp_matlab.set')) # see MATLAB code to compare the results at the end of the file
+        pop_saveset(
+            EEG_matlab, os.path.join(local_url, 'eeglab_data_with_ica_tmp_matlab.set')
+        )  # see MATLAB code to compare the results at the end of the file
 
         # EEG_octave = pop_resample(self.EEG.copy(), self.new_freq, engine='octave')
         # pop_saveset(EEG_octave, os.path.join(local_url, 'eeglab_data_with_ica_tmp_octave.set')) # see MATLAB code to compare the results at the end of the file
@@ -37,16 +40,21 @@ class TestPopResample(unittest.TestCase):
         # print("Sampling rate ok")
 
         # Compare data shapes
-        self.assertEqual(EEG_python['data'].shape[1], EEG_matlab['data'].shape[1],
-                        'Data shapes differ between Python and MATLAB')
+        self.assertEqual(
+            EEG_python['data'].shape[1], EEG_matlab['data'].shape[1], 'Data shapes differ between Python and MATLAB'
+        )
         print("Data shape ok")
         # self.assertEqual(EEG_python['data'].shape[1], EEG_octave['data'].shape[1],
         #                 'Data shapes differ between Python and Octave')
         # print("Data shape ok")
         # Compare data with tolerance
-        np.testing.assert_allclose(EEG_python['data'], EEG_matlab['data'],
-                                 rtol=1e-5, atol=1e-8,
-                                 err_msg='Python and MATLAB results differ beyond tolerance')
+        np.testing.assert_allclose(
+            EEG_python['data'],
+            EEG_matlab['data'],
+            rtol=1e-5,
+            atol=1e-8,
+            err_msg='Python and MATLAB results differ beyond tolerance',
+        )
         # np.testing.assert_allclose(EEG_matlab['data'].flatten(), EEG_octave['data'].flatten(),
         #                          rtol=1e-5, atol=1e-8,
         #                          err_msg='Python and MATLAB results differ beyond tolerance')
@@ -63,6 +71,7 @@ class TestPopResample(unittest.TestCase):
 
     def test_advanced(self):
         pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pop_rmbase.py
+++ b/tests/test_pop_rmbase.py
@@ -1,25 +1,19 @@
 import os
-import sys
 import unittest
-import os
 
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
-import sys
 import numpy as np
-
-# Ensure tests dir is in path for unittest discovery
-test_dir = os.path.dirname(os.path.abspath(__file__))
-if test_dir not in sys.path:
-    sys.path.insert(0, test_dir)
 
 from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+
 try:
     from .fixtures import create_test_eeg
 except (ImportError, ValueError):
     from fixtures import create_test_eeg
+
+if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
+    raise unittest.SkipTest("MATLAB not available")
 
 
 # where the test resources
@@ -33,12 +27,12 @@ def ensure_file(fname: str) -> str:
     local_file = os.path.abspath(f"{local_url}{fname}")
     if not os.path.exists(local_file):
         from urllib.request import urlretrieve
+
         urlretrieve(full_url, local_file)
     return local_file
 
 
 class TestPopRmbaseFunctional(unittest.TestCase):
-
     def test_epoched_pointrange_all_channels(self):
         # Create epoched EEG: nbchan x pnts x trials
         EEG = create_test_eeg(n_channels=4, n_samples=200, srate=200.0, n_trials=3)
@@ -56,7 +50,6 @@ class TestPopRmbaseFunctional(unittest.TestCase):
 
     def test_epoched_chanlist_subset(self):
         EEG = create_test_eeg(n_channels=5, n_samples=100, srate=100.0, n_trials=2)
-        data_before = EEG['data'].copy()
         # Only baseline-correct channels 1 and 3 (0-based indices)
         out = pop_rmbase(EEG, pointrange=[1, 30], chanlist=[1, 3])
         m_sel = np.mean(out['data'][[1, 3], 0:30, :], axis=1)
@@ -77,7 +70,7 @@ class TestPopRmbaseFunctional(unittest.TestCase):
         EEG = create_test_eeg(n_channels=2, n_samples=200, srate=200.0, n_trials=1)
         # Add two boundary events splitting into three segments within baseline window
         EEG['event'] = [
-            {'type': 'boundary', 'latency': 51.0},   # 1-based → between 50 and 51 (0-based split at 50)
+            {'type': 'boundary', 'latency': 51.0},  # 1-based → between 50 and 51 (0-based split at 50)
             {'type': 'boundary', 'latency': 151.0},  # split at 150
         ]
         # Full baseline range
@@ -97,7 +90,7 @@ class TestPopRmbaseFunctional(unittest.TestCase):
         out = pop_rmbase(EEG, timerange=[0.10, 0.49])
         a = 10
         b = 49
-        m = np.mean(out['data'][:, a:b+1], axis=1)
+        m = np.mean(out['data'][:, a : b + 1], axis=1)
         self.assertTrue(np.allclose(m, 0.0, atol=1e-10))
 
     def test_bad_timerange_raises(self):
@@ -114,7 +107,6 @@ class TestPopRmbaseFunctional(unittest.TestCase):
 
 
 class TestPopRmbaseParity(unittest.TestCase):
-
     def setUp(self):
         # Load a real dataset used across tests
         self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
@@ -143,7 +135,6 @@ class TestPopRmbaseParity(unittest.TestCase):
         nbchan = int(self.EEG['nbchan'])
         chanlist = list(range(0, min(5, nbchan)))
 
-
         EEG_py = pop_rmbase(self.EEG.copy(), pointrange=pr, chanlist=chanlist)
         EEG_ml = self.eeglab.pop_rmbase(self.EEG.copy(), [], pr, np.array(chanlist) + 1)  # MATLAB 1-based
 
@@ -154,4 +145,3 @@ class TestPopRmbaseParity(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_pop_saveset.py
+++ b/tests/test_pop_saveset.py
@@ -1,8 +1,6 @@
 import os
 import unittest
-import numpy as np
-from eegprep import pop_loadset, pop_resample, pop_saveset  # Explicitly import pop_resample
-
+from eegprep import pop_loadset, pop_saveset  # Explicitly import pop_resample
 
 
 # where the test resources
@@ -12,28 +10,34 @@ local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 web_root = 'https://sccntestdatasets.s3.us-east-2.amazonaws.com/'
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
+
 def ensure_file(fname: str) -> str:
     """Download a file if it does not exist and return the local path."""
     full_url = f"{web_root}{fname}"
     local_file = f"{local_url}{fname}"
     if not os.path.exists(local_file):
         from urllib.request import urlretrieve
+
         urlretrieve(full_url, local_file)
     return local_file
 
-class TestPopSaveset(unittest.TestCase):
 
+class TestPopSaveset(unittest.TestCase):
     def setUp(self):
         pass
 
     def test_flanker(self):
         pass
         self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
-        pop_saveset(self.EEG, os.path.join(local_url, 'eeglab_data_tmp.set')) # see MATLAB code to compare the results at the end of the file
+        pop_saveset(
+            self.EEG, os.path.join(local_url, 'eeglab_data_tmp.set')
+        )  # see MATLAB code to compare the results at the end of the file
 
     def test_basic(self):
         self.EEG = pop_loadset(os.path.join(local_url, 'eeglab_data_with_ica_tmp.set'))
-        pop_saveset(self.EEG, os.path.join(local_url, 'eeglab_data_tmp.set')) # see MATLAB code to compare the results at the end of the file
+        pop_saveset(
+            self.EEG, os.path.join(local_url, 'eeglab_data_tmp.set')
+        )  # see MATLAB code to compare the results at the end of the file
         # """Test basic resampling functionality with different engines"""
         # # Apply resampling with different engines
         # EEG_python = pop_resample(self.EEG.copy(), self.new_freq, engine='scipy')

--- a/tests/test_pop_select.py
+++ b/tests/test_pop_select.py
@@ -3,11 +3,9 @@ import os
 import unittest
 import numpy as np
 import copy
-import os
 
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
-from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
 from eegprep.functions.popfunc.pop_select import pop_select
 from eegprep.functions.popfunc.pop_epoch import pop_epoch
 
@@ -15,14 +13,17 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch
 web_root = 'https://sccntestdatasets.s3.us-east-2.amazonaws.com/'
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
-def ensure_file(fname: str) -> str: # duplicate of test_clean_rawdata.py
+
+def ensure_file(fname: str) -> str:  # duplicate of test_clean_rawdata.py
     """Download a file if it does not exist and return the local path."""
     full_url = f"{web_root}{fname}"
     local_file = os.path.abspath(f"{local_url}{fname}")
     if not os.path.exists(local_file):
         from urllib.request import urlretrieve
+
         urlretrieve(full_url, local_file)
     return local_file
+
 
 def _chan_labels(EEG):
     labs = []
@@ -35,11 +36,10 @@ def _chan_labels(EEG):
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
 class TestPopSelectParity(unittest.TestCase):
-
     def setUp(self):
         # Load the same dataset in both backends
         self.EEG_py = pop_loadset(ensure_file('FlankerTest.set'))
-        self.eeglab = get_eeglab('MAT')       # MATLAB bridge
+        self.eeglab = get_eeglab('MAT')  # MATLAB bridge
 
     def test_parity_channel_by_name(self):
         # Keep first 3 channels by name to avoid 0 vs 1-based index differences
@@ -49,7 +49,7 @@ class TestPopSelectParity(unittest.TestCase):
 
         EEG_py_in1 = copy.deepcopy(self.EEG_py)
         EEG_py_in2 = copy.deepcopy(self.EEG_py)
-        EEG_py_out =              pop_select(EEG_py_in1, channel=keep_names)
+        EEG_py_out = pop_select(EEG_py_in1, channel=keep_names)
         EEG_mat_out = self.eeglab.pop_select(EEG_py_in2, 'channel', keep_names)
 
         # Shapes and metadata
@@ -73,7 +73,7 @@ class TestPopSelectParity(unittest.TestCase):
         k = min(5, trials)
         keep_trials = list(range(1, k + 1))  # 1-based
 
-        EEG_py_out =              pop_select(copy.deepcopy(EEG_py_epochs), trial=keep_trials)
+        EEG_py_out = pop_select(copy.deepcopy(EEG_py_epochs), trial=keep_trials)
         EEG_mat_out = self.eeglab.pop_select(copy.deepcopy(EEG_py_epochs), 'trial', keep_trials)
 
         self.assertEqual(EEG_py_out['trials'], k)
@@ -94,7 +94,7 @@ class TestPopSelectParity(unittest.TestCase):
         tmin = xmin
         tmax = xmin + min(0.2, max(0.05, xmax - xmin))
 
-        EEG_py_out =              pop_select(copy.deepcopy(self.EEG_py), time=np.array([[tmin, tmax]], dtype=float))
+        EEG_py_out = pop_select(copy.deepcopy(self.EEG_py), time=np.array([[tmin, tmax]], dtype=float))
         EEG_mat_out = self.eeglab.pop_select(copy.deepcopy(self.EEG_py), 'time', np.array([tmin, tmax]))
 
         self.assertTrue(np.allclose(EEG_py_out['xmin'], tmin, atol=1e-12))
@@ -120,7 +120,7 @@ class TestPopSelectParity(unittest.TestCase):
         # Remove a middle slice
         rm_seg = np.array([[xmin + 0.1 * span, xmin + 0.2 * span]], dtype=float)
 
-        EEG_py_out =              pop_select(copy.deepcopy(self.EEG_py), rmtime=rm_seg)
+        EEG_py_out = pop_select(copy.deepcopy(self.EEG_py), rmtime=rm_seg)
         EEG_mat_out = self.eeglab.pop_select(copy.deepcopy(self.EEG_py), 'rmtime', rm_seg.flatten())
 
         self.assertEqual(EEG_py_out['pnts'], EEG_mat_out['pnts'])
@@ -128,10 +128,12 @@ class TestPopSelectParity(unittest.TestCase):
         self.assertEqual(EEG_py_out['nbchan'], EEG_mat_out['nbchan'])
         # Compare data only up to the smaller size due to potential boundary differences
         min_pnts = min(EEG_py_out['pnts'], EEG_mat_out['pnts'])
-        self.assertTrue(np.allclose(EEG_py_out['data'][:, :min_pnts], EEG_mat_out['data'][:, :min_pnts], atol=1e-7, equal_nan=True))
+        self.assertTrue(
+            np.allclose(EEG_py_out['data'][:, :min_pnts], EEG_mat_out['data'][:, :min_pnts], atol=1e-7, equal_nan=True)
+        )
+
 
 class TestPopSelectFunctional(unittest.TestCase):
-
     def setUp(self):
         self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
 
@@ -168,7 +170,9 @@ class TestPopSelectFunctional(unittest.TestCase):
         # choose a 10-sample window via points
         pt_start = 1
         pt_end = min(self.EEG['pnts'], 10)
-        EEG_out = pop_select(copy.deepcopy(self.EEG), point=[pt_start, pt_end], time=[[xmin, xmin + 1000.0]])  # absurd time to force precedence
+        EEG_out = pop_select(
+            copy.deepcopy(self.EEG), point=[pt_start, pt_end], time=[[xmin, xmin + 1000.0]]
+        )  # absurd time to force precedence
 
         # Expect exactly pt_end - pt_start + 1 samples in output
         expected_pnts = pt_end - pt_start + 1
@@ -194,7 +198,7 @@ class TestPopSelectFunctional(unittest.TestCase):
     def test_event_epoch_field_removal_on_single_trial(self):
         EEG = copy.deepcopy(self.EEG)
         if int(EEG.get('trials')) > 2:
-            EEG_out = pop_select(EEG, trial=[1,2])
+            EEG_out = pop_select(EEG, trial=[1, 2])
 
             self.assertEqual(np.asarray(EEG_out.get('epoch')).size, 0)
 
@@ -216,12 +220,12 @@ class TestPopSelectEdgeCases(unittest.TestCase):
                 {'labels': 'Fz', 'X': 0, 'Y': 1, 'Z': 0},
                 {'labels': 'Cz', 'X': 0, 'Y': 0, 'Z': 1},
                 {'labels': 'Pz', 'X': 0, 'Y': -1, 'Z': 0},
-                {'labels': 'Oz', 'X': 0, 'Y': -1, 'Z': -1}
+                {'labels': 'Oz', 'X': 0, 'Y': -1, 'Z': -1},
             ],
             'event': [
                 {'type': 'stimulus', 'latency': 50, 'epoch': 1},
                 {'type': 'response', 'latency': 150, 'epoch': 2},
-                {'type': 'stimulus', 'latency': 250, 'epoch': 3}
+                {'type': 'stimulus', 'latency': 250, 'epoch': 3},
             ],
             'epoch': [{}, {}, {}],
             'icaact': None,
@@ -235,7 +239,7 @@ class TestPopSelectEdgeCases(unittest.TestCase):
             'stats': {},
             'dipfit': None,
             'roi': None,
-            'chaninfo': {}
+            'chaninfo': {},
         }
 
     def test_missing_data_error(self):
@@ -420,8 +424,6 @@ class TestPopSelectEdgeCases(unittest.TestCase):
         # When trials [3, 1] are selected, they become new trials [1, 2]
         # So original epoch 3 becomes new epoch 1, and original epoch 1 becomes new epoch 2
         if len(EEG_out['event']) >= 2:
-            # Find events by their original type to verify mapping
-            event_types = [ev['type'] for ev in EEG_out['event']]
             # The event from original epoch 3 should now be in epoch 1
             # The event from original epoch 1 should now be in epoch 2
             self.assertEqual(len(EEG_out['event']), 2)

--- a/tests/test_pop_utils.py
+++ b/tests/test_pop_utils.py
@@ -39,7 +39,9 @@ class PopUtilsTests(unittest.TestCase):
         self.assertEqual(format_history_value(np.array([[1, 2], [3, 4]])), "[1 2; 3 4]")
         self.assertEqual(format_history_value(["Fz", "Cz"]), "{'Fz' 'Cz'}")
         self.assertEqual(format_history_value([-np.inf, np.inf]), "[-Inf Inf]")
-        self.assertEqual(format_history_value(PureWindowsPath("sample_data/eeglab_data.set")), "'sample_data/eeglab_data.set'")
+        self.assertEqual(
+            format_history_value(PureWindowsPath("sample_data/eeglab_data.set")), "'sample_data/eeglab_data.set'"
+        )
 
     def test_format_history_value_supports_pop_specific_options(self):
         self.assertEqual(format_history_value(True, bool_style="onoff"), "'on'")

--- a/tests/test_pymat.py
+++ b/tests/test_pymat.py
@@ -1,14 +1,11 @@
 import unittest
 import numpy as np
-import tempfile
-import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from eegprep.functions.adminfunc.pymat import py2mat, mat2py, default_empty
 
 
 class TestPy2Mat(unittest.TestCase):
-
     def test_py2mat_none_input(self):
         """Test py2mat with None input."""
         result = py2mat(None)
@@ -26,10 +23,7 @@ class TestPy2Mat(unittest.TestCase):
 
     def test_py2mat_list_of_dicts(self):
         """Test py2mat with list of dictionaries."""
-        input_dicts = [
-            {'name': 'item1', 'value': 1.5},
-            {'name': 'item2', 'value': 2.5}
-        ]
+        input_dicts = [{'name': 'item1', 'value': 1.5}, {'name': 'item2', 'value': 2.5}]
         result = py2mat(input_dicts)
 
         self.assertEqual(len(result), 2)
@@ -56,10 +50,7 @@ class TestPy2Mat(unittest.TestCase):
 
     def test_py2mat_nested_dict(self):
         """Test py2mat with nested dictionary."""
-        input_dict = {
-            'name': 'parent',
-            'child': {'nested_name': 'child', 'nested_value': 100}
-        }
+        input_dict = {'name': 'parent', 'child': {'nested_name': 'child', 'nested_value': 100}}
         result = py2mat(input_dict)
 
         self.assertEqual(len(result), 1)
@@ -82,10 +73,7 @@ class TestPy2Mat(unittest.TestCase):
 
     def test_py2mat_numpy_array_values(self):
         """Test py2mat with numpy arrays as values."""
-        input_dict = {
-            'data': np.array([1, 2, 3]),
-            'matrix': np.array([[1, 2], [3, 4]])
-        }
+        input_dict = {'data': np.array([1, 2, 3]), 'matrix': np.array([[1, 2], [3, 4]])}
         result = py2mat(input_dict)
 
         self.assertEqual(len(result), 1)
@@ -94,10 +82,7 @@ class TestPy2Mat(unittest.TestCase):
 
     def test_py2mat_numpy_array_of_dicts(self):
         """Test py2mat with numpy array containing dictionaries."""
-        dict_array = np.array([
-            {'sensor': 'A', 'reading': 1.2},
-            {'sensor': 'B', 'reading': 2.3}
-        ], dtype=object)
+        dict_array = np.array([{'sensor': 'A', 'reading': 1.2}, {'sensor': 'B', 'reading': 2.3}], dtype=object)
 
         input_dict = {'measurements': dict_array}
         result = py2mat(input_dict)
@@ -113,7 +98,7 @@ class TestPy2Mat(unittest.TestCase):
             'list_data': [1, 2, 3],
             'tuple_data': (4, 5, 6),
             'empty_list': [],
-            'nested_list': [[1, 2], [3, 4]]
+            'nested_list': [[1, 2], [3, 4]],
         }
         result = py2mat(input_dict)
 
@@ -128,10 +113,7 @@ class TestPy2Mat(unittest.TestCase):
 
     def test_py2mat_string_handling(self):
         """Test py2mat handles strings correctly."""
-        input_dicts = [
-            {'short': 'hi', 'long': 'this is a longer string'},
-            {'short': 'bye', 'long': 'another string'}
-        ]
+        input_dicts = [{'short': 'hi', 'long': 'this is a longer string'}, {'short': 'bye', 'long': 'another string'}]
         result = py2mat(input_dicts)
 
         self.assertEqual(len(result), 2)
@@ -144,7 +126,13 @@ class TestPy2Mat(unittest.TestCase):
         """Test py2mat handles None values appropriately."""
         input_dicts = [
             {'string_field': 'hello', 'int_field': 42, 'float_field': 3.14, 'bool_field': True, 'none_field': None},
-            {'string_field': None, 'int_field': None, 'float_field': None, 'bool_field': None, 'none_field': 'not_none'}
+            {
+                'string_field': None,
+                'int_field': None,
+                'float_field': None,
+                'bool_field': None,
+                'none_field': 'not_none',
+            },
         ]
         result = py2mat(input_dicts)
 
@@ -158,7 +146,7 @@ class TestPy2Mat(unittest.TestCase):
 
         # Second row - check None handling
         self.assertEqual(result[1]['string_field'], '')  # None -> empty string
-        self.assertEqual(result[1]['int_field'], 0)      # None -> 0
+        self.assertEqual(result[1]['int_field'], 0)  # None -> 0
         self.assertTrue(np.isnan(result[1]['float_field']))  # None -> NaN
         self.assertEqual(result[1]['bool_field'], False)  # None -> False
 
@@ -189,7 +177,6 @@ class TestPy2Mat(unittest.TestCase):
 
 
 class TestMat2Py(unittest.TestCase):
-
     def test_mat2py_dict(self):
         """Test mat2py with dictionary input."""
         input_dict = {'a': np.array([1, 2, 3]), 'b': 'hello'}
@@ -319,6 +306,7 @@ class TestMat2Py(unittest.TestCase):
 
     def test_mat2py_scipy_mat_struct(self):
         """Test mat2py with scipy.io.matlab.mat_struct."""
+
         # Create a mock class that behaves like mat_struct
         class MockMatStruct:
             def __init__(self):
@@ -340,6 +328,7 @@ class TestMat2Py(unittest.TestCase):
 
     def test_mat2py_object_with_attributes(self):
         """Test mat2py with object that has attributes."""
+
         class TestObject:
             def __init__(self):
                 self.public_attr = 'public_value'
@@ -360,6 +349,7 @@ class TestMat2Py(unittest.TestCase):
 
     def test_mat2py_object_with_no_accessible_attributes(self):
         """Test mat2py with object that has no accessible attributes."""
+
         class EmptyObject:
             def __init__(self):
                 self._private_only = 'private'
@@ -375,6 +365,7 @@ class TestMat2Py(unittest.TestCase):
 
     def test_mat2py_fallback(self):
         """Test mat2py fallback for unknown types."""
+
         class UnknownType:
             pass
 
@@ -432,13 +423,14 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_mat2py_complex_dtype(self):
         """Test mat2py with complex number arrays."""
-        complex_array = np.array([1+2j, 3+4j])
+        complex_array = np.array([1 + 2j, 3 + 4j])
         result = mat2py(complex_array)
 
         np.testing.assert_array_equal(result, complex_array)
 
     def test_mat2py_attribute_access_error(self):
         """Test mat2py handles attribute access errors gracefully."""
+
         class ProblematicObject:
             @property
             def problematic_attr(self):
@@ -472,11 +464,7 @@ class TestTypeHandling(unittest.TestCase):
 
     def test_py2mat_numpy_scalar_types(self):
         """Test py2mat with numpy scalar types."""
-        input_dict = {
-            'np_int': np.int32(42),
-            'np_float': np.float64(3.14),
-            'np_bool': np.bool_(True)
-        }
+        input_dict = {'np_int': np.int32(42), 'np_float': np.float64(3.14), 'np_bool': np.bool_(True)}
         result = py2mat(input_dict)
 
         self.assertEqual(len(result), 1)
@@ -510,16 +498,10 @@ class TestPyMatEdgeCases(unittest.TestCase):
         """Test py2mat with deeply nested structures."""
         nested_dict = {
             'level1': {
-                'level2': {
-                    'level3': [1, 2, 3],
-                    'data': np.array([4, 5, 6])
-                },
-                'array': np.array([[1, 2], [3, 4]])
+                'level2': {'level3': [1, 2, 3], 'data': np.array([4, 5, 6])},
+                'array': np.array([[1, 2], [3, 4]]),
             },
-            'list_of_dicts': [
-                {'a': 1, 'b': [7, 8]},
-                {'a': 2, 'b': [9, 10]}
-            ]
+            'list_of_dicts': [{'a': 1, 'b': [7, 8]}, {'a': 2, 'b': [9, 10]}],
         }
 
         result = py2mat(nested_dict)
@@ -539,8 +521,8 @@ class TestPyMatEdgeCases(unittest.TestCase):
         test_dict = {
             'int8': np.int8(42),
             'float32': np.float32(2.718),
-            'complex128': np.complex128(3+4j),
-            'bool': np.bool_(True)
+            'complex128': np.complex128(3 + 4j),
+            'bool': np.bool_(True),
         }
 
         result = py2mat(test_dict)
@@ -572,7 +554,7 @@ class TestPyMatEdgeCases(unittest.TestCase):
             'empty_string': '',
             'numeric_string': '12345',
             'special_chars': '!@#$%^&*()',
-            'multiline': 'line1\nline2\nline3'
+            'multiline': 'line1\nline2\nline3',
         }
 
         result = py2mat(test_dict)
@@ -589,7 +571,7 @@ class TestPyMatEdgeCases(unittest.TestCase):
             'inf_value': np.inf,
             'neg_inf': -np.inf,
             'list_with_none': [1, None, 3],
-            'array_with_nan': np.array([1.0, np.nan, 3.0])
+            'array_with_nan': np.array([1.0, np.nan, 3.0]),
         }
 
         result = py2mat(test_dict)
@@ -606,12 +588,7 @@ class TestPyMatEdgeCases(unittest.TestCase):
 
     def test_py2mat_round_trip_validation(self):
         """Test round-trip conversion py2mat -> mat2py."""
-        original_dict = {
-            'string': 'test',
-            'number': 42,
-            'float': 3.14159,
-            'array': np.array([1, 2, 3, 4])
-        }
+        original_dict = {'string': 'test', 'number': 42, 'float': 3.14159, 'array': np.array([1, 2, 3, 4])}
 
         # Convert to MATLAB format
         mat_result = py2mat(original_dict)
@@ -628,11 +605,7 @@ class TestPyMatEdgeCases(unittest.TestCase):
         # Large list of dicts
         large_list = [{'id': i, 'data': np.random.randn(10)} for i in range(100)]
 
-        test_dict = {
-            'large_array': large_array,
-            'large_list': large_list,
-            'metadata': 'test'
-        }
+        test_dict = {'large_array': large_array, 'large_list': large_list, 'metadata': 'test'}
 
         result = py2mat(test_dict)
         self.assertEqual(len(result), 1)
@@ -650,11 +623,7 @@ class TestMat2PyExtended(unittest.TestCase):
     def test_mat2py_basic_conversion(self):
         """Test basic mat2py conversion."""
         # Simulate MATLAB struct-like input
-        matlab_struct = {
-            'string_field': 'test_value',
-            'numeric_field': 42,
-            'array_field': np.array([1, 2, 3, 4])
-        }
+        matlab_struct = {'string_field': 'test_value', 'numeric_field': 42, 'array_field': np.array([1, 2, 3, 4])}
 
         result = mat2py(matlab_struct)
 
@@ -665,13 +634,8 @@ class TestMat2PyExtended(unittest.TestCase):
     def test_mat2py_nested_structures(self):
         """Test mat2py with nested structures."""
         nested_matlab = {
-            'level1': {
-                'level2': {
-                    'data': np.array([1, 2, 3]),
-                    'string': 'nested_value'
-                }
-            },
-            'top_level': 'value'
+            'level1': {'level2': {'data': np.array([1, 2, 3]), 'string': 'nested_value'}},
+            'top_level': 'value',
         }
 
         result = mat2py(nested_matlab)
@@ -687,7 +651,7 @@ class TestMat2PyExtended(unittest.TestCase):
             'scalar': np.array([[42]]),  # 2D scalar that should be squeezed
             'vector': np.array([[1, 2, 3, 4]]),  # Row vector
             'matrix': np.array([[1, 2], [3, 4]]),  # 2D matrix
-            '3d_array': np.random.randn(2, 3, 4)  # 3D array
+            '3d_array': np.random.randn(2, 3, 4),  # 3D array
         }
 
         result = mat2py(test_arrays)
@@ -709,10 +673,7 @@ class TestMat2PyExtended(unittest.TestCase):
         # Simulate MATLAB cell array of strings
         string_cell = np.array(['string1', 'string2', 'string3'], dtype=object)
 
-        test_struct = {
-            'cell_strings': string_cell,
-            'regular_string': 'single_string'
-        }
+        test_struct = {'cell_strings': string_cell, 'regular_string': 'single_string'}
 
         result = mat2py(test_struct)
 
@@ -729,7 +690,7 @@ class TestMat2PyExtended(unittest.TestCase):
             'empty_array': np.array([]),
             'empty_2d': np.array([[]]),
             'none_value': None,
-            'zero_array': np.array([0])
+            'zero_array': np.array([0]),
         }
 
         result = mat2py(test_struct)
@@ -784,14 +745,8 @@ class TestPyMatIntegration(unittest.TestCase):
         # Start with simpler Python structure to avoid complex comparisons
         python_data = {
             'experiment': 'EEG_test',
-            'settings': {
-                'srate': 250.0,
-                'channels': 64
-            },
-            'metadata': {
-                'version': '1.0',
-                'notes': None
-            }
+            'settings': {'srate': 250.0, 'channels': 64},
+            'metadata': {'version': '1.0', 'notes': None},
         }
 
         # Convert to MATLAB format
@@ -826,7 +781,7 @@ class TestPyMatIntegration(unittest.TestCase):
         unusual_dict = {
             'mixed_list': [1, 'string', 3.14, None],
             'empty_nested': {'inner': {}},
-            'list_of_mixed': [1, [2, 3], {'nested': 4}]
+            'list_of_mixed': [1, [2, 3], {'nested': 4}],
         }
 
         result = py2mat(unusual_dict)

--- a/tests/test_runamica.py
+++ b/tests/test_runamica.py
@@ -77,8 +77,7 @@ class TestWriteParamFile(unittest.TestCase):
                 kv[parts[0]] = parts[1]
 
         # Required keys must be present
-        for key in ('files', 'outdir', 'data_dim', 'field_dim',
-                     'num_models', 'max_iter', 'num_mix_comps', 'pcakeep'):
+        for key in ('files', 'outdir', 'data_dim', 'field_dim', 'num_models', 'max_iter', 'num_mix_comps', 'pcakeep'):
             self.assertIn(key, kv, f"Missing required param: {key}")
 
         # Integer params should parse as int
@@ -144,9 +143,9 @@ class TestLoadAmicaOutput(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix='amica_test_load_')
         self.num_models = 1
-        self.nw = 4          # num_pcs
-        self.data_dim = 4    # number of channels
-        self.num_mix = 3     # num_mix_comps
+        self.nw = 4  # num_pcs
+        self.data_dim = 4  # number of channels
+        self.num_mix = 3  # num_mix_comps
         self.max_iter = 50
         self.field_dim = 2000
 
@@ -272,8 +271,7 @@ class TestFindAmicaBinary(unittest.TestCase):
                 _find_amica_binary()
 
 
-@unittest.skipUnless(is_amica_available(),
-                     "AMICA binary not functional on this platform")
+@unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestRunamicaIntegration(unittest.TestCase):
     """Integration test: run AMICA binary on small synthetic data."""
 
@@ -306,10 +304,10 @@ class TestRunamicaIntegration(unittest.TestCase):
         # Reconstruction test: pinv(W@S) @ W @ S @ data ~ data
         WS = weights @ sphere
         from eegprep.functions.miscfunc.pinv import pinv
+
         reconstructed = pinv(WS) @ WS @ data
         np.testing.assert_allclose(
-            reconstructed, data, atol=1e-6,
-            err_msg="AMICA reconstruction should reproduce input data"
+            reconstructed, data, atol=1e-6, err_msg="AMICA reconstruction should reproduce input data"
         )
 
     def test_runamica_custom_outdir(self):
@@ -352,10 +350,9 @@ class TestRunamicaIntegration(unittest.TestCase):
             # LL should generally increase (AMICA maximizes LL).
             # Compare first 10% mean to last 10% mean.
             n = len(LL)
-            early = np.mean(LL[:max(1, n // 10)])
-            late = np.mean(LL[-(max(1, n // 10)):])
-            self.assertGreater(late, early,
-                               "Log-likelihood should increase over training")
+            early = np.mean(LL[: max(1, n // 10)])
+            late = np.mean(LL[-(max(1, n // 10)) :])
+            self.assertGreater(late, early, "Log-likelihood should increase over training")
 
 
 if __name__ == '__main__':

--- a/tests/test_runica.py
+++ b/tests/test_runica.py
@@ -31,9 +31,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(10, 1000)
 
         # Run ICA with limited steps for speed
-        weights, sphere, compvars, bias, signs, lrates = runica(
-            data, maxsteps=10, verbose=False, rndreset='off'
-        )
+        weights, sphere, compvars, bias, signs, lrates = runica(data, maxsteps=10, verbose=False, rndreset='off')
 
         # Check output shapes
         self.assertEqual(weights.shape, (10, 10))
@@ -56,9 +54,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(10, 1000)
 
         # Run extended ICA
-        w, s, compvars, bias, signs, lrates = runica(
-            data, extended=1, maxsteps=10, verbose=False, rndreset='off'
-        )
+        w, s, compvars, bias, signs, lrates = runica(data, extended=1, maxsteps=10, verbose=False, rndreset='off')
 
         # Check signs is a vector (not diagonal matrix)
         self.assertEqual(signs.shape, (10,))
@@ -104,9 +100,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, compvars, bias, signs, lrates = runica(
-            data, sphering='on', maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, compvars, bias, signs, lrates = runica(data, sphering='on', maxsteps=5, verbose=False, rndreset='off')
 
         # Sphere should not be identity
         self.assertFalse(np.allclose(s, np.eye(5)))
@@ -116,9 +110,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, compvars, bias, signs, lrates = runica(
-            data, sphering='off', maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, compvars, bias, signs, lrates = runica(data, sphering='off', maxsteps=5, verbose=False, rndreset='off')
 
         # Sphere should be identity
         self.assertTrue(np.allclose(s, np.eye(5)))
@@ -130,9 +122,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, compvars, bias, signs, lrates = runica(
-            data, sphering='none', maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, compvars, bias, signs, lrates = runica(data, sphering='none', maxsteps=5, verbose=False, rndreset='off')
 
         # Sphere should be identity
         self.assertTrue(np.allclose(s, np.eye(5)))
@@ -143,14 +133,10 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # First run (copy data to avoid modification)
-        w1, s1, cv1, b1, sg1, lr1 = runica(
-            data.copy(), rndreset='off', maxsteps=10, verbose=False
-        )
+        w1, s1, cv1, b1, sg1, lr1 = runica(data.copy(), rndreset='off', maxsteps=10, verbose=False)
 
         # Second run (same data)
-        w2, s2, cv2, b2, sg2, lr2 = runica(
-            data.copy(), rndreset='off', maxsteps=10, verbose=False
-        )
+        w2, s2, cv2, b2, sg2, lr2 = runica(data.copy(), rndreset='off', maxsteps=10, verbose=False)
 
         # Results should be identical
         np.testing.assert_allclose(w1, w2, rtol=1e-12, atol=1e-12)
@@ -164,9 +150,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, cv, bias, sg, lr = runica(
-            data, bias='on', maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, bias='on', maxsteps=5, verbose=False, rndreset='off')
 
         # Bias should be non-zero after training
         self.assertTrue(np.any(bias != 0))
@@ -176,9 +160,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, cv, bias, sg, lr = runica(
-            data, bias='off', maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, bias='off', maxsteps=5, verbose=False, rndreset='off')
 
         # Bias should remain zero
         self.assertTrue(np.all(bias == 0))
@@ -189,9 +171,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # Run with momentum
-        w, s, cv, bias, sg, lr = runica(
-            data, momentum=0.5, maxsteps=10, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, momentum=0.5, maxsteps=10, verbose=False, rndreset='off')
 
         # Should complete without error
         self.assertEqual(w.shape, (5, 5))
@@ -202,9 +182,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # Run with custom learning rate
-        w, s, cv, bias, sg, lr = runica(
-            data, lrate=0.001, maxsteps=10, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, lrate=0.001, maxsteps=10, verbose=False, rndreset='off')
 
         # First learning rate should match input
         self.assertAlmostEqual(lr[0], 0.001, places=6)
@@ -215,9 +193,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # Run with custom block size
-        w, s, cv, bias, sg, lr = runica(
-            data, block=50, maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, block=50, maxsteps=5, verbose=False, rndreset='off')
 
         # Should complete without error
         self.assertEqual(w.shape, (5, 5))
@@ -228,10 +204,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # Run with custom annealing
-        w, s, cv, bias, sg, lr = runica(
-            data, anneal=0.95, annealdeg=45, maxsteps=10,
-            verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, anneal=0.95, annealdeg=45, maxsteps=10, verbose=False, rndreset='off')
 
         # Should complete without error
         self.assertEqual(w.shape, (5, 5))
@@ -242,9 +215,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         data = np.random.randn(5, 500)
 
         # Run with tight stopping criterion
-        w, s, cv, bias, sg, lr = runica(
-            data, stop=1e-8, maxsteps=100, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, stop=1e-8, maxsteps=100, verbose=False, rndreset='off')
 
         # Should converge before maxsteps
         self.assertLessEqual(len(lr), 100)
@@ -254,9 +225,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(5, 500)
 
-        w, s, compvars, bias, sg, lr = runica(
-            data, maxsteps=50, verbose=False, rndreset='off'
-        )
+        w, s, compvars, bias, sg, lr = runica(data, maxsteps=50, verbose=False, rndreset='off')
 
         # Component variances should be in descending order
         self.assertTrue(np.all(compvars[:-1] >= compvars[1:]))
@@ -266,9 +235,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(3, 300)
 
-        w, s, cv, bias, sg, lr = runica(
-            data, maxsteps=10, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, maxsteps=10, verbose=False, rndreset='off')
 
         self.assertEqual(w.shape, (3, 3))
 
@@ -277,9 +244,7 @@ class TestRunicaFunctionality(unittest.TestCase):
         np.random.seed(42)
         data = np.random.randn(35, 1000)
 
-        w, s, cv, bias, sg, lr = runica(
-            data, maxsteps=5, verbose=False, rndreset='off'
-        )
+        w, s, cv, bias, sg, lr = runica(data, maxsteps=5, verbose=False, rndreset='off')
 
         # Should use 1e-7 stopping threshold for >32 channels
         self.assertEqual(w.shape, (35, 35))
@@ -345,9 +310,7 @@ class TestRunicaParity(unittest.TestCase):
         data = np.random.randn(5, 500).astype(np.float64)
 
         # Python runica
-        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(
-            data.copy(), rndreset='off', maxsteps=50, verbose=False
-        )
+        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(data.copy(), rndreset='off', maxsteps=50, verbose=False)
 
         # MATLAB runica
         temp_file = tempfile.mktemp(suffix='.mat')
@@ -364,7 +327,6 @@ class TestRunicaParity(unittest.TestCase):
         ml_data = scipy.io.loadmat(temp_file + '_out.mat')
         w_ml = ml_data['w_ml']
         s_ml = ml_data['s_ml']
-        b_ml = ml_data['b_ml']
 
         # Clean up
         os.remove(temp_file)
@@ -372,10 +334,9 @@ class TestRunicaParity(unittest.TestCase):
 
         # Compare sphere (should be exact - computed before randomness)
         max_sphere_diff = np.max(np.abs(s_py - s_ml))
-        print(f"\nBasic ICA parity:")
+        print("\nBasic ICA parity:")
         print(f"  Max sphere diff: {max_sphere_diff:.2e}")
-        np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12,
-                                  err_msg="Sphere matrices should match")
+        np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12, err_msg="Sphere matrices should match")
 
         # Verify both produced valid ICA decompositions
         # Check that unmixing matrices are invertible
@@ -394,7 +355,6 @@ class TestRunicaParity(unittest.TestCase):
 
         # Verify component variances sum to approximately total variance
         total_var_py = np.sum(cv_py)
-        total_var_ml = np.sum(cv_py)  # Use same Python variance for comparison
 
         print(f"  Python total component variance: {total_var_py:.6f}")
         print(f"  Component variances are ordered: {np.all(cv_py[:-1] >= cv_py[1:])}")
@@ -436,7 +396,6 @@ class TestRunicaParity(unittest.TestCase):
         ml_data = scipy.io.loadmat(temp_file + '_out.mat')
         w_ml = ml_data['w_ml']
         s_ml = ml_data['s_ml']
-        b_ml = ml_data['b_ml']
         sg_ml = ml_data['sg_ml'].flatten()
 
         # Clean up
@@ -445,10 +404,9 @@ class TestRunicaParity(unittest.TestCase):
 
         # Compare sphere (should be exact)
         max_sphere_diff = np.max(np.abs(s_py - s_ml))
-        print(f"\nExtended ICA parity:")
+        print("\nExtended ICA parity:")
         print(f"  Max sphere diff: {max_sphere_diff:.2e}")
-        np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12,
-                                  err_msg="Sphere matrices should match")
+        np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12, err_msg="Sphere matrices should match")
 
         # Compare signs (may differ due to kurtosis estimation randomness)
         print(f"  Python signs: {sg_py}")
@@ -532,9 +490,7 @@ class TestRunicaParity(unittest.TestCase):
         data = np.random.randn(10, 500).astype(np.float64)
 
         # Python runica
-        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(
-            data.copy(), pca=5, rndreset='off', maxsteps=50, verbose=False
-        )
+        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(data.copy(), pca=5, rndreset='off', maxsteps=50, verbose=False)
 
         # MATLAB runica
         temp_file = tempfile.mktemp(suffix='.mat')
@@ -557,7 +513,7 @@ class TestRunicaParity(unittest.TestCase):
         os.remove(temp_file + '_out.mat')
 
         # Compare sphere (should be identity)
-        print(f"\nPCA reduction parity:")
+        print("\nPCA reduction parity:")
         print(f"  Python sphere is identity: {np.allclose(s_py, np.eye(10))}")
         print(f"  MATLAB sphere is identity: {np.allclose(s_ml, np.eye(10))}")
         self.assertTrue(np.allclose(s_py, np.eye(10)))
@@ -616,7 +572,7 @@ class TestRunicaParity(unittest.TestCase):
         os.remove(temp_file + '_out.mat')
 
         # Compare sphere (should be identity)
-        print(f"\nSpheringOff parity:")
+        print("\nSpheringOff parity:")
         print(f"  Python sphere is identity: {np.allclose(s_py, np.eye(5))}")
         print(f"  MATLAB sphere is identity: {np.allclose(s_ml, np.eye(5))}")
         np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12)
@@ -672,7 +628,7 @@ class TestRunicaParity(unittest.TestCase):
 
         # Compare sphere
         max_sphere_diff = np.max(np.abs(s_py - s_ml))
-        print(f"\nBiasOff parity:")
+        print("\nBiasOff parity:")
         print(f"  Max sphere diff: {max_sphere_diff:.2e}")
         np.testing.assert_allclose(s_py, s_ml, rtol=1e-10, atol=1e-12)
 
@@ -708,9 +664,7 @@ class TestRunicaParity(unittest.TestCase):
         data = np.random.randn(5, 1000).astype(np.float64)
 
         # Python runica (more steps for better convergence)
-        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(
-            data.copy(), rndreset='off', maxsteps=200, verbose=False
-        )
+        w_py, s_py, cv_py, b_py, sg_py, lr_py = runica(data.copy(), rndreset='off', maxsteps=200, verbose=False)
 
         # MATLAB runica
         temp_file = tempfile.mktemp(suffix='.mat')
@@ -734,7 +688,7 @@ class TestRunicaParity(unittest.TestCase):
         os.remove(temp_file + '_out.mat')
 
         # Compare convergence behavior
-        print(f"\nConvergence parity:")
+        print("\nConvergence parity:")
         print(f"  Python steps: {len(lr_py)}")
         print(f"  MATLAB steps: {len(lr_ml)}")
         print(f"  Python final lrate: {lr_py[-1]:.6e}")

--- a/tests/test_sample_data_pop_functions.py
+++ b/tests/test_sample_data_pop_functions.py
@@ -620,7 +620,9 @@ def test_pop_chansel_formats_sample_channel_display_and_selection(sample_eeg):
 def test_eeg_store_retrieve_newset_and_delset_use_sample_dataset_indices(sample_eeg):
     alleeg, current, current_set = eeg_store(None, sample_eeg, 0)
     retrieved, alleeg, retrieved_set = eeg_retrieve(alleeg, 1)
-    alleeg, current, current_set, newset_command = pop_newset(alleeg, retrieved, current_set, "setname", "Stored sample")
+    alleeg, current, current_set, newset_command = pop_newset(
+        alleeg, retrieved, current_set, "setname", "Stored sample"
+    )
     alleeg, del_command = pop_delset(alleeg, 1)
 
     assert current["data"].shape == sample_eeg["data"].shape

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -71,25 +71,26 @@ class TestSphericalSplineInterpolate(unittest.TestCase):
         """Set up test fixtures."""
         # Create simple 3D electrode positions (as expected by the function)
         # 4 electrodes on unit sphere
-        self.src_positions = np.array([
-            [1.0, 0.0, 0.0, -1.0],    # x coordinates
-            [0.0, 1.0, 0.0, 0.0],     # y coordinates
-            [0.0, 0.0, 1.0, 0.0]      # z coordinates
-        ])
+        self.src_positions = np.array(
+            [
+                [1.0, 0.0, 0.0, -1.0],  # x coordinates
+                [0.0, 1.0, 0.0, 0.0],  # y coordinates
+                [0.0, 0.0, 1.0, 0.0],  # z coordinates
+            ]
+        )
 
         # Destination positions (where to interpolate)
-        self.dest_positions = np.array([
-            [0.707, -0.707],    # x coordinates
-            [0.707, 0.707],     # y coordinates
-            [0.0, 0.0]          # z coordinates
-        ])
+        self.dest_positions = np.array(
+            [
+                [0.707, -0.707],  # x coordinates
+                [0.707, 0.707],  # y coordinates
+                [0.0, 0.0],  # z coordinates
+            ]
+        )
 
     def test_spherical_spline_interpolate_basic(self):
         """Test basic sphericalSplineInterpolate functionality."""
-        W, Gss, Gds, Hds = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions
-        )
+        W, Gss, Gds, Hds = sphericalSplineInterpolate(self.src_positions, self.dest_positions)
 
         # Check return value shapes
         n_src = self.src_positions.shape[1]
@@ -109,18 +110,10 @@ class TestSphericalSplineInterpolate(unittest.TestCase):
     def test_spherical_spline_interpolate_different_types(self):
         """Test sphericalSplineInterpolate with different interpolation types."""
         # Test 'spline' type (default)
-        W_spline, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            type='spline'
-        )
+        W_spline, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, type='spline')
 
         # Test 'slap' type
-        W_slap, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            type='slap'
-        )
+        W_slap, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, type='slap')
 
         # Both should return finite matrices of the same shape
         self.assertEqual(W_spline.shape, W_slap.shape)
@@ -133,17 +126,9 @@ class TestSphericalSplineInterpolate(unittest.TestCase):
     def test_spherical_spline_interpolate_regularization(self):
         """Test sphericalSplineInterpolate with different regularization parameters."""
         # Test with different lambda values
-        W_low_reg, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            lambda_reg=1e-10
-        )
+        W_low_reg, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, lambda_reg=1e-10)
 
-        W_high_reg, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            lambda_reg=1e-2
-        )
+        W_high_reg, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, lambda_reg=1e-2)
 
         # Both should be finite and same shape
         self.assertEqual(W_low_reg.shape, W_high_reg.shape)
@@ -153,17 +138,9 @@ class TestSphericalSplineInterpolate(unittest.TestCase):
     def test_spherical_spline_interpolate_different_orders(self):
         """Test sphericalSplineInterpolate with different polynomial orders."""
         # Test with different orders
-        W_order2, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            order=2
-        )
+        W_order2, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, order=2)
 
-        W_order6, _, _, _ = sphericalSplineInterpolate(
-            self.src_positions,
-            self.dest_positions,
-            order=6
-        )
+        W_order6, _, _, _ = sphericalSplineInterpolate(self.src_positions, self.dest_positions, order=6)
 
         # Both should be finite and same shape
         self.assertEqual(W_order2.shape, W_order6.shape)
@@ -186,7 +163,7 @@ class TestSphericalSplineInterpolateErrorHandling(unittest.TestCase):
     def test_invalid_interpolation_type(self):
         """Test error handling for invalid interpolation type."""
         src = np.array([[1, 0], [0, 1], [0, 0]])  # 3x2
-        dest = np.array([[0.5], [0.5], [0.0]])   # 3x1
+        dest = np.array([[0.5], [0.5], [0.0]])  # 3x1
 
         with self.assertRaises(ValueError):
             sphericalSplineInterpolate(src, dest, type='invalid_type')
@@ -208,4 +185,3 @@ class TestSphericalSplineInterpolateErrorHandling(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_topoplot.py
+++ b/tests/test_topoplot.py
@@ -1,5 +1,6 @@
 # Disable multithreading for deterministic numerical results in parity tests
 import os
+
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["NUMEXPR_NUM_THREADS"] = "1"
@@ -10,8 +11,7 @@ import unittest
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from unittest.mock import patch, MagicMock
-import warnings
+from unittest.mock import patch
 import tempfile
 import scipy.io
 
@@ -52,7 +52,7 @@ class TestGriddataV4(unittest.TestCase):
         # Find closest grid points to known data points
         for i, (xi, yi, vi) in enumerate(zip(self.x, self.y, self.v)):
             # Find closest grid point
-            dist = np.sqrt((self.xq - xi)**2 + (self.yq - yi)**2)
+            dist = np.sqrt((self.xq - xi) ** 2 + (self.yq - yi) ** 2)
             min_idx = np.unravel_index(np.argmin(dist), dist.shape)
 
             # Value should be close to expected (within interpolation tolerance)
@@ -130,7 +130,7 @@ class TestTopoplot(unittest.TestCase):
             {'labels': 'F3', 'theta': 315, 'radius': 0.5},
             {'labels': 'F4', 'theta': 45, 'radius': 0.5},
             {'labels': 'P3', 'theta': 225, 'radius': 0.5},
-            {'labels': 'P4', 'theta': 135, 'radius': 0.5}
+            {'labels': 'P4', 'theta': 135, 'radius': 0.5},
         ]
 
         # Create synthetic data vector (one value per channel)
@@ -140,7 +140,7 @@ class TestTopoplot(unittest.TestCase):
         self.minimal_chan_locs = [
             {'labels': 'Cz', 'theta': 0, 'radius': 0.0},
             {'labels': 'Fz', 'theta': 0, 'radius': 0.3},
-            {'labels': 'Pz', 'theta': 180, 'radius': 0.3}
+            {'labels': 'Pz', 'theta': 180, 'radius': 0.3},
         ]
         self.minimal_data = np.array([1.0, 0.5, -0.5])
 
@@ -175,11 +175,7 @@ class TestTopoplot(unittest.TestCase):
         # Clear any existing figures first
         plt.close('all')
 
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Should complete without creating plots
         self.assertIsNone(handle)
@@ -191,11 +187,7 @@ class TestTopoplot(unittest.TestCase):
 
     def test_topoplot_with_chanlocs_present(self):
         """Test topoplot with channel locations present."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Should successfully process channel locations
         self.assertIsInstance(Zi, np.ndarray)
@@ -210,19 +202,11 @@ class TestTopoplot(unittest.TestCase):
     def test_topoplot_without_chanlocs(self):
         """Test topoplot with minimal or missing channel location info."""
         # Create channel locations without theta/radius
-        incomplete_chanlocs = [
-            {'labels': 'Ch1'},
-            {'labels': 'Ch2'},
-            {'labels': 'Ch3'}
-        ]
+        incomplete_chanlocs = [{'labels': 'Ch1'}, {'labels': 'Ch2'}, {'labels': 'Ch3'}]
 
         # This should handle missing theta/radius gracefully
         try:
-            handle, Zi, plotrad, xi, yi = topoplot(
-                np.array([1, 0, -1]),
-                incomplete_chanlocs,
-                noplot='on'
-            )
+            handle, Zi, plotrad, xi, yi = topoplot(np.array([1, 0, -1]), incomplete_chanlocs, noplot='on')
             # If it completes, check basic properties
             self.assertIsInstance(Zi, np.ndarray)
         except (KeyError, IndexError, ValueError):
@@ -235,17 +219,13 @@ class TestTopoplot(unittest.TestCase):
         nan_chanlocs = [
             {'labels': 'Ch1', 'theta': 0, 'radius': 0.3},
             {'labels': 'Ch2', 'theta': np.nan, 'radius': 0.4},  # NaN theta
-            {'labels': 'Ch3', 'theta': 90, 'radius': np.nan},   # NaN radius
-            {'labels': 'Ch4', 'theta': 180, 'radius': 0.3}
+            {'labels': 'Ch3', 'theta': 90, 'radius': np.nan},  # NaN radius
+            {'labels': 'Ch4', 'theta': 180, 'radius': 0.3},
         ]
 
         datavector_nan = np.array([1.0, 2.0, -1.0, 0.5])
 
-        handle, Zi, plotrad, xi, yi = topoplot(
-            datavector_nan,
-            nan_chanlocs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(datavector_nan, nan_chanlocs, noplot='on')
 
         # Should handle NaN positions by excluding them
         self.assertIsInstance(Zi, np.ndarray)
@@ -258,11 +238,7 @@ class TestTopoplot(unittest.TestCase):
         nan_datavector[2] = np.nan  # Set one value to NaN
         nan_datavector[5] = np.inf  # Set one value to inf
 
-        handle, Zi, plotrad, xi, yi = topoplot(
-            nan_datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(nan_datavector, self.chan_locs, noplot='on')
 
         # Should handle NaN/inf data values gracefully
         self.assertIsInstance(Zi, np.ndarray)
@@ -275,7 +251,7 @@ class TestTopoplot(unittest.TestCase):
             handle, Zi, plotrad, xi, yi = topoplot(
                 self.minimal_data,
                 self.minimal_chan_locs,
-                noplot='off'  # Enable plotting
+                noplot='off',  # Enable plotting
             )
 
             # Check that plotting components are created
@@ -284,11 +260,7 @@ class TestTopoplot(unittest.TestCase):
 
     def test_color_limits_and_masking(self):
         """Test color limits and head boundary masking."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Check that values outside head boundary are masked (NaN)
         head_mask = np.sqrt(xi**2 + yi**2) <= 0.5  # rmax = 0.5
@@ -310,12 +282,7 @@ class TestTopoplot(unittest.TestCase):
         results = []
         for method in methods:
             with self.subTest(method=method):
-                handle, Zi, plotrad, xi, yi = topoplot(
-                    self.datavector,
-                    self.chan_locs,
-                    noplot='on',
-                    method=method
-                )
+                handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on', method=method)
 
                 results.append(Zi)
 
@@ -330,11 +297,7 @@ class TestTopoplot(unittest.TestCase):
     def test_electrode_display_control(self):
         """Test electrode display control based on number of channels."""
         # Test with few channels (should show electrodes)
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.minimal_data,
-            self.minimal_chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.minimal_data, self.minimal_chan_locs, noplot='on')
         # With 3 channels, ELECTRODES should be 'on'
         self.assertIsInstance(Zi, np.ndarray)
 
@@ -342,31 +305,17 @@ class TestTopoplot(unittest.TestCase):
         many_chanlocs = []
         many_data = []
         for i in range(100):  # More than MAXDEFAULTSHOWLOCS (64)
-            many_chanlocs.append({
-                'labels': f'Ch{i}',
-                'theta': i * 3.6,
-                'radius': 0.3 + (i % 10) * 0.02
-            })
+            many_chanlocs.append({'labels': f'Ch{i}', 'theta': i * 3.6, 'radius': 0.3 + (i % 10) * 0.02})
             many_data.append(np.sin(i * 0.1))
 
-        handle, Zi, plotrad, xi, yi = topoplot(
-            np.array(many_data),
-            many_chanlocs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(np.array(many_data), many_chanlocs, noplot='on')
         # With >64 channels, ELECTRODES should be 'off' but still work
         self.assertIsInstance(Zi, np.ndarray)
 
     def test_custom_parameters(self):
         """Test topoplot with custom parameters."""
         handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on',
-            intrad=0.8,
-            plotrad=0.7,
-            headrad=0.6,
-            ELECTRODES='off'
+            self.datavector, self.chan_locs, noplot='on', intrad=0.8, plotrad=0.7, headrad=0.6, ELECTRODES='off'
         )
 
         # Should complete with custom parameters
@@ -375,12 +324,7 @@ class TestTopoplot(unittest.TestCase):
 
     def test_plotgrid_parameter(self):
         """Test plotgrid parameter."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on',
-            plotgrid='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on', plotgrid='on')
 
         # Should complete with plotgrid enabled
         self.assertIsInstance(Zi, np.ndarray)
@@ -392,11 +336,7 @@ class TestTopoplot(unittest.TestCase):
 
         # Single channel may cause issues due to insufficient data for interpolation
         try:
-            handle, Zi, plotrad, xi, yi = topoplot(
-                single_data,
-                single_chanloc,
-                noplot='on'
-            )
+            handle, Zi, plotrad, xi, yi = topoplot(single_data, single_chanloc, noplot='on')
             # If it succeeds, check basic properties
             self.assertIsInstance(Zi, np.ndarray)
         except (UnboundLocalError, IndexError, ValueError, np.linalg.LinAlgError):
@@ -415,11 +355,7 @@ class TestTopoplot(unittest.TestCase):
 
     def test_coordinate_transformation(self):
         """Test coordinate transformation from polar to Cartesian."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Check that coordinate grids are reasonable
         # Grid should be centered around origin
@@ -433,33 +369,20 @@ class TestTopoplot(unittest.TestCase):
     def test_radius_calculations(self):
         """Test plotrad and intrad calculations."""
         # Test with default radius calculations
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         self.assertGreater(plotrad, 0)
         self.assertLessEqual(plotrad, 1.0)
 
         # Test with custom intrad
-        handle2, Zi2, plotrad2, xi2, yi2 = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on',
-            intrad=0.8
-        )
+        handle2, Zi2, plotrad2, xi2, yi2 = topoplot(self.datavector, self.chan_locs, noplot='on', intrad=0.8)
 
         # plotrad should be adjusted when intrad is specified
         self.assertLessEqual(plotrad2, 0.8)
 
     def test_head_boundary_masking(self):
         """Test that values outside head boundary are properly masked."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Calculate head boundary (rmax = 0.5)
         rmax = 0.5
@@ -473,11 +396,7 @@ class TestTopoplot(unittest.TestCase):
 
     def test_interpolation_grid_properties(self):
         """Test properties of the interpolation grid."""
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Grid should be square
         self.assertEqual(xi.shape[0], xi.shape[1])
@@ -498,11 +417,7 @@ class TestTopoplot(unittest.TestCase):
         # Test with 2D data vector
         data_2d = self.datavector.reshape(-1, 1)
 
-        handle, Zi, plotrad, xi, yi = topoplot(
-            data_2d,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(data_2d, self.chan_locs, noplot='on')
 
         # Should handle 2D input by flattening
         self.assertIsInstance(Zi, np.ndarray)
@@ -512,8 +427,8 @@ class TestTopoplot(unittest.TestCase):
         # Test with matching data and channel counts
         handle, Zi, plotrad, xi, yi = topoplot(
             self.datavector,  # 9 elements
-            self.chan_locs,   # 9 elements
-            noplot='on'
+            self.chan_locs,  # 9 elements
+            noplot='on',
         )
 
         # Should handle matching data gracefully
@@ -525,8 +440,8 @@ class TestTopoplot(unittest.TestCase):
         try:
             handle2, Zi2, plotrad2, xi2, yi2 = topoplot(
                 self.datavector,  # 9 elements
-                extra_chanlocs,   # 10 elements
-                noplot='on'
+                extra_chanlocs,  # 10 elements
+                noplot='on',
             )
             self.assertIsInstance(Zi2, np.ndarray)
         except (IndexError, ValueError):
@@ -539,22 +454,14 @@ class TestTopoplot(unittest.TestCase):
         self.assertEqual(matplotlib.get_backend(), 'Agg')
 
         # Test that function works without display
-        handle, Zi, plotrad, xi, yi = topoplot(
-            self.datavector,
-            self.chan_locs,
-            noplot='on'
-        )
+        handle, Zi, plotrad, xi, yi = topoplot(self.datavector, self.chan_locs, noplot='on')
 
         # Should complete successfully with Agg backend
         self.assertIsInstance(Zi, np.ndarray)
 
         # Test with plotting enabled (should not crash with Agg)
         with patch('matplotlib.pyplot.show'):
-            handle, Zi, plotrad, xi, yi = topoplot(
-                self.minimal_data,
-                self.minimal_chan_locs,
-                noplot='off'
-            )
+            handle, Zi, plotrad, xi, yi = topoplot(self.minimal_data, self.minimal_chan_locs, noplot='off')
             self.assertIsInstance(Zi, np.ndarray)
 
 
@@ -613,9 +520,9 @@ class TestTopoplotParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: <1e-6, Nearly perfect parity
         # Max relative diff: <1e-5
-        np.testing.assert_allclose(Zi_py, Zi_ml, rtol=1e-5, atol=1e-8,
-                                   err_msg="topoplot Zi results differ beyond tolerance",
-                                   equal_nan=True)
+        np.testing.assert_allclose(
+            Zi_py, Zi_ml, rtol=1e-5, atol=1e-8, err_msg="topoplot Zi results differ beyond tolerance", equal_nan=True
+        )
 
     def test_parity_multiple_components(self):
         """Test parity with MATLAB for multiple IC topographies."""
@@ -651,9 +558,14 @@ class TestTopoplotParity(unittest.TestCase):
             # Compare results
             # Max absolute diff: <1e-6, Nearly perfect parity
             # Max relative diff: <1e-5
-            np.testing.assert_allclose(Zi_py, Zi_ml, rtol=1e-5, atol=1e-8,
-                                       err_msg=f"topoplot Zi results differ for IC {ic_idx}",
-                                       equal_nan=True)
+            np.testing.assert_allclose(
+                Zi_py,
+                Zi_ml,
+                rtol=1e-5,
+                atol=1e-8,
+                err_msg=f"topoplot Zi results differ for IC {ic_idx}",
+                equal_nan=True,
+            )
 
             # Clean up IC-specific file
             os.remove(f'{temp_file}_ic{ic_idx}.mat')
@@ -701,9 +613,9 @@ class TestTopoplotParity(unittest.TestCase):
         # Compare results
         # Max absolute diff: TBD
         # Max relative diff: TBD
-        np.testing.assert_allclose(Zi_py, Zi_ml, rtol=1e-5, atol=1e-8,
-                                   err_msg="topoplot Zi results differ for gridscale=32",
-                                   equal_nan=True)
+        np.testing.assert_allclose(
+            Zi_py, Zi_ml, rtol=1e-5, atol=1e-8, err_msg="topoplot Zi results differ for gridscale=32", equal_nan=True
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_utils_asr.py
+++ b/tests/test_utils_asr.py
@@ -1,9 +1,6 @@
 import unittest
 import numpy as np
-import warnings
-from unittest.mock import patch, MagicMock
-import scipy.signal
-import scipy.linalg
+from unittest.mock import patch
 
 from eegprep.plugins.clean_rawdata.asr_calibrate import asr_calibrate
 from eegprep.plugins.clean_rawdata.asr_process import asr_process
@@ -26,7 +23,7 @@ class TestAsrCalibrate(unittest.TestCase):
         for i in range(self.n_channels):
             # Simple AR(1) process for more realistic EEG-like data
             for j in range(1, self.n_samples):
-                self.clean_data[i, j] += 0.8 * self.clean_data[i, j-1]
+                self.clean_data[i, j] += 0.8 * self.clean_data[i, j - 1]
 
     def test_basic_calibration(self):
         """Test basic ASR calibration functionality."""
@@ -113,7 +110,7 @@ class TestAsrCalibrate(unittest.TestCase):
             window_overlap=0.5,
             max_dropout_fraction=0.2,
             min_clean_fraction=0.3,
-            maxmem=32
+            maxmem=32,
         )
 
         # Should complete without errors
@@ -139,7 +136,7 @@ class TestAsrCalibrate(unittest.TestCase):
         with patch('eegprep.plugins.clean_rawdata.asr_calibrate.cov_mean') as mock_cov_mean:
             mock_cov_mean.return_value = np.eye(self.n_channels) * 0.5
 
-            state = asr_calibrate(self.clean_data, self.srate, useriemannian='calib')
+            asr_calibrate(self.clean_data, self.srate, useriemannian='calib')
 
             # Should have called cov_mean with robust=True
             mock_cov_mean.assert_called_once()
@@ -166,7 +163,7 @@ class TestAsrCalibrate(unittest.TestCase):
             # Return data with NaN values to simulate filter divergence
             mock_sosfilt.return_value = (
                 np.full((4, 1000), np.nan),
-                np.zeros((2, 4, 2))  # Mock iir_state
+                np.zeros((2, 4, 2)),  # Mock iir_state
             )
 
             with self.assertRaises(RuntimeError) as cm:
@@ -208,7 +205,7 @@ class TestAsrCalibrate(unittest.TestCase):
                 mock_geom_median.return_value = np.eye(self.n_channels).flatten()
 
                 with self.assertLogs('eegprep.plugins.clean_rawdata.asr_calibrate', level='WARNING') as log:
-                    state = asr_calibrate(self.clean_data, self.srate, useriemannian='calib')
+                    asr_calibrate(self.clean_data, self.srate, useriemannian='calib')
 
                 # Check that warning was logged and fallback was used
                 self.assertTrue(any('NaNs' in msg for msg in log.output))
@@ -273,13 +270,7 @@ class TestAsrProcess(unittest.TestCase):
     def test_custom_processing_parameters(self):
         """Test processing with custom parameters."""
         cleaned_data, new_state = asr_process(
-            self.test_data,
-            self.srate,
-            self.state,
-            window_len=0.25,
-            lookahead=0.1,
-            step_size=16,
-            max_dims=0.5
+            self.test_data, self.srate, self.state, window_len=0.25, lookahead=0.1, step_size=16, max_dims=0.5
         )
 
         # Should complete without errors
@@ -292,7 +283,7 @@ class TestAsrProcess(unittest.TestCase):
             self.test_data,
             self.srate,
             self.state,
-            max_dims=3  # Integer instead of fraction
+            max_dims=3,  # Integer instead of fraction
         )
 
         self.assertEqual(cleaned_data.shape, self.test_data.shape)
@@ -324,7 +315,7 @@ class TestAsrProcess(unittest.TestCase):
                     large_data,
                     self.srate,
                     self.state,
-                    max_mem=10  # Low memory limit
+                    max_mem=10,  # Low memory limit
                 )
 
             # Check that splitting was logged
@@ -397,7 +388,7 @@ class TestAsrProcess(unittest.TestCase):
             small_data,
             self.srate,
             self.state,
-            window_len=0.1  # Very small window
+            window_len=0.1,  # Very small window
         )
 
         # Should complete without errors despite small data
@@ -438,7 +429,7 @@ class TestAsrIntegration(unittest.TestCase):
 
         # Add some correlated structure between channels
         for i in range(n_channels):
-            for j in range(i+1, n_channels):
+            for j in range(i + 1, n_channels):
                 if np.random.rand() > 0.7:  # 30% chance of correlation
                     correlation = 0.3 * np.random.randn()
                     data[j] += correlation * data[i]
@@ -446,7 +437,7 @@ class TestAsrIntegration(unittest.TestCase):
         # Add some temporal autocorrelation
         for i in range(n_channels):
             for j in range(1, n_samples):
-                data[i, j] += 0.7 * data[i, j-1] * np.random.rand()
+                data[i, j] += 0.7 * data[i, j - 1] * np.random.rand()
 
         return data
 
@@ -465,7 +456,7 @@ class TestAsrIntegration(unittest.TestCase):
             blink_duration = 20
             if blink_time + blink_duration < n_samples:
                 blink_artifact = 5.0 * np.exp(-np.arange(blink_duration) / 5.0)
-                data[0, blink_time:blink_time + blink_duration] += blink_artifact
+                data[0, blink_time : blink_time + blink_duration] += blink_artifact
 
     def test_full_calibration_and_processing_pipeline(self):
         """Test complete ASR pipeline from calibration to processing."""
@@ -480,10 +471,12 @@ class TestAsrIntegration(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(cleaned_data)))
 
         # Check that artifacts were reduced (RMS should be lower in artifact regions)
-        artifact_region = slice(self.test_data.shape[1] // 4, self.test_data.shape[1] // 4 + self.test_data.shape[1] // 10)
+        artifact_region = slice(
+            self.test_data.shape[1] // 4, self.test_data.shape[1] // 4 + self.test_data.shape[1] // 10
+        )
 
-        original_rms = np.sqrt(np.mean(self.test_data[1, artifact_region]**2))
-        cleaned_rms = np.sqrt(np.mean(cleaned_data[1, artifact_region]**2))
+        original_rms = np.sqrt(np.mean(self.test_data[1, artifact_region] ** 2))
+        cleaned_rms = np.sqrt(np.mean(cleaned_data[1, artifact_region] ** 2))
 
         # Cleaned data should have lower RMS in artifact region
         self.assertLess(cleaned_rms, original_rms)
@@ -521,16 +514,14 @@ class TestAsrIntegration(unittest.TestCase):
         parameter_sets = [
             {'cutoff': 3.0, 'window_len': 0.25, 'max_dims': 0.5},
             {'cutoff': 7.0, 'window_len': 1.0, 'max_dims': 2},
-            {'cutoff': 4.0, 'blocksize': 20, 'window_overlap': 0.8}
+            {'cutoff': 4.0, 'blocksize': 20, 'window_overlap': 0.8},
         ]
 
         for params in parameter_sets:
             with self.subTest(params=params):
                 # Split parameters between calibration and processing
-                calib_params = {k: v for k, v in params.items()
-                              if k in ['cutoff', 'blocksize', 'window_overlap']}
-                process_params = {k: v for k, v in params.items()
-                                if k in ['window_len', 'max_dims']}
+                calib_params = {k: v for k, v in params.items() if k in ['cutoff', 'blocksize', 'window_overlap']}
+                process_params = {k: v for k, v in params.items() if k in ['window_len', 'max_dims']}
 
                 # Test pipeline
                 state = asr_calibrate(self.calib_data, self.srate, **calib_params)

--- a/tests/test_utils_covariance.py
+++ b/tests/test_utils_covariance.py
@@ -1,11 +1,17 @@
 import unittest
 import numpy as np
-import warnings
 from unittest.mock import patch
 
 from eegprep.plugins.clean_rawdata.private.covariance import (
-    diag_nd, cov_logm, cov_expm, cov_powm, cov_sqrtm, cov_rsqrtm,
-    cov_sqrtm2, cov_mean, cov_shrinkage
+    diag_nd,
+    cov_logm,
+    cov_expm,
+    cov_powm,
+    cov_sqrtm,
+    cov_rsqrtm,
+    cov_sqrtm2,
+    cov_mean,
+    cov_shrinkage,
 )
 
 
@@ -25,10 +31,12 @@ class TestDiagNd(unittest.TestCase):
         result = diag_nd(x)
 
         # Should create 2 diagonal matrices
-        expected = np.array([
-            [[1, 0], [0, 2]],  # diag([1, 2])
-            [[3, 0], [0, 4]]   # diag([3, 4])
-        ])
+        expected = np.array(
+            [
+                [[1, 0], [0, 2]],  # diag([1, 2])
+                [[3, 0], [0, 4]],  # diag([3, 4])
+            ]
+        )
         np.testing.assert_array_equal(result, expected)
 
     def test_3d_input(self):
@@ -53,17 +61,10 @@ class TestCovarianceMatrixOperations(unittest.TestCase):
         self.cov_2x2 = np.array([[2.0, 1.0], [1.0, 2.0]])
 
         # 3x3 positive definite matrix
-        self.cov_3x3 = np.array([
-            [4.0, 1.0, 0.5],
-            [1.0, 3.0, 1.0],
-            [0.5, 1.0, 2.0]
-        ])
+        self.cov_3x3 = np.array([[4.0, 1.0, 0.5], [1.0, 3.0, 1.0], [0.5, 1.0, 2.0]])
 
         # Stack of covariance matrices
-        self.cov_stack = np.array([
-            [[2.0, 1.0], [1.0, 2.0]],
-            [[3.0, 0.5], [0.5, 1.5]]
-        ])
+        self.cov_stack = np.array([[[2.0, 1.0], [1.0, 2.0]], [[3.0, 0.5], [0.5, 1.5]]])
 
     def test_cov_logm_single_matrix(self):
         """Test matrix logarithm of single covariance matrix."""
@@ -175,11 +176,7 @@ class TestCovMean(unittest.TestCase):
     def setUp(self):
         """Create test data."""
         # Create a stack of similar covariance matrices
-        self.cov_stack = np.array([
-            [[2.0, 0.5], [0.5, 1.5]],
-            [[2.2, 0.3], [0.3, 1.8]],
-            [[1.8, 0.7], [0.7, 1.2]]
-        ])
+        self.cov_stack = np.array([[[2.0, 0.5], [0.5, 1.5]], [[2.2, 0.3], [0.3, 1.8]], [[1.8, 0.7], [0.7, 1.2]]])
 
         # Single matrix (should return itself)
         self.single_cov = np.array([[[3.0, 1.0], [1.0, 2.0]]])
@@ -253,10 +250,12 @@ class TestCovMean(unittest.TestCase):
     def test_nancheck_functionality(self):
         """Test NaN checking functionality."""
         # Create data that might cause numerical issues
-        problematic_cov = np.array([
-            [[1e10, 0], [0, 1e-10]],  # Very different scales
-            [[1e-10, 0], [0, 1e10]]
-        ])
+        problematic_cov = np.array(
+            [
+                [[1e10, 0], [0, 1e-10]],  # Very different scales
+                [[1e-10, 0], [0, 1e10]],
+            ]
+        )
 
         # Should not raise with nancheck=False (default)
         result = cov_mean(problematic_cov, nancheck=False)
@@ -283,17 +282,10 @@ class TestCovShrinkage(unittest.TestCase):
     def setUp(self):
         """Create test covariance matrices."""
         self.cov_2x2 = np.array([[4.0, 2.0], [2.0, 3.0]])
-        self.cov_3x3 = np.array([
-            [5.0, 1.0, 0.5],
-            [1.0, 4.0, 1.5],
-            [0.5, 1.5, 3.0]
-        ])
+        self.cov_3x3 = np.array([[5.0, 1.0, 0.5], [1.0, 4.0, 1.5], [0.5, 1.5, 3.0]])
 
         # Stack of matrices
-        self.cov_stack = np.array([
-            [[4.0, 2.0], [2.0, 3.0]],
-            [[6.0, 1.0], [1.0, 2.0]]
-        ])
+        self.cov_stack = np.array([[[4.0, 2.0], [2.0, 3.0]], [[6.0, 1.0], [1.0, 2.0]]])
 
     def test_no_shrinkage(self):
         """Test that zero shrinkage returns original matrix."""
@@ -408,7 +400,7 @@ class TestEdgeCases(unittest.TestCase):
         log_result = cov_logm(near_singular)
         exp_result = cov_expm(log_result)
         sqrt_result = cov_sqrtm(near_singular)
-        rsqrt_result = cov_rsqrtm(near_singular)
+        cov_rsqrtm(near_singular)
 
         # Check round-trip accuracy
         np.testing.assert_array_almost_equal(exp_result, near_singular, decimal=8)
@@ -468,4 +460,3 @@ class TestEdgeCases(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_utils_ransac.py
+++ b/tests/test_utils_ransac.py
@@ -101,14 +101,12 @@ class TestCalcProjector(unittest.TestCase):
         """Set up test fixtures with synthetic channel locations."""
         # Create synthetic 3D channel locations (spherical coordinates)
         self.n_channels = 8
-        theta = np.linspace(0, 2*np.pi, self.n_channels, endpoint=False)
-        phi = np.pi/4  # Fixed elevation
+        theta = np.linspace(0, 2 * np.pi, self.n_channels, endpoint=False)
+        phi = np.pi / 4  # Fixed elevation
 
-        self.locs = np.column_stack([
-            np.cos(theta) * np.cos(phi),
-            np.sin(theta) * np.cos(phi),
-            np.sin(phi) * np.ones(self.n_channels)
-        ])
+        self.locs = np.column_stack(
+            [np.cos(theta) * np.cos(phi), np.sin(theta) * np.cos(phi), np.sin(phi) * np.ones(self.n_channels)]
+        )
 
         # Test parameters
         self.num_samples = 5
@@ -117,6 +115,7 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_basic_projector_calculation(self):
         """Test basic projector matrix calculation."""
+
         # Mock the sphericalSplineInterpolate function
         # Input: src_locs (3, subset_size), dest_locs (3, n_channels)
         # Output: W (n_channels, subset_size)
@@ -125,14 +124,10 @@ class TestCalcProjector(unittest.TestCase):
             n_dest = dest_locs.shape[1]  # n_channels (columns in transposed input)
             return np.random.randn(n_dest, n_src), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
-            result = calc_projector(
-                self.locs,
-                self.num_samples,
-                self.subset_size,
-                stream=self.rng
-            )
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ) as mock_interp:
+            result = calc_projector(self.locs, self.num_samples, self.subset_size, stream=self.rng)
 
         # Check output shape
         expected_shape = (self.n_channels, self.n_channels * self.num_samples)
@@ -143,13 +138,15 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_deterministic_with_fixed_stream(self):
         """Test that results are deterministic with fixed random stream."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
             return np.ones((n_dest, n_src)), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             rng1 = np.random.RandomState(999)
             rng2 = np.random.RandomState(999)
 
@@ -160,14 +157,16 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_default_random_stream(self):
         """Test that default random stream is used when none provided."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
             # Return deterministic values for reproducible test
             return np.ones((n_dest, n_src)), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # Call without providing stream - should use default seed
             result1 = calc_projector(self.locs, 2, 2)
             result2 = calc_projector(self.locs, 2, 2)
@@ -178,22 +177,18 @@ class TestCalcProjector(unittest.TestCase):
     def test_matlab_subroutine(self):
         """Test using MATLAB subroutine."""
         mock_matlab = MagicMock()
+
         def mock_matlab_interp(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # MATLAB uses transposed input
             n_dest = dest_locs.shape[1]
             return np.random.randn(n_dest, n_src), None
+
         mock_matlab.sphericalSplineInterpolate.side_effect = mock_matlab_interp
 
         with patch('eegprep.plugins.clean_rawdata.private.ransac.get_eeglab') as mock_get_eeglab:
             mock_get_eeglab.return_value = mock_matlab
 
-            result = calc_projector(
-                self.locs,
-                self.num_samples,
-                self.subset_size,
-                stream=self.rng,
-                subroutine='matlab'
-            )
+            result = calc_projector(self.locs, self.num_samples, self.subset_size, stream=self.rng, subroutine='matlab')
 
         # Check that MATLAB was requested and used
         mock_get_eeglab.assert_called_once_with('MAT')
@@ -203,22 +198,18 @@ class TestCalcProjector(unittest.TestCase):
     def test_octave_subroutine(self):
         """Test using Octave subroutine."""
         mock_octave = MagicMock()
+
         def mock_octave_interp(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # Octave uses transposed input
             n_dest = dest_locs.shape[1]
             return np.random.randn(n_dest, n_src), None
+
         mock_octave.sphericalSplineInterpolate.side_effect = mock_octave_interp
 
         with patch('eegprep.plugins.clean_rawdata.private.ransac.get_eeglab') as mock_get_eeglab:
             mock_get_eeglab.return_value = mock_octave
 
-            result = calc_projector(
-                self.locs,
-                self.num_samples,
-                self.subset_size,
-                stream=self.rng,
-                subroutine='octave'
-            )
+            result = calc_projector(self.locs, self.num_samples, self.subset_size, stream=self.rng, subroutine='octave')
 
         # Check that Octave was requested and used
         mock_get_eeglab.assert_called_once_with('OCT')
@@ -229,17 +220,14 @@ class TestCalcProjector(unittest.TestCase):
         """Test error handling for invalid subroutine."""
         with self.assertRaises(ValueError) as cm:
             calc_projector(
-                self.locs,
-                self.num_samples,
-                self.subset_size,
-                stream=self.rng,
-                subroutine='invalid_subroutine'
+                self.locs, self.num_samples, self.subset_size, stream=self.rng, subroutine='invalid_subroutine'
             )
 
         self.assertIn('Unknown subroutine: invalid_subroutine', str(cm.exception))
 
     def test_different_sample_parameters(self):
         """Test with different sampling parameters."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
@@ -249,8 +237,9 @@ class TestCalcProjector(unittest.TestCase):
             result[:min_dim, :min_dim] = np.eye(min_dim)
             return result, None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # Test with different num_samples
             result1 = calc_projector(self.locs, 3, 2, stream=self.rng)
             result2 = calc_projector(self.locs, 6, 2, stream=self.rng)
@@ -264,6 +253,7 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_complex_interpolation_result_handling(self):
         """Test handling of complex interpolation results."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
@@ -272,8 +262,9 @@ class TestCalcProjector(unittest.TestCase):
             imag_part = np.random.randn(n_dest, n_src)
             return real_part + 1j * imag_part, None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             result = calc_projector(self.locs, 2, 2, stream=self.rng)
 
             # Result should be real (np.real applied)
@@ -282,6 +273,7 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_sampling_coverage_across_channels(self):
         """Test that sampling covers different channel subsets."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
@@ -290,15 +282,11 @@ class TestCalcProjector(unittest.TestCase):
             result[:min_dim, :min_dim] = np.eye(min_dim)
             return result, None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ) as mock_interp:
             # Use many samples to ensure different subsets are chosen
-            result = calc_projector(
-                self.locs,
-                num_samples=20,
-                subset_size=3,
-                stream=np.random.RandomState(777)
-            )
+            result = calc_projector(self.locs, num_samples=20, subset_size=3, stream=np.random.RandomState(777))
 
             # Check that result has expected shape
             expected_shape = (self.n_channels, self.n_channels * 20)
@@ -309,13 +297,15 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_edge_case_single_sample(self):
         """Test with single sample."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
             return np.random.randn(n_dest, n_src), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ) as mock_interp:
             result = calc_projector(self.locs, 1, 2, stream=self.rng)
 
             self.assertEqual(result.shape, (self.n_channels, self.n_channels))
@@ -323,20 +313,17 @@ class TestCalcProjector(unittest.TestCase):
 
     def test_large_subset_size(self):
         """Test with subset size close to total number of channels."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
             return np.random.randn(n_dest, n_src), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ) as mock_interp:
             # Use subset_size = n_channels - 1
-            result = calc_projector(
-                self.locs,
-                3,
-                self.n_channels - 1,
-                stream=self.rng
-            )
+            result = calc_projector(self.locs, 3, self.n_channels - 1, stream=self.rng)
 
             self.assertEqual(result.shape, (self.n_channels, self.n_channels * 3))
             self.assertEqual(mock_interp.call_count, 3)
@@ -359,21 +346,18 @@ class TestRansacIntegration(unittest.TestCase):
 
     def test_no_fail_path_with_realistic_data(self):
         """Test that RANSAC functions don't fail with realistic data."""
+
         # Mock the interpolation to avoid dependency on complex spatial functions
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
             return np.random.randn(n_dest, n_src), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # This should not raise any exceptions
-            result = calc_projector(
-                self.locs,
-                num_samples=10,
-                subset_size=8,
-                stream=np.random.RandomState(555)
-            )
+            result = calc_projector(self.locs, num_samples=10, subset_size=8, stream=np.random.RandomState(555))
 
             # Basic sanity checks
             self.assertIsInstance(result, np.ndarray)
@@ -406,14 +390,11 @@ class TestRansacIntegration(unittest.TestCase):
 
             return result, None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func):
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # Calculate projector matrix
-            projector = calc_projector(
-                locs,
-                num_samples=15,
-                subset_size=10,
-                stream=np.random.RandomState(888)
-            )
+            projector = calc_projector(locs, num_samples=15, subset_size=10, stream=np.random.RandomState(888))
 
             # Verify basic properties
             self.assertEqual(projector.shape, (total_channels, total_channels * 15))
@@ -432,6 +413,7 @@ class TestRansacIntegration(unittest.TestCase):
 
     def test_deterministic_behavior_for_reproducibility(self):
         """Test that RANSAC behavior is reproducible for debugging."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
@@ -439,8 +421,9 @@ class TestRansacIntegration(unittest.TestCase):
             rng = np.random.RandomState(123)
             return rng.randn(n_dest, n_src), None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # Multiple runs with same seed should give identical results
             results = []
             for _ in range(3):
@@ -448,7 +431,7 @@ class TestRansacIntegration(unittest.TestCase):
                     self.locs,
                     num_samples=5,
                     subset_size=6,
-                    stream=np.random.RandomState(999)  # Same seed each time
+                    stream=np.random.RandomState(999),  # Same seed each time
                 )
                 results.append(result.copy())
 
@@ -458,6 +441,7 @@ class TestRansacIntegration(unittest.TestCase):
 
     def test_parameter_validation_implicit(self):
         """Test that functions handle edge cases gracefully."""
+
         def mock_interp_func(src_locs, dest_locs):
             n_src = src_locs.shape[1]  # subset_size
             n_dest = dest_locs.shape[1]  # n_channels
@@ -466,24 +450,17 @@ class TestRansacIntegration(unittest.TestCase):
             result[:min_dim, :min_dim] = np.eye(min_dim)
             return result, None
 
-        with patch('eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func) as mock_interp:
-
+        with patch(
+            'eegprep.plugins.clean_rawdata.private.ransac.sphericalSplineInterpolate', side_effect=mock_interp_func
+        ):
             # Test minimum viable parameters
-            result = calc_projector(
-                self.locs,
-                num_samples=1,
-                subset_size=1,
-                stream=np.random.RandomState(111)
-            )
+            result = calc_projector(self.locs, num_samples=1, subset_size=1, stream=np.random.RandomState(111))
 
             self.assertEqual(result.shape, (self.n_channels, self.n_channels))
 
             # Test with subset_size equal to number of channels
             result = calc_projector(
-                self.locs,
-                num_samples=2,
-                subset_size=self.n_channels,
-                stream=np.random.RandomState(222)
+                self.locs, num_samples=2, subset_size=self.n_channels, stream=np.random.RandomState(222)
             )
 
             self.assertEqual(result.shape, (self.n_channels, self.n_channels * 2))

--- a/tests/test_utils_testing.py
+++ b/tests/test_utils_testing.py
@@ -8,7 +8,6 @@ from eegprep.utils.testing import compare_eeg, DebuggableTestCase, is_debug
 
 
 class TestCompareEeg(unittest.TestCase):
-
     def test_compare_eeg_identical_arrays(self):
         """Test comparing identical arrays passes."""
         a = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -126,7 +125,6 @@ class MockTestCase(DebuggableTestCase):
 
 
 class TestDebuggableTestCase(unittest.TestCase):
-
     def test_debugTestCase_loads_and_runs_tests(self):
         """Test that debugTestCase loads and runs test methods."""
         # Mock the test suite and its debug method
@@ -155,19 +153,22 @@ class TestDebuggableTestCase(unittest.TestCase):
 
 
 class TestIsDebug(unittest.TestCase):
-
     def test_is_debug_no_tracer(self):
         """Test is_debug returns False when no tracer is active."""
+
         def mock_gettrace():
             return None
+
         with patch.object(sys, 'gettrace', mock_gettrace):
             self.assertFalse(is_debug())
 
     def test_is_debug_with_tracer(self):
         """Test is_debug returns True when tracer is active."""
         mock_tracer = MagicMock()
+
         def mock_gettrace():
             return mock_tracer
+
         with patch.object(sys, 'gettrace', mock_gettrace):
             self.assertTrue(is_debug())
 
@@ -180,17 +181,19 @@ class TestIsDebug(unittest.TestCase):
 
     def test_is_debug_gettrace_returns_none_function(self):
         """Test is_debug when gettrace returns a function that returns None."""
+
         def mock_gettrace():
             return None
+
         with patch.object(sys, 'gettrace', mock_gettrace):
             self.assertFalse(is_debug())
 
 
 class TestModuleConstants(unittest.TestCase):
-
     def test_module_exports(self):
         """Test that __all__ contains expected exports."""
         from eegprep.utils.testing import __all__
+
         expected_exports = [
             'compare_eeg',
             'DebuggableTestCase',
@@ -204,11 +207,13 @@ class TestModuleConstants(unittest.TestCase):
     def test_default_32_bit_constant(self):
         """Test default_32_bit constant value."""
         from eegprep.utils.testing import default_32_bit
+
         self.assertTrue(default_32_bit)
 
     def test_flatten_to_2d_constant(self):
         """Test flatten_to_2d constant value."""
         from eegprep.utils.testing import flatten_to_2d
+
         self.assertTrue(flatten_to_2d)
 
 

--- a/tests/test_visual_parity.py
+++ b/tests/test_visual_parity.py
@@ -14,10 +14,7 @@ from tools.visual_parity.menu_inventory import compare_menu_trees
 from eegprep.functions.guifunc.visual_capture import _main_window_menu_state as _eegprep_main_window_menu_state
 
 
-ONE_PIXEL_PNG = (
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
-    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
-)
+ONE_PIXEL_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
 
 
 class VisualParityConfigTests(unittest.TestCase):
@@ -30,7 +27,9 @@ class VisualParityConfigTests(unittest.TestCase):
         self.assertIn("eegprep.functions.guifunc.visual_capture", cases["main_window"].targets["eegprep"].command)
         self.assertIn("adjust_events_dialog", cases)
         self.assertEqual(cases["adjust_events_dialog"].targets["eeglab"].type, "matlab_dialog")
-        self.assertIn("eegprep.functions.guifunc.visual_capture", cases["adjust_events_dialog"].targets["eegprep"].command)
+        self.assertIn(
+            "eegprep.functions.guifunc.visual_capture", cases["adjust_events_dialog"].targets["eegprep"].command
+        )
         self.assertIn("reref_dialog", cases)
         self.assertEqual(cases["reref_dialog"].targets["eeglab"].action, "pop_reref")
         self.assertEqual(cases["reref_dialog_channel_ref"].targets["eeglab"].action, "pop_reref:channels")

--- a/tools/visual_parity/capture.py
+++ b/tools/visual_parity/capture.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 try:
     from .config import DEFAULT_MANIFEST, TargetSpec, VisualCase, format_command, load_manifest
 except ImportError:  # pragma: no cover - supports direct script execution
-    from config import DEFAULT_MANIFEST, TargetSpec, VisualCase, format_command, load_manifest
+    from config import DEFAULT_MANIFEST, TargetSpec, VisualCase, format_command, load_manifest  # ty: ignore[unresolved-import]
 
 
 DEFAULT_OUTPUT_DIR = pathlib.Path(".visual-parity")

--- a/tools/visual_parity/capture.py
+++ b/tools/visual_parity/capture.py
@@ -49,11 +49,7 @@ def _matlab_string(value: pathlib.Path | str) -> str:
 
 def _matlab_run_expression(script_path: pathlib.Path) -> str:
     script = _matlab_string(script_path.as_posix())
-    return (
-        f"try, run({script}); "
-        "catch ME, disp(getReport(ME, 'extended')); exit(1); "
-        "end; exit(0);"
-    )
+    return f"try, run({script}); catch ME, disp(getReport(ME, 'extended')); exit(1); end; exit(0);"
 
 
 def _split_action(action: str) -> tuple[str, str]:

--- a/tools/visual_parity/compare.py
+++ b/tools/visual_parity/compare.py
@@ -151,14 +151,18 @@ def _save_image(path: pathlib.Path, image: RgbaImage) -> None:
         raw.append(0)
         raw.extend(image.pixels[start : start + row_length])
     ihdr = struct.pack(">IIBBBBB", image.width, image.height, 8, 6, 0, 0, 0)
-    png = PNG_SIGNATURE + _png_chunk(b"IHDR", ihdr) + _png_chunk(b"IDAT", zlib.compress(bytes(raw))) + _png_chunk(b"IEND", b"")
+    png = (
+        PNG_SIGNATURE
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", zlib.compress(bytes(raw)))
+        + _png_chunk(b"IEND", b"")
+    )
     path.write_bytes(png)
 
 
 def _pad_to_height(image: RgbaImage, height: int) -> RgbaImage:
     if image.height == height:
         return image
-    row_length = image.width * 4
     padding = bytes((255, 255, 255, 255)) * image.width * (height - image.height)
     return RgbaImage(width=image.width, height=height, pixels=image.pixels + padding)
 
@@ -174,9 +178,7 @@ def write_side_by_side(reference: RgbaImage, candidate: RgbaImage, path: pathlib
         out_row = row_index * output_width * 4
         ref_row = row_index * reference.width * 4
         cand_row = row_index * candidate.width * 4
-        output[out_row : out_row + reference.width * 4] = reference.pixels[
-            ref_row : ref_row + reference.width * 4
-        ]
+        output[out_row : out_row + reference.width * 4] = reference.pixels[ref_row : ref_row + reference.width * 4]
         cand_start = out_row + (reference.width + 16) * 4
         output[cand_start : cand_start + candidate.width * 4] = candidate.pixels[
             cand_row : cand_row + candidate.width * 4
@@ -311,9 +313,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"mean_abs_delta: {result.mean_abs_delta:.6f}")
     print(f"different_pixel_ratio: {result.different_pixel_ratio:.6f}")
 
-    if args.fail_threshold is not None and (
-        result.size_mismatch or result.mean_abs_delta > args.fail_threshold
-    ):
+    if args.fail_threshold is not None and (result.size_mismatch or result.mean_abs_delta > args.fail_threshold):
         return 1
     return 0
 

--- a/tools/visual_parity/menu_inventory.py
+++ b/tools/visual_parity/menu_inventory.py
@@ -59,21 +59,15 @@ def compare_menu_trees(reference: list[dict[str, Any]], candidate: list[dict[str
         cand_node = candidate[index]
         path = _label(ref_node) or f"index {index}"
         if _label(ref_node) != _label(cand_node):
-            differences.append(
-                f"{path}: label mismatch, expected {_label(ref_node)!r}, got {_label(cand_node)!r}"
-            )
+            differences.append(f"{path}: label mismatch, expected {_label(ref_node)!r}, got {_label(cand_node)!r}")
         if _enabled(ref_node) != _enabled(cand_node):
-            differences.append(
-                f"{path}: enabled mismatch, expected {_enabled(ref_node)}, got {_enabled(cand_node)}"
-            )
+            differences.append(f"{path}: enabled mismatch, expected {_enabled(ref_node)}, got {_enabled(cand_node)}")
         if _separator(ref_node) != _separator(cand_node):
             differences.append(
                 f"{path}: separator mismatch, expected {_separator(ref_node)}, got {_separator(cand_node)}"
             )
         if _checked(ref_node) != _checked(cand_node):
-            differences.append(
-                f"{path}: checked mismatch, expected {_checked(ref_node)}, got {_checked(cand_node)}"
-            )
+            differences.append(f"{path}: checked mismatch, expected {_checked(ref_node)}, got {_checked(cand_node)}")
 
         child_differences = compare_menu_trees(
             _children(ref_node),
@@ -101,9 +95,7 @@ def write_report(differences: list[str], report_path: pathlib.Path) -> None:
         report_path.write_text("Menu inventories match.\n")
         return
     report_path.write_text(
-        "Menu inventory differences:\n\n"
-        + "\n".join(f"- {difference}" for difference in differences)
-        + "\n"
+        "Menu inventory differences:\n\n" + "\n".join(f"- {difference}" for difference in differences) + "\n"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -751,7 +751,9 @@ torch = [
 dev = [
     { name = "pytest" },
     { name = "pyyaml" },
+    { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "ty" },
 ]
 release = [
     { name = "build" },
@@ -802,7 +804,9 @@ provides-extras = ["torch", "eeglabio", "gui", "console", "docs", "all"]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", specifier = ">=0.15.14" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
+    { name = "ty", specifier = ">=0.0.39" },
 ]
 release = [
     { name = "build", specifier = ">=1.2" },
@@ -2981,6 +2985,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3736,6 +3765,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.39"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/8d/7b5c74dc287fbcb37bae9853cec13bf44717c1735298500e4aeba31579a9/ty-0.0.39.tar.gz", hash = "sha256:f750277e76a01ecd86185960eca73823c26a53c51103568d56d4d904575159fd", size = 5702365, upload-time = "2026-05-22T21:09:56.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/9b89802c26d12d0f7a27bc25d4066d941d42891e8898f9f26499f0067e32/ty-0.0.39-py3-none-linux_armv6l.whl", hash = "sha256:c1bb7ac70f1f7d70cc6655fd96558039e4562b10f489fa49c7ebfd5fcee73ad1", size = 11360431, upload-time = "2026-05-22T21:09:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c6/663ded50e823dbf9fb9d002eca46b7cb1fb2c72b744b84f22ce732a0ee0b/ty-0.0.39-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3435b64c1e59c14c9aa39c20cc018823937cd38d55db853e74d95b8f420569b0", size = 11096281, upload-time = "2026-05-22T21:09:15.383Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/5d38ba9a6456ff4c78d212cf464fd8b9a25d8118465197b0b2dc891c0b19/ty-0.0.39-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f136377ce46c73677701a9e1ad730bf72f699bcec046e422eb79d0886cac3ab", size = 10529674, upload-time = "2026-05-22T21:09:46.471Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6f/43638cb8106445d3c8817256a0731cde9dd7b6a53ae2e881294bc1930ca3/ty-0.0.39-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36b65fb0cc17f03e851d40e210d420be94ab8bc52d041328ad1e45f616036a61", size = 11055561, upload-time = "2026-05-22T21:09:36.981Z" },
+    { url = "https://files.pythonhosted.org/packages/91/17/95e62cf4458527ce78dc386eba18f8b10c3fb64cd8c9e7e59b262ff6029d/ty-0.0.39-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4967967bfadf3860ff84c3fccdbaec8edf8aa20d0d727521084733d853de6657", size = 11127185, upload-time = "2026-05-22T21:09:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c0/93666c213db5c71ab1b1f1a0db5f66bf8c7c0e0b0bf59859f5da8f0b3c36/ty-0.0.39-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e10ecb1297099ddf9a1f054f8bd921d1863ce85fb819a3c96ed27865a1ba6ed", size = 11608459, upload-time = "2026-05-22T21:09:12.862Z" },
+    { url = "https://files.pythonhosted.org/packages/79/85/3b26585afc8b50230d6464bb0642feef4fab3f847e38b1f0ffa971a81446/ty-0.0.39-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b19cca70e465d71b0510656343883d62372bbe74b7845cae7c0e701d6d5264b", size = 12177101, upload-time = "2026-05-22T21:09:40.519Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4a/1039e4f6afc576dc1c3a4d22a6478904a1ad3766597cd0b93c077ab9dfce/ty-0.0.39-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:56c6704b01b9b3d80ff26b2918423b742516d1e469bef830e9254dcedc9185bf", size = 11827815, upload-time = "2026-05-22T21:09:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c5/4688652870e350a76a8157f7ffb59ad54f37d5d10725aa7076f66ac94ec8/ty-0.0.39-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40b7840ff46764b6a6757f4ade1cd0530fc3e8a0b435ca93e7602360e4cb90b6", size = 11694429, upload-time = "2026-05-22T21:09:21.568Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/72/8a1c4e823bb5bdc935a1c8140e100304e36a68a4139592f170aa9736fdb7/ty-0.0.39-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1c62a3a87ce26b50819f0dbf03bd95f23f19eeb87bbc7aa732ec64277c77f1aa", size = 11869846, upload-time = "2026-05-22T21:09:28.053Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9f/cf982457b861ae22d657c5dcdbc631199f7f90264279db1d17230dfbc3ff/ty-0.0.39-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f8c34bc81a9c3516e49904e9d8330aac385377cca98390193ea02b903a40fcf0", size = 11029763, upload-time = "2026-05-22T21:09:06.791Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/95b64f6d43ae6e8f0b7e13dacf9c196d35819af22b1924171fba31383156/ty-0.0.39-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:66f5ab11586a64e79cb692ad685ee5469325c31b5f30bd3554f52f36dbe28cc4", size = 11146761, upload-time = "2026-05-22T21:09:10.178Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/0a89cfb06f7632a05bf56c78e0affb4a40f81759e275376cea75c9c5abe9/ty-0.0.39-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e8d89732bcbbcb091f439e556dfc4932f198b118b47d5b85212c60662099670e", size = 11281843, upload-time = "2026-05-22T21:09:34.234Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/53/64c4a27067a46643fea2b3fcf21a8a2f838d91a65ffdd14f2e82945b9538/ty-0.0.39-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:eceb6c91dcd05a231119f82abdd9aa337513de23ca6ac990bc44f88791dc1799", size = 11792477, upload-time = "2026-05-22T21:09:24.923Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e8/02f4dd4a12bcdbda0006f9c7ff3b99a4be06bd0d257d3bd4a5b66de074e6/ty-0.0.39-py3-none-win32.whl", hash = "sha256:891c3262314dbc80bf3e872634d23dd216306945daa9a9fcc206ce5ed21ac4c9", size = 10615377, upload-time = "2026-05-22T21:09:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5a/aaeb22faa8d4dae90a287d4c3636c671edcff3b99be5f4fc8b79ad71eef6/ty-0.0.39-py3-none-win_amd64.whl", hash = "sha256:ba7f2d54452535419e90f6f03ff39282999e87b43c21c00559f6d7ad711a36d5", size = 11710711, upload-time = "2026-05-22T21:09:53.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/17/ae7339651bfcaa5f54698c8c70eaf5031baa400ecb67baec31d03a56cbd4/ty-0.0.39-py3-none-win_arm64.whl", hash = "sha256:eb4cf0fefbbfedf9a352597bb2431ebdcb7eb3a595c0f825f228e897a0ec285d", size = 11081409, upload-time = "2026-05-22T21:09:03.741Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Ruff linting, Ruff format verification, and ty checks to CI after dependency installation. Configure a narrow initial baseline so formatting and high-signal static checks run consistently across the project. Includes cleanup needed for the new gates and a regression test for MATLAB skip behavior.