### PR TITLE
Add Phase 4 time-frequency and statistics workflows

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -94,6 +94,13 @@ Spectral Analysis
    eegprep.eeg_autocorr
    eegprep.eeg_autocorr_welch
    eegprep.eeg_autocorr_fftw
+   eegprep.newtimef
+   eegprep.newcrossf
+   eegprep.signalstat
+   eegprep.pop_newtimef
+   eegprep.pop_newcrossf
+   eegprep.pop_signalstat
+   eegprep.pop_eventstat
 
 Epoching and Selection
 ======================

--- a/docs/source/api/signal_processing.rst
+++ b/docs/source/api/signal_processing.rst
@@ -15,6 +15,23 @@ Spectral Analysis
 
 .. autofunction:: eegprep.eeg_rpsd
 
+Time-Frequency And Statistics
+=============================
+
+.. autofunction:: eegprep.newtimef
+
+.. autofunction:: eegprep.newcrossf
+
+.. autofunction:: eegprep.signalstat
+
+.. autofunction:: eegprep.pop_newtimef
+
+.. autofunction:: eegprep.pop_newcrossf
+
+.. autofunction:: eegprep.pop_signalstat
+
+.. autofunction:: eegprep.pop_eventstat
+
 Resampling
 ==========
 

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -64,6 +64,8 @@ _LAZY_EXPORTS = {
     "loadset": ("eegprep.functions.popfunc.pop_loadset", "loadset"),
     "mne2eeg": ("eegprep.functions.redefine_functions", "mne2eeg"),
     "mne2eeg_epochs": ("eegprep.functions.redefine_functions", "mne2eeg_epochs"),
+    "newcrossf": ("eegprep.functions.timefreqfunc.newcrossf", "newcrossf"),
+    "newtimef": ("eegprep.functions.timefreqfunc.newtimef", "newtimef"),
     "options": ("eegprep.functions.redefine_functions", "options"),
     "picard": ("eegprep.functions.redefine_functions", "picard"),
     "point2lat": ("eegprep.functions.redefine_functions", "point2lat"),
@@ -98,6 +100,7 @@ _LAZY_EXPORTS = {
     "pop_comperp": ("eegprep.functions.popfunc.pop_comperp", "pop_comperp"),
     "pop_envtopo": ("eegprep.functions.popfunc.pop_envtopo", "pop_envtopo"),
     "pop_erpimage": ("eegprep.functions.popfunc.pop_erpimage", "pop_erpimage"),
+    "pop_eventstat": ("eegprep.functions.popfunc.pop_eventstat", "pop_eventstat"),
     "pop_fileio_brainvision_mat": (
         "eegprep.functions.popfunc.pop_fileio_brainvision_mat",
         "pop_fileio_brainvision_mat",
@@ -123,6 +126,8 @@ _LAZY_EXPORTS = {
     "pop_leadfield": ("eegprep.plugins.dipfit.pop_leadfield", "pop_leadfield"),
     "pop_mergeset": ("eegprep.functions.popfunc.pop_mergeset", "pop_mergeset"),
     "pop_multifit": ("eegprep.plugins.dipfit.pop_multifit", "pop_multifit"),
+    "pop_newcrossf": ("eegprep.functions.popfunc.pop_newcrossf", "pop_newcrossf"),
+    "pop_newtimef": ("eegprep.functions.popfunc.pop_newtimef", "pop_newtimef"),
     "pop_plotdata": ("eegprep.functions.popfunc.pop_plotdata", "pop_plotdata"),
     "pop_plottopo": ("eegprep.functions.popfunc.pop_plottopo", "pop_plottopo"),
     "pop_prop": ("eegprep.functions.popfunc.pop_prop", "pop_prop"),
@@ -145,6 +150,7 @@ _LAZY_EXPORTS = {
     "pop_select": ("eegprep.functions.popfunc.pop_select", "pop_select"),
     "pop_selectevent": ("eegprep.functions.popfunc.pop_selectevent", "pop_selectevent"),
     "pop_selectcomps": ("eegprep.functions.popfunc.pop_selectcomps", "pop_selectcomps"),
+    "pop_signalstat": ("eegprep.functions.popfunc.pop_signalstat", "pop_signalstat"),
     "pop_study": ("eegprep.functions.studyfunc.pop_study", "pop_study"),
     "pop_studyerp": ("eegprep.functions.studyfunc.pop_studyerp", "pop_studyerp"),
     "pop_studywizard": ("eegprep.functions.studyfunc.pop_studywizard", "pop_studywizard"),
@@ -163,6 +169,7 @@ _LAZY_EXPORTS = {
         "eegprep.functions.guifunc.select_multiple_datasets",
         "select_multiple_datasets",
     ),
+    "signalstat": ("eegprep.functions.sigprocfunc.signalstat", "signalstat"),
     "topoplot": ("eegprep.functions.sigprocfunc.topoplot", "topoplot"),
 }
 

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -52,6 +52,7 @@ IMPLEMENTED_ACTIONS = {
     "pop_envtopo",
     "pop_epoch",
     "pop_erpimage",
+    "pop_eventstat",
     "pop_eventinfo",
     "pop_expevents",
     "pop_expica",
@@ -115,7 +116,10 @@ IMPLEMENTED_ACTIONS = {
     "pop_participantinfo",
     "pop_mergeset",
     "pop_multifit",
+    "pop_newcrossf",
+    "pop_newtimef",
     "pop_writeeeg",
+    "pop_signalstat",
     "bids_exporter",
     "plugin_menu",
     "quit",
@@ -425,6 +429,10 @@ class MenuActionDispatcher:
             "pop_erpimage",
             "pop_envtopo",
             "pop_comperp",
+            "pop_newtimef",
+            "pop_newcrossf",
+            "pop_signalstat",
+            "pop_eventstat",
         }:
             self._run_plot_function(base, variant, parent)
             return
@@ -1167,6 +1175,22 @@ class MenuActionDispatcher:
 
             datasets = self.session.ALLEEG or (selection if isinstance(selection, list) else [selection])
             _result, command = pop_comperp(datasets, flag=0 if variant == "components" else 1, return_com=True)
+        elif name == "pop_newtimef":
+            from eegprep.functions.popfunc.pop_newtimef import pop_newtimef
+
+            _result, command = pop_newtimef(selection, typeproc=0 if variant == "components" else 1, return_com=True)
+        elif name == "pop_newcrossf":
+            from eegprep.functions.popfunc.pop_newcrossf import pop_newcrossf
+
+            _result, command = pop_newcrossf(selection, typeproc=0 if variant == "components" else 1, return_com=True)
+        elif name == "pop_signalstat":
+            from eegprep.functions.popfunc.pop_signalstat import pop_signalstat
+
+            _result, command = pop_signalstat(selection, typeproc=0 if variant == "components" else 1, return_com=True)
+        elif name == "pop_eventstat":
+            from eegprep.functions.popfunc.pop_eventstat import pop_eventstat
+
+            _result, command = pop_eventstat(selection, return_com=True)
         else:
             self.show_coming_soon(name, parent)
             return

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -25,16 +25,6 @@ def _phase_entries(phase: str, actions: tuple[str, ...]) -> dict[str, Placeholde
 
 PLACEHOLDER_ACTION_METADATA: Mapping[str, PlaceholderMetadata] = {
     **_phase_entries(
-        "4",
-        (
-            "pop_eventstat",
-            "pop_newcrossf",
-            "pop_newtimef",
-            "pop_signalstat",
-            "pop_viewprops:channels",
-        ),
-    ),
-    **_phase_entries(
         "5",
         (
             "pop_clust",

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -34,9 +34,12 @@ from eegprep.functions.popfunc.pop_headplot import pop_headplot_dialog_spec
 from eegprep.functions.popfunc.pop_interp import pop_interp_dialog_spec
 from eegprep.functions.popfunc.pop_jointprob import pop_jointprob_dialog_spec
 from eegprep.functions.popfunc.pop_mergeset import pop_mergeset_dialog_spec
+from eegprep.functions.popfunc.pop_eventstat import pop_eventstat_dialog_spec
 from eegprep.functions.popfunc.pop_plotdata import pop_plotdata_dialog_spec
 from eegprep.functions.popfunc.pop_plottopo import pop_plottopo_dialog_spec
 from eegprep.functions.popfunc.pop_prop import pop_prop_dialog_spec
+from eegprep.functions.popfunc.pop_newcrossf import pop_newcrossf_dialog_spec
+from eegprep.functions.popfunc.pop_newtimef import pop_newtimef_dialog_spec
 from eegprep.functions.popfunc.pop_reref import pop_reref_dialog_spec
 from eegprep.functions.popfunc.pop_rejchan import pop_rejchan_dialog_spec
 from eegprep.functions.popfunc.pop_rejcont import pop_rejcont_dialog_spec
@@ -50,6 +53,7 @@ from eegprep.functions.popfunc.pop_rmbase import pop_rmbase_dialog_spec
 from eegprep.functions.popfunc.pop_runica import pop_runica_dialog_spec
 from eegprep.functions.popfunc.pop_select import pop_select_dialog_spec
 from eegprep.functions.popfunc.pop_selectevent import pop_selectevent_dialog_spec
+from eegprep.functions.popfunc.pop_signalstat import pop_signalstat_dialog_spec
 from eegprep.functions.popfunc.pop_selectcomps import pop_selectcomps_dialog_spec
 from eegprep.functions.popfunc.pop_spectopo import pop_spectopo_dialog_spec
 from eegprep.functions.popfunc.pop_subcomp import pop_subcomp_dialog_spec
@@ -656,6 +660,42 @@ def capture_pop_comperp_dialog(output: pathlib.Path, *, variant: str = "channels
     _grab_dialog(dialog, output, app)
 
 
+def capture_pop_newtimef_dialog(output: pathlib.Path, *, variant: str = "channels") -> None:
+    """Render and capture the pop_newtimef dialog."""
+    eeg = _demo_main_eeg(epoched=True, setname="pop demo")
+    spec = pop_newtimef_dialog_spec(eeg, typeproc=0 if variant == "components" else 1)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
+def capture_pop_newcrossf_dialog(output: pathlib.Path, *, variant: str = "channels") -> None:
+    """Render and capture the pop_newcrossf dialog."""
+    eeg = _demo_main_eeg(epoched=True, setname="pop demo")
+    spec = pop_newcrossf_dialog_spec(eeg, typeproc=0 if variant == "components" else 1)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
+def capture_pop_signalstat_dialog(output: pathlib.Path, *, variant: str = "channels") -> None:
+    """Render and capture the pop_signalstat dialog."""
+    eeg = _demo_main_eeg(epoched=True, setname="pop demo")
+    spec = pop_signalstat_dialog_spec(eeg, typeproc=0 if variant == "components" else 1)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
+def capture_pop_eventstat_dialog(output: pathlib.Path) -> None:
+    """Render and capture the pop_eventstat dialog."""
+    eeg = _demo_main_eeg(epoched=True, setname="pop demo")
+    spec = pop_eventstat_dialog_spec(eeg)
+    renderer = QtDialogRenderer()
+    app, dialog, _widgets = renderer.build_dialog(spec)
+    _grab_dialog(dialog, output, app)
+
+
 def capture_pop_runica_dialog(output: pathlib.Path) -> None:
     """Render and capture the pop_runica dialog."""
     eeg = _demo_main_eeg()
@@ -1016,6 +1056,20 @@ def main(argv: list[str] | None = None) -> int:
         capture_pop_comperp_dialog(args.output, variant="channels")
     elif args.case == "pop_comperp_components_dialog":
         capture_pop_comperp_dialog(args.output, variant="components")
+    elif args.case == "pop_newtimef_channels_dialog":
+        capture_pop_newtimef_dialog(args.output, variant="channels")
+    elif args.case == "pop_newtimef_components_dialog":
+        capture_pop_newtimef_dialog(args.output, variant="components")
+    elif args.case == "pop_newcrossf_channels_dialog":
+        capture_pop_newcrossf_dialog(args.output, variant="channels")
+    elif args.case == "pop_newcrossf_components_dialog":
+        capture_pop_newcrossf_dialog(args.output, variant="components")
+    elif args.case == "pop_signalstat_channels_dialog":
+        capture_pop_signalstat_dialog(args.output, variant="channels")
+    elif args.case == "pop_signalstat_components_dialog":
+        capture_pop_signalstat_dialog(args.output, variant="components")
+    elif args.case == "pop_eventstat_dialog":
+        capture_pop_eventstat_dialog(args.output)
     elif args.case == "pop_runica_dialog":
         capture_pop_runica_dialog(args.output)
     elif args.case == "pop_runica_multiple_dialog":

--- a/src/eegprep/functions/popfunc/pop_eventstat.py
+++ b/src/eegprep/functions/popfunc/pop_eventstat.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc.eeg_point2lat import eeg_point2lat
 from eegprep.functions.popfunc._plot_utils import history_command, numeric_vector
 from eegprep.functions.sigprocfunc.signalstat import signalstat
 
@@ -140,9 +141,19 @@ def _event_in_latency_range(EEG: dict[str, Any], event: dict[str, Any], bounds: 
         latency = float(np.asarray(event.get("latency")).squeeze())
     except (TypeError, ValueError):
         return False
-    srate = float(EEG.get("srate", 1) or 1)
-    xmin = float(EEG.get("xmin", 0) or 0)
-    latency_ms = (latency - 1) / srate * 1000.0 + xmin * 1000.0
+    try:
+        epoch = float(np.asarray(event.get("epoch", 1)).squeeze())
+    except (TypeError, ValueError):
+        epoch = 1.0
+    latency_ms = float(
+        eeg_point2lat(
+            [latency],
+            [epoch],
+            float(EEG.get("srate", 1) or 1),
+            [float(EEG.get("xmin", 0) or 0) * 1000.0, float(EEG.get("xmax", 0) or 0) * 1000.0],
+            1e-3,
+        )[0]
+    )
     return bool(bounds[0] <= latency_ms <= bounds[1])
 
 

--- a/src/eegprep/functions/popfunc/pop_eventstat.py
+++ b/src/eegprep/functions/popfunc/pop_eventstat.py
@@ -1,0 +1,159 @@
+"""EEGLAB-style wrapper for event-field statistics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._plot_utils import history_command, numeric_vector
+from eegprep.functions.sigprocfunc.signalstat import signalstat
+
+
+def pop_eventstat(
+    EEG: dict[str, Any] | None = None,
+    eventfield: str | None = None,
+    type: Any = None,
+    latrange: Any = None,
+    percent: float = 5,
+    *,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+):
+    """Compute and plot statistics for numeric EEG event fields."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    if gui is None:
+        gui = eventfield is None
+    if gui:
+        result = _run_gui(EEG, renderer=renderer)
+        if result is None:
+            return (None, "") if return_com else None
+        eventfield = result["eventfield"]
+        type = result["type"]
+        latrange = result["latrange"]
+        percent = result["percent"]
+    eventfield = str(eventfield or "latency")
+    values = event_values(EEG, eventfield, type=type, latrange=latrange)
+    if values.size == 0:
+        raise ValueError("No such events found. See Edit > Event values to confirm event type.")
+    label = "Event values"
+    title = (
+        f"All event statistics for '{eventfield}' info"
+        if _is_empty(type)
+        else f"Event {type!r} statistics for '{eventfield}' info"
+    )
+    result = signalstat(values, 1, label, float(percent), title)
+    command = history_command("pop_eventstat", eventfield, type, latrange, percent)
+    return (result, command) if return_com else result
+
+
+def pop_eventstat_dialog_spec(EEG: dict[str, Any]) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_eventstat``."""
+    _ = EEG
+    controls = (
+        ControlSpec("text", "Event field to process:"),
+        ControlSpec("edit", tag="eventfield", value="latency"),
+        ControlSpec("text", 'Event type(s) ([]=all):\nSelect "Edit > Event values" to see type values'),
+        ControlSpec("edit", tag="type", value=""),
+        ControlSpec("text", "Event latency range (ms)\nDefault is whole epoch or data"),
+        ControlSpec("edit", tag="latrange", value=""),
+        ControlSpec("text", "Percent for trimmed statistics:"),
+        ControlSpec("edit", tag="percent", value="5"),
+    )
+    return DialogSpec(
+        title="Plot event statistics -- pop_eventstat()",
+        controls=controls,
+        geometry=((1, 1), (1, 1), (1, 1), (1, 1)),
+        function_name="pop_eventstat",
+        eeglab_source="functions/popfunc/pop_eventstat.m",
+        help_text="pophelp('pop_eventstat')",
+        size=(560, 230),
+    )
+
+
+def event_values(EEG: dict[str, Any], eventfield: str, *, type: Any = None, latrange: Any = None) -> np.ndarray:
+    """Extract numeric event-field values using EEGLAB-style filters."""
+    requested_types = _type_set(type)
+    lat_bounds = numeric_vector(latrange)
+    values = []
+    for event in _event_list(EEG.get("event", [])):
+        if requested_types and str(event.get("type", "")) not in requested_types:
+            continue
+        if lat_bounds.size == 2 and not _event_in_latency_range(EEG, event, lat_bounds):
+            continue
+        if eventfield not in event:
+            continue
+        try:
+            value = float(np.asarray(event[eventfield]).squeeze())
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(value):
+            values.append(value)
+    return np.asarray(values, dtype=float)
+
+
+def _run_gui(EEG: dict[str, Any], *, renderer: Any | None = None) -> dict[str, Any] | None:
+    result = inputgui(pop_eventstat_dialog_spec(EEG), renderer=renderer)
+    if result is None:
+        return None
+    return {
+        "eventfield": str(result.get("eventfield", "latency") or "latency").strip(),
+        "type": _parse_type_text(result.get("type", "")),
+        "latrange": numeric_vector(result.get("latrange", [])).tolist(),
+        "percent": float(numeric_vector(result.get("percent", 5))[0]),
+    }
+
+
+def _event_list(events: Any) -> list[dict[str, Any]]:
+    if events is None:
+        return []
+    if isinstance(events, np.ndarray):
+        events = events.ravel().tolist()
+    if isinstance(events, dict):
+        return [events]
+    return [event for event in events if isinstance(event, dict)]
+
+
+def _type_set(value: Any) -> set[str]:
+    if _is_empty(value):
+        return set()
+    if isinstance(value, str):
+        return {part.strip().strip("'\"") for part in value.replace(",", " ").split() if part.strip()}
+    if isinstance(value, (list, tuple, set, np.ndarray)):
+        return {str(item).strip().strip("'\"") for item in np.asarray(list(value), dtype=object).ravel().tolist()}
+    return {str(value)}
+
+
+def _parse_type_text(value: Any) -> Any:
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return sorted(_type_set(text))
+
+
+def _event_in_latency_range(EEG: dict[str, Any], event: dict[str, Any], bounds: np.ndarray) -> bool:
+    try:
+        latency = float(np.asarray(event.get("latency")).squeeze())
+    except (TypeError, ValueError):
+        return False
+    srate = float(EEG.get("srate", 1) or 1)
+    xmin = float(EEG.get("xmin", 0) or 0)
+    latency_ms = (latency - 1) / srate * 1000.0 + xmin * 1000.0
+    return bool(bounds[0] <= latency_ms <= bounds[1])
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip().strip("[]{}") == ""
+    if isinstance(value, np.ndarray):
+        return value.size == 0
+    return isinstance(value, (list, tuple, set)) and len(value) == 0
+
+
+__all__ = ["event_values", "pop_eventstat", "pop_eventstat_dialog_spec"]

--- a/src/eegprep/functions/popfunc/pop_newcrossf.py
+++ b/src/eegprep/functions/popfunc/pop_newcrossf.py
@@ -1,0 +1,188 @@
+"""EEGLAB-style wrapper for channel/component cross-coherence plots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._plot_utils import (
+    component_activations,
+    data_time_slice,
+    history_command,
+    numeric_vector,
+    parse_plot_options_text,
+)
+from eegprep.functions.popfunc._pop_utils import parse_key_value_args
+from eegprep.functions.timefreqfunc.newcrossf import newcrossf
+
+
+def pop_newcrossf(
+    EEG: dict[str, Any] | None = None,
+    typeproc: int = 1,
+    num1: Any = None,
+    num2: Any = None,
+    tlimits: Any = None,
+    cycles: Any = None,
+    *args: Any,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+    **kwargs: Any,
+):
+    """Plot event-related channel/component cross-coherence."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    typeproc = int(typeproc)
+    if gui is None:
+        gui = num1 is None or num2 is None
+    options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
+    if gui:
+        result = _run_gui(EEG, typeproc=typeproc, renderer=renderer)
+        if result is None:
+            return (None, "") if return_com else None
+        num1 = result["num1"]
+        num2 = result["num2"]
+        tlimits = result["tlimits"]
+        cycles = result["cycles"]
+        options.update(result["options"])
+    if num1 is None:
+        num1 = 1
+    if num2 is None:
+        num2 = 2
+    if tlimits is None:
+        tlimits = [float(EEG.get("xmin", 0)) * 1000.0, float(EEG.get("xmax", 0)) * 1000.0]
+    if cycles is None:
+        cycles = [3, 0.5]
+    _reject_unsupported_options(options)
+    signal1, signal2, times = _selected_signals(EEG, typeproc, num1, num2, tlimits)
+    result = newcrossf(
+        signal1, signal2, signal1.shape[0], [times[0], times[-1]], float(EEG.get("srate", 1) or 1), cycles, **options
+    )
+    command = history_command(
+        "pop_newcrossf", typeproc, _first_index(num1), _first_index(num2), tlimits, cycles, **options
+    )
+    return (result, command) if return_com else result
+
+
+def pop_newcrossf_dialog_spec(EEG: dict[str, Any], *, typeproc: int = 1) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_newcrossf``."""
+    is_channel = bool(int(typeproc))
+    unit = "channel" if is_channel else "component"
+    controls = [
+        ControlSpec("text", f"First {unit} number", font_weight="bold"),
+        ControlSpec("edit", tag="num1", value="1"),
+        ControlSpec("spacer"),
+        ControlSpec("text", f"Second {unit} number", font_weight="bold"),
+        ControlSpec("edit", tag="num2", value="2"),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Epoch time range [min max] (msec)", font_weight="bold"),
+        ControlSpec(
+            "edit",
+            tag="tlimits",
+            value=f"{float(EEG.get('xmin', 0)) * 1000:g} {float(EEG.get('xmax', 0)) * 1000:g}",
+        ),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Wavelet cycles (0->FFT, see Help)", font_weight="bold"),
+        ControlSpec("edit", tag="cycles", value="3 0.5"),
+        ControlSpec("spacer"),
+        ControlSpec("text", "[set]->log. scale for frequencies (match STUDY)", font_weight="bold"),
+        ControlSpec("checkbox", tag="logscale", value=False),
+        ControlSpec("spacer"),
+        ControlSpec("text", "[set]->Linear coher / [unset]->Phase coher", font_weight="bold"),
+        ControlSpec("checkbox", tag="coher", value=False),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Bootstrap significance level (Ex: 0.01 -> 1%)", font_weight="bold"),
+        ControlSpec("edit", tag="alpha", value=""),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Optional newcrossf() arguments (see Help)", font_weight="bold"),
+        ControlSpec("edit", tag="options", value="'padratio', 1"),
+        ControlSpec("spacer"),
+        ControlSpec("checkbox", "Plot coherence amplitude", tag="plotamp", value=True),
+        ControlSpec("checkbox", "Plot coherence phase", tag="plotphase", value=True),
+    ]
+    return DialogSpec(
+        title=(
+            "Plot channel cross-coherence -- pop_newcrossf()"
+            if is_channel
+            else "Plot component cross-coherence -- pop_newcrossf()"
+        ),
+        controls=tuple(controls),
+        geometry=((1, 0.5, 0.5),) * 4 + ((0.92, 0.15, 0.73),) * 2 + ((1, 0.5, 0.5), (1, 0.8, 0.2), (1,), (1, 1)),
+        function_name="pop_newcrossf",
+        eeglab_source="functions/popfunc/pop_newcrossf.m",
+        help_text="pophelp('pop_newcrossf')",
+        size=(809, 430),
+    )
+
+
+def _run_gui(EEG: dict[str, Any], *, typeproc: int, renderer: Any | None = None) -> dict[str, Any] | None:
+    result = inputgui(pop_newcrossf_dialog_spec(EEG, typeproc=typeproc), renderer=renderer)
+    if result is None:
+        return None
+    options = parse_plot_options_text(result.get("options", ""))
+    options["type"] = "coher" if bool(result.get("coher", False)) else "phasecoher"
+    if bool(result.get("logscale", False)):
+        options["freqscale"] = "log"
+    alpha = numeric_vector(result.get("alpha", []))
+    if alpha.size:
+        options["alpha"] = float(alpha[0])
+    if not bool(result.get("plotamp", True)):
+        options["plotamp"] = "off"
+    if not bool(result.get("plotphase", True)):
+        options["plotphase"] = "off"
+    return {
+        "num1": _first_index(result.get("num1", 1)),
+        "num2": _first_index(result.get("num2", 2)),
+        "tlimits": numeric_vector(result.get("tlimits", [])).tolist(),
+        "cycles": numeric_vector(result.get("cycles", "3 0.5")).tolist(),
+        "options": options,
+    }
+
+
+def _selected_signals(
+    EEG: dict[str, Any], typeproc: int, num1: Any, num2: Any, tlimits: Any
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    data, times = data_time_slice(EEG, tlimits)
+    first = int(_first_index(num1)) - 1
+    second = int(_first_index(num2)) - 1
+    if typeproc == 1:
+        if first < 0 or second < 0 or first >= data.shape[0] or second >= data.shape[0]:
+            raise ValueError(f"channel numbers must be 1-based and within 1..{data.shape[0]}")
+        return data[first, :, :], data[second, :, :], times
+    acts = component_activations(EEG)
+    full_times = np.linspace(float(EEG.get("xmin", 0)) * 1000.0, float(EEG.get("xmax", 0)) * 1000.0, acts.shape[1])
+    bounds = numeric_vector(tlimits)
+    if bounds.size == 2:
+        mask = (full_times >= bounds[0]) & (full_times <= bounds[1])
+        acts = acts[:, mask, :]
+        full_times = full_times[mask]
+    if first < 0 or second < 0 or first >= acts.shape[0] or second >= acts.shape[0]:
+        raise ValueError(f"component numbers must be 1-based and within 1..{acts.shape[0]}")
+    return acts[first, :, :], acts[second, :, :], full_times
+
+
+def _reject_unsupported_options(options: dict[str, Any]) -> None:
+    unsupported = {"rboot", "boottype", "baseboot", "condboot", "shuffle", "subitc", "amplag"}
+    present = sorted(key for key in unsupported if key in options)
+    if present:
+        raise NotImplementedError(f"pop_newcrossf does not yet support: {', '.join(present)}")
+    if "alpha" in options and _first_numeric_option(options["alpha"]) != 0:
+        raise NotImplementedError("pop_newcrossf bootstrap significance is not yet available")
+
+
+def _first_index(value: Any) -> int:
+    values = numeric_vector(value, dtype=int)
+    if values.size != 1:
+        raise ValueError("pop_newcrossf requires exactly one channel/component number")
+    return int(values[0])
+
+
+def _first_numeric_option(value: Any) -> float:
+    values = numeric_vector(value)
+    return float(values[0]) if values.size else 0.0
+
+
+__all__ = ["pop_newcrossf", "pop_newcrossf_dialog_spec"]

--- a/src/eegprep/functions/popfunc/pop_newtimef.py
+++ b/src/eegprep/functions/popfunc/pop_newtimef.py
@@ -1,0 +1,265 @@
+"""EEGLAB-style wrapper for channel/component time-frequency plots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+from eegprep.functions.popfunc._plot_utils import (
+    channel_labels,
+    component_activations,
+    data_time_slice,
+    history_command,
+    numeric_vector,
+    parse_plot_options_text,
+)
+from eegprep.functions.popfunc._pop_utils import parse_key_value_args
+from eegprep.functions.timefreqfunc.newtimef import newtimef
+
+
+def pop_newtimef(
+    EEG: dict[str, Any] | None = None,
+    typeproc: int = 1,
+    num: Any = None,
+    tlimits: Any = None,
+    cycles: Any = None,
+    *args: Any,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+    **kwargs: Any,
+):
+    """Plot a channel or component ERSP/ITC decomposition."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    typeproc = int(typeproc)
+    if gui is None:
+        gui = num is None
+    options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
+    if gui:
+        result = _run_gui(EEG, typeproc=typeproc, renderer=renderer)
+        if result is None:
+            return (None, "") if return_com else None
+        num = result["num"]
+        tlimits = result["tlimits"]
+        cycles = result["cycles"]
+        options.update(result["options"])
+    if num is None:
+        num = 1
+    if tlimits is None:
+        tlimits = [float(EEG.get("xmin", 0)) * 1000.0, float(EEG.get("xmax", 0)) * 1000.0]
+    if cycles is None:
+        cycles = [3, 0.8]
+    _reject_unsupported_options(options)
+    data, times = _selected_signal(EEG, typeproc, num, tlimits)
+    result = newtimef(data, data.shape[0], [times[0], times[-1]], float(EEG.get("srate", 1) or 1), cycles, **options)
+    command = history_command("pop_newtimef", typeproc, _first_index(num), tlimits, cycles, **options)
+    return (result, command) if return_com else result
+
+
+def pop_newtimef_dialog_spec(EEG: dict[str, Any], *, typeproc: int = 1) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_newtimef``."""
+    is_channel = bool(int(typeproc))
+    labels = channel_labels(EEG)
+    controls = [
+        ControlSpec("text", "Channel number" if is_channel else "Component number", font_weight="bold"),
+        ControlSpec("edit", tag="num", value="1"),
+        ControlSpec(
+            "pushbutton",
+            "...",
+            tag="num_button",
+            enabled=is_channel and bool(labels),
+            callback=CallbackSpec(
+                "select_channels",
+                params={
+                    "button": "num_button",
+                    "target": "num",
+                    "channels": labels,
+                    "selectionmode": "single",
+                    "return_indices": True,
+                },
+                matlab_callback="pop_chansel({tmpchanlocs.labels}, 'withindex', 'on', 'selectionmode', 'single')",
+            ),
+        ),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Sub epoch time limits [min max] (msec)", font_weight="bold"),
+        ControlSpec(
+            "edit",
+            tag="tlimits",
+            value=f"{float(EEG.get('xmin', 0)) * 1000:g} {float(EEG.get('xmax', 0)) * 1000:g}",
+        ),
+        ControlSpec("popupmenu", "|".join(_NTIMES_CHOICES), tag="ntimesout", value=4),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Frequency limits [min max] (Hz) or sequence", font_weight="bold"),
+        ControlSpec("edit", tag="freqs", value=""),
+        ControlSpec("popupmenu", "|".join(_NFREQS_CHOICES), tag="nfreqs", value=2),
+        ControlSpec("checkbox", "Log spaced", tag="freqscale", value=False),
+        ControlSpec("text", "Baseline limits [min max] (msec) (0->pre-stim.)", font_weight="bold"),
+        ControlSpec("edit", tag="baseline", value="0"),
+        ControlSpec("popupmenu", "|".join(_BASELINE_CHOICES), tag="basenorm", value=1),
+        ControlSpec("checkbox", "No baseline", tag="nobase", value=False),
+        ControlSpec("text", "Wavelet cycles [min max/fact] or sequence", font_weight="bold"),
+        ControlSpec("edit", tag="cycles", value="3 0.8"),
+        ControlSpec("checkbox", "Use FFT", tag="fft", value=False),
+        ControlSpec("pushbutton", "tf cycle calc", tag="calcpush", enabled=False),
+        ControlSpec("text", "ERSP color limits [max] (min=-max)", font_weight="bold"),
+        ControlSpec("edit", tag="erspmax", value=""),
+        ControlSpec("checkbox", "see log power (set)", tag="scale", value=True),
+        ControlSpec("spacer"),
+        ControlSpec("text", "ITC color limits [max]", font_weight="bold"),
+        ControlSpec("edit", tag="itcmax", value=""),
+        ControlSpec("checkbox", "plot ITC phase (set)", tag="plotphase", value=False),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Bootstrap significance level (Ex: 0.01 -> 1%)", font_weight="bold"),
+        ControlSpec("edit", tag="alpha", value=""),
+        ControlSpec("checkbox", "FDR correct (set)", tag="fdr", value=False),
+        ControlSpec("spacer"),
+        ControlSpec("text", "Optional newtimef() arguments (see Help)", font_weight="bold"),
+        ControlSpec("edit", tag="options", value=""),
+        ControlSpec("spacer"),
+        ControlSpec("checkbox", "Plot Event Related Spectral Power", tag="plotersp", value=True),
+        ControlSpec("checkbox", "Plot Inter Trial Coherence", tag="plotitc", value=True),
+        ControlSpec("checkbox", "Plot curve at each frequency", tag="plotcurve", value=False),
+    ]
+    return DialogSpec(
+        title=(
+            "Plot channel time frequency -- pop_newtimef()"
+            if is_channel
+            else "Plot component time frequency -- pop_newtimef()"
+        ),
+        controls=tuple(controls),
+        geometry=((1, 0.3, 0.25, 0.75),) + ((1, 0.3, 0.6, 0.4),) * 7 + ((0.975, 1.27), (1,), (1.2, 1, 1.2)),
+        function_name="pop_newtimef",
+        eeglab_source="functions/popfunc/pop_newtimef.m",
+        help_text="pophelp('pop_newtimef')",
+        size=(930, 531),
+    )
+
+
+def _run_gui(EEG: dict[str, Any], *, typeproc: int, renderer: Any | None = None) -> dict[str, Any] | None:
+    result = inputgui(pop_newtimef_dialog_spec(EEG, typeproc=typeproc), renderer=renderer)
+    if result is None:
+        return None
+    options = parse_plot_options_text(result.get("options", ""))
+    freqs = numeric_vector(result.get("freqs", [])).tolist()
+    if freqs:
+        options["freqs"] = freqs
+    baseline = numeric_vector(result.get("baseline", [])).tolist()
+    if bool(result.get("nobase", False)):
+        options["baseline"] = [float("nan")]
+    elif baseline:
+        options["baseline"] = baseline
+    alpha = numeric_vector(result.get("alpha", []))
+    if alpha.size:
+        options["alpha"] = float(alpha[0])
+    if bool(result.get("freqscale", False)):
+        options["freqscale"] = "log"
+    if not bool(result.get("scale", True)):
+        options["scale"] = "abs"
+    if not bool(result.get("plotphase", False)):
+        options["plotphase"] = "off"
+    if not bool(result.get("plotersp", True)):
+        options["plotersp"] = "off"
+    if not bool(result.get("plotitc", True)):
+        options["plotitc"] = "off"
+    if bool(result.get("plotcurve", False)):
+        options["plottype"] = "curve"
+    _add_popup_options(
+        options,
+        int(result.get("ntimesout", 4) or 4),
+        int(result.get("nfreqs", 2) or 2),
+        int(result.get("basenorm", 1) or 1),
+        freqs,
+    )
+    cycles = [0] if bool(result.get("fft", False)) else numeric_vector(result.get("cycles", "3 0.8")).tolist()
+    return {
+        "num": _first_index(result.get("num", 1)),
+        "tlimits": numeric_vector(result.get("tlimits", [])).tolist(),
+        "cycles": cycles,
+        "options": options,
+    }
+
+
+def _selected_signal(EEG: dict[str, Any], typeproc: int, num: Any, tlimits: Any) -> tuple[np.ndarray, np.ndarray]:
+    data, times = data_time_slice(EEG, tlimits)
+    index = int(_first_index(num)) - 1
+    if typeproc == 1:
+        if index < 0 or index >= data.shape[0]:
+            raise ValueError(f"channel number must be 1-based and within 1..{data.shape[0]}")
+        return data[index, :, :], times
+    acts = component_activations(EEG)
+    full_times = np.linspace(float(EEG.get("xmin", 0)) * 1000.0, float(EEG.get("xmax", 0)) * 1000.0, acts.shape[1])
+    bounds = numeric_vector(tlimits)
+    if bounds.size == 2:
+        mask = (full_times >= bounds[0]) & (full_times <= bounds[1])
+        acts = acts[:, mask, :]
+        full_times = full_times[mask]
+    if index < 0 or index >= acts.shape[0]:
+        raise ValueError(f"component number must be 1-based and within 1..{acts.shape[0]}")
+    return acts[index, :, :], full_times
+
+
+def _add_popup_options(options: dict[str, Any], ntimesout: int, nfreqs: int, basenorm: int, freqs: list[float]) -> None:
+    ntimes_values = {1: 50, 2: 100, 3: 150, 5: 300, 6: 400}
+    if ntimesout in ntimes_values:
+        options["timesout"] = ntimes_values[ntimesout]
+    padratio_values = {1: 1, 2: 2, 3: 4}
+    if nfreqs in padratio_values:
+        options["padratio"] = padratio_values[nfreqs]
+    elif nfreqs == 4 and freqs:
+        options["nfreqs"] = len(freqs)
+    if basenorm in {2, 4}:
+        options["basenorm"] = "on"
+    if basenorm >= 3:
+        options["trialbase"] = "full"
+
+
+def _reject_unsupported_options(options: dict[str, Any]) -> None:
+    unsupported = {"timewarp", "timewarpms", "timewarpidx", "rboot", "pboot", "erspboot", "itcboot"}
+    present = sorted(key for key in unsupported if key in options)
+    if present:
+        raise NotImplementedError(f"pop_newtimef does not yet support: {', '.join(present)}")
+    if "alpha" in options and _first_numeric_option(options["alpha"]) != 0:
+        raise NotImplementedError("pop_newtimef bootstrap significance is not yet available")
+    if str(options.get("plottype", "image")).lower() != "image":
+        raise NotImplementedError("pop_newtimef curve plots are not yet available")
+
+
+def _first_index(value: Any) -> int:
+    values = numeric_vector(value, dtype=int)
+    if values.size != 1:
+        raise ValueError("pop_newtimef requires exactly one channel/component number")
+    return int(values[0])
+
+
+def _first_numeric_option(value: Any) -> float:
+    values = numeric_vector(value)
+    return float(values[0]) if values.size else 0.0
+
+
+_NTIMES_CHOICES = (
+    "Use 50 time points",
+    "Use 100 time points",
+    "Use 150 time points",
+    "Use 200 time points",
+    "Use 300 time points",
+    "Use 400 time points",
+)
+_NFREQS_CHOICES = (
+    "Use limits, padding 1",
+    "Use limits, padding 2",
+    "Use limits, padding 4",
+    "Use actual freqs.",
+)
+_BASELINE_CHOICES = (
+    "Use divisive baseline (DIV)",
+    "Use standard deviation (STD)",
+    "Use single trial DIV baseline",
+    "Use single trial STD baseline",
+)
+
+
+__all__ = ["pop_newtimef", "pop_newtimef_dialog_spec"]

--- a/src/eegprep/functions/popfunc/pop_newtimef.py
+++ b/src/eegprep/functions/popfunc/pop_newtimef.py
@@ -114,15 +114,22 @@ def pop_newtimef_dialog_spec(EEG: dict[str, Any], *, typeproc: int = 1) -> Dialo
         ControlSpec("checkbox", "plot ITC phase (set)", tag="plotphase", value=False),
         ControlSpec("spacer"),
         ControlSpec("text", "Bootstrap significance level (Ex: 0.01 -> 1%)", font_weight="bold"),
-        ControlSpec("edit", tag="alpha", value=""),
-        ControlSpec("checkbox", "FDR correct (set)", tag="fdr", value=False),
+        ControlSpec("edit", tag="alpha", value="", enabled=False, tooltip="Bootstrap masking is not yet available."),
+        ControlSpec("checkbox", "FDR correct (set)", tag="fdr", value=False, enabled=False),
         ControlSpec("spacer"),
         ControlSpec("text", "Optional newtimef() arguments (see Help)", font_weight="bold"),
         ControlSpec("edit", tag="options", value=""),
         ControlSpec("spacer"),
         ControlSpec("checkbox", "Plot Event Related Spectral Power", tag="plotersp", value=True),
         ControlSpec("checkbox", "Plot Inter Trial Coherence", tag="plotitc", value=True),
-        ControlSpec("checkbox", "Plot curve at each frequency", tag="plotcurve", value=False),
+        ControlSpec(
+            "checkbox",
+            "Plot curve at each frequency",
+            tag="plotcurve",
+            value=False,
+            enabled=False,
+            tooltip="Curve plots are not yet available in EEGPrep.",
+        ),
     ]
     return DialogSpec(
         title=(
@@ -159,8 +166,6 @@ def _run_gui(EEG: dict[str, Any], *, typeproc: int, renderer: Any | None = None)
         options["freqscale"] = "log"
     if not bool(result.get("scale", True)):
         options["scale"] = "abs"
-    if not bool(result.get("plotphase", False)):
-        options["plotphase"] = "off"
     if not bool(result.get("plotersp", True)):
         options["plotersp"] = "off"
     if not bool(result.get("plotitc", True)):
@@ -174,6 +179,8 @@ def _run_gui(EEG: dict[str, Any], *, typeproc: int, renderer: Any | None = None)
         int(result.get("basenorm", 1) or 1),
         freqs,
     )
+    if freqs == [] and "winsize" not in options and float(EEG.get("xmin", 0) or 0) < 0:
+        options["winsize"] = max(2, int(round(-float(EEG.get("xmin", 0)) * float(EEG.get("srate", 1) or 1))))
     cycles = [0] if bool(result.get("fft", False)) else numeric_vector(result.get("cycles", "3 0.8")).tolist()
     return {
         "num": _first_index(result.get("num", 1)),
@@ -203,7 +210,7 @@ def _selected_signal(EEG: dict[str, Any], typeproc: int, num: Any, tlimits: Any)
 
 
 def _add_popup_options(options: dict[str, Any], ntimesout: int, nfreqs: int, basenorm: int, freqs: list[float]) -> None:
-    ntimes_values = {1: 50, 2: 100, 3: 150, 5: 300, 6: 400}
+    ntimes_values = {1: 50, 2: 100, 3: 150, 4: 200, 5: 300, 6: 400}
     if ntimesout in ntimes_values:
         options["timesout"] = ntimes_values[ntimesout]
     padratio_values = {1: 1, 2: 2, 3: 4}
@@ -224,6 +231,8 @@ def _reject_unsupported_options(options: dict[str, Any]) -> None:
         raise NotImplementedError(f"pop_newtimef does not yet support: {', '.join(present)}")
     if "alpha" in options and _first_numeric_option(options["alpha"]) != 0:
         raise NotImplementedError("pop_newtimef bootstrap significance is not yet available")
+    if str(options.get("basenorm", "off")).lower() == "on" or str(options.get("trialbase", "off")).lower() != "off":
+        raise NotImplementedError("pop_newtimef baseline normalization modes are not yet available")
     if str(options.get("plottype", "image")).lower() != "image":
         raise NotImplementedError("pop_newtimef curve plots are not yet available")
 

--- a/src/eegprep/functions/popfunc/pop_signalstat.py
+++ b/src/eegprep/functions/popfunc/pop_signalstat.py
@@ -1,0 +1,104 @@
+"""EEGLAB-style wrapper for channel/component signal statistics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._plot_utils import component_activations, history_command, numeric_vector
+from eegprep.functions.sigprocfunc.signalstat import signalstat
+
+
+def pop_signalstat(
+    EEG: dict[str, Any] | None = None,
+    typeproc: int = 1,
+    cnum: Any = None,
+    percent: float = 5,
+    *,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+):
+    """Compute and plot statistics for one channel or component."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    typeproc = int(typeproc)
+    if gui is None:
+        gui = cnum is None
+    if gui:
+        result = _run_gui(EEG, typeproc=typeproc, renderer=renderer)
+        if result is None:
+            return (None, "") if return_com else None
+        cnum = result["cnum"]
+        percent = result["percent"]
+    if cnum is None:
+        cnum = 1
+    index = _single_index(cnum)
+    if typeproc == 1:
+        data = np.asarray(EEG.get("data"), dtype=float)
+        if data.ndim == 3:
+            data = data.reshape(data.shape[0], -1)
+        if index < 1 or index > data.shape[0]:
+            raise ValueError(f"channel number must be 1-based and within 1..{data.shape[0]}")
+        values = data[index - 1, :]
+        dlabel = None
+        dlabel2 = f"Channel {index}"
+        map_value = index
+    else:
+        acts = component_activations(EEG)
+        if index < 1 or index > acts.shape[0]:
+            raise ValueError(f"component number must be 1-based and within 1..{acts.shape[0]}")
+        values = acts[index - 1, :, :].reshape(-1)
+        dlabel = "Component Activity"
+        dlabel2 = f"Component {index}"
+        map_value = (
+            np.asarray(EEG.get("icawinv", []), dtype=float)[:, index - 1]
+            if np.asarray(EEG.get("icawinv", [])).size
+            else None
+        )
+    result = signalstat(values, 1, dlabel, float(percent), dlabel2, map_value, EEG.get("chanlocs", []))
+    command = history_command("pop_signalstat", typeproc, index, percent)
+    return (result, command) if return_com else result
+
+
+def pop_signalstat_dialog_spec(EEG: dict[str, Any], *, typeproc: int = 1) -> DialogSpec:
+    """Return the EEGLAB-like dialog spec for ``pop_signalstat``."""
+    _ = EEG
+    controls = (
+        ControlSpec("text", "Channel number:" if int(typeproc) else "Component number:"),
+        ControlSpec("edit", tag="cnum", value="1"),
+        ControlSpec("text", "Trim percentage (each end):"),
+        ControlSpec("edit", tag="percent", value="5"),
+    )
+    return DialogSpec(
+        title="Plot signal statistics -- pop_signalstat()",
+        controls=controls,
+        geometry=((1, 1), (1, 1)),
+        function_name="pop_signalstat",
+        eeglab_source="functions/popfunc/pop_signalstat.m",
+        help_text="pophelp('pop_signalstat')",
+        size=(420, 150),
+    )
+
+
+def _run_gui(EEG: dict[str, Any], *, typeproc: int, renderer: Any | None = None) -> dict[str, Any] | None:
+    result = inputgui(pop_signalstat_dialog_spec(EEG, typeproc=typeproc), renderer=renderer)
+    if result is None:
+        return None
+    return {
+        "cnum": _single_index(result.get("cnum", 1)),
+        "percent": float(numeric_vector(result.get("percent", 5))[0]),
+    }
+
+
+def _single_index(value: Any) -> int:
+    values = numeric_vector(value, dtype=int)
+    if values.size != 1:
+        raise ValueError("channel/component number must be a single integer")
+    return int(values[0])
+
+
+__all__ = ["pop_signalstat", "pop_signalstat_dialog_spec"]

--- a/src/eegprep/functions/sigprocfunc/signalstat.py
+++ b/src/eegprep/functions/sigprocfunc/signalstat.py
@@ -1,0 +1,160 @@
+"""Signal/event statistics helper matching EEGLAB ``signalstat`` basics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import warnings
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import stats
+
+
+@dataclass(frozen=True)
+class SignalStatResult:
+    """Statistics returned by ``signalstat``."""
+
+    mean: float
+    std: float
+    skewness: float
+    kurtosis: float
+    median: float
+    zlow: float
+    zhigh: float
+    trimmed_mean: float
+    trimmed_std: float
+    trimmed_indices: np.ndarray
+    kstest_h: int
+    figure: Any | None = None
+
+    def matlab_tuple(self) -> tuple[Any, ...]:
+        """Return the EEGLAB output tuple order."""
+        return (
+            self.mean,
+            self.std,
+            self.skewness,
+            self.kurtosis,
+            self.median,
+            self.zlow,
+            self.zhigh,
+            self.trimmed_mean,
+            self.trimmed_std,
+            self.trimmed_indices,
+            self.kstest_h,
+        )
+
+
+def signalstat(
+    data: Any,
+    plotlab: int = 1,
+    dlabel: str | None = None,
+    percent: float = 5,
+    dlabel2: str = "",
+    map: Any = None,
+    chan_locs: Any = None,
+) -> SignalStatResult:
+    """Compute EEGLAB-style summary statistics for a real-valued signal."""
+    values = np.asarray(data, dtype=float).ravel()
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        raise ValueError("signalstat requires at least one finite data value")
+    if percent < 0 or percent > 100:
+        raise ValueError("signalstat percent must be between 0 and 100")
+    mean = float(np.mean(values))
+    std = float(np.std(values, ddof=1)) if values.size > 1 else 0.0
+    skewness = float(stats.skew(values, bias=False)) if values.size > 2 and std else 0.0
+    kurtosis = float(stats.kurtosis(values, fisher=True, bias=False)) if values.size > 3 and std else 0.0
+    median = float(np.median(values))
+    trim_fraction = float(percent) / 100.0 / 2.0
+    zlow = float(_matlab_quantile(values, trim_fraction))
+    zhigh = float(_matlab_quantile(values, 1.0 - trim_fraction))
+    trimmed_indices = np.flatnonzero((values >= zlow) & (values <= zhigh))
+    trimmed = values[trimmed_indices]
+    trimmed_mean = float(np.mean(trimmed)) if trimmed.size else float("nan")
+    trimmed_std = float(np.std(trimmed, ddof=1)) if trimmed.size > 1 else 0.0
+    kstest_h = _kstest_h(values, mean, std)
+    figure = None
+    if int(plotlab) == 1:
+        figure = _plot_signalstat(values, mean, std, dlabel or "Potential [V]", dlabel2, map, chan_locs)
+    elif int(plotlab) != 0:
+        raise ValueError("signalstat plotlab must be 0 or 1")
+    return SignalStatResult(
+        mean,
+        std,
+        skewness,
+        kurtosis,
+        median,
+        zlow,
+        zhigh,
+        trimmed_mean,
+        trimmed_std,
+        trimmed_indices,
+        kstest_h,
+        figure,
+    )
+
+
+def _kstest_h(values: np.ndarray, mean: float, std: float) -> int:
+    if values.size < 2 or std <= 0:
+        return -1
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        _statistic, pvalue = stats.kstest(values, "norm", args=(mean, std))
+    return int(pvalue < 0.05)
+
+
+def _plot_signalstat(
+    values: np.ndarray,
+    mean: float,
+    std: float,
+    dlabel: str,
+    dlabel2: str,
+    map_values: Any,
+    chan_locs: Any,
+):
+    fig, axes = plt.subplots(2, 2, figsize=(8.0, 6.0))
+    axes = axes.ravel()
+    axes[0].hist(values, bins=max(10, min(80, round(values.size / 100))), color=(0.56, 0.66, 0.9), edgecolor="black")
+    axes[0].set_title("Data histogram")
+    axes[0].set_xlabel(dlabel)
+    axes[0].set_ylabel("Count")
+    if std > 0:
+        xs = np.linspace(float(np.min(values)), float(np.max(values)), 200)
+        density = stats.norm.pdf(xs, mean, std) * values.size * (xs[1] - xs[0])
+        axes[0].plot(xs, density, color="black")
+    axes[1].boxplot(values)
+    axes[1].set_title("Boxplot")
+    stats.probplot(values, dist="norm", plot=axes[2])
+    axes[2].set_title("QQ plot")
+    axes[3].axis("off")
+    text = (
+        f"Mean: {mean:.6g}\n"
+        f"Std: {std:.6g}\n"
+        f"Median: {np.median(values):.6g}\n"
+        f"Skewness: {stats.skew(values, bias=False) if values.size > 2 and std else 0:.6g}\n"
+        f"Kurtosis: {stats.kurtosis(values, fisher=True, bias=False) if values.size > 3 and std else 0:.6g}"
+    )
+    axes[3].text(0.02, 0.98, text, va="top", family="monospace")
+    if dlabel2:
+        fig.suptitle(dlabel2)
+    _ = map_values, chan_locs
+    fig.tight_layout()
+    return fig
+
+
+def _matlab_quantile(values: np.ndarray, probability: float) -> float:
+    sorted_values = np.sort(np.asarray(values, dtype=float).ravel())
+    if sorted_values.size == 0:
+        return float("nan")
+    position = sorted_values.size * float(probability) + 0.5
+    if position <= 1:
+        return float(sorted_values[0])
+    if position >= sorted_values.size:
+        return float(sorted_values[-1])
+    lower = int(np.floor(position))
+    fraction = position - lower
+    return float(sorted_values[lower - 1] + fraction * (sorted_values[lower] - sorted_values[lower - 1]))
+
+
+__all__ = ["SignalStatResult", "signalstat"]

--- a/src/eegprep/functions/sigprocfunc/signalstat.py
+++ b/src/eegprep/functions/sigprocfunc/signalstat.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy import stats
 
+from eegprep.functions.sigprocfunc.topoplot import topoplot
+
 
 @dataclass(frozen=True)
 class SignalStatResult:
@@ -113,7 +115,8 @@ def _plot_signalstat(
     map_values: Any,
     chan_locs: Any,
 ):
-    fig, axes = plt.subplots(2, 2, figsize=(8.0, 6.0))
+    has_map = _has_topomap(map_values, chan_locs)
+    fig, axes = plt.subplots(2, 3 if has_map else 2, figsize=(9.5 if has_map else 8.0, 6.0))
     axes = axes.ravel()
     axes[0].hist(values, bins=max(10, min(80, round(values.size / 100))), color=(0.56, 0.66, 0.9), edgecolor="black")
     axes[0].set_title("Data histogram")
@@ -127,7 +130,13 @@ def _plot_signalstat(
     axes[1].set_title("Boxplot")
     stats.probplot(values, dist="norm", plot=axes[2])
     axes[2].set_title("QQ plot")
-    axes[3].axis("off")
+    if has_map:
+        _plot_stat_topomap(axes[3], map_values, chan_locs)
+        text_axis = axes[4]
+        axes[5].axis("off")
+    else:
+        text_axis = axes[3]
+    text_axis.axis("off")
     text = (
         f"Mean: {mean:.6g}\n"
         f"Std: {std:.6g}\n"
@@ -135,12 +144,30 @@ def _plot_signalstat(
         f"Skewness: {stats.skew(values, bias=False) if values.size > 2 and std else 0:.6g}\n"
         f"Kurtosis: {stats.kurtosis(values, fisher=True, bias=False) if values.size > 3 and std else 0:.6g}"
     )
-    axes[3].text(0.02, 0.98, text, va="top", family="monospace")
+    text_axis.text(0.02, 0.98, text, va="top", family="monospace")
     if dlabel2:
         fig.suptitle(dlabel2)
-    _ = map_values, chan_locs
     fig.tight_layout()
     return fig
+
+
+def _has_topomap(map_values: Any, chan_locs: Any) -> bool:
+    if chan_locs is None:
+        return False
+    return (
+        np.asarray([] if map_values is None else map_values).size > 0
+        and len(np.asarray(chan_locs, dtype=object).ravel()) > 0
+    )
+
+
+def _plot_stat_topomap(axis: Any, map_values: Any, chan_locs: Any) -> None:
+    values = np.asarray(map_values, dtype=float).ravel()
+    if values.size == 1:
+        topoplot([], chan_locs, style="blank", electrodes="off", axes=axis)
+        axis.set_title(f"Channel {int(values[0])}")
+        return
+    topoplot(values, chan_locs, electrodes="off", axes=axis, colorbar=False)
+    axis.set_title("Topographic map")
 
 
 def _matlab_quantile(values: np.ndarray, probability: float) -> float:

--- a/src/eegprep/functions/timefreqfunc/__init__.py
+++ b/src/eegprep/functions/timefreqfunc/__init__.py
@@ -1,0 +1,6 @@
+"""EEGLAB-style time-frequency helper functions."""
+
+from eegprep.functions.timefreqfunc.newcrossf import CrossFrequencyResult, newcrossf
+from eegprep.functions.timefreqfunc.newtimef import TimeFrequencyResult, newtimef
+
+__all__ = ["CrossFrequencyResult", "TimeFrequencyResult", "newcrossf", "newtimef"]

--- a/src/eegprep/functions/timefreqfunc/newcrossf.py
+++ b/src/eegprep/functions/timefreqfunc/newcrossf.py
@@ -1,0 +1,154 @@
+"""Deterministic EEGLAB-style ``newcrossf`` numerical core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eegprep.functions.timefreqfunc.newtimef import (
+    _as_epochs,
+    _limits,
+    _numeric_vector,
+    _select_freqs,
+    _select_times,
+    _trial_stft,
+    _winsize,
+)
+
+
+@dataclass(frozen=True)
+class CrossFrequencyResult:
+    """Computed coherence/cross-spectrum arrays."""
+
+    coherence: np.ndarray
+    phase: np.ndarray
+    times: np.ndarray
+    freqs: np.ndarray
+    allcoher: np.ndarray
+    alltf_x: np.ndarray
+    alltf_y: np.ndarray
+    figure: Any | None = None
+
+
+def newcrossf(
+    x: Any,
+    y: Any,
+    frames: int,
+    tlimits: Any,
+    srate: float,
+    cycles: Any = 0,
+    **kwargs: Any,
+) -> CrossFrequencyResult:
+    """Compute an EEGLAB-like event-related coherence decomposition."""
+    x_epochs = _as_epochs(x, int(frames))
+    y_epochs = _as_epochs(y, int(frames))
+    if x_epochs.shape != y_epochs.shape:
+        raise ValueError("newcrossf inputs must have matching frames and trials")
+    frames = x_epochs.shape[0]
+    tlimits = _limits(tlimits, frames, float(srate))
+    cycles_array = _numeric_vector(cycles)
+    winsize = _winsize(frames, float(srate), cycles_array, kwargs.get("winsize"), kwargs.get("freqs"))
+    padratio = int(_first_numeric(kwargs.get("padratio"), 2))
+    nfft = max(winsize, int(2 ** np.ceil(np.log2(max(winsize, 1)))) * max(padratio, 1))
+    noverlap = min(winsize - 1, max(0, int(_first_numeric(kwargs.get("overlap"), winsize // 2))))
+
+    full_freqs, times_seconds, tf_x = _trial_stft(x_epochs, float(srate), winsize, noverlap, nfft)
+    _freqs_y, _times_y, tf_y = _trial_stft(y_epochs, float(srate), winsize, noverlap, nfft)
+    freqs, tf_x = _select_freqs(full_freqs, tf_x, kwargs.get("freqs"), kwargs.get("nfreqs"), kwargs.get("freqscale"))
+    freq_indices = np.asarray([int(np.argmin(np.abs(full_freqs - freq))) for freq in freqs], dtype=int)
+    tf_y = tf_y[freq_indices, :, :]
+    full_times = tlimits[0] + times_seconds * 1000.0
+    times, tf_x = _select_times(full_times, tf_x, kwargs.get("timesout"))
+    time_indices = np.asarray([int(np.argmin(np.abs(full_times - time))) for time in times], dtype=int)
+    tf_y = tf_y[:, time_indices, :]
+
+    cross = tf_x * np.conjugate(tf_y)
+    mode = str(kwargs.get("type", "phasecoher")).lower()
+    if mode == "coher":
+        denominator = np.sqrt(np.nanmean(np.abs(tf_x) ** 2, axis=2) * np.nanmean(np.abs(tf_y) ** 2, axis=2))
+        coherence_complex = np.nanmean(cross, axis=2) / np.maximum(denominator, np.finfo(float).tiny)
+        coherence = np.abs(coherence_complex)
+    elif mode == "crossspec":
+        coherence_complex = np.nanmean(cross, axis=2)
+        coherence = np.abs(coherence_complex)
+    elif mode == "phasecoher":
+        unit = np.divide(cross, np.maximum(np.abs(cross), np.finfo(float).tiny))
+        coherence_complex = np.nanmean(unit, axis=2)
+        coherence = np.abs(coherence_complex)
+    else:
+        raise NotImplementedError("newcrossf currently supports type='phasecoher', 'coher', or 'crossspec'")
+    phase = np.angle(coherence_complex)
+
+    figure = None
+    if _is_on(kwargs.get("plot", "on")):
+        figure = _plot_cross_frequency(
+            coherence,
+            phase,
+            times,
+            freqs,
+            title=str(kwargs.get("title", "Cross-coherence")),
+            plotamp=_is_on(kwargs.get("plotamp", kwargs.get("plotersp", "on"))),
+            plotphase=_is_on(kwargs.get("plotphase", "on")),
+        )
+    return CrossFrequencyResult(coherence, phase, times, freqs, cross, tf_x, tf_y, figure)
+
+
+def _plot_cross_frequency(
+    coherence: np.ndarray,
+    phase: np.ndarray,
+    times: np.ndarray,
+    freqs: np.ndarray,
+    *,
+    title: str,
+    plotamp: bool,
+    plotphase: bool,
+):
+    panels = int(plotamp) + int(plotphase)
+    if panels == 0:
+        return None
+    fig, axes = plt.subplots(panels, 1, figsize=(7.5, 5.0), squeeze=False)
+    row = 0
+    if plotamp:
+        image = axes[row, 0].imshow(
+            coherence,
+            aspect="auto",
+            origin="lower",
+            extent=[times[0], times[-1], freqs[0], freqs[-1]],
+            interpolation="nearest",
+            vmin=0,
+            vmax=max(1.0, float(np.nanmax(coherence))),
+        )
+        axes[row, 0].set_title(title)
+        axes[row, 0].set_ylabel("Frequency (Hz)")
+        fig.colorbar(image, ax=axes[row, 0], label="Coherence")
+        row += 1
+    if plotphase:
+        image = axes[row, 0].imshow(
+            phase,
+            aspect="auto",
+            origin="lower",
+            extent=[times[0], times[-1], freqs[0], freqs[-1]],
+            interpolation="nearest",
+            vmin=-np.pi,
+            vmax=np.pi,
+        )
+        axes[row, 0].set_ylabel("Frequency (Hz)")
+        axes[row, 0].set_xlabel("Time (ms)")
+        fig.colorbar(image, ax=axes[row, 0], label="Phase (rad)")
+    fig.tight_layout()
+    return fig
+
+
+def _first_numeric(value: Any, default: float) -> float:
+    values = _numeric_vector(value)
+    return float(values[0]) if values.size else float(default)
+
+
+def _is_on(value: Any) -> bool:
+    return str(value).lower() not in {"0", "false", "off", "no", "none"}
+
+
+__all__ = ["CrossFrequencyResult", "newcrossf"]

--- a/src/eegprep/functions/timefreqfunc/newcrossf.py
+++ b/src/eegprep/functions/timefreqfunc/newcrossf.py
@@ -8,15 +8,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 
-from eegprep.functions.timefreqfunc.newtimef import (
-    _as_epochs,
-    _limits,
-    _numeric_vector,
-    _select_freqs,
-    _select_times,
-    _trial_stft,
-    _winsize,
-)
+from eegprep.functions.timefreqfunc.newtimef import compute_time_frequency
 
 
 @dataclass(frozen=True)
@@ -43,30 +35,15 @@ def newcrossf(
     **kwargs: Any,
 ) -> CrossFrequencyResult:
     """Compute an EEGLAB-like event-related coherence decomposition."""
-    x_epochs = _as_epochs(x, int(frames))
-    y_epochs = _as_epochs(y, int(frames))
-    if x_epochs.shape != y_epochs.shape:
-        raise ValueError("newcrossf inputs must have matching frames and trials")
-    frames = x_epochs.shape[0]
-    tlimits = _limits(tlimits, frames, float(srate))
-    cycles_array = _numeric_vector(cycles)
-    winsize = _winsize(frames, float(srate), cycles_array, kwargs.get("winsize"), kwargs.get("freqs"))
-    padratio = int(_first_numeric(kwargs.get("padratio"), 2))
-    nfft = max(winsize, int(2 ** np.ceil(np.log2(max(winsize, 1)))) * max(padratio, 1))
-    noverlap = min(winsize - 1, max(0, int(_first_numeric(kwargs.get("overlap"), winsize // 2))))
-
-    full_freqs, times_seconds, tf_x = _trial_stft(x_epochs, float(srate), winsize, noverlap, nfft)
-    _freqs_y, _times_y, tf_y = _trial_stft(y_epochs, float(srate), winsize, noverlap, nfft)
-    freqs, tf_x = _select_freqs(full_freqs, tf_x, kwargs.get("freqs"), kwargs.get("nfreqs"), kwargs.get("freqscale"))
-    freq_indices = np.asarray([int(np.argmin(np.abs(full_freqs - freq))) for freq in freqs], dtype=int)
-    tf_y = tf_y[freq_indices, :, :]
-    full_times = tlimits[0] + times_seconds * 1000.0
-    times, tf_x = _select_times(full_times, tf_x, kwargs.get("timesout"))
-    time_indices = np.asarray([int(np.argmin(np.abs(full_times - time))) for time in times], dtype=int)
-    tf_y = tf_y[:, time_indices, :]
+    freqs, times, tf_x = compute_time_frequency(x, frames, tlimits, srate, cycles, **kwargs)
+    freqs_y, times_y, tf_y = compute_time_frequency(y, frames, tlimits, srate, cycles, **kwargs)
+    if tf_x.shape != tf_y.shape or not np.array_equal(freqs, freqs_y) or not np.array_equal(times, times_y):
+        raise ValueError("newcrossf inputs must have matching frames, trials, times, and frequencies")
 
     cross = tf_x * np.conjugate(tf_y)
     mode = str(kwargs.get("type", "phasecoher")).lower()
+    if tf_x.shape[2] == 1 and mode != "crossspec":
+        mode = "crossspec"
     if mode == "coher":
         denominator = np.sqrt(np.nanmean(np.abs(tf_x) ** 2, axis=2) * np.nanmean(np.abs(tf_y) ** 2, axis=2))
         coherence_complex = np.nanmean(cross, axis=2) / np.maximum(denominator, np.finfo(float).tiny)
@@ -140,11 +117,6 @@ def _plot_cross_frequency(
         fig.colorbar(image, ax=axes[row, 0], label="Phase (rad)")
     fig.tight_layout()
     return fig
-
-
-def _first_numeric(value: Any, default: float) -> float:
-    values = _numeric_vector(value)
-    return float(values[0]) if values.size else float(default)
 
 
 def _is_on(value: Any) -> bool:

--- a/src/eegprep/functions/timefreqfunc/newtimef.py
+++ b/src/eegprep/functions/timefreqfunc/newtimef.py
@@ -31,27 +31,8 @@ def newtimef(
     cycles: Any = 0,
     **kwargs: Any,
 ) -> TimeFrequencyResult:
-    """Compute an EEGLAB-like ERSP/ITC time-frequency decomposition.
-
-    This standalone core intentionally implements the deterministic STFT path
-    used by EEGPrep's plot wrappers. EEGLAB's full ``newtimef`` also includes
-    multiple wavelet implementations, bootstrapping, and time-warping; those are
-    outside this stable numerical core and are rejected clearly by the wrappers.
-    """
-    epochs = _as_epochs(data, int(frames))
-    frames = epochs.shape[0]
-    srate = float(srate)
-    tlimits = _limits(tlimits, frames, srate)
-    cycles_array = _numeric_vector(cycles)
-    winsize = _winsize(frames, srate, cycles_array, kwargs.get("winsize"), kwargs.get("freqs"))
-    padratio = int(_first_numeric(kwargs.get("padratio"), 2))
-    nfft = max(winsize, int(2 ** np.ceil(np.log2(max(winsize, 1)))) * max(padratio, 1))
-    noverlap = min(winsize - 1, max(0, int(_first_numeric(kwargs.get("overlap"), winsize // 2))))
-
-    freqs, times_seconds, tfdata = _trial_stft(epochs, srate, winsize, noverlap, nfft)
-    freqs, tfdata = _select_freqs(freqs, tfdata, kwargs.get("freqs"), kwargs.get("nfreqs"), kwargs.get("freqscale"))
-    times = tlimits[0] + times_seconds * 1000.0
-    times, tfdata = _select_times(times, tfdata, kwargs.get("timesout"))
+    """Compute an EEGLAB-like ERSP/ITC time-frequency decomposition."""
+    freqs, times, tfdata = compute_time_frequency(data, frames, tlimits, srate, cycles, **kwargs)
 
     power = np.abs(tfdata) ** 2
     powbase = _baseline_power(power, times, kwargs.get("baseline", 0))
@@ -77,6 +58,44 @@ def newtimef(
             plotitc=_is_on(kwargs.get("plotitc", "on")),
         )
     return TimeFrequencyResult(ersp, itc, powbase, times, freqs, tfdata, figure)
+
+
+def compute_time_frequency(
+    data: Any,
+    frames: int,
+    tlimits: Any,
+    srate: float,
+    cycles: Any = 0,
+    **kwargs: Any,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(freqs, times_ms, tfdata)`` for one signal using EEGLAB-like defaults."""
+    epochs = _as_epochs(data, int(frames))
+    frames = epochs.shape[0]
+    srate = float(srate)
+    tlimits = _limits(tlimits, frames, srate)
+    cycles_array = _numeric_vector(cycles)
+    if cycles_array.size and cycles_array[0] > 0:
+        return _trial_wavelet(
+            epochs,
+            srate,
+            tlimits,
+            cycles_array,
+            kwargs.get("winsize"),
+            kwargs.get("freqs"),
+            kwargs.get("nfreqs"),
+            kwargs.get("freqscale"),
+            kwargs.get("timesout"),
+            kwargs.get("padratio"),
+        )
+    winsize = _winsize(frames, srate, cycles_array, kwargs.get("winsize"), kwargs.get("freqs"))
+    padratio = int(_first_numeric(kwargs.get("padratio"), 2))
+    nfft = max(winsize, int(2 ** np.ceil(np.log2(max(winsize, 1)))) * max(padratio, 1))
+    noverlap = min(winsize - 1, max(0, int(_first_numeric(kwargs.get("overlap"), winsize // 2))))
+    freqs, times_seconds, tfdata = _trial_stft(epochs, srate, winsize, noverlap, nfft)
+    freqs, tfdata = _select_freqs(freqs, tfdata, kwargs.get("freqs"), kwargs.get("nfreqs"), kwargs.get("freqscale"))
+    times = tlimits[0] + times_seconds * 1000.0
+    times, tfdata = _select_times(times, tfdata, kwargs.get("timesout"))
+    return freqs, times, tfdata
 
 
 def _as_epochs(data: Any, frames: int) -> np.ndarray:
@@ -124,14 +143,43 @@ def _trial_stft(
     return freqs, times, tfdata
 
 
+def _trial_wavelet(
+    epochs: np.ndarray,
+    srate: float,
+    tlimits: np.ndarray,
+    cycles: np.ndarray,
+    explicit_winsize: Any,
+    requested_freqs: Any,
+    nfreqs: Any,
+    freqscale: Any,
+    timesout: Any,
+    padratio: Any,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    winsize = _winsize(epochs.shape[0], srate, np.asarray([0.0]), explicit_winsize, None)
+    freqs = _wavelet_freqs(srate, epochs.shape[0], winsize, cycles, requested_freqs, nfreqs, freqscale, padratio)
+    wavelets = _morlet_wavelets(freqs, _wavelet_cycles(freqs, cycles), srate)
+    max_winsize = max(len(wavelet) for wavelet in wavelets)
+    times, indices = _time_output_indices(epochs.shape[0], tlimits, max_winsize, timesout)
+    tfdata = np.empty((len(freqs), len(indices), epochs.shape[1]), dtype=complex)
+    for trial in range(epochs.shape[1]):
+        signal_values = epochs[:, trial]
+        for freq_index, wavelet in enumerate(wavelets):
+            half_width = len(wavelet) // 2
+            for time_index, center in enumerate(indices):
+                segment = signal_values[center - half_width : center + half_width + 1]
+                segment = segment - np.nanmean(segment)
+                tfdata[freq_index, time_index, trial] = np.sum(wavelet * segment)
+    return freqs, times, tfdata
+
+
 def _winsize(frames: int, srate: float, cycles: np.ndarray, explicit: Any, freqs: Any) -> int:
     if explicit is not None and not _empty(explicit):
         return _bounded_window(int(_first_numeric(explicit, frames)), frames)
-    if cycles.size and cycles[0] > 0:
+    if cycles.size and cycles[0] > 0 and not _empty(freqs):
         freq_values = _numeric_vector(freqs)
         fmin = float(np.nanmin(freq_values)) if freq_values.size else max(1.0, srate / max(frames, 1))
         return _bounded_window(int(round(cycles[0] * srate / max(fmin, np.finfo(float).eps))), frames)
-    default = min(frames, max(8, int(2 ** np.floor(np.log2(max(frames / 8, 1))))))
+    default = min(frames, max(4, int(2 ** max(np.ceil(np.log2(max(frames, 2))) - 3, 2))))
     return _bounded_window(default, frames)
 
 
@@ -183,6 +231,97 @@ def _select_times(times: np.ndarray, tfdata: np.ndarray, timesout: Any) -> tuple
     else:
         indices = np.unique([int(np.argmin(np.abs(times - value))) for value in values])
     return times[indices], tfdata[:, indices, :]
+
+
+def _wavelet_freqs(
+    srate: float,
+    frames: int,
+    winsize: int,
+    cycles: np.ndarray,
+    requested: Any,
+    nfreqs: Any,
+    freqscale: Any,
+    padratio: Any,
+) -> np.ndarray:
+    freq_values = _numeric_vector(requested)
+    if freq_values.size > 2:
+        return freq_values.astype(float)
+    min_freq = max(float(cycles[0]) * float(srate) / max(winsize, 1), float(srate) / max(frames, 1))
+    max_freq = min(50.0, float(srate) / 2.0)
+    if freq_values.size == 1:
+        return freq_values.astype(float)
+    if freq_values.size == 2:
+        min_freq = float(freq_values[0])
+        max_freq = float(freq_values[1])
+    if min_freq > max_freq:
+        min_freq = max_freq
+    count_values = _numeric_vector(nfreqs, dtype=int)
+    if count_values.size and count_values[0] > 0:
+        count = int(count_values[0])
+    else:
+        count = max(1, int(round(winsize / 2 * max(1, int(_first_numeric(padratio, 2))))))
+    if count == 1:
+        return np.asarray([min_freq], dtype=float)
+    if str(freqscale).lower() == "log" and min_freq > 0 and max_freq > 0:
+        return np.geomspace(min_freq, max_freq, count)
+    return np.linspace(min_freq, max_freq, count)
+
+
+def _wavelet_cycles(freqs: np.ndarray, cycles: np.ndarray) -> np.ndarray:
+    if cycles.size == 1:
+        return np.full(freqs.shape, float(cycles[0]))
+    if cycles.size == 2:
+        high_cycles = float(cycles[1])
+        if high_cycles < 1 and freqs.size and freqs[0] > 0:
+            high_cycles = float(cycles[0]) * float(freqs[-1]) / float(freqs[0]) * (1.0 - high_cycles)
+        return np.linspace(float(cycles[0]), high_cycles, freqs.size)
+    if cycles.size != freqs.size:
+        raise ValueError("cycles must be scalar, length two, or match the number of frequencies")
+    return cycles.astype(float)
+
+
+def _morlet_wavelets(freqs: np.ndarray, cycles: np.ndarray, srate: float) -> list[np.ndarray]:
+    wavelets = []
+    for freq, cycle_count in zip(freqs, cycles):
+        normalized_freq = float(freq) / float(srate)
+        sigma_freq = normalized_freq / max(float(cycle_count), np.finfo(float).eps)
+        sigma_time = 1.0 / (2.0 * np.pi * sigma_freq)
+        half_width = int(np.floor(sigma_time * 7.0 / 2.0))
+        samples = np.arange(0, half_width * 2 + 1, dtype=float) - half_width
+        amplitude = 1.0 / np.sqrt(sigma_time * np.sqrt(np.pi))
+        wavelet = (
+            amplitude * np.exp(-(samples**2) / (2.0 * sigma_time**2)) * np.exp(2j * np.pi * normalized_freq * samples)
+        )
+        wavelets.append(wavelet)
+    return wavelets
+
+
+def _time_output_indices(
+    frames: int, tlimits: np.ndarray, winsize: int, timesout: Any
+) -> tuple[np.ndarray, np.ndarray]:
+    full_times = np.linspace(float(tlimits[0]), float(tlimits[1]), int(frames))
+    half_width = int(winsize) // 2
+    start = half_width
+    stop = int(frames) - half_width - 1
+    if stop < start:
+        raise ValueError("Not enough data points, reduce the window size or lowest frequency")
+    requested = _numeric_vector(timesout)
+    if requested.size == 0:
+        count = 200
+        indices = np.linspace(start, stop, min(count, stop - start + 1)).round().astype(int)
+    elif requested.size == 1 and requested[0] > 0:
+        count = min(int(requested[0]), stop - start + 1)
+        indices = np.linspace(start, stop, count).round().astype(int)
+    elif requested.size == 1 and requested[0] < 0:
+        step = max(1, int(abs(requested[0])))
+        indices = np.arange(start, stop + 1, step)
+    else:
+        indices = np.asarray([int(np.argmin(np.abs(full_times - value))) for value in requested], dtype=int)
+        indices = indices[(indices >= start) & (indices <= stop)]
+        if indices.size == 0:
+            raise ValueError("No time points. Reduce time window or minimum frequency.")
+    indices = np.unique(indices)
+    return full_times[indices], indices
 
 
 def _baseline_power(power: np.ndarray, times: np.ndarray, baseline: Any) -> np.ndarray:
@@ -316,4 +455,4 @@ def _is_on(value: Any) -> bool:
     return str(value).lower() not in {"0", "false", "off", "no", "none"}
 
 
-__all__ = ["TimeFrequencyResult", "newtimef"]
+__all__ = ["TimeFrequencyResult", "compute_time_frequency", "newtimef"]

--- a/src/eegprep/functions/timefreqfunc/newtimef.py
+++ b/src/eegprep/functions/timefreqfunc/newtimef.py
@@ -1,0 +1,319 @@
+"""Deterministic EEGLAB-style ``newtimef`` numerical core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import signal
+
+
+@dataclass(frozen=True)
+class TimeFrequencyResult:
+    """Computed event-related spectral perturbation and ITC arrays."""
+
+    ersp: np.ndarray
+    itc: np.ndarray
+    powbase: np.ndarray
+    times: np.ndarray
+    freqs: np.ndarray
+    tfdata: np.ndarray
+    figure: Any | None = None
+
+
+def newtimef(
+    data: Any,
+    frames: int,
+    tlimits: Any,
+    srate: float,
+    cycles: Any = 0,
+    **kwargs: Any,
+) -> TimeFrequencyResult:
+    """Compute an EEGLAB-like ERSP/ITC time-frequency decomposition.
+
+    This standalone core intentionally implements the deterministic STFT path
+    used by EEGPrep's plot wrappers. EEGLAB's full ``newtimef`` also includes
+    multiple wavelet implementations, bootstrapping, and time-warping; those are
+    outside this stable numerical core and are rejected clearly by the wrappers.
+    """
+    epochs = _as_epochs(data, int(frames))
+    frames = epochs.shape[0]
+    srate = float(srate)
+    tlimits = _limits(tlimits, frames, srate)
+    cycles_array = _numeric_vector(cycles)
+    winsize = _winsize(frames, srate, cycles_array, kwargs.get("winsize"), kwargs.get("freqs"))
+    padratio = int(_first_numeric(kwargs.get("padratio"), 2))
+    nfft = max(winsize, int(2 ** np.ceil(np.log2(max(winsize, 1)))) * max(padratio, 1))
+    noverlap = min(winsize - 1, max(0, int(_first_numeric(kwargs.get("overlap"), winsize // 2))))
+
+    freqs, times_seconds, tfdata = _trial_stft(epochs, srate, winsize, noverlap, nfft)
+    freqs, tfdata = _select_freqs(freqs, tfdata, kwargs.get("freqs"), kwargs.get("nfreqs"), kwargs.get("freqscale"))
+    times = tlimits[0] + times_seconds * 1000.0
+    times, tfdata = _select_times(times, tfdata, kwargs.get("timesout"))
+
+    power = np.abs(tfdata) ** 2
+    powbase = _baseline_power(power, times, kwargs.get("baseline", 0))
+    scale = str(kwargs.get("scale", "log")).lower()
+    if scale == "abs":
+        ersp = np.nanmean(power, axis=2) / powbase[:, np.newaxis]
+    elif scale == "log":
+        ersp = 10.0 * np.log10(np.maximum(np.nanmean(power, axis=2), np.finfo(float).tiny) / powbase[:, np.newaxis])
+    else:
+        raise ValueError("scale must be 'log' or 'abs'")
+    phase = np.divide(tfdata, np.maximum(np.abs(tfdata), np.finfo(float).tiny))
+    itc = np.nanmean(phase, axis=2)
+
+    figure = None
+    if _is_on(kwargs.get("plot", "on")):
+        figure = _plot_time_frequency(
+            ersp,
+            np.abs(itc),
+            times,
+            freqs,
+            title=str(kwargs.get("title", "Time-frequency")),
+            plotersp=_is_on(kwargs.get("plotersp", "on")),
+            plotitc=_is_on(kwargs.get("plotitc", "on")),
+        )
+    return TimeFrequencyResult(ersp, itc, powbase, times, freqs, tfdata, figure)
+
+
+def _as_epochs(data: Any, frames: int) -> np.ndarray:
+    values = np.asarray(data, dtype=float)
+    if values.ndim == 3:
+        if values.shape[0] != 1:
+            raise ValueError("newtimef expects a single channel/component")
+        return values[0].reshape(values.shape[1], values.shape[2])
+    if values.ndim == 2:
+        if values.shape[0] == frames:
+            return values
+        if values.shape[1] == frames:
+            return values.T
+        if values.shape[0] == 1:
+            values = values.ravel()
+        else:
+            raise ValueError("2-D data must be frames x trials")
+    if values.ndim == 1:
+        if frames <= 0 or values.size % frames:
+            raise ValueError("1-D data length must be a multiple of frames")
+        return values.reshape(-1, frames).T
+    raise ValueError("newtimef data must be 1-D, 2-D, or 3-D")
+
+
+def _trial_stft(
+    epochs: np.ndarray, srate: float, winsize: int, noverlap: int, nfft: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    trial_spectra = []
+    freqs = np.asarray([])
+    times = np.asarray([])
+    for trial in range(epochs.shape[1]):
+        freqs, times, spectrum = signal.stft(
+            epochs[:, trial],
+            fs=srate,
+            window="hann",
+            nperseg=winsize,
+            noverlap=noverlap,
+            nfft=nfft,
+            detrend=False,
+            boundary=None,
+            padded=False,
+        )
+        trial_spectra.append(spectrum)
+    tfdata = np.stack(trial_spectra, axis=2)
+    return freqs, times, tfdata
+
+
+def _winsize(frames: int, srate: float, cycles: np.ndarray, explicit: Any, freqs: Any) -> int:
+    if explicit is not None and not _empty(explicit):
+        return _bounded_window(int(_first_numeric(explicit, frames)), frames)
+    if cycles.size and cycles[0] > 0:
+        freq_values = _numeric_vector(freqs)
+        fmin = float(np.nanmin(freq_values)) if freq_values.size else max(1.0, srate / max(frames, 1))
+        return _bounded_window(int(round(cycles[0] * srate / max(fmin, np.finfo(float).eps))), frames)
+    default = min(frames, max(8, int(2 ** np.floor(np.log2(max(frames / 8, 1))))))
+    return _bounded_window(default, frames)
+
+
+def _bounded_window(value: int, frames: int) -> int:
+    return max(2, min(int(value), int(frames)))
+
+
+def _select_freqs(
+    freqs: np.ndarray, tfdata: np.ndarray, requested: Any, nfreqs: Any, freqscale: Any
+) -> tuple[np.ndarray, np.ndarray]:
+    freq_values = _numeric_vector(requested)
+    if freq_values.size == 1:
+        target = freq_values
+    elif freq_values.size == 2:
+        mask = (freqs >= freq_values[0]) & (freqs <= freq_values[1])
+        target = freqs[mask]
+    elif freq_values.size > 2:
+        target = freq_values
+    else:
+        target = freqs[freqs > 0]
+        if target.size == 0:
+            target = freqs
+        target = target[target <= min(50.0, freqs[-1])]
+    if target.size == 0:
+        target = freqs
+    count_values = _numeric_vector(nfreqs, dtype=int)
+    if count_values.size and count_values[0] > 0 and target.size > int(count_values[0]):
+        count = int(count_values[0])
+        positive = target[target > 0]
+        if str(freqscale).lower() == "log" and positive.size:
+            grid = np.geomspace(np.nanmin(positive), np.nanmax(target), count)
+        else:
+            grid = np.linspace(float(target[0]), float(target[-1]), count)
+        target = grid
+    indices = np.unique([int(np.argmin(np.abs(freqs - value))) for value in target])
+    return freqs[indices], tfdata[indices, :, :]
+
+
+def _select_times(times: np.ndarray, tfdata: np.ndarray, timesout: Any) -> tuple[np.ndarray, np.ndarray]:
+    values = _numeric_vector(timesout, dtype=float)
+    if values.size == 0:
+        return times, tfdata
+    if values.size == 1 and values[0] > 0:
+        count = min(int(values[0]), times.size)
+        indices = np.unique(np.linspace(0, times.size - 1, count).round().astype(int))
+    elif values.size == 1 and values[0] < 0:
+        step = max(1, int(abs(values[0])))
+        indices = np.arange(0, times.size, step)
+    else:
+        indices = np.unique([int(np.argmin(np.abs(times - value))) for value in values])
+    return times[indices], tfdata[:, indices, :]
+
+
+def _baseline_power(power: np.ndarray, times: np.ndarray, baseline: Any) -> np.ndarray:
+    values = _numeric_vector(baseline)
+    if values.size and np.any(np.isnan(values)):
+        return np.ones(power.shape[0], dtype=float)
+    if values.size == 0:
+        mask = times < 0
+    elif values.size == 1:
+        mask = times <= values[0]
+    elif values.size == 2:
+        mask = (times >= values[0]) & (times <= values[1])
+    else:
+        raise ValueError("baseline must be empty, scalar, [min max], or NaN")
+    if not np.any(mask):
+        baseline_power = np.nanmean(power, axis=(1, 2))
+    else:
+        baseline_power = np.nanmean(power[:, mask, :], axis=(1, 2))
+    return np.maximum(baseline_power, np.finfo(float).tiny)
+
+
+def _plot_time_frequency(
+    ersp: np.ndarray,
+    itc: np.ndarray,
+    times: np.ndarray,
+    freqs: np.ndarray,
+    *,
+    title: str,
+    plotersp: bool,
+    plotitc: bool,
+):
+    panels = int(plotersp) + int(plotitc)
+    if panels == 0:
+        return None
+    fig, axes = plt.subplots(panels, 1, figsize=(7.5, 5.0), squeeze=False)
+    row = 0
+    if plotersp:
+        image = axes[row, 0].imshow(
+            ersp,
+            aspect="auto",
+            origin="lower",
+            extent=[times[0], times[-1], freqs[0], freqs[-1]],
+            interpolation="nearest",
+        )
+        axes[row, 0].set_title(title)
+        axes[row, 0].set_ylabel("Frequency (Hz)")
+        fig.colorbar(image, ax=axes[row, 0], label="ERSP")
+        row += 1
+    if plotitc:
+        image = axes[row, 0].imshow(
+            itc,
+            aspect="auto",
+            origin="lower",
+            extent=[times[0], times[-1], freqs[0], freqs[-1]],
+            interpolation="nearest",
+            vmin=0,
+            vmax=max(1.0, float(np.nanmax(itc))),
+        )
+        axes[row, 0].set_ylabel("Frequency (Hz)")
+        axes[row, 0].set_xlabel("Time (ms)")
+        fig.colorbar(image, ax=axes[row, 0], label="ITC")
+    fig.tight_layout()
+    return fig
+
+
+def _limits(value: Any, frames: int, srate: float) -> np.ndarray:
+    values = _numeric_vector(value)
+    if values.size == 2:
+        return values.astype(float)
+    duration = (frames - 1) / float(srate) * 1000.0
+    return np.asarray([0.0, duration], dtype=float)
+
+
+def _numeric_vector(value: Any, *, dtype: Any = float) -> np.ndarray:
+    if value is None:
+        return np.asarray([], dtype=dtype)
+    if isinstance(value, np.ndarray):
+        return value.astype(dtype).ravel()
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return np.asarray([value], dtype=dtype)
+    if isinstance(value, str):
+        text = value.strip().strip("[]")
+        if not text:
+            return np.asarray([], dtype=dtype)
+        values = []
+        for token in text.replace(",", " ").split():
+            if ":" in token:
+                values.extend(_colon_sequence(token))
+            else:
+                values.append(float(token))
+        return np.asarray(values, dtype=dtype)
+    if isinstance(value, (list, tuple)):
+        return np.asarray(value, dtype=dtype).ravel()
+    return np.asarray([value], dtype=dtype)
+
+
+def _first_numeric(value: Any, default: float) -> float:
+    values = _numeric_vector(value)
+    return float(values[0]) if values.size else float(default)
+
+
+def _colon_sequence(token: str) -> list[float]:
+    pieces = token.split(":")
+    if len(pieces) not in {2, 3}:
+        raise ValueError(f"Invalid colon range: {token}")
+    start = float(pieces[0])
+    if len(pieces) == 2:
+        stop = float(pieces[1])
+        step = 1.0 if stop >= start else -1.0
+    else:
+        step = float(pieces[1])
+        stop = float(pieces[2])
+    if step == 0 or (stop - start) * step < 0:
+        return []
+    count = int(np.floor((stop - start) / step + 1e-9)) + 1
+    values = [float(start + index * step) for index in range(max(count, 0))]
+    if values and np.isclose(values[-1], stop, rtol=0.0, atol=max(abs(step), 1.0) * 1e-12):
+        values[-1] = stop
+    return values
+
+
+def _empty(value: Any) -> bool:
+    return (
+        value is None
+        or (isinstance(value, str) and not value.strip())
+        or (isinstance(value, (list, tuple, np.ndarray)) and np.asarray(value).size == 0)
+    )
+
+
+def _is_on(value: Any) -> bool:
+    return str(value).lower() not in {"0", "false", "off", "no", "none"}
+
+
+__all__ = ["TimeFrequencyResult", "newtimef"]

--- a/src/eegprep/plugins/ICLabel/pop_viewprops.py
+++ b/src/eegprep/plugins/ICLabel/pop_viewprops.py
@@ -97,8 +97,7 @@ def pop_viewprops_dialog_spec(EEG: dict[str, Any], typecomp: int | bool = 1) -> 
         controls=tuple(controls),
         known_differences=(
             "EEGPrep omits EEGBrowser/eegplot scrolling activity from the property overview.",
-            "Extended channel-property panels are scheduled for Phase 4 plotting work; "
-            "the GUI menu shows a coming-soon placeholder for channel mode.",
+            "Channel mode renders a non-scrolling overview so the GUI and console remain usable without EEGBrowser.",
         ),
     )
 

--- a/src/eegprep/resources/help/pop_eventstat.md
+++ b/src/eegprep/resources/help/pop_eventstat.md
@@ -1,0 +1,15 @@
+POP_EVENTSTAT - Plot statistics for numeric event fields.
+
+`pop_eventstat` extracts numeric values from `EEG["event"]`, optionally filters
+by event type and latency range, and runs `signalstat` on the resulting event
+values.
+
+Examples:
+
+```python
+stats = pop_eventstat(EEG, "latency", [], [], 5)
+stats = pop_eventstat(EEG, "duration", ["square"], [0, 300], 5)
+```
+
+String-valued event fields are ignored because the statistical workflow requires
+numeric values.

--- a/src/eegprep/resources/help/pop_newcrossf.md
+++ b/src/eegprep/resources/help/pop_newcrossf.md
@@ -1,0 +1,15 @@
+POP_NEWCROSSF - Plot channel or component cross-coherence.
+
+`pop_newcrossf` computes time-frequency coherence between two channels or two
+ICA components and plots coherence amplitude and phase.
+
+Examples:
+
+```python
+result = pop_newcrossf(EEG, 1, 1, 2, [-100, 200], [3, 0.5])
+result = pop_newcrossf(EEG, 0, 1, 2, [-100, 200], [0], type="coher")
+```
+
+Supported deterministic coherence modes are `phasecoher`, `coher`, and
+`crossspec`. EEGLAB bootstrap and shuffle significance options are not yet
+ported and raise clear `NotImplementedError` messages.

--- a/src/eegprep/resources/help/pop_newcrossf.md
+++ b/src/eegprep/resources/help/pop_newcrossf.md
@@ -11,5 +11,6 @@ result = pop_newcrossf(EEG, 0, 1, 2, [-100, 200], [0], type="coher")
 ```
 
 Supported deterministic coherence modes are `phasecoher`, `coher`, and
-`crossspec`. EEGLAB bootstrap and shuffle significance options are not yet
-ported and raise clear `NotImplementedError` messages.
+`crossspec`. Single-trial continuous inputs use EEGLAB's cross-spectrum mode.
+EEGLAB bootstrap and shuffle significance options are not yet ported and raise
+clear `NotImplementedError` messages.

--- a/src/eegprep/resources/help/pop_newtimef.md
+++ b/src/eegprep/resources/help/pop_newtimef.md
@@ -10,7 +10,9 @@ result = pop_newtimef(EEG, 1, 1, [-100, 200], [3, 0.8])
 result = pop_newtimef(EEG, 0, 2, [-100, 200], [0], freqs=[4, 30], padratio=2)
 ```
 
-The EEGPrep implementation provides a deterministic STFT-backed numerical core
-with EEGLAB-compatible inputs, history strings, and plotting layout. EEGLAB
-features that rely on permutation/bootstrap masking, time-warping, or curve
-plotting currently fail clearly rather than silently changing behavior.
+The EEGPrep implementation provides deterministic FFT/STFT output for
+`cycles=[0]` and Morlet wavelet output for non-zero `cycles`, with
+EEGLAB-compatible inputs, history strings, and plotting layout. EEGLAB features
+that rely on permutation/bootstrap masking, time-warping, baseline
+normalization modes, or curve plotting currently fail clearly rather than
+silently changing behavior.

--- a/src/eegprep/resources/help/pop_newtimef.md
+++ b/src/eegprep/resources/help/pop_newtimef.md
@@ -1,0 +1,16 @@
+POP_NEWTIMEF - Plot channel or component time-frequency decomposition.
+
+`pop_newtimef` computes an event-related spectral perturbation (ERSP) image and
+inter-trial coherence (ITC) image for one channel or ICA component.
+
+Examples:
+
+```python
+result = pop_newtimef(EEG, 1, 1, [-100, 200], [3, 0.8])
+result = pop_newtimef(EEG, 0, 2, [-100, 200], [0], freqs=[4, 30], padratio=2)
+```
+
+The EEGPrep implementation provides a deterministic STFT-backed numerical core
+with EEGLAB-compatible inputs, history strings, and plotting layout. EEGLAB
+features that rely on permutation/bootstrap masking, time-warping, or curve
+plotting currently fail clearly rather than silently changing behavior.

--- a/src/eegprep/resources/help/pop_signalstat.md
+++ b/src/eegprep/resources/help/pop_signalstat.md
@@ -13,4 +13,5 @@ stats = pop_signalstat(EEG, 0, 2, 10)
 ```
 
 The GUI asks for the channel/component number and trim percentage, then renders
-a histogram, boxplot, QQ plot, and statistics panel.
+a histogram, boxplot, QQ plot, topographic context when channel locations are
+available, and statistics panel.

--- a/src/eegprep/resources/help/pop_signalstat.md
+++ b/src/eegprep/resources/help/pop_signalstat.md
@@ -1,0 +1,16 @@
+POP_SIGNALSTAT - Plot statistics for a channel or component signal.
+
+`pop_signalstat` computes the same core statistic outputs as EEGLAB's
+`signalstat`: mean, standard deviation, skewness, excess kurtosis, median,
+low/high trim quantiles, trimmed mean, trimmed standard deviation, retained
+indices, and a Kolmogorov-Smirnov normality flag.
+
+Examples:
+
+```python
+stats = pop_signalstat(EEG, 1, 1, 5)
+stats = pop_signalstat(EEG, 0, 2, 10)
+```
+
+The GUI asks for the channel/component number and trim percentage, then renders
+a histogram, boxplot, QQ plot, and statistics panel.

--- a/tests/test_gui_rejection_dialogs.py
+++ b/tests/test_gui_rejection_dialogs.py
@@ -95,12 +95,12 @@ class RejectionDialogTests(unittest.TestCase):
             "pop_rejspec:ica",
             "pop_rejtrend:data",
             "pop_selectcomps",
+            "pop_viewprops:channels",
             "pop_viewprops:components",
         ]
         for action in implemented:
             self.assertEqual(action_kind(action), "implemented")
         self.assertEqual(action_kind("pop_eegplot:reject_data"), "placeholder")
-        self.assertEqual(action_kind("pop_viewprops:channels"), "placeholder")
 
     def test_gui_command_is_valid_python_with_keywords(self):
         class Renderer:

--- a/tests/test_menu_placeholder_inventory.py
+++ b/tests/test_menu_placeholder_inventory.py
@@ -46,9 +46,13 @@ def test_placeholder_inventory_classifies_representative_phase_work():
     assert action_kind("pop_rejchan") == "implemented"
     assert placeholder_metadata("pop_spectopo") is None
     assert action_kind("pop_spectopo") == "implemented"
-    assert placeholder_metadata("pop_signalstat").phase == "4"
-    assert placeholder_metadata("pop_viewprops:channels").phase == "4"
-    assert action_kind("pop_viewprops:channels") == "placeholder"
+    assert placeholder_metadata("pop_signalstat") is None
+    assert action_kind("pop_signalstat") == "implemented"
+    assert action_kind("pop_newtimef") == "implemented"
+    assert action_kind("pop_newcrossf") == "implemented"
+    assert action_kind("pop_eventstat") == "implemented"
+    assert placeholder_metadata("pop_viewprops:channels") is None
+    assert action_kind("pop_viewprops:channels") == "implemented"
     assert action_kind("pop_viewprops:components") == "implemented"
     assert placeholder_metadata("pop_studydesign").phase == "5"
     assert placeholder_metadata("eeglab_update").phase == "6"

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -14,14 +14,21 @@ from eegprep.functions.popfunc.pop_eegfilt import pop_eegfilt
 from eegprep.functions.popfunc.pop_editeventfield import pop_editeventfield
 from eegprep.functions.popfunc.pop_editeventvals import pop_editeventvals
 from eegprep.functions.popfunc.pop_epoch import pop_epoch
+from eegprep.functions.popfunc.pop_eventstat import pop_eventstat
 from eegprep.functions.popfunc.pop_fileio_brainvision_mat import pop_fileio_brainvision_mat
 from eegprep.functions.popfunc.pop_mergeset import pop_mergeset
+from eegprep.functions.popfunc.pop_newcrossf import pop_newcrossf
+from eegprep.functions.popfunc.pop_newtimef import pop_newtimef
 from eegprep.functions.popfunc.pop_rmdat import pop_rmdat
 from eegprep.functions.popfunc.pop_rmbase import pop_rmbase
 from eegprep.functions.popfunc.pop_select import pop_select
 from eegprep.functions.popfunc.pop_selectevent import pop_selectevent
+from eegprep.functions.popfunc.pop_signalstat import pop_signalstat
 from eegprep.functions.sigprocfunc.eegrej import eegrej as sigproc_eegrej
 from eegprep.functions.sigprocfunc.rmbase import rmbase as sigproc_rmbase
+from eegprep.functions.sigprocfunc.signalstat import signalstat
+from eegprep.functions.timefreqfunc.newcrossf import newcrossf
+from eegprep.functions.timefreqfunc.newtimef import newtimef
 from eegprep.plugins.ICLabel.pop_icflag import pop_icflag
 from eegprep.plugins.firfilt.pop_eegfiltnew import pop_eegfiltnew
 from eegprep.plugins.firfilt.pop_firma import pop_firma
@@ -50,16 +57,23 @@ class TestPackageExports(unittest.TestCase):
         self.assertIs(eegprep.pop_editeventfield, pop_editeventfield)
         self.assertIs(eegprep.pop_editeventvals, pop_editeventvals)
         self.assertIs(eegprep.pop_epoch, pop_epoch)
+        self.assertIs(eegprep.pop_eventstat, pop_eventstat)
         self.assertIs(eegprep.pop_fileio_brainvision_mat, pop_fileio_brainvision_mat)
         self.assertIs(eegprep.pop_firma, pop_firma)
         self.assertIs(eegprep.pop_firpm, pop_firpm)
         self.assertIs(eegprep.pop_firws, pop_firws)
         self.assertIs(eegprep.pop_mergeset, pop_mergeset)
+        self.assertIs(eegprep.pop_newcrossf, pop_newcrossf)
+        self.assertIs(eegprep.pop_newtimef, pop_newtimef)
         self.assertIs(eegprep.pop_rmdat, pop_rmdat)
         self.assertIs(eegprep.pop_rmbase, pop_rmbase)
         self.assertIs(eegprep.pop_select, pop_select)
         self.assertIs(eegprep.pop_selectevent, pop_selectevent)
+        self.assertIs(eegprep.pop_signalstat, pop_signalstat)
         self.assertIs(eegprep.pop_icflag, pop_icflag)
+        self.assertIs(eegprep.newcrossf, newcrossf)
+        self.assertIs(eegprep.newtimef, newtimef)
+        self.assertIs(eegprep.signalstat, signalstat)
 
 
 if __name__ == "__main__":

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+import importlib
+import os
+from pathlib import Path
+from unittest import mock
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import scipy.io
+
+from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher, action_kind
+from eegprep.functions.guifunc.spec import controls_by_tag
+from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.functions.popfunc.pop_epoch import pop_epoch
+from eegprep.functions.popfunc.pop_eventstat import event_values, pop_eventstat, pop_eventstat_dialog_spec
+from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.functions.popfunc.pop_newcrossf import pop_newcrossf, pop_newcrossf_dialog_spec
+from eegprep.functions.popfunc.pop_newtimef import pop_newtimef, pop_newtimef_dialog_spec
+from eegprep.functions.popfunc.pop_signalstat import pop_signalstat, pop_signalstat_dialog_spec
+from eegprep.functions.sigprocfunc.signalstat import signalstat
+from eegprep.functions.timefreqfunc.newcrossf import newcrossf
+from eegprep.functions.timefreqfunc.newtimef import newtimef
+from tests.fixtures import SAMPLE_DATASET_PATH, create_test_eeg_with_ica
+
+
+@pytest.fixture(scope="module")
+def sample_eeg():
+    return pop_loadset(SAMPLE_DATASET_PATH)
+
+
+@pytest.fixture(scope="module")
+def sample_epoch(sample_eeg):
+    eeg, _command = pop_epoch(deepcopy(sample_eeg), ["square"], [-0.1, 0.2], return_com=True)
+    return eeg
+
+
+@pytest.fixture
+def ica_epoch():
+    return create_test_eeg_with_ica(n_channels=6, n_samples=96, n_trials=5, n_components=4)
+
+
+def test_newtimef_synthetic_returns_deterministic_shapes():
+    srate = 128
+    times = np.arange(0, 1, 1 / srate)
+    trials = np.stack([np.sin(2 * np.pi * 10 * times), np.sin(2 * np.pi * 10 * times + 0.2)], axis=1)
+
+    result = newtimef(trials, trials.shape[0], [0, 1000], srate, 0, freqs=[5, 20], timesout=12, plot="off")
+
+    assert result.ersp.shape == result.itc.shape == (result.freqs.size, result.times.size)
+    assert result.tfdata.shape[2] == trials.shape[1]
+    assert result.times.size <= 12
+    assert np.isfinite(result.ersp).all()
+    assert np.all(np.abs(result.itc) <= 1 + 1e-12)
+
+
+def test_newcrossf_identical_synthetic_signals_have_unit_phase_coherence():
+    srate = 128
+    times = np.arange(0, 1, 1 / srate)
+    trials = np.stack([np.sin(2 * np.pi * 12 * times), np.sin(2 * np.pi * 12 * times + 0.3)], axis=1)
+
+    result = newcrossf(trials, trials, trials.shape[0], [0, 1000], srate, 0, freqs=[8, 16], plot="off")
+
+    assert result.coherence.shape == result.phase.shape
+    assert np.nanmean(result.coherence) > 0.99
+    assert np.nanmax(np.abs(result.phase)) < 1e-10
+
+
+def test_pop_newtimef_channel_and_component_paths_are_replayable(sample_epoch, ica_epoch):
+    result, command = pop_newtimef(sample_epoch, 1, 1, [-100, 200], [0], plot="off", return_com=True)
+    component_result, component_command = pop_newtimef(ica_epoch, 0, 1, [-100, 200], [0], plot="off", return_com=True)
+
+    assert result.ersp.ndim == 2
+    assert component_result.ersp.ndim == 2
+    assert "pop_newtimef(EEG, 1, 1" in command
+    assert "pop_newtimef(EEG, 0, 1" in component_command
+    _assert_python_command(command)
+    _assert_python_command(component_command)
+    namespace = {"EEG": sample_epoch, "pop_newtimef": pop_newtimef}
+    replayed = eval(command, namespace)
+    assert replayed.ersp.shape == result.ersp.shape
+
+
+def test_pop_newcrossf_channel_and_component_paths_are_replayable(sample_epoch, ica_epoch):
+    result, command = pop_newcrossf(sample_epoch, 1, 1, 2, [-100, 200], [0], plot="off", return_com=True)
+    component_result, component_command = pop_newcrossf(
+        ica_epoch, 0, 1, 2, [-100, 200], [0], plot="off", return_com=True
+    )
+
+    assert result.coherence.ndim == 2
+    assert component_result.coherence.ndim == 2
+    assert "pop_newcrossf(EEG, 1, 1, 2" in command
+    assert "pop_newcrossf(EEG, 0, 1, 2" in component_command
+    _assert_python_command(command)
+    _assert_python_command(component_command)
+
+
+def test_pop_signalstat_sample_and_component_paths(sample_eeg, ica_epoch):
+    result, command = pop_signalstat(sample_eeg, 1, 1, 5, return_com=True)
+    component_result, component_command = pop_signalstat(ica_epoch, 0, 1, 5, return_com=True)
+
+    assert np.isfinite(result.mean)
+    assert np.isfinite(component_result.mean)
+    assert result.trimmed_indices.size > 0
+    assert "pop_signalstat(EEG, 1, 1, 5)" == command
+    assert "pop_signalstat(EEG, 0, 1, 5)" == component_command
+    _assert_python_command(command)
+    plt.close(result.figure)
+    plt.close(component_result.figure)
+
+
+def test_pop_eventstat_extracts_sample_event_latencies(sample_eeg):
+    values = event_values(sample_eeg, "latency", type=["square"])
+    result, command = pop_eventstat(sample_eeg, "latency", ["square"], [], 5, return_com=True)
+
+    assert values.size > 0
+    assert result.mean == pytest.approx(float(np.mean(values)))
+    assert "pop_eventstat(EEG, 'latency', ['square'], [], 5)" == command
+    _assert_python_command(command)
+    plt.close(result.figure)
+
+
+def test_timefreq_statistics_dialog_specs_match_eeglab_control_inventory(sample_eeg):
+    newtimef = pop_newtimef_dialog_spec(sample_eeg, typeproc=1)
+    newcrossf = pop_newcrossf_dialog_spec(sample_eeg, typeproc=1)
+    signal_spec = pop_signalstat_dialog_spec(sample_eeg, typeproc=1)
+    event_spec = pop_eventstat_dialog_spec(sample_eeg)
+
+    assert newtimef.title == "Plot channel time frequency -- pop_newtimef()"
+    assert controls_by_tag(newtimef)["num_button"].callback.name == "select_channels"
+    assert controls_by_tag(newtimef)["baseline"].value == "0"
+    assert controls_by_tag(newcrossf)["coher"].value is False
+    assert signal_spec.title == "Plot signal statistics -- pop_signalstat()"
+    assert controls_by_tag(signal_spec)["percent"].value == "5"
+    assert event_spec.title == "Plot event statistics -- pop_eventstat()"
+    assert controls_by_tag(event_spec)["eventfield"].value == "latency"
+
+
+def test_timefreq_statistics_menu_actions_are_implemented():
+    assert action_kind("pop_newtimef:channels") == "implemented"
+    assert action_kind("pop_newcrossf:components") == "implemented"
+    assert action_kind("pop_signalstat:channels") == "implemented"
+    assert action_kind("pop_eventstat") == "implemented"
+
+
+@pytest.mark.parametrize(
+    ("action", "module_path", "expected_kwargs", "command"),
+    [
+        (
+            "pop_newtimef:channels",
+            "eegprep.functions.popfunc.pop_newtimef.pop_newtimef",
+            {"typeproc": 1, "return_com": True},
+            "pop_newtimef(EEG, 1, 1)",
+        ),
+        (
+            "pop_newcrossf:components",
+            "eegprep.functions.popfunc.pop_newcrossf.pop_newcrossf",
+            {"typeproc": 0, "return_com": True},
+            "pop_newcrossf(EEG, 0, 1, 2)",
+        ),
+        (
+            "pop_signalstat:channels",
+            "eegprep.functions.popfunc.pop_signalstat.pop_signalstat",
+            {"typeproc": 1, "return_com": True},
+            "pop_signalstat(EEG, 1, 1, 5)",
+        ),
+        (
+            "pop_eventstat",
+            "eegprep.functions.popfunc.pop_eventstat.pop_eventstat",
+            {"return_com": True},
+            "pop_eventstat(EEG, 'latency', [], [], 5)",
+        ),
+    ],
+)
+def test_timefreq_statistics_menu_dispatch_records_history(sample_eeg, action, module_path, expected_kwargs, command):
+    session = EEGPrepSession()
+    session.store_current(sample_eeg, new=True)
+    stored_eeg = session.EEG
+    dispatcher = MenuActionDispatcher(session)
+
+    with mock.patch(module_path, return_value=("figure", command)) as pop_function:
+        dispatcher.dispatch(action)
+
+    pop_function.assert_called_once()
+    assert len(pop_function.call_args.args) == 1
+    assert pop_function.call_args.args[0] is stored_eeg
+    assert pop_function.call_args.kwargs == expected_kwargs
+    assert session.EEG is stored_eeg
+    assert session.ALLCOM[-1] == command
+
+
+def test_signalstat_matches_numpy_for_known_vector():
+    values = np.asarray([1, 2, 3, 4, 100], dtype=float)
+    result = signalstat(values, plotlab=0, percent=40)
+
+    assert result.mean == pytest.approx(np.mean(values))
+    assert result.std == pytest.approx(np.std(values, ddof=1))
+    assert result.median == pytest.approx(np.median(values))
+    assert result.zlow == pytest.approx(1.5)
+    assert result.zhigh == pytest.approx(52.0)
+    assert result.trimmed_indices.tolist() == [1, 2, 3]
+
+
+@pytest.mark.matlab
+def test_signalstat_statistics_match_eeglab(tmp_path):
+    if os.environ.get("EEGPREP_SKIP_MATLAB") == "1":
+        pytest.skip("MATLAB tests disabled via EEGPREP_SKIP_MATLAB")
+    try:
+        matlab_engine = importlib.import_module("matlab.engine")
+    except ImportError as exc:
+        pytest.skip(f"MATLAB not available: {exc}")
+    eeglab_root = Path("/tmp/eeglab-timefreq-ref")
+    if not eeglab_root.exists():
+        pytest.skip("EEGLAB reference checkout not available")
+
+    values = np.asarray([1.0, 2.5, -3.0, 4.25, 5.5, 9.0, 12.0, 20.0])
+    output = tmp_path / "signalstat.mat"
+    engine = matlab_engine.start_matlab()
+    try:
+        engine.addpath(str(eeglab_root / "functions" / "sigprocfunc"), nargout=0)
+        engine.eval(
+            f"""
+            data = [{_matlab_vector(values)}];
+            [M,SD,sk,k,med,zlow,zhi,tM,tSD,tndx,ksh] = signalstat(data, 0, [], 10);
+            save('{_matlab_string(output)}', 'M', 'SD', 'sk', 'k', 'med', 'zlow', 'zhi', 'tM', 'tSD', 'tndx', 'ksh');
+            """,
+            nargout=0,
+        )
+    finally:
+        engine.quit()
+
+    result = signalstat(values, plotlab=0, percent=10)
+    matlab = scipy.io.loadmat(output, squeeze_me=True)
+    np.testing.assert_allclose(result.mean, matlab["M"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.std, matlab["SD"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.skewness, matlab["sk"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.kurtosis, matlab["k"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.median, matlab["med"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.zlow, matlab["zlow"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.zhigh, matlab["zhi"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.trimmed_mean, matlab["tM"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result.trimmed_std, matlab["tSD"], rtol=1e-12, atol=1e-12)
+    np.testing.assert_array_equal(result.trimmed_indices + 1, np.asarray(matlab["tndx"], dtype=int).ravel())
+
+
+def _assert_python_command(command: str) -> None:
+    ast.parse(command, mode="eval")
+
+
+def _matlab_vector(values: np.ndarray) -> str:
+    return " ".join(f"{float(value):.17g}" for value in np.asarray(values, dtype=float).ravel())
+
+
+def _matlab_string(path: Path) -> str:
+    return str(path).replace("'", "''")

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -23,6 +23,7 @@ from eegprep.functions.popfunc.pop_epoch import pop_epoch
 from eegprep.functions.popfunc.pop_eventstat import event_values, pop_eventstat, pop_eventstat_dialog_spec
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_newcrossf import pop_newcrossf, pop_newcrossf_dialog_spec
+from eegprep.functions.popfunc.pop_newtimef import _run_gui as run_newtimef_gui
 from eegprep.functions.popfunc.pop_newtimef import pop_newtimef, pop_newtimef_dialog_spec
 from eegprep.functions.popfunc.pop_signalstat import pop_signalstat, pop_signalstat_dialog_spec
 from eegprep.functions.sigprocfunc.signalstat import signalstat
@@ -61,6 +62,14 @@ def test_newtimef_synthetic_returns_deterministic_shapes():
     assert np.all(np.abs(result.itc) <= 1 + 1e-12)
 
 
+def test_newtimef_nonzero_cycles_use_wavelet_time_grid(sample_epoch):
+    result = pop_newtimef(sample_epoch, 1, 1, [-100, 200], [3, 0.8], plot="off")
+
+    assert result.times.size > 1
+    assert result.freqs.size > 0
+    assert result.tfdata.shape == (result.freqs.size, result.times.size, sample_epoch["trials"])
+
+
 def test_newcrossf_identical_synthetic_signals_have_unit_phase_coherence():
     srate = 128
     times = np.arange(0, 1, 1 / srate)
@@ -71,6 +80,16 @@ def test_newcrossf_identical_synthetic_signals_have_unit_phase_coherence():
     assert result.coherence.shape == result.phase.shape
     assert np.nanmean(result.coherence) > 0.99
     assert np.nanmax(np.abs(result.phase)) < 1e-10
+
+
+def test_newcrossf_single_trial_switches_to_cross_spectrum():
+    rng = np.random.default_rng(0)
+    first = rng.normal(size=512)
+    second = rng.normal(size=512)
+
+    result = newcrossf(first, second, 512, [0, 511], 256, 0, plot="off")
+
+    assert np.nanmean(result.coherence) < 0.5
 
 
 def test_pop_newtimef_channel_and_component_paths_are_replayable(sample_epoch, ica_epoch):
@@ -127,6 +146,26 @@ def test_pop_eventstat_extracts_sample_event_latencies(sample_eeg):
     plt.close(result.figure)
 
 
+def test_pop_eventstat_epoched_latrange_uses_epoch_relative_latency(sample_epoch):
+    all_values = event_values(sample_epoch, "latency", type=["square"])
+    ranged_values = event_values(sample_epoch, "latency", type=["square"], latrange=[-100, 200])
+
+    assert ranged_values.size == all_values.size == sample_epoch["trials"]
+
+
+def test_pop_newtimef_gui_defaults_are_replayable_and_honest(sample_eeg):
+    result = run_newtimef_gui(sample_eeg, typeproc=1, renderer=_DefaultDialogRenderer())
+
+    assert result["options"]["timesout"] == 200
+    assert "plotphase" not in result["options"]
+    assert "plottype" not in result["options"]
+
+
+def test_pop_newtimef_rejects_unimplemented_baseline_modes(sample_epoch):
+    with pytest.raises(NotImplementedError, match="baseline normalization"):
+        pop_newtimef(sample_epoch, 1, 1, [-100, 200], [3, 0.8], basenorm="on", plot="off")
+
+
 def test_timefreq_statistics_dialog_specs_match_eeglab_control_inventory(sample_eeg):
     newtimef = pop_newtimef_dialog_spec(sample_eeg, typeproc=1)
     newcrossf = pop_newcrossf_dialog_spec(sample_eeg, typeproc=1)
@@ -136,6 +175,8 @@ def test_timefreq_statistics_dialog_specs_match_eeglab_control_inventory(sample_
     assert newtimef.title == "Plot channel time frequency -- pop_newtimef()"
     assert controls_by_tag(newtimef)["num_button"].callback.name == "select_channels"
     assert controls_by_tag(newtimef)["baseline"].value == "0"
+    assert controls_by_tag(newtimef)["plotcurve"].enabled is False
+    assert controls_by_tag(newtimef)["alpha"].enabled is False
     assert controls_by_tag(newcrossf)["coher"].value is False
     assert signal_spec.title == "Plot signal statistics -- pop_signalstat()"
     assert controls_by_tag(signal_spec)["percent"].value == "5"
@@ -208,6 +249,14 @@ def test_signalstat_matches_numpy_for_known_vector():
     assert result.trimmed_indices.tolist() == [1, 2, 3]
 
 
+def test_signalstat_plots_topographic_context_when_map_is_available(ica_epoch):
+    result = pop_signalstat(ica_epoch, 0, 1, 5)
+
+    titles = [axis.get_title() for axis in result.figure.axes]
+    assert "Topographic map" in titles
+    plt.close(result.figure)
+
+
 @pytest.mark.matlab
 def test_signalstat_statistics_match_eeglab(tmp_path):
     if os.environ.get("EEGPREP_SKIP_MATLAB") == "1":
@@ -216,8 +265,8 @@ def test_signalstat_statistics_match_eeglab(tmp_path):
         matlab_engine = importlib.import_module("matlab.engine")
     except ImportError as exc:
         pytest.skip(f"MATLAB not available: {exc}")
-    eeglab_root = Path("/tmp/eeglab-timefreq-ref")
-    if not eeglab_root.exists():
+    eeglab_root = _eeglab_reference_root()
+    if eeglab_root is None:
         pytest.skip("EEGLAB reference checkout not available")
 
     values = np.asarray([1.0, 2.5, -3.0, 4.25, 5.5, 9.0, 12.0, 20.0])
@@ -260,3 +309,27 @@ def _matlab_vector(values: np.ndarray) -> str:
 
 def _matlab_string(path: Path) -> str:
     return str(path).replace("'", "''")
+
+
+def _eeglab_reference_root() -> Path | None:
+    repo_root = Path(__file__).resolve().parents[1]
+    candidates = []
+    if os.environ.get("EEGPREP_EEGLAB_ROOT"):
+        candidates.append(Path(os.environ["EEGPREP_EEGLAB_ROOT"]))
+    candidates.extend(
+        [
+            repo_root / "src" / "eegprep" / "eeglab",
+            repo_root.parent / "eeglab",
+            Path("/tmp/eeglab-timefreq-ref"),
+        ]
+    )
+    for candidate in candidates:
+        if (candidate / "functions" / "sigprocfunc" / "signalstat.m").exists():
+            return candidate
+    return None
+
+
+class _DefaultDialogRenderer:
+    def run(self, spec, initial_values=None):
+        _ = initial_values
+        return {control.tag: control.value for control in spec.controls if control.tag}

--- a/tests/test_visual_parity.py
+++ b/tests/test_visual_parity.py
@@ -61,6 +61,15 @@ class VisualParityConfigTests(unittest.TestCase):
         self.assertEqual(cases["pop_envtopo_dialog"].targets["eeglab"].action, "pop_envtopo")
         self.assertEqual(cases["pop_comperp_channels_dialog"].targets["eeglab"].action, "pop_comperp:channels")
         self.assertEqual(cases["pop_comperp_components_dialog"].targets["eeglab"].action, "pop_comperp:components")
+        self.assertEqual(cases["pop_newtimef_channels_dialog"].targets["eeglab"].action, "pop_newtimef:channels")
+        self.assertEqual(cases["pop_newtimef_components_dialog"].targets["eeglab"].action, "pop_newtimef:components")
+        self.assertEqual(cases["pop_newcrossf_channels_dialog"].targets["eeglab"].action, "pop_newcrossf:channels")
+        self.assertEqual(cases["pop_newcrossf_components_dialog"].targets["eeglab"].action, "pop_newcrossf:components")
+        self.assertEqual(cases["pop_signalstat_channels_dialog"].targets["eeglab"].action, "pop_signalstat:channels")
+        self.assertEqual(
+            cases["pop_signalstat_components_dialog"].targets["eeglab"].action, "pop_signalstat:components"
+        )
+        self.assertEqual(cases["pop_eventstat_dialog"].targets["eeglab"].action, "pop_eventstat")
         self.assertEqual(cases["pop_runica_dialog"].targets["eeglab"].action, "pop_runica")
         self.assertEqual(cases["pop_iclabel_dialog"].targets["eeglab"].action, "pop_iclabel")
         self.assertEqual(cases["pop_icflag_dialog"].targets["eeglab"].action, "pop_icflag")
@@ -425,6 +434,13 @@ class VisualParityCaptureTests(unittest.TestCase):
             ("pop_envtopo_dialog", "pop_envtopo", "com = pop_envtopo(EEG);"),
             ("pop_comperp_channels_dialog", "pop_comperp", "pop_comperp(ALLEEG, 1);"),
             ("pop_comperp_components_dialog", "pop_comperp", "pop_comperp(ALLEEG, 0);"),
+            ("pop_newtimef_channels_dialog", "pop_newtimef", "com = pop_newtimef(EEG, 1);"),
+            ("pop_newtimef_components_dialog", "pop_newtimef", "com = pop_newtimef(EEG, 0);"),
+            ("pop_newcrossf_channels_dialog", "pop_newcrossf", "com = pop_newcrossf(EEG, 1);"),
+            ("pop_newcrossf_components_dialog", "pop_newcrossf", "com = pop_newcrossf(EEG, 0);"),
+            ("pop_signalstat_channels_dialog", "pop_signalstat", "com = pop_signalstat(EEG, 1);"),
+            ("pop_signalstat_components_dialog", "pop_signalstat", "com = pop_signalstat(EEG, 0);"),
+            ("pop_eventstat_dialog", "pop_eventstat", "com = pop_eventstat(EEG);"),
         ]
         for case_id, action, expected_call in cases:
             with self.subTest(case_id=case_id), tempfile.TemporaryDirectory() as tmpdir:

--- a/tools/visual_parity/capture.py
+++ b/tools/visual_parity/capture.py
@@ -700,6 +700,10 @@ def _write_matlab_simple_pop_dialog_script(
         "pop_erpimage": "Channel ERP image -- pop_erpimage()",
         "pop_envtopo": "Plot component and ERP envelopes -- pop_envtopo()",
         "pop_comperp": "ERP grand average/RMS - pop_comperp()",
+        "pop_newtimef": "Plot channel time frequency -- pop_newtimef()",
+        "pop_newcrossf": "Plot channel cross-coherence -- pop_newcrossf()",
+        "pop_signalstat": "Plot signal statistics -- pop_signalstat()",
+        "pop_eventstat": "Plot event statistics -- pop_eventstat()",
         "pop_runica": "Run ICA decomposition -- pop_runica()",
         "pop_subcomp": "Remove components from data -- pop_subcomp()",
         "pop_autorej": "Automatic epoch rejection -- pop_autorej()",
@@ -744,6 +748,10 @@ def _write_matlab_simple_pop_dialog_script(
         target_title = "Component head plot(s) -- pop_headplot()"
     elif action == "pop_erpimage" and variant == "components":
         target_title = "Component ERP image -- pop_erpimage()"
+    elif action == "pop_newtimef" and variant == "components":
+        target_title = "Plot component time frequency -- pop_newtimef()"
+    elif action == "pop_newcrossf" and variant == "components":
+        target_title = "Plot component cross-coherence -- pop_newcrossf()"
     else:
         target_title = title_by_action[action]
     script_path.write_text(
@@ -854,6 +862,26 @@ def _write_matlab_simple_pop_dialog_script(
                 "        else",
                 "            pop_comperp(ALLEEG, 1);",
                 "        end",
+                "    case 'pop_newtimef'",
+                "        if strcmp(variant, 'components')",
+                "            com = pop_newtimef(EEG, 0);",
+                "        else",
+                "            com = pop_newtimef(EEG, 1);",
+                "        end",
+                "    case 'pop_newcrossf'",
+                "        if strcmp(variant, 'components')",
+                "            com = pop_newcrossf(EEG, 0);",
+                "        else",
+                "            com = pop_newcrossf(EEG, 1);",
+                "        end",
+                "    case 'pop_signalstat'",
+                "        if strcmp(variant, 'components')",
+                "            com = pop_signalstat(EEG, 0);",
+                "        else",
+                "            com = pop_signalstat(EEG, 1);",
+                "        end",
+                "    case 'pop_eventstat'",
+                "        com = pop_eventstat(EEG);",
                 "    case 'pop_runica'",
                 "        [EEG, com] = pop_runica(EEG);",
                 "    case 'pop_subcomp'",
@@ -1036,7 +1064,7 @@ def _write_matlab_simple_pop_dialog_script(
                 "    EEG.epoch = struct('event', {1, 2});",
                 "    EEG.icaact = zeros(4, EEG.pnts, EEG.trials);",
                 "end",
-                "if any(strcmp(action, {'pop_autorej', 'pop_eegthresh', 'pop_jointprob', 'pop_rejkurt', 'pop_rejmenu', 'pop_rejspec', 'pop_rejtrend'})) || ismember(action, {'pop_timtopo', 'pop_plottopo', 'pop_plotdata', 'pop_erpimage', 'pop_envtopo', 'pop_comperp'})",
+                "if any(strcmp(action, {'pop_autorej', 'pop_eegthresh', 'pop_jointprob', 'pop_rejkurt', 'pop_rejmenu', 'pop_rejspec', 'pop_rejtrend'})) || ismember(action, {'pop_timtopo', 'pop_plottopo', 'pop_plotdata', 'pop_erpimage', 'pop_envtopo', 'pop_comperp', 'pop_newtimef', 'pop_newcrossf', 'pop_signalstat', 'pop_eventstat'})",
                 "    EEG.pnts = 250;",
                 "    EEG.trials = 2;",
                 "    EEG.xmin = -0.2;",
@@ -1813,6 +1841,10 @@ def capture_target(
             "pop_erpimage",
             "pop_envtopo",
             "pop_comperp",
+            "pop_newtimef",
+            "pop_newcrossf",
+            "pop_signalstat",
+            "pop_eventstat",
             "pop_topoplot",
             "coregister",
             "select_multiple_datasets",
@@ -1895,6 +1927,10 @@ def capture_target(
             "pop_erpimage",
             "pop_envtopo",
             "pop_comperp",
+            "pop_newtimef",
+            "pop_newcrossf",
+            "pop_signalstat",
+            "pop_eventstat",
             "pop_topoplot",
             "coregister",
             "pop_autorej",

--- a/tools/visual_parity/cases.json
+++ b/tools/visual_parity/cases.json
@@ -1205,6 +1205,181 @@
       }
     },
     {
+      "id": "pop_newtimef_channels_dialog",
+      "description": "Channel time-frequency dialog opened from pop_newtimef.",
+      "window_size": [930, 531],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_newtimef:channels"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_newtimef_channels_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_newtimef_components_dialog",
+      "description": "Component time-frequency dialog opened from pop_newtimef.",
+      "window_size": [930, 531],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_newtimef:components"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_newtimef_components_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_newcrossf_channels_dialog",
+      "description": "Channel cross-coherence dialog opened from pop_newcrossf.",
+      "window_size": [809, 430],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_newcrossf:channels"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_newcrossf_channels_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_newcrossf_components_dialog",
+      "description": "Component cross-coherence dialog opened from pop_newcrossf.",
+      "window_size": [809, 430],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_newcrossf:components"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_newcrossf_components_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_signalstat_channels_dialog",
+      "description": "Channel signal-statistics dialog opened from pop_signalstat.",
+      "window_size": [420, 150],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_signalstat:channels"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_signalstat_channels_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_signalstat_components_dialog",
+      "description": "Component signal-statistics dialog opened from pop_signalstat.",
+      "window_size": [420, 150],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_signalstat:components"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_signalstat_components_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "pop_eventstat_dialog",
+      "description": "Event-statistics dialog opened from pop_eventstat.",
+      "window_size": [560, 230],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_dialog",
+          "action": "pop_eventstat"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "pop_eventstat_dialog",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
       "id": "pop_runica_dialog",
       "description": "ICA decomposition dialog opened from pop_runica.",
       "window_size": [824, 334],


### PR DESCRIPTION
Add EEGLAB-style time-frequency, cross-coherence, signal statistics, and event statistics workflows with GUI/menu dispatch, help resources, visual parity cases, and sample-data tests. Removes the remaining channel viewprops placeholder because the non-scrolling channel overview is implemented while browser scrolling remains excluded.

Part of #64