### PR TITLE
[Plot] Implement topography plot foundation

### DIFF
--- a/docs/source/api/generated/eegprep.pop_topoplot.rst
+++ b/docs/source/api/generated/eegprep.pop_topoplot.rst
@@ -1,0 +1,6 @@
+eegprep.pop_topoplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_topoplot

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -114,6 +114,7 @@ Visualization
    :toctree: generated/
 
    eegprep.cart2topo
+   eegprep.pop_topoplot
    eegprep.topoplot
 
 Format Conversion

--- a/docs/source/api/signal_processing.rst
+++ b/docs/source/api/signal_processing.rst
@@ -32,4 +32,6 @@ Topography
 
 .. autofunction:: eegprep.cart2topo
 
+.. autofunction:: eegprep.pop_topoplot
+
 .. autofunction:: eegprep.topoplot

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -105,6 +105,7 @@ _LAZY_EXPORTS = {
     "pop_studyerp": ("eegprep.functions.studyfunc.pop_studyerp", "pop_studyerp"),
     "pop_studywizard": ("eegprep.functions.studyfunc.pop_studywizard", "pop_studywizard"),
     "pop_subcomp": ("eegprep.functions.popfunc.pop_subcomp", "pop_subcomp"),
+    "pop_topoplot": ("eegprep.functions.popfunc.pop_topoplot", "pop_topoplot"),
     "pop_writeeeg": ("eegprep.functions.popfunc.pop_writeeeg", "pop_writeeeg"),
     "reref": ("eegprep.functions.redefine_functions", "reref"),
     "resample": ("eegprep.functions.redefine_functions", "resample"),

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -69,12 +69,14 @@ IMPLEMENTED_ACTIONS = {
     "pop_studywizard",
     "pop_subcomp",
     "pop_taskinfo",
+    "pop_topoplot",
     "pop_participantinfo",
     "pop_writeeeg",
     "bids_exporter",
     "plugin_menu",
     "quit",
     "retrieve_dataset",
+    "topoplot",
     "tutorial",
     "updates",
     "validate_bids",
@@ -271,6 +273,12 @@ class MenuActionDispatcher:
             return
         if base == "pop_subcomp":
             self._run_pop_function("pop_subcomp", parent)
+            return
+        if base == "topoplot":
+            self._plot_channel_locations(variant, parent)
+            return
+        if base == "pop_topoplot":
+            self._run_topoplot(variant, parent)
             return
         self.show_coming_soon(action, parent)
 
@@ -733,6 +741,27 @@ class MenuActionDispatcher:
         if command:
             self._store_current_from_gui(eeg_out, command=command)
             self._refresh()
+
+    def _plot_channel_locations(self, variant: str, parent: Any | None) -> None:
+        selection = self._current_selection_or_warn(parent)
+        if selection is None:
+            return
+        from eegprep.functions.popfunc.pop_topoplot import plot_channel_locations
+
+        _figure, command = plot_channel_locations(selection, mode=variant or "labels", return_com=True)
+        self._add_history_from_gui(command)
+        self._refresh()
+
+    def _run_topoplot(self, variant: str, parent: Any | None) -> None:
+        selection = self._current_selection_or_warn(parent)
+        if selection is None:
+            return
+        from eegprep.functions.popfunc.pop_topoplot import pop_topoplot
+
+        typeplot = 0 if variant == "components" else 1
+        _figures, command = pop_topoplot(selection, typeplot=typeplot, return_com=True)
+        self._add_history_from_gui(command)
+        self._refresh()
 
     def _store_current_from_gui(self, eeg: Any, **kwargs: Any) -> Any:
         command = kwargs.get("command")

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -91,8 +91,6 @@ PLACEHOLDER_ACTION_METADATA: Mapping[str, PlaceholderMetadata] = {
             "pop_signalstat",
             "pop_spectopo",
             "pop_timtopo",
-            "pop_topoplot",
-            "topoplot",
         ),
     ),
     **_phase_entries(

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 import pathlib
 import sys
 
@@ -25,6 +26,7 @@ from eegprep.functions.popfunc.pop_rmbase import pop_rmbase_dialog_spec
 from eegprep.functions.popfunc.pop_runica import pop_runica_dialog_spec
 from eegprep.functions.popfunc.pop_select import pop_select_dialog_spec
 from eegprep.functions.popfunc.pop_subcomp import pop_subcomp_dialog_spec
+from eegprep.functions.popfunc.pop_topoplot import pop_topoplot_dialog_spec
 from eegprep.plugins.ICLabel.pop_icflag import pop_icflag_dialog_spec
 from eegprep.plugins.ICLabel.pop_iclabel import pop_iclabel_dialog_spec
 from eegprep.plugins.clean_rawdata.pop_clean_rawdata import pop_clean_rawdata_dialog_spec
@@ -293,11 +295,11 @@ def _matlab_scaled_pixmap(pixmap, app):
     ratio = float(pixmap.devicePixelRatio() or 1)
     if screen is not None:
         ratio = max(ratio, float(screen.devicePixelRatio() or 1))
-    if ratio <= 1:
-        return pixmap
     matlab_ratio = 1.5
     scale = matlab_ratio / ratio
-    return pixmap.scaled(max(1, round(pixmap.width() * scale)), max(1, round(pixmap.height() * scale)))
+    if math.isclose(scale, 1.0):
+        return pixmap
+    return pixmap.scaled(max(1, math.floor(pixmap.width() * scale)), max(1, math.floor(pixmap.height() * scale)))
 
 
 def capture_adjust_events_dialog(output: pathlib.Path) -> None:
@@ -392,6 +394,15 @@ def capture_pop_epoch_dialog(output: pathlib.Path) -> None:
     """Render and capture the pop_epoch dialog."""
     eeg = _demo_main_eeg(setname="pop demo")
     spec = pop_epoch_dialog_spec(eeg)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
+def capture_pop_topoplot_dialog(output: pathlib.Path, *, variant: str = "erp") -> None:
+    """Render and capture the pop_topoplot dialog."""
+    eeg = _demo_main_eeg(setname="pop demo")
+    spec = pop_topoplot_dialog_spec(eeg, typeplot=0 if variant == "components" else 1)
     renderer = QtDialogRenderer()
     app, dialog, _widgets = renderer.build_dialog(spec)
     _grab_dialog(dialog, output, app)
@@ -586,6 +597,10 @@ def main(argv: list[str] | None = None) -> int:
         capture_pop_rmbase_dialog(args.output)
     elif args.case == "pop_epoch_dialog":
         capture_pop_epoch_dialog(args.output)
+    elif args.case == "pop_topoplot_erp_dialog":
+        capture_pop_topoplot_dialog(args.output, variant="erp")
+    elif args.case == "pop_topoplot_components_dialog":
+        capture_pop_topoplot_dialog(args.output, variant="components")
     elif args.case == "pop_runica_dialog":
         capture_pop_runica_dialog(args.output)
     elif args.case == "pop_runica_multiple_dialog":

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.miscfunc.misc import round_mat
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args, parse_text_tokens
 from eegprep.functions.sigprocfunc.topoplot import topoplot
@@ -95,7 +96,6 @@ def pop_topoplot(
         topotitle=topotitle,
         rowcols=rowcols_array,
         options=dict(options),
-        typeplot=typeplot,
     )
     command = _history_command(typeplot, items_array, topotitle, rowcols_array, int(bool(plotdip)), options)
     return (figures, command) if return_com else figures
@@ -186,6 +186,8 @@ def plot_channel_locations(EEG: dict[str, Any], *, mode: str = "labels", return_
     chanlocs = chanlocs_as_list(EEG.get("chanlocs", []))
     if not chanlocs:
         raise ValueError("cannot plot topography without channel location file")
+    if mode not in {"labels", "numbers"}:
+        raise ValueError("mode must be 'labels' or 'numbers'")
     electrodes = "numpoint" if mode == "numbers" else "labelpoint"
     fig, *_ = topoplot([], chanlocs, style="blank", electrodes=electrodes, title="Channel locations")
     command = f"topoplot([], EEG['chanlocs'], style='blank', electrodes={electrodes!r})"
@@ -215,13 +217,14 @@ def _plot_map_pages(
     topotitle: str,
     rowcols: tuple[int, int],
     options: dict[str, Any],
-    typeplot: int,
 ) -> list[Any]:
     rows, cols = rowcols
     per_page = rows * cols
     figures = []
     colorbar = _is_on(options.pop("colorbar", "on"))
-    maplimits = options.pop("maplimits", _default_maplimits(maps, typeplot))
+    maplimits = options.pop("maplimits", None)
+    if maplimits is None or _is_absmax_maplimits(maplimits):
+        maplimits = _default_maplimits(maps)
     for page_start in range(0, len(maps), per_page):
         page_maps = maps[page_start : page_start + per_page]
         page_labels = labels[page_start : page_start + per_page]
@@ -311,7 +314,7 @@ def _latency_positions(EEG: dict[str, Any], latencies_ms: np.ndarray) -> np.ndar
     if xmax == xmin and np.any(finite):
         raise ValueError("requested latency is outside the epoch time range")
     if xmax != xmin and np.any(finite):
-        positions[finite] = np.rint(((latencies_ms[finite] / 1000.0) - xmin) / (xmax - xmin) * (pnts - 1)).astype(int)
+        positions[finite] = round_mat(((latencies_ms[finite] / 1000.0) - xmin) / (xmax - xmin) * (pnts - 1)).astype(int)
     valid = np.isnan(latencies_ms) | ((positions >= 0) & (positions < pnts))
     if not np.all(valid):
         raise ValueError("requested latency is outside the epoch time range")
@@ -329,9 +332,7 @@ def _default_options_text(EEG: dict[str, Any]) -> str:
     return "'electrodes', 'off'" if int(EEG.get("nbchan", 0) or 0) > 64 else "'electrodes', 'on'"
 
 
-def _default_maplimits(maps: list[np.ndarray | None], typeplot: int) -> str | list[float]:
-    if not int(typeplot):
-        return "absmax"
+def _default_maplimits(maps: list[np.ndarray | None]) -> list[float]:
     finite_maps = [np.asarray(values).ravel() for values in maps if values is not None]
     if not finite_maps:
         return [-1.0, 1.0]
@@ -387,17 +388,10 @@ def _parse_colon_sequence(token: str) -> list[float]:
         raise ValueError(f"Invalid colon range: {token}")
     if (stop - start) * step < 0:
         return []
-    values = []
-    current = start
-    tolerance = abs(step) * 1e-10
-    if step > 0:
-        while current <= stop + tolerance:
-            values.append(float(current))
-            current += step
-    else:
-        while current >= stop - tolerance:
-            values.append(float(current))
-            current += step
+    count = int(math.floor((stop - start) / step + 1e-9)) + 1
+    values = [float(start + index * step) for index in range(max(count, 0))]
+    if values and math.isclose(values[-1], stop, rel_tol=0.0, abs_tol=max(abs(step), 1.0) * 1e-12):
+        values[-1] = float(stop)
     return values
 
 
@@ -471,6 +465,10 @@ def _validate_topoplot_inputs(EEG: dict[str, Any], typeplot: int) -> None:
 
 def _is_on(value: Any) -> bool:
     return str(value).lower() in {"on", "yes", "true", "1"}
+
+
+def _is_absmax_maplimits(value: Any) -> bool:
+    return isinstance(value, str) and value.lower() == "absmax"
 
 
 def _is_plotdip_value(value: Any) -> bool:

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -54,6 +54,9 @@ def pop_topoplot(
     typeplot = int(typeplot)
     if gui is None:
         gui = items is None
+    if typeplot not in {0, 1}:
+        raise ValueError("typeplot must be 1 for ERP maps or 0 for component maps")
+    _validate_topoplot_inputs(EEG, typeplot)
     if gui:
         result = _run_gui(EEG, typeplot=typeplot, renderer=renderer)
         if result is None:
@@ -175,7 +178,11 @@ def pop_topoplot_dialog_spec(EEG: dict[str, Any], *, typeplot: int = 1) -> Dialo
 
 
 def plot_channel_locations(EEG: dict[str, Any], *, mode: str = "labels", return_com: bool = False):
-    """Plot channel locations by name or by number, matching EEGLAB menu actions."""
+    """Plot channel locations by name or by number, matching EEGLAB menu actions.
+
+    The returned command is valid ``eegprep-console`` Python, matching the
+    Python-callable history shape used by ``pop_topoplot``.
+    """
     chanlocs = chanlocs_as_list(EEG.get("chanlocs", []))
     if not chanlocs:
         raise ValueError("cannot plot topography without channel location file")
@@ -218,20 +225,33 @@ def _plot_map_pages(
     for page_start in range(0, len(maps), per_page):
         page_maps = maps[page_start : page_start + per_page]
         page_labels = labels[page_start : page_start + per_page]
+        plotted_map_count = sum(values is not None for values in page_maps)
         fig, axes = plt.subplots(rows, cols, squeeze=False, figsize=(cols * 2.1, rows * 2.0))
+        colorbar_image = None
+        plotted_axes = []
         for ax, values, label in zip(axes.ravel(), page_maps, page_labels):
             if values is None:
                 ax.axis("off")
                 continue
             topoplot(
-                values, chanlocs, axes=ax, colorbar=colorbar and len(page_maps) == 1, maplimits=maplimits, **options
+                values,
+                chanlocs,
+                axes=ax,
+                colorbar=colorbar and plotted_map_count == 1,
+                maplimits=maplimits,
+                **options,
             )
+            if ax.images:
+                colorbar_image = ax.images[-1]
+                plotted_axes.append(ax)
             ax.set_title(label)
         for ax in axes.ravel()[len(page_maps) :]:
             ax.axis("off")
         if topotitle:
             fig.suptitle(topotitle, fontweight="bold")
         fig.tight_layout()
+        if colorbar and plotted_map_count > 1 and colorbar_image is not None:
+            fig.colorbar(colorbar_image, ax=plotted_axes, shrink=0.7)
         figures.append(fig)
     return figures
 
@@ -258,9 +278,8 @@ def _erp_maps(EEG: dict[str, Any], latencies_ms: np.ndarray) -> tuple[list[np.nd
 
 def _component_maps(EEG: dict[str, Any], components: np.ndarray) -> tuple[list[np.ndarray | None], list[str]]:
     _require_chanlocs(EEG)
+    _require_ica(EEG)
     icawinv = np.asarray(EEG.get("icawinv", []), dtype=float)
-    if icawinv.size == 0:
-        raise ValueError("no ICA data for this set, first run ICA")
     maps = []
     labels = []
     for component in components:
@@ -273,6 +292,7 @@ def _component_maps(EEG: dict[str, Any], components: np.ndarray) -> tuple[list[n
             raise ValueError(f"component index {index} is outside available ICA components")
         values = icawinv[:, index - 1]
         maps.append(-values if component < 0 else values)
+        # EEGLAB titles inverted-polarity maps with the negative component index.
         labels.append(f"IC {int(component)}")
     return maps, labels
 
@@ -285,9 +305,14 @@ def _latency_positions(EEG: dict[str, Any], latencies_ms: np.ndarray) -> np.ndar
         raise ValueError("EEG.pnts must be positive")
     positions = np.zeros_like(latencies_ms, dtype=int)
     finite = np.isfinite(latencies_ms)
+    invalid = ~finite & ~np.isnan(latencies_ms)
+    if np.any(invalid):
+        raise ValueError("requested latency is outside the epoch time range")
+    if xmax == xmin and np.any(finite):
+        raise ValueError("requested latency is outside the epoch time range")
     if xmax != xmin and np.any(finite):
         positions[finite] = np.rint(((latencies_ms[finite] / 1000.0) - xmin) / (xmax - xmin) * (pnts - 1)).astype(int)
-    valid = ~finite | ((positions >= 0) & (positions < pnts))
+    valid = np.isnan(latencies_ms) | ((positions >= 0) & (positions < pnts))
     if not np.all(valid):
         raise ValueError("requested latency is outside the epoch time range")
     positions[np.isnan(latencies_ms)] = 0
@@ -333,12 +358,47 @@ def _normalise_rowcols(rowcols: Any, count: int) -> tuple[int, int]:
 
 
 def _parse_items_text(text: str) -> list[float]:
-    stripped = text.strip()
-    if re.fullmatch(r"\d+\s*:\s*\d+", stripped):
-        start, stop = [int(part.strip()) for part in stripped.split(":")]
-        step = 1 if stop >= start else -1
-        return [float(value) for value in range(start, stop + step, step)]
-    return _parse_numeric_sequence(stripped).tolist()
+    stripped = re.sub(r"\s*:\s*", ":", text.strip().strip("[]"))
+    if not stripped:
+        return []
+    values = []
+    for token in re.split(r"[\s,]+", stripped):
+        if not token:
+            continue
+        if ":" in token:
+            values.extend(_parse_colon_sequence(token))
+        else:
+            values.append(_parse_float_token(token))
+    return values
+
+
+def _parse_colon_sequence(token: str) -> list[float]:
+    pieces = token.split(":")
+    if len(pieces) not in {2, 3}:
+        raise ValueError(f"Invalid colon range: {token}")
+    start = _parse_float_token(pieces[0])
+    if len(pieces) == 2:
+        stop = _parse_float_token(pieces[1])
+        step = 1.0 if stop >= start else -1.0
+    else:
+        step = _parse_float_token(pieces[1])
+        stop = _parse_float_token(pieces[2])
+    if step == 0 or not np.all(np.isfinite([start, step, stop])):
+        raise ValueError(f"Invalid colon range: {token}")
+    if (stop - start) * step < 0:
+        return []
+    values = []
+    current = start
+    tolerance = abs(step) * 1e-10
+    if step > 0:
+        while current <= stop + tolerance:
+            values.append(float(current))
+            current += step
+    else:
+        while current >= stop - tolerance:
+            values.append(float(current))
+            current += step
+    return values
 
 
 def _parse_rowcols_text(text: str) -> list[float]:
@@ -395,6 +455,18 @@ def _parse_float_token(token: str) -> float:
 def _require_chanlocs(EEG: dict[str, Any]) -> None:
     if not chanlocs_as_list(EEG.get("chanlocs", [])):
         raise ValueError("cannot plot topography without channel location file")
+
+
+def _require_ica(EEG: dict[str, Any]) -> None:
+    icawinv = EEG.get("icawinv", [])
+    if icawinv is None or np.asarray(icawinv).size == 0:
+        raise ValueError("no ICA data for this set, first run ICA")
+
+
+def _validate_topoplot_inputs(EEG: dict[str, Any], typeplot: int) -> None:
+    _require_chanlocs(EEG)
+    if typeplot == 0:
+        _require_ica(EEG)
 
 
 def _is_on(value: Any) -> bool:

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -1,0 +1,450 @@
+"""EEGLAB-style wrapper for 2-D scalp maps."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._chanutils import chanlocs_as_list
+from eegprep.functions.popfunc._pop_utils import parse_key_value_args, parse_text_tokens
+from eegprep.functions.sigprocfunc.topoplot import topoplot
+
+
+def pop_topoplot(
+    EEG: dict[str, Any] | None = None,
+    typeplot: int = 1,
+    items: Any = None,
+    topotitle: str | None = None,
+    rowcols: Any = None,
+    plotdip: Any = 0,
+    *args: Any,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+    **kwargs: Any,
+):
+    """Plot EEGLAB-style 2-D scalp maps for ERP latencies or ICA components.
+
+    Args:
+        EEG: EEGLAB-style EEG dictionary.
+        typeplot: ``1`` for channel ERP latency maps, ``0`` for component maps.
+        items: Latencies in ms when ``typeplot=1`` or 1-based component
+            indices when ``typeplot=0``. Negative component indices invert map
+            polarity and ``NaN`` leaves a blank subplot.
+        topotitle: Figure title.
+        rowcols: Optional ``[rows, columns]`` layout. Empty uses EEGLAB's
+            near-square page geometry.
+        plotdip: Accepted for EEGLAB signature compatibility; DIPFIT overlays
+            are deferred to the Phase 4 headplot/DIPFIT integration.
+        gui: Force or suppress the EEGLAB-like input dialog.
+        renderer: Optional dialog renderer for tests.
+        return_com: Return ``(figures, command)`` when true.
+        **kwargs: Additional ``topoplot`` options such as ``electrodes``,
+            ``colorbar`` and ``maplimits``.
+    """
+    if EEG is None:
+        return ([], "") if return_com else []
+
+    typeplot = int(typeplot)
+    if gui is None:
+        gui = items is None
+    if gui:
+        result = _run_gui(EEG, typeplot=typeplot, renderer=renderer)
+        if result is None:
+            return ([], "") if return_com else []
+        items = result["items"]
+        topotitle = result["topotitle"]
+        rowcols = result["rowcols"]
+        plotdip = result["plotdip"]
+        kwargs = {**kwargs, **result["options"]}
+    elif items is None:
+        raise ValueError("items must be provided when gui=False")
+
+    option_args = args
+    if plotdip is not None and not _is_plotdip_value(plotdip):
+        option_args = (plotdip, *args)
+        plotdip = 0
+    options = parse_key_value_args(option_args, kwargs, lowercase_kwargs=True)
+    options = _normalise_topoplot_options(EEG, options)
+    items_array = _parse_numeric_sequence(items)
+    if items_array.size == 0:
+        raise ValueError("Nothing to plot; provide at least one latency or component index")
+    rowcols_array = _normalise_rowcols(rowcols, len(items_array))
+    topotitle = str(EEG.get("setname") or "") if topotitle is None else str(topotitle)
+
+    if typeplot == 1:
+        maps, labels = _erp_maps(EEG, items_array)
+    elif typeplot == 0:
+        maps, labels = _component_maps(EEG, items_array)
+    else:
+        raise ValueError("typeplot must be 1 for ERP maps or 0 for component maps")
+
+    figures = _plot_map_pages(
+        maps,
+        labels,
+        chanlocs_as_list(EEG.get("chanlocs", [])),
+        topotitle=topotitle,
+        rowcols=rowcols_array,
+        options=dict(options),
+        typeplot=typeplot,
+    )
+    command = _history_command(typeplot, items_array, topotitle, rowcols_array, int(bool(plotdip)), options)
+    return (figures, command) if return_com else figures
+
+
+def pop_topoplot_dialog_spec(EEG: dict[str, Any], *, typeplot: int = 1) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_topoplot``."""
+    title = (
+        "Plot ERP scalp maps in 2-D -- pop_topoplot()"
+        if int(typeplot)
+        else "Plot component scalp maps in 2-D -- pop_topoplot()"
+    )
+    if int(typeplot):
+        first_label = "Plotting ERP scalp maps at these latencies"
+        range_label = f"(range: {round(float(EEG.get('xmin', 0)) * 1000)} to {round(float(EEG.get('xmax', 0)) * 1000)} ms, NaN -> empty):"
+        item_value = ""
+    else:
+        first_label = "Component numbers"
+        range_label = "(negate index to invert component polarity; NaN -> empty subplot; Ex: -1 NaN 3)"
+        n_components = np.asarray(EEG.get("icaweights", [])).shape[0]
+        item_value = f"1:{n_components}" if n_components else ""
+
+    controls = [
+        ControlSpec("text", first_label),
+        ControlSpec("edit", tag="items", value=item_value),
+        ControlSpec("text", range_label),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Plot title"),
+        ControlSpec("edit", tag="topotitle", value=str(EEG.get("setname") or "")),
+        ControlSpec("text", "Plot geometry (rows,col.); [] -> near square"),
+        ControlSpec("edit", tag="rowcols", value="[]"),
+    ]
+    if not int(typeplot):
+        controls.extend(
+            [
+                ControlSpec("text", "Plot associated dipole(s) (if present)"),
+                ControlSpec("checkbox", tag="plotdip", value=False),
+                ControlSpec("spacer"),
+                ControlSpec("spacer"),
+            ]
+        )
+    controls.extend(
+        [
+            ControlSpec("spacer"),
+            ControlSpec(
+                "text",
+                f"-> Additional topoplot(){' (and dipole)' if not int(typeplot) else ''} options (see Help)",
+            ),
+            ControlSpec("edit", tag="options", value=_default_options_text(EEG)),
+        ]
+    )
+    geometry: tuple[Any, ...] = (
+        (1.5, 1),
+        1,
+        1,
+        (1.5, 1),
+        (1.5, 1),
+        (1.55, 0.2, 0.8),
+        1,
+        1,
+        1,
+    )
+    if int(typeplot):
+        geometry = geometry[:5] + geometry[6:]
+        geomvert = (1, 1, 0.8, 1, 1, 0.5, 1, 1)
+        size = (645, 404)
+    else:
+        geomvert = (1, 1, 0.5, 1, 1, 1, 0.2, 1, 1)
+        size = (697, 440)
+    return DialogSpec(
+        title=title,
+        controls=tuple(controls),
+        geometry=geometry,
+        function_name="pop_topoplot",
+        eeglab_source="functions/popfunc/pop_topoplot.m",
+        help_text="pophelp('pop_topoplot')",
+        size=size,
+        geomvert=geomvert,
+    )
+
+
+def plot_channel_locations(EEG: dict[str, Any], *, mode: str = "labels", return_com: bool = False):
+    """Plot channel locations by name or by number, matching EEGLAB menu actions."""
+    chanlocs = chanlocs_as_list(EEG.get("chanlocs", []))
+    if not chanlocs:
+        raise ValueError("cannot plot topography without channel location file")
+    electrodes = "numpoint" if mode == "numbers" else "labelpoint"
+    fig, *_ = topoplot([], chanlocs, style="blank", electrodes=electrodes, title="Channel locations")
+    command = f"topoplot([], EEG['chanlocs'], style='blank', electrodes={electrodes!r})"
+    return (fig, command) if return_com else fig
+
+
+def _run_gui(EEG: dict[str, Any], *, typeplot: int, renderer: Any | None = None) -> dict[str, Any] | None:
+    spec = pop_topoplot_dialog_spec(EEG, typeplot=typeplot)
+    result = inputgui(spec, renderer=renderer)
+    if not result:
+        return None
+    options_text = str(result.get("options", "") or "")
+    return {
+        "items": _parse_items_text(str(result.get("items", "") or "")),
+        "topotitle": str(result.get("topotitle", "") or ""),
+        "rowcols": _parse_rowcols_text(str(result.get("rowcols", "") or "")),
+        "plotdip": bool(result.get("plotdip", False)),
+        "options": _parse_options_text(options_text),
+    }
+
+
+def _plot_map_pages(
+    maps: list[np.ndarray | None],
+    labels: list[str],
+    chanlocs: list[dict[str, Any]],
+    *,
+    topotitle: str,
+    rowcols: tuple[int, int],
+    options: dict[str, Any],
+    typeplot: int,
+) -> list[Any]:
+    rows, cols = rowcols
+    per_page = rows * cols
+    figures = []
+    colorbar = _is_on(options.pop("colorbar", "on"))
+    maplimits = options.pop("maplimits", _default_maplimits(maps, typeplot))
+    for page_start in range(0, len(maps), per_page):
+        page_maps = maps[page_start : page_start + per_page]
+        page_labels = labels[page_start : page_start + per_page]
+        fig, axes = plt.subplots(rows, cols, squeeze=False, figsize=(cols * 2.1, rows * 2.0))
+        for ax, values, label in zip(axes.ravel(), page_maps, page_labels):
+            if values is None:
+                ax.axis("off")
+                continue
+            topoplot(
+                values, chanlocs, axes=ax, colorbar=colorbar and len(page_maps) == 1, maplimits=maplimits, **options
+            )
+            ax.set_title(label)
+        for ax in axes.ravel()[len(page_maps) :]:
+            ax.axis("off")
+        if topotitle:
+            fig.suptitle(topotitle, fontweight="bold")
+        fig.tight_layout()
+        figures.append(fig)
+    return figures
+
+
+def _erp_maps(EEG: dict[str, Any], latencies_ms: np.ndarray) -> tuple[list[np.ndarray | None], list[str]]:
+    _require_chanlocs(EEG)
+    data = np.asarray(EEG.get("data"))
+    if data.ndim == 2:
+        data = data[:, :, np.newaxis]
+    if data.ndim != 3:
+        raise ValueError("EEG.data must be a 2-D or 3-D channel-major array")
+    positions = _latency_positions(EEG, latencies_ms)
+    maps = []
+    labels = []
+    for latency, position in zip(latencies_ms, positions):
+        if np.isnan(latency):
+            maps.append(None)
+            labels.append("")
+            continue
+        maps.append(np.nanmean(data[:, position, :], axis=1))
+        labels.append(f"{int(round(float(latency)))} ms")
+    return maps, labels
+
+
+def _component_maps(EEG: dict[str, Any], components: np.ndarray) -> tuple[list[np.ndarray | None], list[str]]:
+    _require_chanlocs(EEG)
+    icawinv = np.asarray(EEG.get("icawinv", []), dtype=float)
+    if icawinv.size == 0:
+        raise ValueError("no ICA data for this set, first run ICA")
+    maps = []
+    labels = []
+    for component in components:
+        if np.isnan(component):
+            maps.append(None)
+            labels.append("")
+            continue
+        index = int(abs(component))
+        if index < 1 or index > icawinv.shape[1]:
+            raise ValueError(f"component index {index} is outside available ICA components")
+        values = icawinv[:, index - 1]
+        maps.append(-values if component < 0 else values)
+        labels.append(f"IC {int(component)}")
+    return maps, labels
+
+
+def _latency_positions(EEG: dict[str, Any], latencies_ms: np.ndarray) -> np.ndarray:
+    pnts = int(EEG.get("pnts", 0))
+    xmin = float(EEG.get("xmin", 0))
+    xmax = float(EEG.get("xmax", xmin))
+    if pnts <= 0:
+        raise ValueError("EEG.pnts must be positive")
+    positions = np.zeros_like(latencies_ms, dtype=int)
+    finite = np.isfinite(latencies_ms)
+    if xmax != xmin and np.any(finite):
+        positions[finite] = np.rint(((latencies_ms[finite] / 1000.0) - xmin) / (xmax - xmin) * (pnts - 1)).astype(int)
+    valid = ~finite | ((positions >= 0) & (positions < pnts))
+    if not np.all(valid):
+        raise ValueError("requested latency is outside the epoch time range")
+    positions[np.isnan(latencies_ms)] = 0
+    return positions
+
+
+def _normalise_topoplot_options(EEG: dict[str, Any], options: dict[str, Any]) -> dict[str, Any]:
+    normalised = {str(key).lower(): value for key, value in options.items()}
+    normalised.setdefault("electrodes", "off" if int(EEG.get("nbchan", 0) or 0) > 64 else "on")
+    return normalised
+
+
+def _default_options_text(EEG: dict[str, Any]) -> str:
+    return "'electrodes', 'off'" if int(EEG.get("nbchan", 0) or 0) > 64 else "'electrodes', 'on'"
+
+
+def _default_maplimits(maps: list[np.ndarray | None], typeplot: int) -> str | list[float]:
+    if not int(typeplot):
+        return "absmax"
+    finite_maps = [np.asarray(values).ravel() for values in maps if values is not None]
+    if not finite_maps:
+        return [-1.0, 1.0]
+    finite_values = np.concatenate(finite_maps)
+    finite_values = finite_values[np.isfinite(finite_values)]
+    if finite_values.size == 0:
+        return [-1.0, 1.0]
+    limit = float(np.max(np.abs(finite_values)))
+    return [-limit, limit] if limit else [-1.0, 1.0]
+
+
+def _normalise_rowcols(rowcols: Any, count: int) -> tuple[int, int]:
+    values = _parse_numeric_sequence(rowcols)
+    if values.size == 0 or int(values[0]) == 0:
+        cols = int(math.ceil(math.sqrt(count)))
+        rows = int(math.ceil(count / cols))
+        return rows, cols
+    if values.size != 2:
+        raise ValueError("rowcols must be [] or [rows, columns]")
+    rows, cols = int(values[0]), int(values[1])
+    if rows < 1 or cols < 1:
+        raise ValueError("rowcols values must be positive")
+    return rows, cols
+
+
+def _parse_items_text(text: str) -> list[float]:
+    stripped = text.strip()
+    if re.fullmatch(r"\d+\s*:\s*\d+", stripped):
+        start, stop = [int(part.strip()) for part in stripped.split(":")]
+        step = 1 if stop >= start else -1
+        return [float(value) for value in range(start, stop + step, step)]
+    return _parse_numeric_sequence(stripped).tolist()
+
+
+def _parse_rowcols_text(text: str) -> list[float]:
+    return _parse_numeric_sequence(text).tolist()
+
+
+def _parse_numeric_sequence(value: Any) -> np.ndarray:
+    if value is None:
+        return np.asarray([], dtype=float)
+    if isinstance(value, np.ndarray):
+        return value.astype(float).ravel()
+    if isinstance(value, (list, tuple)):
+        return np.asarray(value, dtype=float).ravel()
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return np.asarray([value], dtype=float)
+    text = str(value).strip().strip("[]")
+    if not text:
+        return np.asarray([], dtype=float)
+    return np.asarray([_parse_float_token(token) for token in re.split(r"[\s,]+", text) if token], dtype=float)
+
+
+def _parse_options_text(text: str) -> dict[str, Any]:
+    tokens = parse_text_tokens(text)
+    if not tokens:
+        return {}
+    if len(tokens) % 2:
+        raise ValueError("Additional topoplot options must be key/value pairs")
+    return {str(tokens[index]).lower(): _parse_option_value(tokens[index + 1]) for index in range(0, len(tokens), 2)}
+
+
+def _parse_option_value(value: Any) -> Any:
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("[") and text.endswith("]"):
+            return _parse_numeric_sequence(text).tolist()
+        try:
+            return _parse_float_token(text)
+        except ValueError:
+            return text
+    return value
+
+
+def _parse_float_token(token: str) -> float:
+    text = str(token).strip()
+    if text.lower() == "nan":
+        return float("nan")
+    if text.lower() == "inf":
+        return float("inf")
+    if text.lower() == "-inf":
+        return float("-inf")
+    return float(text)
+
+
+def _require_chanlocs(EEG: dict[str, Any]) -> None:
+    if not chanlocs_as_list(EEG.get("chanlocs", [])):
+        raise ValueError("cannot plot topography without channel location file")
+
+
+def _is_on(value: Any) -> bool:
+    return str(value).lower() in {"on", "yes", "true", "1"}
+
+
+def _is_plotdip_value(value: Any) -> bool:
+    return value is None or isinstance(value, (bool, int, float, np.integer, np.floating))
+
+
+def _history_command(
+    typeplot: int,
+    items: np.ndarray,
+    topotitle: str,
+    rowcols: tuple[int, int],
+    plotdip: int,
+    options: dict[str, Any],
+) -> str:
+    pieces = [
+        "EEG",
+        f"typeplot={int(typeplot)}",
+        f"items={_python_literal(items)}",
+        f"topotitle={_python_literal(topotitle)}",
+        f"rowcols={_python_literal(list(rowcols))}",
+        f"plotdip={int(plotdip)}",
+    ]
+    for key, value in options.items():
+        pieces.append(f"{key}={_python_literal(value)}")
+    return f"pop_topoplot({', '.join(pieces)})"
+
+
+def _python_literal(value: Any) -> str:
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if isinstance(value, (np.integer, np.floating)):
+        value = value.item()
+    if isinstance(value, float):
+        if np.isnan(value):
+            return "float('nan')"
+        if np.isposinf(value):
+            return "float('inf')"
+        if np.isneginf(value):
+            return "float('-inf')"
+        if value.is_integer():
+            return str(int(value))
+    if isinstance(value, list):
+        return "[" + ", ".join(_python_literal(item) for item in value) + "]"
+    if isinstance(value, tuple):
+        return "(" + ", ".join(_python_literal(item) for item in value) + ("," if len(value) == 1 else "") + ")"
+    return repr(value)
+
+
+__all__ = ["plot_channel_locations", "pop_topoplot", "pop_topoplot_dialog_spec"]

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -302,6 +302,8 @@ def _blank_topoplot(chan_locs, *, noplot='off', electrodes='on', gridscale=67, *
     xi_1d = np.linspace(-0.5, 0.5, int(gridscale))
     yi_1d = np.linspace(-0.5, 0.5, int(gridscale))
     xi, yi = np.meshgrid(xi_1d, yi_1d)
+    # Blank topoplots are decorative channel-location views; Zi is not a
+    # numerical interpolation result.
     Zi = np.full_like(xi, np.nan, dtype=float)
     if str(noplot).lower() != 'off':
         return None, Zi, 0.5, xi, yi

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -97,7 +97,7 @@ def topoplot(datavector, chan_locs, **kwargs):
     rmax = 0.5  # actual head radius
     INTSQUARE = 'on'
     default_intrad = 1
-    ELECTRODES = kwargs.get('ELECTRODES', 'on')
+    ELECTRODES = kwargs.get('electrodes', kwargs.get('ELECTRODES', 'on'))
     MAXDEFAULTSHOWLOCS = 64
     intrad = kwargs.get('intrad', np.nan)
     plotrad = kwargs.get('plotrad', np.nan)
@@ -109,6 +109,7 @@ def topoplot(datavector, chan_locs, **kwargs):
     # This matches MATLAB's coverage and properly interpolates frontal regions.
     # Users can override with method='griddata' for scipy's cubic interpolation (56.2% coverage).
     method = kwargs.get('method', 'v4')
+    style = str(kwargs.get('style', 'map')).lower()
 
     # print method
     # print(f'method = {method}')
@@ -126,12 +127,19 @@ def topoplot(datavector, chan_locs, **kwargs):
     cmap = plt.get_cmap('jet')
     GRID_SCALE = gridscale
 
-    if len(datavector) > MAXDEFAULTSHOWLOCS:
+    datavector = np.array([] if datavector is None else datavector).flatten()
+    if datavector.size == 0 or style == 'blank':
+        blank_kwargs = dict(kwargs)
+        blank_kwargs.pop('noplot', None)
+        blank_kwargs.pop('electrodes', None)
+        blank_kwargs.pop('ELECTRODES', None)
+        return _blank_topoplot(chan_locs, noplot=noplot, electrodes=ELECTRODES, gridscale=gridscale, **blank_kwargs)
+
+    if len(datavector) > MAXDEFAULTSHOWLOCS and str(ELECTRODES).lower() == 'on':
         ELECTRODES = 'off'
-    else:
+    elif str(ELECTRODES).lower() == 'on':
         ELECTRODES = 'on'
 
-    datavector = np.array(datavector).flatten()
     ContourVals = np.array(ContourVals).flatten()
 
     # Read the channel location information
@@ -252,12 +260,14 @@ def topoplot(datavector, chan_locs, **kwargs):
         y_rotated = x.copy()
         extent_rotated = (ymin, ymax, -xmax, -xmin)
 
-        im = ax.imshow(Zi, extent=extent_rotated, origin='lower', cmap=cmap)
+        im = ax.imshow(
+            Zi, extent=extent_rotated, origin='lower', cmap=cmap, **_maplimits_kwargs(kwargs.get('maplimits'), Zi)
+        )
         if kwargs.get('colorbar', own_figure):
             fig.colorbar(im, ax=ax, shrink=0.7)
 
         markersize = kwargs.get('markersize', 6)
-        if ELECTRODES == 'on':
+        if str(ELECTRODES).lower() == 'on':
             ax.scatter(x_rotated, y_rotated, c='k', s=markersize, zorder=5)
         # Head circles: a thick white ring at slightly smaller radius fills the
         # gap between the interpolated image edge and the head outline.
@@ -270,9 +280,7 @@ def topoplot(datavector, chan_locs, **kwargs):
         nose_w = 0.08
         ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
 
-        if kwargs.get('showlabels', False):
-            for i, txt in enumerate(labels):
-                ax.annotate(txt, (x_rotated[i], y_rotated[i]), fontsize=7, ha='right')
+        _draw_electrode_labels(ax, x_rotated, y_rotated, labels, ELECTRODES, showlabels=kwargs.get('showlabels', False))
 
         ax.set_xlim(-0.6, 0.6)
         ax.set_ylim(-0.6, 0.65)
@@ -281,8 +289,103 @@ def topoplot(datavector, chan_locs, **kwargs):
 
         if own_figure:
             ax.set_title('Topoplot')
-            plt.show()
+            _show_if_interactive()
 
         handle = fig
 
     return handle, Zi, plotrad, xi, yi
+
+
+def _blank_topoplot(chan_locs, *, noplot='off', electrodes='on', gridscale=67, **kwargs):
+    """Draw channel locations without interpolated data."""
+    labels, x_rotated, y_rotated = _channel_location_points(chan_locs)
+    xi_1d = np.linspace(-0.5, 0.5, int(gridscale))
+    yi_1d = np.linspace(-0.5, 0.5, int(gridscale))
+    xi, yi = np.meshgrid(xi_1d, yi_1d)
+    Zi = np.full_like(xi, np.nan, dtype=float)
+    if str(noplot).lower() != 'off':
+        return None, Zi, 0.5, xi, yi
+
+    ax = kwargs.get('axes', None)
+    own_figure = ax is None
+    if own_figure:
+        fig, ax = plt.subplots(1, 1)
+    else:
+        fig = ax.figure
+
+    _draw_head(ax)
+    markersize = kwargs.get('markersize', 6)
+    electrode_mode = str(electrodes).lower()
+    if electrode_mode in {'on', 'labelpoint', 'numpoint'}:
+        ax.scatter(x_rotated, y_rotated, c='k', s=markersize, zorder=5)
+    _draw_electrode_labels(ax, x_rotated, y_rotated, labels, electrodes)
+    ax.set_xlim(-0.6, 0.6)
+    ax.set_ylim(-0.6, 0.65)
+    ax.set_aspect('equal')
+    ax.axis('off')
+    ax.set_title(kwargs.get('title', 'Channel locations'))
+    if own_figure:
+        _show_if_interactive()
+    return fig, Zi, 0.5, xi, yi
+
+
+def _channel_location_points(chan_locs):
+    labels = []
+    xs = []
+    ys = []
+    for index, loc in enumerate(chan_locs):
+        if 'theta' not in loc or 'radius' not in loc:
+            continue
+        try:
+            theta_rad = np.deg2rad(float(loc.get('theta')))
+            radius_value = float(loc.get('radius'))
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(theta_rad) or not np.isfinite(radius_value):
+            continue
+        labels.append(str(loc.get('labels', index + 1)))
+        x = np.cos(theta_rad) * radius_value
+        y = np.sin(theta_rad) * radius_value
+        xs.append(-y)
+        ys.append(x)
+    return np.asarray(labels), np.asarray(xs), np.asarray(ys)
+
+
+def _draw_head(ax):
+    theta_c = np.linspace(0, 2 * np.pi, 100)
+    rmax = 0.5
+    ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=1.5, zorder=4)
+    nose_w = 0.08
+    ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
+
+
+def _draw_electrode_labels(ax, x, y, labels, electrodes, *, showlabels=False):
+    electrode_mode = str(electrodes).lower()
+    if electrode_mode == 'numpoint':
+        text_labels = [str(index + 1) for index in range(len(labels))]
+    elif electrode_mode in {'labelpoint', 'labels'} or showlabels:
+        text_labels = labels
+    else:
+        return
+    for x_pos, y_pos, text in zip(x, y, text_labels):
+        ax.annotate(text, (x_pos, y_pos), fontsize=7, ha='center', va='center')
+
+
+def _show_if_interactive():
+    if 'agg' not in plt.get_backend().lower():
+        plt.show()
+
+
+def _maplimits_kwargs(maplimits, data):
+    if maplimits is None:
+        return {}
+    if isinstance(maplimits, str):
+        if maplimits.lower() == 'absmax':
+            limit = np.nanmax(np.abs(data))
+            return {"vmin": -limit, "vmax": limit} if np.isfinite(limit) and limit > 0 else {}
+        if maplimits.lower() == 'maxmin':
+            return {}
+    values = np.asarray(maplimits, dtype=float).ravel()
+    if values.size >= 2 and np.all(np.isfinite(values[:2])):
+        return {"vmin": float(values[0]), "vmax": float(values[1])}
+    return {}

--- a/src/eegprep/resources/help/pop_topoplot.md
+++ b/src/eegprep/resources/help/pop_topoplot.md
@@ -1,0 +1,23 @@
+# pop_topoplot
+
+`pop_topoplot` plots EEGLAB-style 2-D scalp maps.
+
+Use `typeplot=1` to plot channel ERP maps at selected latencies in
+milliseconds:
+
+```python
+pop_topoplot(EEG, typeplot=1, items=[0, 100, 200], topotitle="ERP maps")
+```
+
+Use `typeplot=0` to plot ICA component maps. Component numbers are 1-based to
+match EEGLAB. Negative component numbers invert polarity and `float("nan")`
+leaves a blank subplot:
+
+```python
+pop_topoplot(EEG, typeplot=0, items=[1, -2, float("nan"), 3], topotitle="IC maps")
+```
+
+Additional `topoplot` options can be passed as keyword arguments, for example
+`electrodes="on"`, `colorbar="off"`, or `maplimits=[-5, 5]`.
+
+DIPFIT dipole overlays and 3-D head plots are handled by later Phase 4 work.

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -43,6 +43,11 @@ def _fake_pop_without_command(eeg, *, return_com=False):
     return (output, "") if return_com else output
 
 
+def _fake_pop_topoplot(eeg, *, return_com=False):
+    command = "pop_topoplot(EEG, typeplot=1, items=[0])"
+    return (["figure"], command) if return_com else ["figure"]
+
+
 def test_workspace_starts_with_eeglab_style_names():
     session = EEGPrepSession()
     workspace = EEGPrepConsoleWorkspace(session, exports={})
@@ -493,6 +498,19 @@ def test_pop_call_without_history_command_records_raw_console_source():
     assert command == ""
     assert session.EEG["setname"] == "no-history-command"
     assert session.ALLCOM == ["pop_interp(EEG)"]
+
+
+def test_non_mutating_pop_plot_call_records_history_without_storing_dataset():
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg(), new=True)
+    original_eeg = session.EEG
+    workspace = EEGPrepConsoleWorkspace(session, exports={"pop_topoplot": _fake_pop_topoplot})
+
+    result = workspace.namespace["pop_topoplot"](workspace.namespace["EEG"])
+
+    assert result == (["figure"], "pop_topoplot(EEG, typeplot=1, items=[0])")
+    assert session.EEG is original_eeg
+    assert session.ALLCOM == ["pop_topoplot(EEG, typeplot=1, items=[0])"]
 
 
 def test_single_assignment_pop_call_without_history_resets_namespace_to_session_eeg():

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -311,7 +311,7 @@ class MainMenuSpecTests(unittest.TestCase):
         self.assertEqual(action_kind("pop_subcomp"), "implemented")
         self.assertEqual(action_kind("pop_exportbids"), "implemented")
         self.assertEqual(action_kind("select_multiple_datasets"), "placeholder")
-        self.assertEqual(action_kind("topoplot:labels"), "placeholder")
+        self.assertEqual(action_kind("topoplot:labels"), "implemented")
         self.assertTrue(all(action_kind(action) in {"implemented", "placeholder"} for action in actions))
         self.assertTrue(
             all(action_kind(action) == "implemented" or is_placeholder_action(action) for action in actions)
@@ -661,6 +661,43 @@ class MenuActionDispatcherTests(unittest.TestCase):
                 self.assertEqual(session.EEG["setname"], setname)
                 self.assertEqual(session.ALLEEG[0]["setname"], setname)
                 self.assertEqual(session.ALLCOM[-1], f"EEG = {action}(EEG);")
+
+    def test_topoplot_menu_actions_record_history_without_replacing_dataset(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(), new=True)
+        dispatcher = MenuActionDispatcher(session)
+        original_eeg = session.EEG
+
+        with mock.patch(
+            "eegprep.functions.popfunc.pop_topoplot.plot_channel_locations",
+            return_value=("figure", "topoplot([], EEG['chanlocs'], style='blank', electrodes='labelpoint')"),
+        ) as locations:
+            dispatcher.dispatch("topoplot:labels")
+
+        locations.assert_called_once_with(original_eeg, mode="labels", return_com=True)
+        self.assertIs(session.EEG, original_eeg)
+        self.assertIs(session.ALLEEG[0], original_eeg)
+        self.assertEqual(
+            session.ALLCOM[-1],
+            "topoplot([], EEG['chanlocs'], style='blank', electrodes='labelpoint')",
+        )
+
+    def test_pop_topoplot_menu_actions_record_history_without_replacing_dataset(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(epoched=True), new=True)
+        dispatcher = MenuActionDispatcher(session)
+        original_eeg = session.EEG
+
+        with mock.patch(
+            "eegprep.functions.popfunc.pop_topoplot.pop_topoplot",
+            return_value=(["figure"], "pop_topoplot(EEG, typeplot=1, items=[0])"),
+        ) as topoplot_func:
+            dispatcher.dispatch("pop_topoplot:erp")
+
+        topoplot_func.assert_called_once_with(original_eeg, typeplot=1, return_com=True)
+        self.assertIs(session.EEG, original_eeg)
+        self.assertIs(session.ALLEEG[0], original_eeg)
+        self.assertEqual(session.ALLCOM[-1], "pop_topoplot(EEG, typeplot=1, items=[0])")
 
     def test_pop_interp_dispatch_uses_generic_gui_command_echo(self):
         session = EEGPrepSession()

--- a/tests/test_pop_topoplot.py
+++ b/tests/test_pop_topoplot.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_topoplot import (
+    _latency_positions,
     _parse_items_text,
     plot_channel_locations,
     pop_topoplot,
@@ -40,6 +41,17 @@ def test_plot_channel_locations_returns_valid_console_command():
     assert command == "topoplot([], EEG['chanlocs'], style='blank', electrodes='numpoint')"
     assert figure.axes[0].get_title() == "Channel locations"
     plt.close(figure)
+
+
+def test_plot_channel_locations_rejects_unknown_mode():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20)
+
+    try:
+        plot_channel_locations(eeg, mode="bad")
+    except ValueError as exc:
+        assert "mode must be" in str(exc)
+    else:
+        raise AssertionError("expected invalid channel-location mode ValueError")
 
 
 def test_pop_topoplot_plots_sample_data_erp_maps_headlessly():
@@ -82,6 +94,25 @@ def test_pop_topoplot_multi_map_pages_include_shared_colorbar_by_default():
     plt.close(figures[0])
 
 
+def test_pop_topoplot_component_pages_use_shared_default_scale():
+    eeg = create_test_eeg_with_ica(n_channels=6, n_samples=30, n_components=2)
+    eeg["icawinv"] = np.column_stack([np.ones(6), np.arange(1, 7) * 10.0])
+
+    figures = pop_topoplot(
+        eeg,
+        typeplot=0,
+        items=[1, 2],
+        topotitle="component scale",
+        rowcols=[1, 2],
+        electrodes="off",
+    )
+
+    clims = [axis.images[0].get_clim() for axis in figures[0].axes[:2]]
+    assert clims[0] == clims[1] == (-60.0, 60.0)
+    assert len(figures[0].axes) == 3
+    plt.close(figures[0])
+
+
 def test_pop_topoplot_plots_component_maps_with_inverted_and_blank_items():
     eeg = create_test_eeg_with_ica(n_channels=6, n_samples=50, n_components=3)
 
@@ -104,10 +135,22 @@ def test_pop_topoplot_plots_component_maps_with_inverted_and_blank_items():
 def test_pop_topoplot_item_text_parses_eeglab_colon_ranges():
     assert _parse_items_text("-100:50:0") == [-100.0, -50.0, 0.0]
     assert _parse_items_text("0.5:0.25:1") == [0.5, 0.75, 1.0]
+    tenth_steps = _parse_items_text("0:0.1:1")
+    assert len(tenth_steps) == 11
+    assert tenth_steps[-1] == 1.0
     parsed = _parse_items_text("1:2 NaN 5")
     assert parsed[:2] == [1.0, 2.0]
     assert np.isnan(parsed[2])
     assert parsed[3] == 5.0
+
+
+def test_pop_topoplot_latency_positions_use_matlab_rounding():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=4)
+    eeg["xmin"] = 0.0
+    eeg["xmax"] = 3.0
+    eeg["pnts"] = 4
+
+    assert _latency_positions(eeg, np.array([500.0, 2500.0])).tolist() == [1, 3]
 
 
 def test_pop_topoplot_gui_parses_signed_decimal_step_ranges():

--- a/tests/test_pop_topoplot.py
+++ b/tests/test_pop_topoplot.py
@@ -6,7 +6,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
-from eegprep.functions.popfunc.pop_topoplot import plot_channel_locations, pop_topoplot, pop_topoplot_dialog_spec
+from eegprep.functions.popfunc.pop_topoplot import (
+    _parse_items_text,
+    plot_channel_locations,
+    pop_topoplot,
+    pop_topoplot_dialog_spec,
+)
 from eegprep.functions.sigprocfunc.topoplot import topoplot
 from tests.fixtures import SAMPLE_DATASET_PATH, create_test_eeg_with_ica
 
@@ -59,6 +64,24 @@ def test_pop_topoplot_plots_sample_data_erp_maps_headlessly():
     plt.close(figures[0])
 
 
+def test_pop_topoplot_multi_map_pages_include_shared_colorbar_by_default():
+    eeg = create_test_eeg_with_ica(n_channels=6, n_samples=30)
+
+    figures = pop_topoplot(
+        eeg,
+        typeplot=1,
+        items=[0, 20],
+        topotitle="shared scale",
+        rowcols=[1, 2],
+        electrodes="off",
+    )
+
+    assert len(figures) == 1
+    assert [axis.get_title() for axis in figures[0].axes[:2]] == ["0 ms", "20 ms"]
+    assert len(figures[0].axes) == 3
+    plt.close(figures[0])
+
+
 def test_pop_topoplot_plots_component_maps_with_inverted_and_blank_items():
     eeg = create_test_eeg_with_ica(n_channels=6, n_samples=50, n_components=3)
 
@@ -78,6 +101,37 @@ def test_pop_topoplot_plots_component_maps_with_inverted_and_blank_items():
     plt.close(figures[0])
 
 
+def test_pop_topoplot_item_text_parses_eeglab_colon_ranges():
+    assert _parse_items_text("-100:50:0") == [-100.0, -50.0, 0.0]
+    assert _parse_items_text("0.5:0.25:1") == [0.5, 0.75, 1.0]
+    parsed = _parse_items_text("1:2 NaN 5")
+    assert parsed[:2] == [1.0, 2.0]
+    assert np.isnan(parsed[2])
+    assert parsed[3] == 5.0
+
+
+def test_pop_topoplot_gui_parses_signed_decimal_step_ranges():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=5, n_trials=2)
+    eeg["xmin"] = -0.1
+    eeg["xmax"] = 0.1
+    eeg["times"] = np.linspace(-100, 100, eeg["pnts"])
+
+    class Renderer:
+        def run(self, spec, initial_values=None):
+            return {
+                "items": "-100:50.0:0",
+                "topotitle": "range",
+                "rowcols": "[1 3]",
+                "options": "'electrodes', 'off', 'colorbar', 'off'",
+            }
+
+    figures, command = pop_topoplot(eeg, typeplot=1, renderer=Renderer(), return_com=True)
+
+    assert [axis.get_title() for axis in figures[0].axes[:3]] == ["-100 ms", "-50 ms", "0 ms"]
+    assert "items=[-100, -50, 0]" in command
+    plt.close(figures[0])
+
+
 def test_pop_topoplot_all_blank_items_do_not_crash():
     eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20, n_components=2)
 
@@ -92,6 +146,23 @@ def test_pop_topoplot_all_blank_items_do_not_crash():
 
     assert len(figures) == 1
     assert "items=[float('nan')]" in command
+    plt.close(figures[0])
+
+
+def test_pop_topoplot_rejects_finite_latency_when_epoch_range_collapsed():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=5)
+    eeg["xmin"] = 0.0
+    eeg["xmax"] = 0.0
+
+    try:
+        pop_topoplot(eeg, typeplot=1, items=[0])
+    except ValueError as exc:
+        assert "outside the epoch time range" in str(exc)
+    else:
+        raise AssertionError("expected collapsed epoch range ValueError")
+
+    figures = pop_topoplot(eeg, typeplot=1, items=[float("nan")], rowcols=[1, 1], colorbar="off")
+    assert len(figures) == 1
     plt.close(figures[0])
 
 
@@ -133,6 +204,31 @@ def test_pop_topoplot_rejects_missing_ica_or_chanlocs():
     eeg["chanlocs"] = []
     try:
         pop_topoplot(eeg, typeplot=1, items=[0])
+    except ValueError as exc:
+        assert "channel location" in str(exc)
+    else:
+        raise AssertionError("expected missing channel location ValueError")
+
+
+def test_pop_topoplot_gui_preflights_missing_inputs_before_dialog():
+    class Renderer:
+        def run(self, spec, initial_values=None):
+            raise AssertionError("renderer should not run when preflight fails")
+
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20, n_components=4)
+    eeg["icawinv"] = None
+
+    try:
+        pop_topoplot(eeg, typeplot=0, renderer=Renderer())
+    except ValueError as exc:
+        assert "no ICA data" in str(exc)
+    else:
+        raise AssertionError("expected missing ICA ValueError")
+
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20)
+    eeg["chanlocs"] = []
+    try:
+        pop_topoplot(eeg, typeplot=1, renderer=Renderer())
     except ValueError as exc:
         assert "channel location" in str(exc)
     else:

--- a/tests/test_pop_topoplot.py
+++ b/tests/test_pop_topoplot.py
@@ -1,0 +1,139 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.functions.popfunc.pop_topoplot import plot_channel_locations, pop_topoplot, pop_topoplot_dialog_spec
+from eegprep.functions.sigprocfunc.topoplot import topoplot
+from tests.fixtures import SAMPLE_DATASET_PATH, create_test_eeg_with_ica
+
+
+def test_topoplot_blank_channel_locations_by_label_and_number():
+    chanlocs = [
+        {"labels": "Fz", "theta": 0, "radius": 0.3},
+        {"labels": "Cz", "theta": 0, "radius": 0.0},
+        {"labels": "Pz", "theta": 180, "radius": 0.3},
+    ]
+
+    label_fig, *_ = topoplot([], chanlocs, style="blank", electrodes="labelpoint")
+    number_fig, *_ = topoplot([], chanlocs, style="blank", electrodes="numpoint")
+
+    assert [text.get_text() for text in label_fig.axes[0].texts] == ["Fz", "Cz", "Pz"]
+    assert [text.get_text() for text in number_fig.axes[0].texts] == ["1", "2", "3"]
+    plt.close(label_fig)
+    plt.close(number_fig)
+
+
+def test_plot_channel_locations_returns_valid_console_command():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20)
+
+    figure, command = plot_channel_locations(eeg, mode="numbers", return_com=True)
+
+    assert command == "topoplot([], EEG['chanlocs'], style='blank', electrodes='numpoint')"
+    assert figure.axes[0].get_title() == "Channel locations"
+    plt.close(figure)
+
+
+def test_pop_topoplot_plots_sample_data_erp_maps_headlessly():
+    eeg = pop_loadset(SAMPLE_DATASET_PATH)
+
+    figures, command = pop_topoplot(
+        eeg,
+        typeplot=1,
+        items=[0, 100],
+        topotitle="sample maps",
+        rowcols=[1, 2],
+        return_com=True,
+        electrodes="off",
+        colorbar="off",
+    )
+
+    assert len(figures) == 1
+    assert [axis.get_title() for axis in figures[0].axes] == ["0 ms", "100 ms"]
+    assert "pop_topoplot(EEG, typeplot=1" in command
+    assert "items=[0, 100]" in command
+    assert "electrodes='off'" in command
+    plt.close(figures[0])
+
+
+def test_pop_topoplot_plots_component_maps_with_inverted_and_blank_items():
+    eeg = create_test_eeg_with_ica(n_channels=6, n_samples=50, n_components=3)
+
+    figures, command = pop_topoplot(
+        eeg,
+        typeplot=0,
+        items=[1, -2, float("nan")],
+        topotitle="IC maps",
+        rowcols=[],
+        return_com=True,
+        colorbar="off",
+    )
+
+    assert len(figures) == 1
+    assert [axis.get_title() for axis in figures[0].axes[:2]] == ["IC 1", "IC -2"]
+    assert "items=[1, -2, float('nan')]" in command
+    plt.close(figures[0])
+
+
+def test_pop_topoplot_all_blank_items_do_not_crash():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20, n_components=2)
+
+    figures, command = pop_topoplot(
+        eeg,
+        typeplot=1,
+        items=[float("nan")],
+        topotitle="blank",
+        rowcols=[1, 1],
+        return_com=True,
+    )
+
+    assert len(figures) == 1
+    assert "items=[float('nan')]" in command
+    plt.close(figures[0])
+
+
+def test_pop_topoplot_gui_parses_eeglab_style_options():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20, n_components=4)
+
+    class Renderer:
+        def run(self, spec, initial_values=None):
+            assert pop_topoplot_dialog_spec(eeg, typeplot=0).title == spec.title
+            return {
+                "items": "1:2",
+                "topotitle": "components",
+                "rowcols": "[1 2]",
+                "plotdip": False,
+                "options": "'electrodes', 'off', 'colorbar', 'off'",
+            }
+
+    figures, command = pop_topoplot(eeg, typeplot=0, renderer=Renderer(), return_com=True)
+
+    assert len(figures) == 1
+    assert "typeplot=0" in command
+    assert "items=[1, 2]" in command
+    assert "colorbar='off'" in command
+    plt.close(figures[0])
+
+
+def test_pop_topoplot_rejects_missing_ica_or_chanlocs():
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20, n_components=4)
+    eeg["icawinv"] = np.array([])
+
+    try:
+        pop_topoplot(eeg, typeplot=0, items=[1])
+    except ValueError as exc:
+        assert "no ICA data" in str(exc)
+    else:
+        raise AssertionError("expected missing ICA ValueError")
+
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=20)
+    eeg["chanlocs"] = []
+    try:
+        pop_topoplot(eeg, typeplot=1, items=[0])
+    except ValueError as exc:
+        assert "channel location" in str(exc)
+    else:
+        raise AssertionError("expected missing channel location ValueError")

--- a/tests/test_topoplot.py
+++ b/tests/test_topoplot.py
@@ -349,6 +349,13 @@ class TestTopoplot(unittest.TestCase):
         handle, Zi, plotrad, xi, yi = topoplot(np.array([]), self.chan_locs, noplot='on')
         self.assertIsNone(handle)
         self.assertIsInstance(Zi, np.ndarray)
+        self.assertTrue(np.all(np.isnan(Zi)))
+        self.assertEqual(plotrad, 0.5)
+        self.assertEqual(xi.shape, yi.shape)
+        self.assertAlmostEqual(xi[0, 0], -0.5)
+        self.assertAlmostEqual(xi[0, -1], 0.5)
+        self.assertAlmostEqual(yi[0, 0], -0.5)
+        self.assertAlmostEqual(yi[-1, 0], 0.5)
 
         # Test with mismatched data and channel count - expect various possible errors
         with self.assertRaises((IndexError, ValueError, UnboundLocalError)):

--- a/tests/test_topoplot.py
+++ b/tests/test_topoplot.py
@@ -345,9 +345,10 @@ class TestTopoplot(unittest.TestCase):
 
     def test_empty_data_handling(self):
         """Test topoplot with empty or invalid data."""
-        # Test with empty data - expect various possible errors
-        with self.assertRaises((IndexError, ValueError, UnboundLocalError)):
-            topoplot(np.array([]), self.chan_locs, noplot='on')
+        # Empty data is EEGLAB's channel-location plotting mode.
+        handle, Zi, plotrad, xi, yi = topoplot(np.array([]), self.chan_locs, noplot='on')
+        self.assertIsNone(handle)
+        self.assertIsInstance(Zi, np.ndarray)
 
         # Test with mismatched data and channel count - expect various possible errors
         with self.assertRaises((IndexError, ValueError, UnboundLocalError)):

--- a/tools/visual_parity/capture.py
+++ b/tools/visual_parity/capture.py
@@ -650,6 +650,7 @@ def _write_matlab_simple_pop_dialog_script(
         "pop_resample": "Resample current dataset -- pop_resample()",
         "pop_epoch": "Extract data epochs - pop_epoch()",
         "pop_rmbase": "Baseline removal - pop_rmbase()",
+        "pop_topoplot": "Plot ERP scalp maps in 2-D -- pop_topoplot()",
         "pop_runica": "Run ICA decomposition -- pop_runica()",
         "pop_subcomp": "Remove components from data -- pop_subcomp()",
         "pop_clean_rawdata": "pop_clean_rawdata()",
@@ -658,13 +659,17 @@ def _write_matlab_simple_pop_dialog_script(
         "pop_iclabel": "ICLabel",
         "pop_icflag": "Flag components using ICLabel -- pop_icflag()",
     }
+    if action == "pop_topoplot" and variant == "components":
+        target_title = "Plot component scalp maps in 2-D -- pop_topoplot()"
+    else:
+        target_title = title_by_action[action]
     script_path.write_text(
         "\n".join(
             [
                 "function eegprep_visual_capture()",
                 "try",
                 f"output_file = {_matlab_string(output_path)};",
-                f"target_title = {_matlab_string(title_by_action[action])};",
+                f"target_title = {_matlab_string(target_title)};",
                 f"action = {_matlab_string(action)};",
                 f"variant = {_matlab_string(variant)};",
                 f"eeglab_root = {_matlab_string(eeglab_root)};",
@@ -691,6 +696,12 @@ def _write_matlab_simple_pop_dialog_script(
                 "        [EEG, com] = pop_epoch(EEG);",
                 "    case 'pop_rmbase'",
                 "        [EEG, com] = pop_rmbase(EEG);",
+                "    case 'pop_topoplot'",
+                "        if strcmp(variant, 'components')",
+                "            com = pop_topoplot(EEG, 0);",
+                "        else",
+                "            com = pop_topoplot(EEG, 1);",
+                "        end",
                 "    case 'pop_runica'",
                 "        [EEG, com] = pop_runica(EEG);",
                 "    case 'pop_subcomp'",
@@ -1253,6 +1264,7 @@ def capture_target(
             "pop_runica",
             "pop_select",
             "pop_subcomp",
+            "pop_topoplot",
             "inputdlg2",
             "pophelp",
         }:
@@ -1288,6 +1300,7 @@ def capture_target(
             "pop_runica",
             "pop_select",
             "pop_subcomp",
+            "pop_topoplot",
         }:
             script_path = _write_matlab_simple_pop_dialog_script(case, output_path, action, variant)
         elif action == "inputdlg2":

--- a/tools/visual_parity/cases.json
+++ b/tools/visual_parity/cases.json
@@ -480,6 +480,56 @@
       }
     },
     {
+      "id": "pop_topoplot_erp_dialog",
+      "description": "ERP scalp-map dialog opened from pop_topoplot.",
+      "window_size": [650, 383],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_topoplot:erp"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_topoplot_erp_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_topoplot_components_dialog",
+      "description": "Component scalp-map dialog opened from pop_topoplot.",
+      "window_size": [650, 445],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_topoplot:components"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_topoplot_components_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
       "id": "pop_runica_dialog",
       "description": "ICA decomposition dialog opened from pop_runica.",
       "window_size": [824, 334],


### PR DESCRIPTION
Add EEGPrep topography plotting foundation for channel-location maps and pop_topoplot 2-D ERP/component scalp maps. Wires the Plot menu, help, docs, console-safe history, headless tests, and visual parity capture cases while leaving headplot/DIPFIT overlays for later Phase 4 work.

Part of #64