### PR TITLE
[Phase 1a] Stabilize EEG session contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,11 @@ Primary references:
 ## GUI And Console Workspace
 
 - EEGPrep's primary interactive workflow is mixed GUI plus `eegprep-console`. Both share one `EEGPrepSession`; `EEG`, `ALLEEG`, `CURRENTSET`, `LASTCOM`, `ALLCOM`, `STUDY`, and `CURRENTSTUDY` must stay synchronized.
+- `EEGPrepSession.CURRENTSET` is a list of EEGLAB-facing 1-based dataset indices; expose it as `0`, scalar `n`, or list `[n, ...]` in the console. Use `selected_dataset_indices()` for read-only multi-dataset state.
 - GUI/menu actions must update datasets and history through `EEGPrepSession` helpers such as `store_current`, `add_history`, and `notify_changed`; do not mutate GUI-only state that the console cannot see.
 - User-facing `pop_*` functions should support `return_com=True` and return EEGLAB-style history commands. The console wrappers rely on `(EEG, com)` results to auto-store bare calls like `pop_reref(EEG, [])`.
 - When adding or changing a GUI-reachable function, test both interaction directions when relevant: GUI action then console inspection, and console command then GUI refresh/history.
+- Menu placeholders must carry phase/exclusion metadata in `menu_placeholders.py`; mark EEGBrowser/eegplot-style scrolling workflows with an explicit exclusion instead of treating them as ordinary TODOs.
 
 ## Code Style
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -119,6 +119,66 @@ Tests run automatically on:
 
 Check CI status on GitHub Actions.
 
+EEG And Session Contracts
+=========================
+
+EEGPrep follows EEGLAB's public data model while keeping Python internals
+explicit and testable. Feature code should treat the following contracts as
+shared foundations rather than per-function conventions.
+
+EEG Dictionaries
+----------------
+
+Stored EEG dictionaries should be normalized through ``eeg_checkset`` or an
+``EEGPrepSession`` storage helper before other code relies on shape or type
+invariants. The core fields are ``data``, ``nbchan``, ``pnts``, ``trials``,
+``srate``, ``xmin``, ``xmax``, ``times``, ``event``, ``urevent``, ``epoch``,
+``chanlocs``, ``chaninfo``, ``history``, ``icaact``, ``icawinv``,
+``icasphere``, ``icaweights``, and ``icachansind``.
+
+Continuous data is channel-major with shape ``(nbchan, pnts)``. Epoched data
+is channel-major with shape ``(nbchan, pnts, trials)``. Event latencies and
+user-visible dataset, channel, epoch, and component indices are EEGLAB-style
+1-based values. Python array indexing remains 0-based inside numerical code.
+
+``event`` entries should keep EEGLAB-facing ``latency`` values and, when
+available, ``urevent`` pointers back to ``urevent`` entries. ``urevent`` is the
+original-event table; functions that create, delete, or reorder events must
+state whether they preserve, extend, or rebuild it. ``epoch`` stores per-epoch
+event metadata for epoched datasets. ``chanlocs`` entries use EEGLAB-style
+channel dictionaries, and ``chaninfo`` stores global channel-location metadata.
+ICA fields must be cleared or recomputed consistently when data, channel
+order, or channel count changes.
+
+Session Selection
+-----------------
+
+``EEGPrepSession.CURRENTSET`` is always a Python ``list[int]`` containing
+EEGLAB-facing 1-based dataset indices. An empty selection is ``[]`` internally
+and ``0`` in the console workspace. A single selected dataset is exposed as
+``CURRENTSET == n`` in the console. Multiple selected datasets are exposed as
+``CURRENTSET == [n, ...]``. Selection order is preserved and duplicate dataset
+indices are invalid.
+
+Read selection state through ``EEGPrepSession.selected_dataset_indices()`` when
+future STUDY or group-level code needs the current dataset vector. Phase 1a
+defines this read contract only; user-facing multi-selection mutation belongs
+to later feature work.
+
+History And Menu Inventory
+--------------------------
+
+User-facing ``pop_*`` functions should support ``return_com=True`` and return a
+history command that can be converted to valid ``eegprep-console`` input. GUI
+and console code should append each successful command once through
+``EEGPrepSession.add_history`` or storage helpers.
+
+Menu placeholders are machine-readable. Each placeholder action has either a
+target epic phase or an explicit exclusion reason such as ``eegbrowser`` for
+EEGBrowser/eegplot-style scrolling workflows. Runtime package code must not
+read, import, or shell out to ``src/eegprep/eeglab``; that tree is only a
+development parity reference.
+
 Building Documentation
 ======================
 

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import eegprep
 from eegprep.functions.adminfunc.eeglab import gui
-from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.functions.guifunc.session import EEGPrepSession, normalize_dataset_indices
 from eegprep.functions.popfunc.pop_newset import pop_newset
 
 
@@ -1086,15 +1086,10 @@ def _is_eeg_selection(value: Any) -> bool:
 
 
 def _normalize_currentset(value: Any) -> list[int]:
-    if value in (None, "", 0):
-        return []
-    if isinstance(value, (int, float)):
-        return [int(value)] if int(value) > 0 else []
-    if isinstance(value, tuple):
-        value = list(value)
-    if isinstance(value, list):
-        return [int(item) for item in value if int(item) > 0]
-    raise ValueError("CURRENTSET must be a 1-based integer or list of integers")
+    try:
+        return normalize_dataset_indices(value)
+    except ValueError as exc:
+        raise ValueError("CURRENTSET must be a 1-based integer or list of integers") from exc
 
 
 def _workspace_assignment_targets(source: str) -> set[str]:

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -1,89 +1,145 @@
 """Explicit placeholders for EEGLAB main-window actions not yet ported.
 
-TODO: replace each action family with the matching EEGPrep GUI flow and
-remove it from this registry when the implementation is complete.
+Each placeholder carries either an implementation phase or an exclusion reason
+so later phase agents can distinguish planned work from intentionally excluded
+browser/external-plugin workflows.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Mapping
 
-PLACEHOLDER_ACTIONS = frozenset(
-    {
-        "eeg_rejsuperpose",
-        "eeglab_update",
-        "pop_autorej",
-        "pop_chanedit",
-        "pop_chanplot",
-        "pop_clust",
-        "pop_clustedit",
-        "pop_comments",
-        "pop_comperp",
-        "pop_copyset",
-        "pop_dipfit_gridsearch",
-        "pop_dipfit_headmodel",
-        "pop_dipfit_loreta",
-        "pop_dipfit_nonlinear",
-        "pop_dipfit_settings",
-        "pop_dipplot",
-        "pop_editeventfield",
-        "pop_editeventvals",
-        "pop_editset",
-        "pop_eegfilt",
-        "pop_eegfiltnew",
-        "pop_eegplot",
-        "pop_eegthresh",
-        "pop_envtopo",
-        "pop_erpimage",
-        "pop_eventstat",
-        "pop_firma",
-        "pop_firpm",
-        "pop_firws",
-        "pop_fileio_brainvision_mat",
-        "pop_headplot",
-        "pop_icflag",
-        "pop_jointprob",
-        "pop_leadfield",
-        "pop_mergeset",
-        "pop_multifit",
-        "pop_newcrossf",
-        "pop_newtimef",
-        "pop_plotdata",
-        "pop_plottopo",
-        "pop_preclust",
-        "pop_precomp",
-        "pop_prop",
-        "pop_rejchan",
-        "pop_rejcont",
-        "pop_rejepoch",
-        "pop_rejkurt",
-        "pop_rejmenu",
-        "pop_rejspec",
-        "pop_rejtrend",
-        "pop_rmbase",
-        "pop_rmdat",
-        "pop_selectcomps",
-        "pop_selectevent",
-        "pop_signalstat",
-        "pop_spectopo",
-        "pop_studydesign",
-        "pop_subcomp",
-        "pop_timtopo",
-        "pop_topoplot",
-        "pop_viewprops",
-        "select_multiple_datasets",
-        "select_study_set",
-        "topoplot",
-    }
-)
+
+@dataclass(frozen=True)
+class PlaceholderMetadata:
+    """Phase ownership or exclusion metadata for a placeholder action."""
+
+    phase: str | None = None
+    excluded_reason: str | None = None
+
+
+def _phase_entries(phase: str, actions: tuple[str, ...]) -> dict[str, PlaceholderMetadata]:
+    return {action: PlaceholderMetadata(phase=phase) for action in actions}
+
+
+PLACEHOLDER_ACTION_METADATA: Mapping[str, PlaceholderMetadata] = {
+    **_phase_entries(
+        "1b",
+        (
+            "pop_chanedit",
+            "pop_comments",
+            "pop_copyset",
+            "pop_editeventfield",
+            "pop_editeventvals",
+            "pop_editset",
+            "pop_fileio_brainvision_mat",
+            "pop_mergeset",
+            "pop_rmdat",
+            "pop_selectevent",
+            "select_multiple_datasets",
+        ),
+    ),
+    **_phase_entries(
+        "2",
+        (
+            "pop_eegfilt",
+            "pop_eegfiltnew",
+            "pop_firma",
+            "pop_firpm",
+            "pop_firws",
+            "pop_rmbase",
+        ),
+    ),
+    **_phase_entries(
+        "3",
+        (
+            "eeg_rejsuperpose",
+            "pop_autorej",
+            "pop_dipfit_gridsearch",
+            "pop_dipfit_headmodel",
+            "pop_dipfit_loreta",
+            "pop_dipfit_nonlinear",
+            "pop_dipfit_settings",
+            "pop_dipplot",
+            "pop_eegthresh",
+            "pop_icflag",
+            "pop_jointprob",
+            "pop_leadfield",
+            "pop_multifit",
+            "pop_rejchan",
+            "pop_rejcont",
+            "pop_rejepoch",
+            "pop_rejkurt",
+            "pop_rejmenu",
+            "pop_rejspec",
+            "pop_rejtrend",
+            "pop_selectcomps",
+            "pop_subcomp",
+            "pop_viewprops",
+        ),
+    ),
+    **_phase_entries(
+        "4",
+        (
+            "pop_chanplot",
+            "pop_comperp",
+            "pop_envtopo",
+            "pop_erpimage",
+            "pop_eventstat",
+            "pop_headplot",
+            "pop_newcrossf",
+            "pop_newtimef",
+            "pop_plotdata",
+            "pop_plottopo",
+            "pop_prop",
+            "pop_signalstat",
+            "pop_spectopo",
+            "pop_timtopo",
+            "pop_topoplot",
+            "topoplot",
+        ),
+    ),
+    **_phase_entries(
+        "5",
+        (
+            "pop_clust",
+            "pop_clustedit",
+            "pop_preclust",
+            "pop_precomp",
+            "pop_studydesign",
+            "select_study_set",
+        ),
+    ),
+    **_phase_entries("6", ("eeglab_update",)),
+    "pop_eegplot": PlaceholderMetadata(excluded_reason="eegbrowser"),
+}
+PLACEHOLDER_ACTIONS = frozenset(PLACEHOLDER_ACTION_METADATA)
+
+
+def placeholder_metadata(action: str) -> PlaceholderMetadata | None:
+    """Return placeholder metadata for ``action`` when registered."""
+    return PLACEHOLDER_ACTION_METADATA.get(action.partition(":")[0])
+
+
+def placeholder_inventory() -> Mapping[str, PlaceholderMetadata]:
+    """Return the machine-readable placeholder inventory."""
+    return PLACEHOLDER_ACTION_METADATA
 
 
 def is_placeholder_action(action: str) -> bool:
     """Return whether a menu action has an explicit coming-soon placeholder."""
-    return action.partition(":")[0] in PLACEHOLDER_ACTIONS
+    return placeholder_metadata(action) is not None
 
 
 def placeholder_message(action: str) -> str:
     """Build the shared EEGLAB-style placeholder message for ``action``."""
+    metadata = placeholder_metadata(action)
+    if metadata is not None and metadata.excluded_reason == "eegbrowser":
+        return (
+            f"{action} depends on EEGBrowser/eegplot-style scrolling browser workflows, "
+            "which are outside the current EEGPrep parity scope."
+        )
     return (
         f"{action} is not yet available in EEGPrep.\n\n"
         "Track progress or request this workflow at https://github.com/sccn/eegprep/issues."

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -28,6 +29,48 @@ def has_eeg_data(eeg: Any) -> bool:
     if isinstance(data, list):
         return len(data) > 0
     return True
+
+
+def normalize_dataset_indices(indices: Any, *, allow_empty: bool = True) -> list[int]:
+    """Normalize EEGLAB-facing 1-based dataset indices for session state."""
+    if indices is None or (isinstance(indices, str) and indices == ""):
+        if allow_empty:
+            return []
+        raise ValueError("Dataset selection must contain at least one index")
+    if isinstance(indices, bool):
+        raise ValueError("Dataset indices must be 1-based integers")
+    if isinstance(indices, np.ndarray):
+        values = [indices.item()] if indices.ndim == 0 else indices.ravel().tolist()
+    elif isinstance(indices, (int, np.integer)):
+        values = [int(indices)]
+    elif isinstance(indices, (float, np.floating)):
+        if not float(indices).is_integer():
+            raise ValueError("Dataset indices must be integers")
+        values = [int(indices)]
+    elif isinstance(indices, Iterable) and not isinstance(indices, (str, bytes, dict)):
+        values = list(indices)
+    else:
+        raise ValueError("Dataset selection must be a 1-based integer or iterable of integers")
+
+    normalized: list[int] = []
+    seen: set[int] = set()
+    for value in values:
+        if isinstance(value, bool):
+            raise ValueError("Dataset indices must be 1-based integers")
+        if isinstance(value, (float, np.floating)) and not float(value).is_integer():
+            raise ValueError("Dataset indices must be integers")
+        index = int(value)
+        if index < 1:
+            if allow_empty and len(values) == 1 and index == 0:
+                continue
+            raise ValueError("EEGLAB dataset indices are 1-based")
+        if index in seen:
+            raise ValueError("Dataset selection cannot contain duplicate indices")
+        seen.add(index)
+        normalized.append(index)
+    if not normalized and not allow_empty:
+        raise ValueError("Dataset selection must contain at least one index")
+    return normalized
 
 
 @dataclass
@@ -119,6 +162,10 @@ class EEGPrepSession:
             return self.CURRENTSET[0]
         return list(self.CURRENTSET)
 
+    def selected_dataset_indices(self) -> list[int]:
+        """Return the selected EEGLAB-facing dataset indices in order."""
+        return list(self.CURRENTSET)
+
     def store_current(
         self,
         eeg: dict[str, Any] | list[dict[str, Any]],
@@ -139,7 +186,7 @@ class EEGPrepSession:
             index = 0 if new or not self.CURRENTSET else self.CURRENTSET[0]
         self.ALLEEG, checked, stored_index = eeg_store(self.ALLEEG, eeg, index)
         self.EEG = checked
-        self.CURRENTSET = list(stored_index) if isinstance(stored_index, list) else [int(stored_index)]
+        self.CURRENTSET = normalize_dataset_indices(stored_index, allow_empty=False)
         if mark_saved:
             self.mark_current_saved()
         self.add_history(command, notify=False)
@@ -148,9 +195,11 @@ class EEGPrepSession:
 
     def retrieve(self, indices: int | list[int]) -> dict[str, Any] | list[dict[str, Any]]:
         """Select dataset(s) from ALLEEG using 1-based indices."""
-        eeg, self.ALLEEG, current = eeg_retrieve(self.ALLEEG, indices)
+        selection = normalize_dataset_indices(indices, allow_empty=False)
+        use_vector = isinstance(indices, (list, tuple)) or (isinstance(indices, np.ndarray) and indices.ndim > 0)
+        eeg, self.ALLEEG, current = eeg_retrieve(self.ALLEEG, selection if use_vector else selection[0])
         self.EEG = eeg
-        self.CURRENTSET = list(current) if isinstance(current, list) else [int(current)]
+        self.CURRENTSET = normalize_dataset_indices(current, allow_empty=False)
         self.notify_changed()
         return eeg
 

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -32,7 +32,12 @@ def has_eeg_data(eeg: Any) -> bool:
 
 
 def normalize_dataset_indices(indices: Any, *, allow_empty: bool = True) -> list[int]:
-    """Normalize EEGLAB-facing 1-based dataset indices for session state."""
+    """Normalize EEGLAB-facing 1-based dataset indices for session state.
+
+    Empty selection is represented by ``None``, ``""``, scalar ``0``, an empty
+    iterable, or a single-item iterable containing ``0`` when ``allow_empty`` is
+    true. Mixed non-positive entries such as ``[0, 1]`` are invalid.
+    """
     if indices is None or (isinstance(indices, str) and indices == ""):
         if allow_empty:
             return []

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,7 +16,6 @@ import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 
-from eegprep.functions.adminfunc.console import _console_python_command
 from eegprep.functions.guifunc.session import EEGPrepSession
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 
@@ -301,6 +300,8 @@ def assert_history_contains_once(session: EEGPrepSession, command: str) -> None:
 
 def assert_history_replayable(command: str) -> str:
     """Assert that an EEGLAB-style command converts to valid Python input."""
+    from eegprep.functions.adminfunc.console import _console_python_command
+
     converted = _console_python_command(command)
     ast.parse(converted)
     return converted

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,12 +4,24 @@ This module provides common test fixtures and utilities that can be reused
 across different test modules.
 """
 
-import os
-import unittest
+import ast
+from copy import deepcopy
 import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+import unittest
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+
+from eegprep.functions.adminfunc.console import _console_python_command
+from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+
+
+SAMPLE_DATASET_PATH = Path(__file__).resolve().parents[1] / "sample_data" / "eeglab_data.set"
 
 
 def matlab_engine_available():
@@ -256,6 +268,60 @@ def cleanup_matplotlib():
     memory leaks and interference between tests.
     """
     plt.close('all')
+
+
+def fresh_sample_eeg() -> dict[str, Any]:
+    """Load a fresh copy of the checked-in EEGLAB sample dataset."""
+    return deepcopy(pop_loadset(str(SAMPLE_DATASET_PATH)))
+
+
+def fresh_session_with_sample(command: str = "EEG = pop_loadset('eeglab_data.set');") -> EEGPrepSession:
+    """Return a new session with one freshly loaded sample dataset selected."""
+    session = EEGPrepSession()
+    session.store_current(fresh_sample_eeg(), new=True, command=command)
+    return session
+
+
+def assert_session_synced(session: EEGPrepSession, namespace: dict[str, Any]) -> None:
+    """Assert that an EEGPrep console namespace mirrors ``session``."""
+    assert namespace["EEG"] is session.EEG
+    assert namespace["ALLEEG"] is session.ALLEEG
+    assert namespace["CURRENTSET"] == session.current_set_value()
+    assert namespace["ALLCOM"] is session.ALLCOM
+    assert namespace["LASTCOM"] == session.LASTCOM
+    assert namespace["STUDY"] is session.STUDY
+    assert namespace["CURRENTSTUDY"] == session.CURRENTSTUDY
+
+
+def assert_history_contains_once(session: EEGPrepSession, command: str) -> None:
+    """Assert that ``command`` was appended exactly once to session history."""
+    assert session.ALLCOM.count(command) == 1
+    assert session.LASTCOM == command
+
+
+def assert_history_replayable(command: str) -> str:
+    """Assert that an EEGLAB-style command converts to valid Python input."""
+    converted = _console_python_command(command)
+    ast.parse(converted)
+    return converted
+
+
+def assert_eeg_fields_close(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    fields: tuple[str, ...] | list[str],
+    *,
+    rtol: float = 1e-7,
+    atol: float = 1e-7,
+) -> None:
+    """Assert selected EEG fields match for lightweight parity scaffolding."""
+    for field in fields:
+        left_value = left[field]
+        right_value = right[field]
+        if isinstance(left_value, np.ndarray) or isinstance(right_value, np.ndarray):
+            np.testing.assert_allclose(left_value, right_value, rtol=rtol, atol=atol)
+        else:
+            assert left_value == right_value
 
 
 class TestFixturesContextManager:

--- a/tests/test_menu_placeholder_inventory.py
+++ b/tests/test_menu_placeholder_inventory.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from eegprep.functions.guifunc.eeglab_menu import eeglab_menus, menu_actions
+from eegprep.functions.guifunc.menu_actions import IMPLEMENTED_ACTIONS, action_kind
+from eegprep.functions.guifunc.menu_placeholders import (
+    PLACEHOLDER_ACTIONS,
+    placeholder_inventory,
+    placeholder_metadata,
+)
+
+
+def _all_menu_actions() -> set[str]:
+    default_actions = menu_actions(eeglab_menus(all_menus=False, include_plugins=True))
+    full_actions = menu_actions(eeglab_menus(all_menus=True, include_plugins=True))
+    return default_actions | full_actions
+
+
+def test_every_menu_action_is_implemented_placeholder_or_explicit_exclusion():
+    unknown = sorted(action for action in _all_menu_actions() if action_kind(action) == "unknown")
+
+    assert unknown == []
+
+
+def test_placeholder_inventory_has_phase_or_exclusion_metadata():
+    inventory = placeholder_inventory()
+
+    assert set(inventory) == PLACEHOLDER_ACTIONS
+    for action, metadata in inventory.items():
+        assert bool(metadata.phase) ^ bool(metadata.excluded_reason), action
+
+
+def test_no_implemented_action_remains_marked_as_placeholder():
+    overlap = sorted(IMPLEMENTED_ACTIONS & PLACEHOLDER_ACTIONS)
+
+    assert overlap == []
+
+
+def test_placeholder_inventory_classifies_representative_phase_work():
+    assert placeholder_metadata("pop_editset").phase == "1b"
+    assert placeholder_metadata("pop_rmbase").phase == "2"
+    assert placeholder_metadata("pop_rejchan").phase == "3"
+    assert placeholder_metadata("pop_spectopo").phase == "4"
+    assert placeholder_metadata("pop_studydesign").phase == "5"
+    assert placeholder_metadata("eeglab_update").phase == "6"
+
+
+def test_eegbrowser_scrolling_actions_are_explicitly_excluded():
+    metadata = placeholder_metadata("pop_eegplot:data")
+
+    assert metadata is not None
+    assert metadata.phase is None
+    assert metadata.excluded_reason == "eegbrowser"
+    assert action_kind("pop_eegplot:data") == "placeholder"

--- a/tests/test_session_contracts.py
+++ b/tests/test_session_contracts.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import ast
+
+import numpy as np
+import pytest
+
+from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace
+from eegprep.functions.guifunc.session import EEGPrepSession, normalize_dataset_indices
+from tests.fixtures import (
+    assert_eeg_fields_close,
+    assert_history_contains_once,
+    assert_history_replayable,
+    assert_session_synced,
+    create_test_eeg,
+    fresh_sample_eeg,
+    fresh_session_with_sample,
+)
+
+
+def test_sample_data_satisfies_core_eeg_contract():
+    eeg = fresh_sample_eeg()
+    data = eeg["data"]
+
+    assert isinstance(data, np.ndarray)
+    assert data.shape[0] == int(eeg["nbchan"])
+    assert data.shape[1] == int(eeg["pnts"])
+    assert int(eeg["trials"]) == 1
+    assert data.ndim == 2
+    assert np.asarray(eeg["times"]).shape == (int(eeg["pnts"]),)
+
+    for field in (
+        "event",
+        "urevent",
+        "epoch",
+        "chanlocs",
+        "chaninfo",
+        "history",
+        "icaact",
+        "icawinv",
+        "icasphere",
+        "icaweights",
+        "icachansind",
+    ):
+        assert field in eeg
+
+    events = list(eeg["event"])
+    chanlocs = list(eeg["chanlocs"])
+    assert events
+    assert chanlocs
+    assert all(isinstance(event, dict) for event in events)
+    assert all(float(event["latency"]) >= 1 for event in events if "latency" in event)
+    assert all(isinstance(chanloc, dict) for chanloc in chanlocs)
+    assert all("labels" in chanloc for chanloc in chanlocs)
+    assert isinstance(eeg["chaninfo"], dict)
+    assert isinstance(eeg["history"], str)
+    assert np.asarray(eeg["icachansind"]).dtype.kind in {"i", "u"}
+
+
+def test_sample_session_and_console_namespace_stay_synced():
+    command = "EEG = pop_loadset('eeglab_data.set');"
+    session = fresh_session_with_sample(command)
+    workspace = EEGPrepConsoleWorkspace(session, exports={})
+    try:
+        assert session.CURRENTSET == [1]
+        assert session.selected_dataset_indices() == [1]
+        assert session.current_set_value() == 1
+        assert_session_synced(session, workspace.namespace)
+        assert_history_contains_once(session, command)
+    finally:
+        workspace.close()
+
+
+def test_multi_dataset_selection_contract_preserves_order_and_console_shape():
+    session = EEGPrepSession()
+    for name in ("first", "second", "third"):
+        eeg = create_test_eeg(n_channels=2, n_samples=8)
+        eeg["setname"] = name
+        session.store_current(eeg, new=True)
+
+    selected = session.retrieve([3, 1])
+    workspace = EEGPrepConsoleWorkspace(session, exports={})
+    try:
+        assert isinstance(selected, list)
+        assert [dataset["setname"] for dataset in selected] == ["third", "first"]
+        assert session.CURRENTSET == [3, 1]
+        assert session.selected_dataset_indices() == [3, 1]
+        assert session.current_set_value() == [3, 1]
+        assert workspace.namespace["EEG"] is session.EEG
+        assert workspace.namespace["CURRENTSET"] == [3, 1]
+    finally:
+        workspace.close()
+
+
+def test_currentset_empty_single_and_multiple_console_values():
+    session = EEGPrepSession()
+    assert session.current_set_value() == 0
+
+    session.store_current(create_test_eeg(n_channels=2, n_samples=8), new=True)
+    assert session.current_set_value() == 1
+
+    session.store_current(create_test_eeg(n_channels=2, n_samples=8), new=True)
+    session.retrieve([1, 2])
+    assert session.current_set_value() == [1, 2]
+
+
+@pytest.mark.parametrize("indices", ([1, 1], [0], [-1], [1.5], True))
+def test_dataset_index_normalization_rejects_invalid_selection(indices):
+    with pytest.raises(ValueError):
+        normalize_dataset_indices(indices, allow_empty=False)
+
+
+def test_console_currentset_assignment_rejects_duplicate_indices():
+    session = EEGPrepSession()
+    for name in ("first", "second"):
+        eeg = create_test_eeg(n_channels=2, n_samples=8)
+        eeg["setname"] = name
+        session.store_current(eeg, new=True)
+    workspace = EEGPrepConsoleWorkspace(session, exports={})
+    try:
+        workspace.namespace["CURRENTSET"] = [1, 1]
+        with pytest.raises(ValueError, match="CURRENTSET"):
+            workspace.after_execute("CURRENTSET = [1, 1]", success=True)
+    finally:
+        workspace.close()
+
+
+def test_history_helpers_accept_replayable_gui_history():
+    converted = assert_history_replayable("EEG = pop_reref( EEG, [], 'keepref', 'on');")
+
+    assert converted == "EEG = pop_reref(EEG, ref=[], keepref='on')"
+    ast.parse(converted)
+
+
+def test_field_comparison_helper_supports_parity_scaffolding():
+    left = {"data": np.array([1.0, 2.0]), "setname": "demo"}
+    right = {"data": np.array([1.0, 2.0 + 1e-8]), "setname": "demo"}
+
+    assert_eeg_fields_close(left, right, ("data", "setname"))

--- a/tests/test_session_contracts.py
+++ b/tests/test_session_contracts.py
@@ -104,13 +104,28 @@ def test_currentset_empty_single_and_multiple_console_values():
     assert session.current_set_value() == [1, 2]
 
 
-@pytest.mark.parametrize("indices", ([1, 1], [0], [-1], [1.5], True))
+def test_dataset_index_normalization_accepts_canonical_empty_values():
+    assert normalize_dataset_indices(0) == []
+    assert normalize_dataset_indices([0]) == []
+    assert normalize_dataset_indices([]) == []
+
+
+@pytest.mark.parametrize("indices", ([1, 1], [0], [-1], [0, 1], [1.5], True))
 def test_dataset_index_normalization_rejects_invalid_selection(indices):
     with pytest.raises(ValueError):
         normalize_dataset_indices(indices, allow_empty=False)
 
 
-def test_console_currentset_assignment_rejects_duplicate_indices():
+@pytest.mark.parametrize(
+    ("source", "value"),
+    (
+        ("CURRENTSET = [1, 1]", [1, 1]),
+        ("CURRENTSET = -1", -1),
+        ("CURRENTSET = [1, -1, 2]", [1, -1, 2]),
+        ("CURRENTSET = [0, 1]", [0, 1]),
+    ),
+)
+def test_console_currentset_assignment_rejects_invalid_indices(source, value):
     session = EEGPrepSession()
     for name in ("first", "second"):
         eeg = create_test_eeg(n_channels=2, n_samples=8)
@@ -118,18 +133,28 @@ def test_console_currentset_assignment_rejects_duplicate_indices():
         session.store_current(eeg, new=True)
     workspace = EEGPrepConsoleWorkspace(session, exports={})
     try:
-        workspace.namespace["CURRENTSET"] = [1, 1]
+        workspace.namespace["CURRENTSET"] = value
         with pytest.raises(ValueError, match="CURRENTSET"):
-            workspace.after_execute("CURRENTSET = [1, 1]", success=True)
+            workspace.after_execute(source, success=True)
     finally:
         workspace.close()
 
 
 def test_history_helpers_accept_replayable_gui_history():
     converted = assert_history_replayable("EEG = pop_reref( EEG, [], 'keepref', 'on');")
+    tree = ast.parse(converted)
+    statement = tree.body[0]
 
-    assert converted == "EEG = pop_reref(EEG, ref=[], keepref='on')"
-    ast.parse(converted)
+    assert isinstance(statement, ast.Assign)
+    assert isinstance(statement.value, ast.Call)
+    assert isinstance(statement.value.func, ast.Name)
+    assert statement.value.func.id == "pop_reref"
+    assert isinstance(statement.value.args[0], ast.Name)
+    assert statement.value.args[0].id == "EEG"
+    assert any(
+        keyword.arg == "keepref" and isinstance(keyword.value, ast.Constant) and keyword.value.value == "on"
+        for keyword in statement.value.keywords
+    )
 
 
 def test_field_comparison_helper_supports_parity_scaffolding():


### PR DESCRIPTION
Stabilize the shared EEG/session/data contracts needed before parallel EEGLAB parity phases proceed. Adds documented EEG field, CURRENTSET, history, and placeholder inventory rules, plus reusable sample/session/history test helpers and contract tests for console/session/menu behavior. Invalid CURRENTSET entries now fail fast instead of being silently filtered.

Closes #61
