### PR TITLE
[Phase 2.1] Implement pop_rmbase baseline parity

### DIFF
--- a/docs/source/api/signal_processing.rst
+++ b/docs/source/api/signal_processing.rst
@@ -23,6 +23,8 @@ Resampling
 Baseline Removal
 ================
 
+.. autofunction:: eegprep.rmbase
+
 .. autofunction:: eegprep.pop_rmbase
 
 Topography

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,14 @@ For a complete list of releases and detailed release notes, see the `GitHub Rele
 Release Notes
 =============
 
+Unreleased
+----------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- ``eegprep.rmbase`` now exposes the low-level EEGLAB-style numeric baseline helper; use ``pop_rmbase`` for EEG dataset dictionaries.
+
 Version 1.0.0 (Current)
 -----------------------
 

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -105,7 +105,7 @@ _LAZY_EXPORTS = {
     "pop_writeeeg": ("eegprep.functions.popfunc.pop_writeeeg", "pop_writeeeg"),
     "reref": ("eegprep.functions.redefine_functions", "reref"),
     "resample": ("eegprep.functions.redefine_functions", "resample"),
-    "rmbase": ("eegprep.functions.redefine_functions", "rmbase"),
+    "rmbase": ("eegprep.functions.sigprocfunc.rmbase", "rmbase"),
     "saveset": ("eegprep.functions.redefine_functions", "saveset"),
     "select": ("eegprep.functions.redefine_functions", "select"),
     "topoplot": ("eegprep.functions.sigprocfunc.topoplot", "topoplot"),

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -57,6 +57,7 @@ IMPLEMENTED_ACTIONS = {
     "pop_savestudy",
     "pop_reref",
     "pop_resample",
+    "pop_rmbase",
     "pop_runica",
     "pop_saveset",
     "pop_select",
@@ -111,6 +112,7 @@ _MULTIPLE_DATASET_ACTIONS = {
     "pop_iclabel",
     "pop_reref",
     "pop_resample",
+    "pop_rmbase",
     "pop_runica",
     "pop_select",
 }
@@ -239,6 +241,9 @@ class MenuActionDispatcher:
             return
         if base == "pop_resample":
             self._run_pop_function("pop_resample", parent)
+            return
+        if base == "pop_rmbase":
+            self._run_pop_function("pop_rmbase", parent)
             return
         if base == "pop_runica":
             self._run_pop_function("pop_runica", parent)
@@ -672,6 +677,10 @@ class MenuActionDispatcher:
             from eegprep.functions.popfunc.pop_resample import pop_resample
 
             out = pop_resample(selection, return_com=True)
+        elif name == "pop_rmbase":
+            from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
+
+            out = pop_rmbase(selection, return_com=True)
         elif name == "pop_runica":
             from eegprep.functions.popfunc.pop_runica import pop_runica
 

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -48,7 +48,6 @@ PLACEHOLDER_ACTION_METADATA: Mapping[str, PlaceholderMetadata] = {
             "pop_firma",
             "pop_firpm",
             "pop_firws",
-            "pop_rmbase",
         ),
     ),
     **_phase_entries(

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -19,6 +19,7 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch_dialog_spec
 from eegprep.functions.popfunc.pop_interp import pop_interp_dialog_spec
 from eegprep.functions.popfunc.pop_reref import pop_reref_dialog_spec
 from eegprep.functions.popfunc.pop_resample import pop_resample_dialog_spec
+from eegprep.functions.popfunc.pop_rmbase import pop_rmbase_dialog_spec
 from eegprep.functions.popfunc.pop_runica import pop_runica_dialog_spec
 from eegprep.functions.popfunc.pop_select import pop_select_dialog_spec
 from eegprep.plugins.ICLabel.pop_iclabel import pop_iclabel_dialog_spec
@@ -149,6 +150,7 @@ def _demo_main_eeg(*, epoched: bool = False, setname: str = "menu demo") -> dict
                 "trials": 2,
                 "xmin": -0.2,
                 "xmax": 0.796,
+                "times": np.linspace(-200, 796, 250),
                 "epoch": [{"event": [1]}, {"event": [2]}],
             }
         )
@@ -355,6 +357,15 @@ def capture_pop_resample_dialog(output: pathlib.Path) -> None:
     _grab_dialog(dialog, output, app)
 
 
+def capture_pop_rmbase_dialog(output: pathlib.Path) -> None:
+    """Render and capture the pop_rmbase dialog."""
+    eeg = _demo_main_eeg(epoched=True, setname="baseline demo")
+    spec = pop_rmbase_dialog_spec(eeg)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
 def capture_pop_epoch_dialog(output: pathlib.Path) -> None:
     """Render and capture the pop_epoch dialog."""
     eeg = _demo_main_eeg(setname="pop demo")
@@ -527,6 +538,8 @@ def main(argv: list[str] | None = None) -> int:
         capture_pop_select_dialog(args.output)
     elif args.case == "pop_resample_dialog":
         capture_pop_resample_dialog(args.output)
+    elif args.case == "pop_rmbase_dialog":
+        capture_pop_rmbase_dialog(args.output)
     elif args.case == "pop_epoch_dialog":
         capture_pop_epoch_dialog(args.output)
     elif args.case == "pop_runica_dialog":

--- a/src/eegprep/functions/popfunc/pop_rmbase.py
+++ b/src/eegprep/functions/popfunc/pop_rmbase.py
@@ -222,14 +222,7 @@ def _remove_continuous_baseline(
             continue
         # EEGLAB's boundary path only writes the selected baseline window.
         window = np.ix_(channel_indices, segment_baseline)
-        if segment_baseline.size == 1:
-            data[window] = 0
-            continue
-        data[window] = rmbase(
-            data[window],
-            segment_baseline.size,
-            np.arange(1, segment_baseline.size + 1),
-        )
+        data[window] = rmbase(data[window])
     return data
 
 

--- a/src/eegprep/functions/popfunc/pop_rmbase.py
+++ b/src/eegprep/functions/popfunc/pop_rmbase.py
@@ -1,244 +1,469 @@
-"""EEG baseline removal utilities."""
+"""EEGLAB-style baseline removal pop function."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+from typing import Any
 
 import numpy as np
-from typing import Iterable, Optional, Tuple
 
-from eegprep.functions.popfunc.eeg_findboundaries import eeg_findboundaries
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
 from eegprep.functions.miscfunc.misc import round_mat
+from eegprep.functions.popfunc._pop_utils import format_history_value, parse_text_tokens
+from eegprep.functions.popfunc.eeg_findboundaries import eeg_findboundaries
+from eegprep.functions.sigprocfunc.rmbase import rmbase
 
 
-def _normalize_pointrange(pointrange: Optional[Iterable], pnts: int) -> np.ndarray:
-    """Normalize MATLAB-like pointrange into a 0-based numpy index vector within [0, pnts-1].
-
-    Accepts:
-      - None or empty → full range
-      - two-element iterable [start, end] inclusive (1-based or 0-based tolerated)
-      - any iterable of indices → will be clipped and uniqued in ascending order
-    """
-    if pointrange is None:
-        return np.arange(pnts, dtype=int)
-
-    if isinstance(pointrange, slice):
-        start = 0 if pointrange.start is None else int(pointrange.start)
-        stop = pnts if pointrange.stop is None else int(pointrange.stop)
-        step = 1 if pointrange.step is None else int(pointrange.step)
-        idx = np.arange(start, stop, step, dtype=int)
-        return idx.astype(int)
-
-    # convert to numpy array of ints/floats
-    arr = np.asarray(list(pointrange))
-
-    if arr.ndim == 1 and arr.size == 0:
-        idx = np.arange(pnts, dtype=int)
-    elif arr.ndim == 1 and arr.size == 2:
-        # tolerate 1-based inputs; convert to 0-based inclusive
-        a = int(arr[0])
-        b = int(arr[1])
-        # if clearly 1-based, shift; otherwise assume 0-based
-        if a >= 1 and b >= 1:
-            a -= 1
-            b -= 1
-        if a < 0:
-            a = 0
-        if b >= pnts:
-            b = pnts - 1
-        if b < a:
-            a, b = b, a
-        idx = np.arange(a, b + 1, dtype=int)
-    else:
-        # arbitrary index list; clip and uniquify sorted
-        idx = np.unique(arr.astype(int))
-        idx = idx[(idx >= 0) & (idx < pnts)]
-
-    return idx.astype(int)
-
-
-def _indices_from_timerange(times: np.ndarray, timerange: Iterable[float]) -> np.ndarray:
-    """Build 0-based indices from a millisecond timerange using EEG['times'] (ms)."""
-    tr = np.asarray(list(timerange), dtype=float)
-    if tr.size != 2:
-        raise ValueError('timerange must contain 2 elements [min_ms, max_ms]')
-    tmin, tmax = float(tr[0]), float(tr[1])
-    if tmin < float(times[0]) or tmax > float(times[-1]):
-        raise ValueError('pop_rmbase(): Bad time range')
-    mask = (times >= tmin) & (times <= tmax)
-    idx = np.where(mask)[0]
-    if idx.size == 0:
-        # fallback to nearest
-        idx = np.array([np.argmin(np.abs(times - tmin))], dtype=int)
-    return idx.astype(int)
-
-
-def _subtract_mean_over_indices(data: np.ndarray, idx: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    """Subtract mean over the provided indices from each channel for 2D data (chans x frames).
-
-    Returns (data_out, means) where means is chans x 1.
-    """
-    if data.ndim != 2:
-        raise ValueError('Expected 2D array (channels x frames)')
-    if idx.size == 0:
-        return data, np.zeros((data.shape[0], 1))
-    means = np.nanmean(data[:, idx], axis=1, keepdims=True)
-    return data - means, means
+_UNSET = object()
+_RANGE_TOKEN = re.compile(r"^(-?\d+(?:\.\d+)?)(?::(-?\d+(?:\.\d+)?))?(?::(-?\d+(?:\.\d+)?))?$")
 
 
 def pop_rmbase(
-    EEG: dict,
-    timerange: Optional[Iterable[float]] = None,
-    pointrange: Optional[Iterable[int]] = None,
-    chanlist: Optional[Iterable[int]] = None,
-) -> dict:
+    EEG: Any = _UNSET,
+    timerange: Any = None,
+    pointrange: Any = None,
+    chanlist: Any = None,
+    *,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+):
+    """Remove baseline means from an epoched or continuous EEG dataset.
+
+    ``timerange`` uses the units stored in ``EEG["times"]``. ``pointrange``
+    and numeric ``chanlist`` values use EEGLAB-facing 1-based indices.
+    Calling ``pop_rmbase(EEG)`` opens the GUI; pass explicit ranges or
+    ``gui=False`` for direct command-line use.
     """
-    POP_RMBASE - remove channel baseline means from an epoched or continuous EEG dataset.
+    if EEG is _UNSET or EEG is None:
+        raise ValueError("pop_rmbase(): EEG dataset is required")
+    if gui is None:
+        gui = timerange is None and pointrange is None and chanlist is None
 
-    Parameters
-    ----------
-    EEG : dict
-        EEGLAB-like EEG structure with keys: 'data', 'nbchan', 'pnts', 'trials', 'times', 'event'.
-        Event latencies are 1-based indices (EEGLAB convention).
-    timerange : [min_ms, max_ms] or None
-        Baseline latency range in milliseconds; overrides pointrange when provided.
-    pointrange : iterable of indices or [start, end]
-        Baseline sample indices (0-based or 1-based tolerated). If None/empty, use whole epoch.
-    chanlist : iterable of channel indices (0-based). If None, all channels are used.
+    if isinstance(EEG, list):
+        if not EEG:
+            return ([], "") if return_com else []
+        if gui:
+            result = _run_gui(EEG[0], renderer=renderer, multiple=True)
+            if result is None:
+                return (EEG, "") if return_com else EEG
+            timerange = result["timerange"]
+            pointrange = result["pointrange"]
+            chanlist = None
+        outputs = [pop_rmbase(item, timerange, pointrange, chanlist, gui=False) for item in EEG]
+        command = _history_command(timerange, pointrange, None, None)
+        return (outputs, command) if return_com else outputs
 
-    Returns
-    -------
-    EEG : dict
-        Updated EEG structure with baseline removed. EEG['icaact'] is cleared.
-    """
-    if (
-        EEG is None
-        or 'data' not in EEG
-        or EEG['data'] is None
-        or (hasattr(EEG['data'], 'size') and EEG['data'].size == 0)
-    ):
-        raise ValueError('pop_rmbase(): cannot remove baseline of an empty dataset')
+    if gui:
+        result = _run_gui(EEG, renderer=renderer, multiple=False)
+        if result is None:
+            return (EEG, "") if return_com else EEG
+        timerange = result["timerange"]
+        pointrange = result["pointrange"]
+        chanlist = result["chanlist"]
 
-    data = EEG['data']
-    nbchan = int(EEG.get('nbchan', data.shape[0]))
-    pnts = int(EEG.get('pnts', data.shape[1] if data.ndim >= 2 else 0))
-    trials = int(EEG.get('trials', data.shape[2] if data.ndim == 3 else 1))
+    output, history_pointrange, history_chanlist = _apply_pop_rmbase_one(EEG, timerange, pointrange, chanlist)
+    history_timerange = timerange if _has_values(timerange) else []
+    if _has_values(history_timerange):
+        history_pointrange = []
+    command = _history_command(history_timerange, history_pointrange, history_chanlist, int(output["nbchan"]))
+    return (output, command) if return_com else output
 
-    if chanlist is None or (isinstance(chanlist, (list, tuple, np.ndarray)) and len(chanlist) == 0):
-        chanlist = list(range(nbchan))
-    else:
-        chanlist = list(map(int, list(chanlist)))
 
-    # Determine baseline indices
-    if timerange is not None and len(list(timerange)) > 0:
-        if 'times' not in EEG or EEG['times'] is None:
-            raise ValueError('EEG["times"] is required when using timerange')
-        pr = _indices_from_timerange(np.asarray(EEG['times'], dtype=float), timerange)
-    elif pointrange is not None and len(list(pointrange)) > 0:
-        pr = _normalize_pointrange(pointrange, pnts)
-    else:
-        pr = np.arange(pnts, dtype=int)
-
-    # Epoched vs continuous handling
-    epoched = trials > 1 or (data.ndim == 3 and data.shape[-1] > 1)
-
-    # Ensure data dimensionality conforms
-    if epoched:
-        if data.ndim != 3:
-            # normalize to (nbchan, pnts, trials)
-            data = data.reshape((nbchan, pnts, trials))
-            EEG['data'] = data
-    else:
-        if data.ndim == 3:
-            data = data[:, :, 0]
-            EEG['data'] = data
-
-    # Remove baseline
-    if not epoched:
-        # Continuous data
-        events = EEG.get('event', [])
-        # Normalize events to list
-        if isinstance(events, np.ndarray):
-            try:
-                events = events.tolist()
-            except Exception:
-                events = []
-        use_boundaries = (
-            isinstance(events, list)
-            and len(events) > 0
-            and isinstance(events[0], dict)
-            and isinstance(events[0].get('type', None), str)
+def pop_rmbase_dialog_spec(EEG: dict[str, Any], *, multiple: bool = False) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_rmbase``."""
+    trials = int(EEG.get("trials", 1) or 1)
+    labels = _channel_field_values(EEG, "labels")
+    types = _channel_field_values(EEG, "type", unique=True)
+    channel_enabled = not multiple
+    controls: list[ControlSpec] = []
+    geometry: list[tuple[float, ...]] = []
+    if trials > 1:
+        controls.extend(
+            [
+                ControlSpec("text", "Baseline latency range ([min max] in ms) ([ ] = whole epoch):"),
+                ControlSpec("edit", tag="timerange", value=_default_baseline_timerange(EEG)),
+                ControlSpec("text", "Or remove baseline points vector (ex:1:56):"),
+                ControlSpec("edit", tag="pointrange", value=""),
+                ControlSpec("text", "Note: press Cancel if you do not want to remove the baseline"),
+            ]
         )
-        if use_boundaries:
-            bidx = eeg_findboundaries(EEG=EEG)
-            if len(bidx) == 0:
-                # Manual check for boundaries - use this instead
-                bidx = [i for i, ev in enumerate(events) if ev.get('type', '') == 'boundary']
-        else:
-            bidx = []
-
-        if bidx:
-            # MATLAB-compatible boundary processing
-            # boundaries = round([ tmpevent(boundaries).latency ] -0.5-pointrange(1)+1);
-            boundary_lats = []
-            for i in bidx:
-                try:
-                    lat = float(events[i].get('latency', np.nan))
-                    if not np.isnan(lat):
-                        boundary_lats.append(lat)
-                except Exception:
-                    continue
-
-            # Convert to MATLAB's boundary indices (relative to baseline start)
-            # MATLAB formula: round(lat - 0.5 - pointrange(1) + 1)
-            boundaries = []
-            for lat in boundary_lats:
-                boundary_idx = int(round_mat(lat - 0.5 - pr[0] + 1))
-                boundaries.append(boundary_idx)
-
-            # Filter boundaries to be within the baseline range
-            # MATLAB: boundaries(boundaries>=pointrange(end)-pointrange(1)) = [];
-            #         boundaries(boundaries<1) = [];
-            baseline_len = pr[-1] - pr[0] + 1  # pointrange(end) - pointrange(1) + 1
-            boundaries = [b for b in boundaries if 1 <= b < baseline_len]
-
-            # Add start and end boundaries
-            # MATLAB: boundaries = [0 boundaries pointrange(end)-pointrange(1)+1];
-            boundaries = [0] + sorted(boundaries) + [baseline_len]
-
-            # Process each segment
-            for index in range(len(boundaries) - 1):
-                # MATLAB: tmprange = [boundaries(index)+1:boundaries(index+1)];
-                start_idx = boundaries[index] + 1  # 1-based in MATLAB
-                end_idx = boundaries[index + 1]  # 1-based in MATLAB
-
-                # Convert to 0-based Python indices within baseline range
-                # pr[0] is 1-based MATLAB index, convert to 0-based Python index
-                baseline_start_py = pr[0] - 1
-                py_start = baseline_start_py + start_idx - 1  # start_idx is 1-based MATLAB
-                py_end = baseline_start_py + end_idx - 1  # end_idx is 1-based MATLAB
-
-                tmprange_len = end_idx - start_idx + 1
-
-                if py_start < 0 or py_end < py_start:
-                    continue
-
-                if tmprange_len > 1:
-                    # Subtract mean of this segment
-                    seg = EEG['data'][chanlist, py_start : py_end + 1]
-                    if seg.size > 0:
-                        seg_means = np.nanmean(seg, axis=1, keepdims=True)
-                        EEG['data'][chanlist, py_start : py_end + 1] = seg - seg_means
-                elif tmprange_len == 1:
-                    EEG['data'][chanlist, py_start : py_end + 1] = 0.0
-        else:
-            # No boundaries: subtract mean over baseline range from whole record
-            EEG['data'][chanlist, :], _ = _subtract_mean_over_indices(EEG['data'][chanlist, :], pr)
+        geometry.extend([(3, 1), (3, 1), (1,)])
+        size = (716, 299)
     else:
-        # Epoched data: for each channel, subtract mean over baseline indices per epoch
-        # data shape: (nbchan, pnts, trials)
-        for indc in chanlist:
-            # mean across baseline points for each epoch → shape (trials,)
-            m = np.nanmean(EEG['data'][indc, pr, :], axis=0)
-            EEG['data'][indc, :, :] = EEG['data'][indc, :, :] - m[np.newaxis, :]
+        controls.append(ControlSpec("text", "Removing the mean of each data channel (press cancel to skip)"))
+        geometry.append((1,))
+        size = (626, 198)
 
-    # Clear ICA activations to remain consistent with EEGLAB behavior
-    EEG['icaact'] = []
+    controls.extend(
+        [
+            ControlSpec("text", "Channel type(s)", enabled=channel_enabled),
+            ControlSpec("edit", tag="chantypes", value="", enabled=channel_enabled),
+            ControlSpec(
+                "pushbutton",
+                "...",
+                tag="chantypes_button",
+                enabled=channel_enabled and bool(types),
+                callback=CallbackSpec(
+                    "select_channels",
+                    params={"button": "chantypes_button", "target": "chantypes", "channels": types},
+                    matlab_callback="pop_chansel({tmpchanlocs.type}, 'withindex', 'off')",
+                ),
+            ),
+            ControlSpec("text", "OR channel(s) (default all)", enabled=channel_enabled),
+            ControlSpec("edit", tag="channels", value="", enabled=channel_enabled),
+            ControlSpec(
+                "pushbutton",
+                "...",
+                tag="channels_button",
+                enabled=channel_enabled and bool(labels),
+                callback=CallbackSpec(
+                    "select_channels",
+                    params={"button": "channels_button", "target": "channels", "channels": labels},
+                    matlab_callback="pop_chansel({tmpchanlocs.labels}, 'withindex', 'on')",
+                ),
+            ),
+        ]
+    )
+    geometry.extend([(2, 1.5, 0.5), (2, 1.5, 0.5)])
+    return DialogSpec(
+        title="Baseline removal - pop_rmbase()",
+        function_name="pop_rmbase",
+        eeglab_source="functions/popfunc/pop_rmbase.m",
+        geometry=tuple(geometry),
+        size=size,
+        help_text="pophelp('pop_rmbase')",
+        controls=tuple(controls),
+        content_margins=(42, 35, 42, 35),
+        row_spacing=18,
+    )
 
-    return EEG
+
+def _run_gui(EEG: dict[str, Any], *, renderer: Any | None = None, multiple: bool = False) -> dict[str, Any] | None:
+    spec = pop_rmbase_dialog_spec(EEG, multiple=multiple)
+    result = inputgui(spec, renderer=renderer)
+    if result is None:
+        return None
+    trials = int(EEG.get("trials", 1) or 1)
+    timerange: Any = []
+    pointrange: Any = []
+    if trials > 1:
+        timerange_text = str(result.get("timerange", "")).strip()
+        pointrange_text = str(result.get("pointrange", "")).strip()
+        if _is_blank_text(timerange_text) and _is_blank_text(pointrange_text):
+            times = np.asarray(EEG["times"], dtype=float).ravel()
+            timerange = [float(times[0]), float(times[-1])]
+        else:
+            timerange = _parse_numeric_vector(timerange_text)
+            pointrange = _parse_numeric_vector(pointrange_text)
+    chanlist = None
+    if not multiple:
+        chantypes = str(result.get("chantypes", "")).strip()
+        channels = str(result.get("channels", "")).strip()
+        if not _is_blank_text(chantypes):
+            chanlist = _resolve_channel_types(EEG, chantypes)
+        elif not _is_blank_text(channels):
+            chanlist = _resolve_channel_indices(EEG, channels, one_based=True)[1]
+    return {"timerange": timerange, "pointrange": pointrange, "chanlist": chanlist}
+
+
+def _apply_pop_rmbase_one(
+    EEG: dict[str, Any],
+    timerange: Any,
+    pointrange: Any,
+    chanlist: Any,
+) -> tuple[dict[str, Any], list[int], list[int] | None]:
+    _validate_eeg(EEG)
+    output = deepcopy(EEG)
+    data = np.asarray(output["data"])
+    nbchan = int(output.get("nbchan", data.shape[0]))
+    pnts = int(output.get("pnts", data.shape[1]))
+    trials = int(output.get("trials", data.shape[2] if data.ndim == 3 else 1))
+    if data.ndim == 2 and trials > 1:
+        data = data.reshape(nbchan, pnts, trials)
+    elif data.ndim == 3 and trials <= 1:
+        data = data[:, :, 0]
+        trials = 1
+    elif data.ndim not in {2, 3}:
+        raise ValueError("pop_rmbase(): EEG data must be 2D or 3D")
+
+    baseline_indices, history_pointrange = _baseline_indices(output, timerange, pointrange, pnts)
+    channel_indices, history_chanlist = _resolve_channel_indices(output, chanlist, one_based=True)
+    if data.ndim == 2:
+        data = _remove_continuous_baseline(output, data, channel_indices, baseline_indices)
+    else:
+        data[channel_indices, :, :] = rmbase(data[channel_indices, :, :], pnts, baseline_indices + 1)
+
+    output["data"] = data
+    output["nbchan"] = nbchan
+    output["pnts"] = pnts
+    output["trials"] = trials
+    output["icaact"] = np.array([])
+    output["saved"] = "no"
+    return output, history_pointrange, history_chanlist
+
+
+def _remove_continuous_baseline(
+    EEG: dict[str, Any],
+    data: np.ndarray,
+    channel_indices: list[int],
+    baseline_indices: np.ndarray,
+) -> np.ndarray:
+    boundaries = _continuous_boundary_starts(EEG, data.shape[1])
+    if not boundaries:
+        data[channel_indices, :] = rmbase(data[channel_indices, :], data.shape[1], baseline_indices + 1)
+        return data
+    segment_bounds = [0, *boundaries, data.shape[1]]
+    for start, stop in zip(segment_bounds[:-1], segment_bounds[1:]):
+        if stop <= start:
+            continue
+        segment_baseline = baseline_indices[(baseline_indices >= start) & (baseline_indices < stop)]
+        if segment_baseline.size == 0:
+            continue
+        if stop - start == 1:
+            data[channel_indices, start:stop] = 0
+            continue
+        data[channel_indices, start:stop] = rmbase(
+            data[channel_indices, start:stop],
+            stop - start,
+            segment_baseline - start + 1,
+        )
+    return data
+
+
+def _baseline_indices(
+    EEG: dict[str, Any],
+    timerange: Any,
+    pointrange: Any,
+    pnts: int,
+) -> tuple[np.ndarray, list[int]]:
+    if _has_values(timerange):
+        times = np.asarray(EEG.get("times"), dtype=float).ravel()
+        if times.size == 0:
+            raise ValueError('EEG["times"] is required when using timerange')
+        values = _parse_numeric_vector(timerange, dtype=float)
+        if len(values) != 2:
+            raise ValueError("timerange must contain [min max]")
+        if values[0] < float(times[0]) or values[-1] > float(times[-1]):
+            raise ValueError("pop_rmbase(): Bad time range")
+        indices = np.where((times >= values[0]) & (times <= values[-1]))[0]
+        if indices.size == 0:
+            raise ValueError("pop_rmbase(): time range does not contain samples")
+        return indices.astype(int), (indices + 1).astype(int).tolist()
+    if _has_values(pointrange):
+        values = _parse_numeric_vector(pointrange, dtype=float)
+        indices = _point_indices_from_values(values, pnts)
+        return indices, (indices + 1).astype(int).tolist()
+    indices = np.arange(pnts, dtype=int)
+    return indices, []
+
+
+def _point_indices_from_values(values: list[float], pnts: int) -> np.ndarray:
+    if not values:
+        return np.arange(pnts, dtype=int)
+    indices = np.asarray(values, dtype=int)
+    indices = indices[(indices >= 1) & (indices <= pnts)]
+    if indices.size == 0:
+        raise ValueError("pointrange does not overlap the data")
+    return np.unique(indices - 1)
+
+
+def _continuous_boundary_starts(EEG: dict[str, Any], pnts: int) -> list[int]:
+    events = EEG.get("event", [])
+    if isinstance(events, np.ndarray):
+        events = events.tolist()
+    if not isinstance(events, list) or not events:
+        return []
+    starts = []
+    for event_index in eeg_findboundaries(EEG=EEG):
+        event = events[event_index]
+        try:
+            latency = float(event.get("latency"))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        start = int(round_mat(latency - 0.5))
+        if 0 < start < pnts:
+            starts.append(start)
+    return sorted(set(starts))
+
+
+def _resolve_channel_indices(
+    EEG: dict[str, Any],
+    chanlist: Any,
+    *,
+    one_based: bool,
+) -> tuple[list[int], list[int] | None]:
+    nbchan = int(EEG.get("nbchan", np.asarray(EEG.get("data")).shape[0]))
+    if not _has_values(chanlist):
+        return list(range(nbchan)), None
+    tokens = _channel_tokens(chanlist)
+    numeric = _numeric_channel_tokens(tokens)
+    if numeric is not None:
+        if not one_based:
+            indices = numeric
+            history = [index + 1 for index in numeric]
+        else:
+            indices = [index - 1 for index in numeric]
+            history = numeric
+        if any(index < 0 or index >= nbchan for index in indices):
+            raise ValueError("chanlist indices must be 1-based and within EEG.nbchan")
+        return sorted(dict.fromkeys(indices)), sorted(dict.fromkeys(history))
+    labels = _channel_field_values(EEG, "labels")
+    lookup = {label.lower(): index for index, label in enumerate(labels)}
+    indices = []
+    for token in tokens:
+        key = str(token).strip().lower()
+        if key not in lookup:
+            raise ValueError(f"Channel '{token}' not found")
+        indices.append(lookup[key])
+    indices = sorted(dict.fromkeys(indices))
+    return indices, [index + 1 for index in indices]
+
+
+def _resolve_channel_types(EEG: dict[str, Any], text: str) -> list[int]:
+    requested = {str(token).strip().lower() for token in parse_text_tokens(text) if str(token).strip()}
+    chanlocs = _chanlocs(EEG)
+    indices = [
+        index + 1 for index, chan in enumerate(chanlocs) if str(chan.get("type", "")).strip().lower() in requested
+    ]
+    if not indices:
+        raise ValueError("No channels matched the selected channel type(s)")
+    return indices
+
+
+def _numeric_channel_tokens(tokens: list[Any]) -> list[int] | None:
+    values = []
+    for token in tokens:
+        if isinstance(token, (int, float, np.integer, np.floating)) and float(token).is_integer():
+            values.append(int(token))
+            continue
+        text = str(token).strip()
+        if not text.isdigit():
+            return None
+        values.append(int(text))
+    return values
+
+
+def _channel_tokens(value: Any) -> list[Any]:
+    if isinstance(value, str):
+        return parse_text_tokens(value, parse_ints=True)
+    if isinstance(value, np.ndarray):
+        return value.ravel().tolist()
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return [value]
+    return list(value)
+
+
+def _parse_numeric_vector(value: Any, *, dtype: type = float) -> list[Any]:
+    if not _has_values(value):
+        return []
+    if isinstance(value, str):
+        text = value.strip().strip("[]")
+        if not text:
+            return []
+        values = []
+        for token in text.replace(",", " ").split():
+            values.extend(_parse_range_token(token))
+        return [dtype(item) for item in values]
+    if isinstance(value, np.ndarray):
+        values = value.ravel().tolist()
+    elif isinstance(value, (int, float, np.integer, np.floating)):
+        values = [value]
+    else:
+        values = list(np.asarray(value).ravel())
+    return [dtype(item) for item in values]
+
+
+def _parse_range_token(token: str) -> list[float]:
+    match = _RANGE_TOKEN.match(token)
+    if match is None or match.group(2) is None:
+        return [float(token)]
+    first = float(match.group(1))
+    if match.group(3) is None:
+        step = 1.0 if float(match.group(2)) >= first else -1.0
+        last = float(match.group(2))
+    else:
+        step = float(match.group(2))
+        last = float(match.group(3))
+    if step == 0:
+        raise ValueError("range step cannot be zero")
+    values = []
+    current = first
+    compare = (lambda left, right: left <= right) if step > 0 else (lambda left, right: left >= right)
+    while compare(current, last):
+        values.append(current)
+        current += step
+    return values
+
+
+def _history_command(timerange: Any, pointrange: Any, chanlist: Any, nbchan: int | None) -> str:
+    timerange_text = format_history_value(_history_sequence(timerange), cell_for_sequence=None)
+    pointrange_text = format_history_value(_history_sequence(pointrange), cell_for_sequence=None)
+    parts = [timerange_text, pointrange_text]
+    if _has_values(chanlist):
+        chan_values = _history_sequence(chanlist)
+        if nbchan is None or chan_values != list(range(1, nbchan + 1)):
+            parts.append(format_history_value(chan_values, cell_for_sequence=None))
+    return f"EEG = pop_rmbase( EEG, {', '.join(parts)});"
+
+
+def _history_sequence(value: Any) -> list[Any]:
+    if not _has_values(value):
+        return []
+    if isinstance(value, np.ndarray):
+        return value.ravel().tolist()
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return [value]
+    return list(value)
+
+
+def _channel_field_values(EEG: dict[str, Any], field: str, *, unique: bool = False) -> list[str]:
+    values = [str(chan.get(field, "")) for chan in _chanlocs(EEG)]
+    if not unique:
+        return values
+    deduped = []
+    for value in values:
+        if value and value not in deduped:
+            deduped.append(value)
+    return deduped
+
+
+def _chanlocs(EEG: dict[str, Any]) -> list[dict[str, Any]]:
+    chanlocs = EEG.get("chanlocs", [])
+    if isinstance(chanlocs, np.ndarray):
+        chanlocs = chanlocs.tolist()
+    return [chan if isinstance(chan, dict) else {} for chan in list(chanlocs or [])]
+
+
+def _default_baseline_timerange(EEG: dict[str, Any]) -> str:
+    times = np.asarray(EEG.get("times", []), dtype=float).ravel()
+    if times.size == 0 or times[0] >= 0:
+        return "[ ]"
+    return f"{times[0]:g} 0"
+
+
+def _validate_eeg(EEG: dict[str, Any]) -> None:
+    if not isinstance(EEG, dict):
+        raise ValueError("pop_rmbase(): EEG must be a dataset dictionary")
+    data = EEG.get("data")
+    if data is None or np.asarray(data).size == 0:
+        raise ValueError("pop_rmbase(): cannot remove baseline of an empty dataset")
+
+
+def _has_values(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return not _is_blank_text(value)
+    if isinstance(value, np.ndarray):
+        return value.size > 0
+    if isinstance(value, (list, tuple)):
+        return len(value) > 0
+    return True
+
+
+def _is_blank_text(text: str) -> bool:
+    stripped = text.strip()
+    return stripped in {"", "[]", "[ ]"}

--- a/src/eegprep/functions/popfunc/pop_rmbase.py
+++ b/src/eegprep/functions/popfunc/pop_rmbase.py
@@ -66,8 +66,6 @@ def pop_rmbase(
 
     output, history_pointrange, history_chanlist = _apply_pop_rmbase_one(EEG, timerange, pointrange, chanlist)
     history_timerange = timerange if _has_values(timerange) else []
-    if _has_values(history_timerange):
-        history_pointrange = []
     command = _history_command(history_timerange, history_pointrange, history_chanlist, int(output["nbchan"]))
     return (output, command) if return_com else output
 
@@ -165,7 +163,7 @@ def _run_gui(EEG: dict[str, Any], *, renderer: Any | None = None, multiple: bool
         if not _is_blank_text(chantypes):
             chanlist = _resolve_channel_types(EEG, chantypes)
         elif not _is_blank_text(channels):
-            chanlist = _resolve_channel_indices(EEG, channels, one_based=True)[1]
+            chanlist = _resolve_channel_indices(EEG, channels)[1]
     return {"timerange": timerange, "pointrange": pointrange, "chanlist": chanlist}
 
 
@@ -190,7 +188,7 @@ def _apply_pop_rmbase_one(
         raise ValueError("pop_rmbase(): EEG data must be 2D or 3D")
 
     baseline_indices, history_pointrange = _baseline_indices(output, timerange, pointrange, pnts)
-    channel_indices, history_chanlist = _resolve_channel_indices(output, chanlist, one_based=True)
+    channel_indices, history_chanlist = _resolve_channel_indices(output, chanlist)
     if data.ndim == 2:
         data = _remove_continuous_baseline(output, data, channel_indices, baseline_indices)
     else:
@@ -222,13 +220,15 @@ def _remove_continuous_baseline(
         segment_baseline = baseline_indices[(baseline_indices >= start) & (baseline_indices < stop)]
         if segment_baseline.size == 0:
             continue
-        if stop - start == 1:
-            data[channel_indices, start:stop] = 0
+        # EEGLAB's boundary path only writes the selected baseline window.
+        window = np.ix_(channel_indices, segment_baseline)
+        if segment_baseline.size == 1:
+            data[window] = 0
             continue
-        data[channel_indices, start:stop] = rmbase(
-            data[channel_indices, start:stop],
-            stop - start,
-            segment_baseline - start + 1,
+        data[window] = rmbase(
+            data[window],
+            segment_baseline.size,
+            np.arange(1, segment_baseline.size + 1),
         )
     return data
 
@@ -251,7 +251,7 @@ def _baseline_indices(
         indices = np.where((times >= values[0]) & (times <= values[-1]))[0]
         if indices.size == 0:
             raise ValueError("pop_rmbase(): time range does not contain samples")
-        return indices.astype(int), (indices + 1).astype(int).tolist()
+        return indices.astype(int), []
     if _has_values(pointrange):
         values = _parse_numeric_vector(pointrange, dtype=float)
         indices = _point_indices_from_values(values, pnts)
@@ -289,27 +289,18 @@ def _continuous_boundary_starts(EEG: dict[str, Any], pnts: int) -> list[int]:
     return sorted(set(starts))
 
 
-def _resolve_channel_indices(
-    EEG: dict[str, Any],
-    chanlist: Any,
-    *,
-    one_based: bool,
-) -> tuple[list[int], list[int] | None]:
+def _resolve_channel_indices(EEG: dict[str, Any], chanlist: Any) -> tuple[list[int], list[int] | None]:
     nbchan = int(EEG.get("nbchan", np.asarray(EEG.get("data")).shape[0]))
     if not _has_values(chanlist):
         return list(range(nbchan)), None
     tokens = _channel_tokens(chanlist)
     numeric = _numeric_channel_tokens(tokens)
     if numeric is not None:
-        if not one_based:
-            indices = numeric
-            history = [index + 1 for index in numeric]
-        else:
-            indices = [index - 1 for index in numeric]
-            history = numeric
+        indices = [index - 1 for index in numeric]
+        history = numeric
         if any(index < 0 or index >= nbchan for index in indices):
             raise ValueError("chanlist indices must be 1-based and within EEG.nbchan")
-        return sorted(dict.fromkeys(indices)), sorted(dict.fromkeys(history))
+        return list(dict.fromkeys(indices)), list(dict.fromkeys(history))
     labels = _channel_field_values(EEG, "labels")
     lookup = {label.lower(): index for index, label in enumerate(labels)}
     indices = []
@@ -318,7 +309,7 @@ def _resolve_channel_indices(
         if key not in lookup:
             raise ValueError(f"Channel '{token}' not found")
         indices.append(lookup[key])
-    indices = sorted(dict.fromkeys(indices))
+    indices = list(dict.fromkeys(indices))
     return indices, [index + 1 for index in indices]
 
 

--- a/src/eegprep/functions/redefine_functions.py
+++ b/src/eegprep/functions/redefine_functions.py
@@ -30,9 +30,9 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_reref import pop_reref
 from eegprep.functions.popfunc.pop_resample import pop_resample
-from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
 from eegprep.functions.popfunc.pop_select import pop_select
+from eegprep.functions.sigprocfunc.rmbase import rmbase as sigproc_rmbase
 
 
 def checkset(*args, **kwargs):
@@ -121,8 +121,8 @@ def resample(*args, **kwargs):
 
 
 def rmbase(*args, **kwargs):
-    """Wrap pop_rmbase."""
-    return pop_rmbase(*args, **kwargs)
+    """Wrap low-level rmbase."""
+    return sigproc_rmbase(*args, **kwargs)
 
 
 def saveset(*args, **kwargs):

--- a/src/eegprep/functions/sigprocfunc/rmbase.py
+++ b/src/eegprep/functions/sigprocfunc/rmbase.py
@@ -1,0 +1,98 @@
+"""Low-level EEGLAB-compatible baseline removal."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def rmbase(data: Any, frames: int | None = 0, basevector: Any = 0, *, return_mean: bool = False):
+    """Subtract per-channel baseline means from continuous or epoched data.
+
+    Args:
+        data: Data array shaped ``(channels, frames * epochs)`` or
+            ``(channels, frames, epochs)``.
+        frames: Samples per epoch. ``0`` or ``None`` uses the full second
+            dimension, matching EEGLAB's default.
+        basevector: EEGLAB-style 1-based baseline frame indices, or ``0``/
+            empty for the whole epoch.
+        return_mean: When true, return ``(dataout, datamean)``.
+
+    Returns:
+        Baseline-corrected data, and optionally the channel-by-epoch means.
+    """
+    array = np.asarray(data)
+    if array.size == 0:
+        raise ValueError("rmbase(): input data is empty")
+    if array.ndim not in {2, 3}:
+        raise ValueError("rmbase(): data must be 2D or 3D")
+
+    original_shape = array.shape
+    matrix = array.transpose(0, 2, 1).reshape(array.shape[0], -1) if array.ndim == 3 else array
+    chans, total_frames = matrix.shape
+    frames = int(frames or 0)
+    if frames == 0:
+        frames = total_frames
+    if frames < 1 or frames > total_frames:
+        raise ValueError("rmbase(): frames must be between 1 and the total number of samples")
+
+    epochs = total_frames // frames
+    if epochs < 1:
+        raise ValueError("rmbase(): frames exceeds available data")
+    if epochs * frames != total_frames:
+        raise ValueError("rmbase(): total sample count must be an integer multiple of frames")
+
+    baseline = _baseline_indices(basevector, frames)
+    output = matrix.astype(np.float64, copy=True) if not np.issubdtype(matrix.dtype, np.floating) else matrix.copy()
+    means = np.zeros((chans, epochs), dtype=np.result_type(matrix.dtype, np.float64))
+    for epoch in range(epochs):
+        start = epoch * frames
+        stop = start + frames
+        epoch_slice = output[:, start:stop]
+        if baseline is None:
+            mean = np.nanmean(matrix[:, start:stop], axis=1, keepdims=True, dtype=np.float64)
+        else:
+            mean = np.nanmean(matrix[:, start + baseline], axis=1, keepdims=True, dtype=np.float64)
+        means[:, epoch : epoch + 1] = mean
+        output[:, start:stop] = epoch_slice - mean
+
+    if array.ndim == 3:
+        output = output.reshape(original_shape[0], original_shape[2], original_shape[1]).transpose(0, 2, 1)
+    else:
+        output = output.reshape(original_shape)
+    return (output, means) if return_mean else output
+
+
+def _baseline_indices(basevector: Any, frames: int) -> np.ndarray | None:
+    values = _as_flat_values(basevector)
+    if not values:
+        return None
+    if len(values) == 1 and int(values[0]) == 0:
+        return None
+    if len(values) == 1:
+        raise ValueError("rmbase(): basevector should be 0 or a vector of frame indices")
+    indices = np.asarray(values, dtype=int)
+    if np.any(indices < 1):
+        raise ValueError("rmbase(): basevector should contain positive EEGLAB frame indices")
+    indices = indices[(indices >= 1) & (indices <= frames)]
+    if indices.size == 0:
+        raise ValueError("rmbase(): basevector does not overlap the epoch")
+    return indices - 1
+
+
+def _as_flat_values(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip().strip("[]")
+        if not text:
+            return []
+        return [float(token) for token in text.replace(",", " ").split()]
+    if isinstance(value, np.ndarray):
+        return value.ravel().tolist()
+    if isinstance(value, (list, tuple)):
+        return list(np.asarray(value).ravel())
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return [value]
+    return list(np.asarray(value).ravel())

--- a/src/eegprep/resources/help/pop_rmbase.md
+++ b/src/eegprep/resources/help/pop_rmbase.md
@@ -1,0 +1,19 @@
+# pop_rmbase
+
+Remove baseline means from continuous or epoched EEG data.
+
+`pop_rmbase` subtracts the mean of selected baseline samples from each selected
+channel. For continuous data, EEGPrep treats boundary events as data
+discontinuities and removes means separately inside each continuous segment.
+For epoched data, the selected baseline is removed separately from each epoch.
+
+## Common usage
+
+```python
+EEG, com = pop_rmbase(EEG, timerange=[-200, 0], return_com=True)
+EEG, com = pop_rmbase(EEG, pointrange=range(1, 51), chanlist=[1, 2], return_com=True)
+```
+
+Numeric channel and sample indices are EEGLAB-style 1-based values. Use
+`timerange` in the units stored in `EEG["times"]`, which is normally
+milliseconds for EEGLAB datasets.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ MATLAB_FILE_SUFFIXES = (
     "tests/test_pop_epoch.py",
     "tests/test_pop_loadset_h5.py",
     "tests/test_pop_resample.py",
-    "tests/test_pop_rmbase.py",
 )
 
 MATLAB_NODEID_PARTS = (
@@ -92,6 +91,7 @@ MATLAB_NODEID_PARTS = (
     "tests/test_matlab_path.py::TestMatlabPath::test_python_matlab_engine",
     "tests/test_matlab_path.py::TestMatlabPath::test_start_matlab_engine",
     "tests/test_pop_reref.py::TestPopReref::test_parity_",
+    "tests/test_pop_rmbase.py::TestPopRmbaseParity::",
     "tests/test_pop_select.py::TestPopSelectParity::",
     "tests/test_runica.py::TestRunicaParity::",
     "tests/test_topoplot.py::TestTopoplotParity::",

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -642,6 +642,7 @@ class MenuActionDispatcherTests(unittest.TestCase):
         action_specs = [
             ("pop_select", "eegprep.functions.popfunc.pop_select.pop_select", "selected"),
             ("pop_resample", "eegprep.functions.popfunc.pop_resample.pop_resample", "resampled"),
+            ("pop_rmbase", "eegprep.functions.popfunc.pop_rmbase.pop_rmbase", "baseline"),
             ("pop_epoch", "eegprep.functions.popfunc.pop_epoch.pop_epoch", "epoched"),
             ("pop_clean_rawdata", "eegprep.plugins.clean_rawdata.pop_clean_rawdata.pop_clean_rawdata", "cleaned"),
             ("pop_runica", "eegprep.functions.popfunc.pop_runica.pop_runica", "ica"),

--- a/tests/test_menu_placeholder_inventory.py
+++ b/tests/test_menu_placeholder_inventory.py
@@ -37,7 +37,7 @@ def test_no_implemented_action_remains_marked_as_placeholder():
 
 def test_placeholder_inventory_classifies_representative_phase_work():
     assert placeholder_metadata("pop_editset").phase == "1b"
-    assert placeholder_metadata("pop_rmbase").phase == "2"
+    assert placeholder_metadata("pop_eegfilt").phase == "2"
     assert placeholder_metadata("pop_rejchan").phase == "3"
     assert placeholder_metadata("pop_spectopo").phase == "4"
     assert placeholder_metadata("pop_studydesign").phase == "5"

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -10,6 +10,7 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch
 from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
 from eegprep.functions.popfunc.pop_select import pop_select
 from eegprep.functions.sigprocfunc.eegrej import eegrej as sigproc_eegrej
+from eegprep.functions.sigprocfunc.rmbase import rmbase as sigproc_rmbase
 
 
 class TestPackageExports(unittest.TestCase):
@@ -17,6 +18,7 @@ class TestPackageExports(unittest.TestCase):
         self.assertIs(eegprep.eegrej, sigproc_eegrej)
         self.assertIs(eegprep.eeg_eegrej, eeg_eegrej)
         self.assertIsNot(eegprep.eegrej, eegprep.eeg_eegrej)
+        self.assertIs(eegprep.rmbase, sigproc_rmbase)
 
     def test_direct_exports_survive_explicit_wrapper_imports(self):
         self.assertIs(eegprep.eeglab, eeglab)

--- a/tests/test_pop_rmbase.py
+++ b/tests/test_pop_rmbase.py
@@ -91,6 +91,18 @@ def test_pop_rmbase_continuous_with_boundaries_is_segmentwise():
         np.testing.assert_allclose(np.mean(out["data"][:, start:stop], axis=1), 0, atol=1e-10)
 
 
+def test_pop_rmbase_continuous_boundary_partial_pointrange_only_changes_selected_samples():
+    eeg = create_test_eeg(n_channels=2, n_samples=100, srate=100.0, n_trials=1)
+    eeg["data"] = np.vstack([np.arange(100, dtype=float), np.arange(100, dtype=float) + 100.0])
+    eeg["event"] = [{"type": "boundary", "latency": 50.5}]
+    before = eeg["data"].copy()
+
+    out = pop_rmbase(eeg, pointrange=range(1, 31))
+
+    np.testing.assert_allclose(np.mean(out["data"][:, :30], axis=1), 0, atol=1e-10)
+    np.testing.assert_allclose(out["data"][:, 30:], before[:, 30:])
+
+
 def test_pop_rmbase_timerange_uses_eeg_times_units():
     eeg = create_test_eeg(n_channels=2, n_samples=100, srate=100.0, n_trials=1)
     eeg["times"] = np.arange(100, dtype=float)
@@ -133,6 +145,27 @@ def test_pop_rmbase_return_com_is_replayable_python_console_input():
     assert command == "EEG = pop_rmbase( EEG, [], [1 2 3 4 5], [1 2]);"
     converted = _console_python_command(command)
     assert converted == "EEG = pop_rmbase(EEG, timerange=[], pointrange=[1, 2, 3, 4, 5], chanlist=[1, 2])"
+
+
+def test_pop_rmbase_return_com_preserves_channel_order():
+    eeg = create_test_eeg(n_channels=3, n_samples=40, srate=100.0, n_trials=1)
+
+    _out, command = pop_rmbase(eeg, pointrange=range(1, 6), chanlist=[3, 1], return_com=True)
+
+    assert command == "EEG = pop_rmbase( EEG, [], [1 2 3 4 5], [3 1]);"
+    converted = _console_python_command(command)
+    assert converted == "EEG = pop_rmbase(EEG, timerange=[], pointrange=[1, 2, 3, 4, 5], chanlist=[3, 1])"
+
+
+def test_pop_rmbase_return_com_timerange_uses_eeglab_history_shape():
+    eeg = create_test_eeg(n_channels=2, n_samples=40, srate=100.0, n_trials=1)
+    eeg["times"] = np.arange(40, dtype=float)
+
+    _out, command = pop_rmbase(eeg, timerange=[10, 19], return_com=True)
+
+    assert command == "EEG = pop_rmbase( EEG, [10 19], []);"
+    converted = _console_python_command(command)
+    assert converted == "EEG = pop_rmbase(EEG, timerange=[10, 19], pointrange=[])"
 
 
 def test_pop_rmbase_gui_cancel_returns_original_dataset():
@@ -198,6 +231,18 @@ class TestPopRmbaseParity(unittest.TestCase):
 
         py_eeg = pop_rmbase(copy.deepcopy(self.eeg), pointrange=pointrange, chanlist=chanlist)
         ml_eeg = self.eeglab.pop_rmbase(copy.deepcopy(self.eeg), [], pointrange, chanlist)
+
+        self.assertEqual(py_eeg["data"].shape, ml_eeg["data"].shape)
+        np.testing.assert_allclose(py_eeg["data"], ml_eeg["data"], atol=1e-6, rtol=1e-6)
+
+    def test_parity_continuous_boundary_partial_pointrange(self):
+        eeg = create_test_eeg(n_channels=2, n_samples=100, srate=100.0, n_trials=1)
+        eeg["data"] = np.vstack([np.arange(100, dtype=float), np.arange(100, dtype=float) + 100.0])
+        eeg["event"] = [{"type": "boundary", "latency": 50.5}]
+        pointrange = list(range(1, 31))
+
+        py_eeg = pop_rmbase(copy.deepcopy(eeg), pointrange=pointrange)
+        ml_eeg = self.eeglab.pop_rmbase(copy.deepcopy(eeg), [], pointrange, [])
 
         self.assertEqual(py_eeg["data"].shape, ml_eeg["data"].shape)
         np.testing.assert_allclose(py_eeg["data"], ml_eeg["data"], atol=1e-6, rtol=1e-6)

--- a/tests/test_pop_rmbase.py
+++ b/tests/test_pop_rmbase.py
@@ -1,147 +1,207 @@
+from __future__ import annotations
+
+import copy
 import os
 import unittest
 
 import numpy as np
+import pytest
 
-from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
-from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+from eegprep.functions.adminfunc.console import _console_python_command
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.functions.popfunc.pop_rmbase import pop_rmbase, pop_rmbase_dialog_spec
+from eegprep.functions.sigprocfunc.rmbase import rmbase
 
 try:
-    from .fixtures import create_test_eeg
+    from .fixtures import SAMPLE_DATASET_PATH, create_test_eeg
 except (ImportError, ValueError):
-    from fixtures import create_test_eeg
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
+    from fixtures import SAMPLE_DATASET_PATH, create_test_eeg
 
 
-# where the test resources
-web_root = 'https://sccntestdatasets.s3.us-east-2.amazonaws.com/'
-local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
-
-
-def ensure_file(fname: str) -> str:
-    """Download a file if it does not exist and return the local path."""
-    full_url = f"{web_root}{fname}"
-    local_file = os.path.abspath(f"{local_url}{fname}")
-    if not os.path.exists(local_file):
-        from urllib.request import urlretrieve
-
-        urlretrieve(full_url, local_file)
-    return local_file
-
-
-class TestPopRmbaseFunctional(unittest.TestCase):
-    def test_epoched_pointrange_all_channels(self):
-        # Create epoched EEG: nbchan x pnts x trials
-        EEG = create_test_eeg(n_channels=4, n_samples=200, srate=200.0, n_trials=3)
-        data_before = EEG['data'].copy()
-
-        # Use pointrange covering first 50 samples (1-based compatible)
-        out = pop_rmbase(EEG, pointrange=[1, 50])
-
-        self.assertEqual(out['data'].shape, (4, 200, 3))
-        # For each channel and epoch, mean over baseline points should be ~0
-        m = np.mean(out['data'][:, 0:50, :], axis=1)
-        self.assertTrue(np.allclose(m, 0.0, atol=1e-10))
-        # Data is changed compared to before
-        self.assertFalse(np.allclose(out['data'], data_before))
-
-    def test_epoched_chanlist_subset(self):
-        EEG = create_test_eeg(n_channels=5, n_samples=100, srate=100.0, n_trials=2)
-        # Only baseline-correct channels 1 and 3 (0-based indices)
-        out = pop_rmbase(EEG, pointrange=[1, 30], chanlist=[1, 3])
-        m_sel = np.mean(out['data'][[1, 3], 0:30, :], axis=1)
-        m_uns = np.mean(out['data'][[0, 2, 4], 0:30, :], axis=1)
-        self.assertTrue(np.allclose(m_sel, 0.0, atol=1e-10))
-        # Unselected channels likely not exactly zero mean over baseline
-        self.assertFalse(np.allclose(m_uns, 0.0, atol=1e-12))
-
-    def test_continuous_no_boundaries(self):
-        EEG = create_test_eeg(n_channels=3, n_samples=300, srate=150.0, n_trials=1)
-        # Baseline over middle range
-        out = pop_rmbase(EEG, pointrange=[51, 250])
-        self.assertEqual(out['data'].ndim, 2)
-        m = np.mean(out['data'][:, 50:250], axis=1)
-        self.assertTrue(np.allclose(m, 0.0, atol=1e-10))
-
-    def test_continuous_with_boundaries_segmentwise(self):
-        EEG = create_test_eeg(n_channels=2, n_samples=200, srate=200.0, n_trials=1)
-        # Add two boundary events splitting into three segments within baseline window
-        EEG['event'] = [
-            {'type': 'boundary', 'latency': 51.0},  # 1-based → between 50 and 51 (0-based split at 50)
-            {'type': 'boundary', 'latency': 151.0},  # split at 150
+def test_rmbase_removes_epoch_baseline_and_returns_means():
+    data = np.array(
+        [
+            [[1.0, 5.0], [3.0, 7.0], [5.0, 9.0]],
+            [[2.0, 8.0], [4.0, 10.0], [6.0, 12.0]],
         ]
-        # Full baseline range
-        out = pop_rmbase(EEG, pointrange=[1, 200])
-        # With the MATLAB-compatible boundary processing, segments may be processed differently
-        # Just check that the overall baseline correction worked (some segments should have zero mean)
-        # This is a functional test to ensure boundary processing doesn't crash
-        self.assertEqual(out['data'].shape, (2, 200))
-        # At least one segment should be baseline corrected
-        overall_mean = np.mean(out['data'], axis=1)
-        self.assertTrue(np.any(np.abs(overall_mean) < 1.0))  # Some baseline correction occurred
+    )
 
-    def test_timerange_indices(self):
-        # Create EEG with times in seconds (fixtures), so pass timerange in seconds as well
-        EEG = create_test_eeg(n_channels=2, n_samples=100, srate=100.0, n_trials=1)
-        # times: 0..0.99 seconds; choose 0.10..0.49
-        out = pop_rmbase(EEG, timerange=[0.10, 0.49])
-        a = 10
-        b = 49
-        m = np.mean(out['data'][:, a : b + 1], axis=1)
-        self.assertTrue(np.allclose(m, 0.0, atol=1e-10))
+    out, means = rmbase(data, frames=3, basevector=[1, 2], return_mean=True)
 
-    def test_bad_timerange_raises(self):
-        EEG = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=1)
-        with self.assertRaises(Exception):
-            pop_rmbase(EEG, timerange=[-1.0, 999.0])
-
-    def test_clears_icaact(self):
-        EEG = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=2)
-        EEG['icaact'] = np.random.randn(1, 50, 2)
-        out = pop_rmbase(EEG, pointrange=[1, 10])
-        # Cleared
-        self.assertEqual(out['icaact'], [])
+    np.testing.assert_allclose(out[:, :2, :].mean(axis=1), 0)
+    np.testing.assert_allclose(means, [[2.0, 6.0], [3.0, 9.0]])
+    assert out.shape == data.shape
 
 
+def test_pop_rmbase_epoched_pointrange_all_channels():
+    eeg = create_test_eeg(n_channels=4, n_samples=200, srate=200.0, n_trials=3)
+    data_before = eeg["data"].copy()
+
+    out = pop_rmbase(eeg, pointrange=range(1, 51))
+
+    assert out["data"].shape == (4, 200, 3)
+    np.testing.assert_allclose(np.mean(out["data"][:, 0:50, :], axis=1), 0, atol=1e-10)
+    assert not np.allclose(out["data"], data_before)
+    np.testing.assert_allclose(eeg["data"], data_before)
+
+
+def test_pop_rmbase_chanlist_subset_uses_one_based_channels():
+    eeg = create_test_eeg(n_channels=5, n_samples=100, srate=100.0, n_trials=2)
+    data_before = eeg["data"].copy()
+
+    out = pop_rmbase(eeg, pointrange=range(1, 31), chanlist=[2, 4])
+
+    np.testing.assert_allclose(np.mean(out["data"][[1, 3], 0:30, :], axis=1), 0, atol=1e-10)
+    np.testing.assert_allclose(out["data"][[0, 2, 4]], data_before[[0, 2, 4]])
+
+
+def test_pop_rmbase_rejects_zero_based_channel_indices():
+    eeg = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=1)
+
+    with pytest.raises(ValueError, match="1-based"):
+        pop_rmbase(eeg, pointrange=range(1, 11), chanlist=[0])
+
+
+def test_pop_rmbase_continuous_no_boundaries():
+    eeg = create_test_eeg(n_channels=3, n_samples=300, srate=150.0, n_trials=1)
+
+    out = pop_rmbase(eeg, pointrange=range(51, 251))
+
+    assert out["data"].ndim == 2
+    np.testing.assert_allclose(np.mean(out["data"][:, 50:250], axis=1), 0, atol=1e-10)
+
+
+def test_pop_rmbase_continuous_with_boundaries_is_segmentwise():
+    eeg = create_test_eeg(n_channels=2, n_samples=200, srate=200.0, n_trials=1)
+    eeg["data"] = np.vstack(
+        [
+            np.r_[np.arange(50) + 10.0, np.arange(100) + 100.0, np.arange(50) - 20.0],
+            np.r_[np.arange(50) - 5.0, np.arange(100) + 20.0, np.arange(50) + 70.0],
+        ]
+    )
+    eeg["event"] = [
+        {"type": "boundary", "latency": 50.5},
+        {"type": "boundary", "latency": 150.5},
+    ]
+
+    out = pop_rmbase(eeg, pointrange=range(1, 201))
+
+    for start, stop in [(0, 50), (50, 150), (150, 200)]:
+        np.testing.assert_allclose(np.mean(out["data"][:, start:stop], axis=1), 0, atol=1e-10)
+
+
+def test_pop_rmbase_timerange_uses_eeg_times_units():
+    eeg = create_test_eeg(n_channels=2, n_samples=100, srate=100.0, n_trials=1)
+    eeg["times"] = np.arange(100, dtype=float)
+
+    out = pop_rmbase(eeg, timerange=[10, 49])
+
+    np.testing.assert_allclose(np.mean(out["data"][:, 10:50], axis=1), 0, atol=1e-10)
+
+
+def test_pop_rmbase_bad_timerange_raises():
+    eeg = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=1)
+    eeg["times"] = np.arange(50, dtype=float)
+
+    with pytest.raises(ValueError, match="Bad time range"):
+        pop_rmbase(eeg, timerange=[-1.0, 999.0])
+
+
+def test_pop_rmbase_clears_icaact_and_preserves_decomposition_fields():
+    eeg = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=2)
+    eeg["icaact"] = np.random.randn(2, 50, 2)
+    eeg["icaweights"] = np.eye(2)
+    eeg["icasphere"] = np.eye(2)
+    eeg["icawinv"] = np.eye(2)
+    eeg["icachansind"] = np.arange(2)
+
+    out = pop_rmbase(eeg, pointrange=range(1, 11))
+
+    assert out["icaact"].size == 0
+    np.testing.assert_allclose(out["icaweights"], np.eye(2))
+    np.testing.assert_allclose(out["icasphere"], np.eye(2))
+    np.testing.assert_allclose(out["icawinv"], np.eye(2))
+    np.testing.assert_array_equal(out["icachansind"], np.arange(2))
+
+
+def test_pop_rmbase_return_com_is_replayable_python_console_input():
+    eeg = create_test_eeg(n_channels=3, n_samples=40, srate=100.0, n_trials=1)
+
+    _out, command = pop_rmbase(eeg, pointrange=range(1, 6), chanlist=[1, 2], return_com=True)
+
+    assert command == "EEG = pop_rmbase( EEG, [], [1 2 3 4 5], [1 2]);"
+    converted = _console_python_command(command)
+    assert converted == "EEG = pop_rmbase(EEG, timerange=[], pointrange=[1, 2, 3, 4, 5], chanlist=[1, 2])"
+
+
+def test_pop_rmbase_gui_cancel_returns_original_dataset():
+    eeg = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=1)
+
+    out, command = pop_rmbase(eeg, gui=True, renderer=_CancelRenderer(), return_com=True)
+
+    assert out is eeg
+    assert command == ""
+
+
+def test_pop_rmbase_dialog_disables_channel_controls_for_multiple_datasets():
+    eeg = create_test_eeg(n_channels=2, n_samples=50, srate=50.0, n_trials=2)
+
+    spec = pop_rmbase_dialog_spec(eeg, multiple=True)
+    controls = {control.tag: control for control in spec.controls if control.tag}
+
+    assert controls["chantypes"].enabled is False
+    assert controls["channels"].enabled is False
+    assert controls["chantypes_button"].enabled is False
+    assert controls["channels_button"].enabled is False
+
+
+def test_pop_rmbase_sample_data_zeroes_selected_baseline_channels_without_warnings():
+    eeg = pop_loadset(SAMPLE_DATASET_PATH)
+
+    out, command = pop_rmbase(eeg, pointrange=range(1, 21), chanlist=[1, 2], return_com=True)
+
+    assert out["data"].shape == eeg["data"].shape
+    np.testing.assert_allclose(np.nanmean(out["data"][0, :20]), 0, atol=1e-5)
+    np.testing.assert_allclose(np.nanmean(out["data"][1, :20]), 0, atol=1e-5)
+    np.testing.assert_allclose(out["data"][2], eeg["data"][2])
+    assert command == ("EEG = pop_rmbase( EEG, [], [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20], [1 2]);")
+
+
+class _CancelRenderer:
+    def run(self, _spec, initial_values=None):
+        del initial_values
+        return None
+
+
+@unittest.skipIf(os.getenv("EEGPREP_SKIP_MATLAB") == "1", "MATLAB not available")
 class TestPopRmbaseParity(unittest.TestCase):
     def setUp(self):
-        # Load a real dataset used across tests
-        self.EEG = pop_loadset(ensure_file('FlankerTest.set'))
-        self.eeglab = get_eeglab('MAT')
+        try:
+            self.eeglab = get_eeglab("MAT")
+        except Exception as exc:
+            self.skipTest(f"MATLAB not available: {exc}")
+        self.eeg = pop_loadset(SAMPLE_DATASET_PATH)
 
-    def test_parity_pointrange(self):
-        # Test parity with MATLAB for all-channels baseline removal
-        # Max abs diff: TBD, Max rel diff: TBD
-        pnts = int(self.EEG['pnts'])
-        pr = [1, min(pnts, 100)]  # 1-based-like bounds
+    def test_parity_pointrange_all_channels(self):
+        pointrange = list(range(1, 51))
 
-        EEG_py = pop_rmbase(self.EEG.copy(), pointrange=pr)
-        EEG_ml = self.eeglab.pop_rmbase(self.EEG.copy(), [], pr, [])
+        py_eeg = pop_rmbase(copy.deepcopy(self.eeg), pointrange=pointrange)
+        ml_eeg = self.eeglab.pop_rmbase(copy.deepcopy(self.eeg), [], pointrange, [])
 
-        # Compare shapes
-        self.assertEqual(EEG_py['data'].shape, EEG_ml['data'].shape)
-        # Numerical comparison within tolerance
-        self.assertTrue(np.allclose(EEG_py['data'], EEG_ml['data'], atol=3.0, rtol=15.0))
+        self.assertEqual(py_eeg["data"].shape, ml_eeg["data"].shape)
+        np.testing.assert_allclose(py_eeg["data"], ml_eeg["data"], atol=1e-6, rtol=1e-6)
 
     def test_parity_chanlist_subset(self):
-        # Test parity with MATLAB for channel subset baseline removal
-        # Max abs diff: 2.42e+00, Max rel diff: 1.28e+01
-        pnts = int(self.EEG['pnts'])
-        pr = [1, min(pnts, 50)]
-        # choose a subset of channels
-        nbchan = int(self.EEG['nbchan'])
-        chanlist = list(range(0, min(5, nbchan)))
+        pointrange = list(range(1, 31))
+        chanlist = [1, 2, 3]
 
-        EEG_py = pop_rmbase(self.EEG.copy(), pointrange=pr, chanlist=chanlist)
-        EEG_ml = self.eeglab.pop_rmbase(self.EEG.copy(), [], pr, np.array(chanlist) + 1)  # MATLAB 1-based
+        py_eeg = pop_rmbase(copy.deepcopy(self.eeg), pointrange=pointrange, chanlist=chanlist)
+        ml_eeg = self.eeglab.pop_rmbase(copy.deepcopy(self.eeg), [], pointrange, chanlist)
 
-        self.assertEqual(EEG_py['data'].shape, EEG_ml['data'].shape)
-
-        self.assertTrue(np.allclose(EEG_py['data'], EEG_ml['data'], atol=3.0, rtol=15.0))
+        self.assertEqual(py_eeg["data"].shape, ml_eeg["data"].shape)
+        np.testing.assert_allclose(py_eeg["data"], ml_eeg["data"], atol=1e-6, rtol=1e-6)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sample_data_pop_functions.py
+++ b/tests/test_sample_data_pop_functions.py
@@ -320,7 +320,7 @@ def test_pop_clean_rawdata_riemannian_asr_runs_on_sample_data_without_warning_no
 
 
 def test_pop_rmbase_zeroes_selected_sample_baseline_channels(sample_eeg):
-    baseline = pop_rmbase(sample_eeg, pointrange=[1, 20], chanlist=[0, 1])
+    baseline = pop_rmbase(sample_eeg, pointrange=range(1, 21), chanlist=[1, 2])
 
     assert baseline["data"].shape == sample_eeg["data"].shape
     assert np.nanmean(baseline["data"][0, :20]) == pytest.approx(0, abs=1e-5)

--- a/tests/test_visual_parity.py
+++ b/tests/test_visual_parity.py
@@ -40,6 +40,7 @@ class VisualParityConfigTests(unittest.TestCase):
         self.assertEqual(cases["pop_select_dialog"].targets["eeglab"].action, "pop_select")
         self.assertEqual(cases["pop_resample_dialog"].targets["eeglab"].action, "pop_resample")
         self.assertEqual(cases["pop_epoch_dialog"].targets["eeglab"].action, "pop_epoch")
+        self.assertEqual(cases["pop_rmbase_dialog"].targets["eeglab"].action, "pop_rmbase")
         self.assertEqual(cases["pop_runica_dialog"].targets["eeglab"].action, "pop_runica")
         self.assertEqual(cases["pop_iclabel_dialog"].targets["eeglab"].action, "pop_iclabel")
         self.assertEqual(cases["pop_clean_rawdata_dialog"].targets["eeglab"].action, "pop_clean_rawdata")
@@ -111,6 +112,27 @@ class VisualParityCaptureTests(unittest.TestCase):
             self.assertNotIn("-batch", captured_command)
             script_text = next((tmp_path / "main_window").glob("*.m")).read_text()
             self.assertIn("'Units', 'pixels'", script_text)
+
+    def test_matlab_capture_honors_eeglab_root_environment(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = pathlib.Path(tmpdir)
+            eeglab_root = tmp_path / "reference-eeglab"
+            case = load_manifest()["main_window"]
+
+            def fake_run_subprocess(target_name, output_path, command, env, timeout_seconds):
+                output_path.write_bytes(base64.b64decode(ONE_PIXEL_PNG))
+                return CaptureResult(target_name, output_path, command, 0)
+
+            with (
+                mock.patch.dict("tools.visual_parity.capture.os.environ", {"EEGPREP_EEGLAB_ROOT": str(eeglab_root)}),
+                mock.patch("tools.visual_parity.capture.shutil.which", return_value="/usr/common/bin/matlab"),
+                mock.patch("tools.visual_parity.capture._run_subprocess", side_effect=fake_run_subprocess),
+            ):
+                results = capture_case(case, "eeglab", output_dir=tmp_path)
+
+            self.assertTrue(results[0].ok)
+            script_text = next((tmp_path / "main_window").glob("*.m")).read_text()
+            self.assertIn(f"eeglab_root = '{eeglab_root.resolve().as_posix()}';", script_text)
 
     def test_matlab_figure_capture_generates_open_menu_script(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -264,6 +286,7 @@ class VisualParityCaptureTests(unittest.TestCase):
         cases = [
             ("pop_resample_dialog", "pop_resample"),
             ("pop_epoch_dialog", "pop_epoch"),
+            ("pop_rmbase_dialog", "pop_rmbase"),
         ]
         for case_id, action in cases:
             with self.subTest(case_id=case_id), tempfile.TemporaryDirectory() as tmpdir:

--- a/tools/visual_parity/capture.py
+++ b/tools/visual_parity/capture.py
@@ -19,11 +19,16 @@ except ImportError:  # pragma: no cover - supports direct script execution
 
 DEFAULT_OUTPUT_DIR = pathlib.Path(".visual-parity")
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-EEGLAB_REFERENCE_ROOT = (
-    REPO_ROOT.parent / "eeglab"
-    if (REPO_ROOT.parent / "eeglab" / "eeglab.m").exists()
-    else REPO_ROOT / "src" / "eegprep" / "eeglab"
-)
+EEGLAB_REFERENCE_ENV = "EEGPREP_EEGLAB_ROOT"
+
+
+def _eeglab_reference_root() -> pathlib.Path:
+    configured = os.environ.get(EEGLAB_REFERENCE_ENV)
+    if configured:
+        return pathlib.Path(configured).expanduser().resolve()
+    if (REPO_ROOT.parent / "eeglab" / "eeglab.m").exists():
+        return REPO_ROOT.parent / "eeglab"
+    return REPO_ROOT / "src" / "eegprep" / "eeglab"
 
 
 @dataclass(frozen=True)
@@ -394,7 +399,7 @@ def _target_env(case: VisualCase, target_name: str, target: TargetSpec, output_p
 
 def _write_matlab_figure_script(case: VisualCase, target: TargetSpec, output_path: pathlib.Path) -> pathlib.Path:
     width, height = case.window_size
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     matlab_command = target.matlab_command.strip() or "eeglab;"
     action, variant = _split_action(target.action)
@@ -459,7 +464,7 @@ def _write_matlab_reref_dialog_script(
     output_path: pathlib.Path,
     variant: str = "default",
 ) -> pathlib.Path:
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     script_path.write_text(
         "\n".join(
@@ -590,7 +595,7 @@ def _write_matlab_simple_pop_dialog_script(
     action: str,
     variant: str = "default",
 ) -> pathlib.Path:
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     inputgui_override_dir = output_path.parent / "inputgui_plot_override"
     inputgui_override_dir.mkdir(exist_ok=True)
@@ -639,6 +644,7 @@ def _write_matlab_simple_pop_dialog_script(
         "pop_select": "Select data -- pop_select()",
         "pop_resample": "Resample current dataset -- pop_resample()",
         "pop_epoch": "Extract data epochs - pop_epoch()",
+        "pop_rmbase": "Baseline removal - pop_rmbase()",
         "pop_runica": "Run ICA decomposition -- pop_runica()",
         "pop_clean_rawdata": "pop_clean_rawdata()",
         "pop_iclabel": "ICLabel",
@@ -673,6 +679,8 @@ def _write_matlab_simple_pop_dialog_script(
                 "        [EEG, com] = pop_resample(EEG);",
                 "    case 'pop_epoch'",
                 "        [EEG, com] = pop_epoch(EEG);",
+                "    case 'pop_rmbase'",
+                "        [EEG, com] = pop_rmbase(EEG);",
                 "    case 'pop_runica'",
                 "        [EEG, com] = pop_runica(EEG);",
                 "    case 'pop_clean_rawdata'",
@@ -748,6 +756,16 @@ def _write_matlab_simple_pop_dialog_script(
                 "    EEG.epoch = struct('event', {1, 2});",
                 "    EEG.icaact = zeros(4, EEG.pnts, EEG.trials);",
                 "end",
+                "if strcmp(action, 'pop_rmbase')",
+                "    EEG.pnts = 500;",
+                "    EEG.trials = 2;",
+                "    EEG.xmin = -0.2;",
+                "    EEG.xmax = 0.796;",
+                "    EEG.times = linspace(-200, 796, EEG.pnts);",
+                "    EEG.data = zeros(4, EEG.pnts, EEG.trials);",
+                "    EEG.epoch = struct('event', {1, 2});",
+                "    EEG.icaact = zeros(4, EEG.pnts, EEG.trials);",
+                "end",
                 "end",
                 "",
                 "function capture_simple_pop_dialog(output_file, target_title, action)",
@@ -781,7 +799,7 @@ def _write_matlab_simple_pop_dialog_script(
 
 
 def _write_matlab_dataset_index_dialog_script(case: VisualCase, output_path: pathlib.Path) -> pathlib.Path:
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     script_path.write_text(
         "\n".join(
@@ -850,7 +868,7 @@ def _write_matlab_pophelp_dialog_script(
     output_path: pathlib.Path,
     function_name: str,
 ) -> pathlib.Path:
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     script_path.write_text(
         "\n".join(
@@ -991,7 +1009,7 @@ def _write_matlab_pophelp_dialog_script(
 
 
 def _write_matlab_pop_chansel_dialog_script(case: VisualCase, output_path: pathlib.Path) -> pathlib.Path:
-    eeglab_root = EEGLAB_REFERENCE_ROOT
+    eeglab_root = _eeglab_reference_root()
     script_path = output_path.parent / f"{case.id}_eeglab_capture.m"
     script_path.write_text(
         "\n".join(
@@ -1132,6 +1150,7 @@ def capture_target(
             "pop_interp",
             "pop_resample",
             "pop_reref",
+            "pop_rmbase",
             "pop_runica",
             "pop_select",
             "inputdlg2",
@@ -1156,7 +1175,15 @@ def capture_target(
             script_path = _write_matlab_simple_pop_dialog_script(case, output_path, action, variant)
         elif action == "pop_chansel":
             script_path = _write_matlab_pop_chansel_dialog_script(case, output_path)
-        elif action in {"pop_clean_rawdata", "pop_epoch", "pop_iclabel", "pop_resample", "pop_runica", "pop_select"}:
+        elif action in {
+            "pop_clean_rawdata",
+            "pop_epoch",
+            "pop_iclabel",
+            "pop_resample",
+            "pop_rmbase",
+            "pop_runica",
+            "pop_select",
+        }:
             script_path = _write_matlab_simple_pop_dialog_script(case, output_path, action, variant)
         elif action == "inputdlg2":
             script_path = _write_matlab_dataset_index_dialog_script(case, output_path)

--- a/tools/visual_parity/cases.json
+++ b/tools/visual_parity/cases.json
@@ -405,6 +405,31 @@
       }
     },
     {
+      "id": "pop_rmbase_dialog",
+      "description": "Baseline-removal dialog opened from pop_rmbase.",
+      "window_size": [716, 299],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_rmbase"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_rmbase_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
       "id": "pop_runica_dialog",
       "description": "ICA decomposition dialog opened from pop_runica.",
       "window_size": [824, 334],


### PR DESCRIPTION
Implement native pop_rmbase and low-level rmbase baseline removal with GUI, menu, console history, help, sample-data coverage, and EEGLAB parity scaffolding. This makes baseline removal a real Phase 2 signal-conditioning workflow instead of a placeholder.

Part of #62