### PR TITLE
Phase 6c standalone STUDY integration hardening

### DIFF
--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -2,10 +2,120 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Phase 5c STUDY clustering implementation notes</title>
+  <title>Phase 6c STUDY standalone integration notes</title>
 </head>
 <body>
-  <h1>Phase 5c STUDY clustering implementation notes</h1>
+  <h1>Phase 6c STUDY standalone integration notes</h1>
+
+  <h2>Phase 6c integration scope</h2>
+  <ul>
+    <li>Folded the still-open Phase 5d issue scope into Phase 6c so the final
+      epic integration PR covers the representative end-to-end STUDY workflow
+      requested by issues #80 and #82.</li>
+    <li>Added <code>tests/test_study_end_to_end.py</code> to exercise a
+      multi-dataset STUDY path from saved ICA datasets through
+      <code>pop_study</code>, design editing, channel/component
+      precompute, channel plotting, preclustering, clustering, cluster
+      plotting, study save/load with datasets, and console inspection.</li>
+    <li>Kept the change set scoped to integration bugs, command-history
+      replayability, release docs, runtime dependency audit behavior, and
+      evidence capture. No new feature family was added.</li>
+  </ul>
+
+  <h2>Phase 6c fixes</h2>
+  <ul>
+    <li><code>eeg_checkset</code> now normalizes non-dict
+      <code>EEG["etc"]</code> values before storing ICA RMS-scaling backup
+      fields. The end-to-end load path found this when <code>pop_loadstudy</code>
+      reloaded ICA <code>.set</code> files whose empty MATLAB
+      <code>etc</code> field became an empty NumPy array.</li>
+    <li><code>trialinfo_from_eeg</code> now handles NumPy
+      <code>epoch</code> arrays without using ambiguous array truthiness. This
+      preserves STUDY metadata refresh after loading epoched datasets from disk.</li>
+    <li><code>pop_chanplot</code> history commands now assign back to
+      <code>STUDY</code>. The console integration flow found that the previous
+      bare <code>pop_chanplot(...)</code> command recorded
+      <code>last_chanplot</code> but was not replayable as a STUDY update.</li>
+    <li><code>eeglabcompat.get_eeglab</code> now resolves EEGLAB from
+      <code>EEGPREP_EEGLAB_ROOT</code> or a sibling checkout and fails clearly
+      when neither exists. Runtime compatibility helpers no longer assume a
+      vendored <code>src/eegprep/eeglab</code> checkout exists in an installed
+      package.</li>
+    <li>Updated STUDY docs to remove stale Phase 5 wording, remove a duplicate
+      API section, and include clustering/preclustering wrappers in the public
+      STUDY API summary.</li>
+    <li>Post-PR review follow-up tightened the loaded ICA assertion in the
+      end-to-end test, marked the intentionally unused save result, expanded
+      the external EEGLAB checkout error message, and logged the
+      non-dict <code>EEG["etc"]</code> replacement path at debug level.</li>
+  </ul>
+
+  <h2>Phase 6c audit evidence</h2>
+  <ul>
+    <li>Runtime dependency audit: <code>rg</code> over package runtime paths
+      found no STUDY runtime reads/imports from <code>src/eegprep/eeglab</code>.
+      <code>eeglabcompat</code> now requires an external checkout via
+      <code>EEGPREP_EEGLAB_ROOT</code> or a sibling development checkout for
+      MATLAB/Octave parity helpers.</li>
+    <li>Placeholder/menu audit: <code>tests/test_menu_placeholder_inventory.py</code>
+      passes with only the explicit EEGBrowser/eegplot exclusion remaining.
+      The Phase 6c end-to-end test also asserts all STUDY-owned menu actions
+      are implemented.</li>
+    <li>Menu inventory audit: EEGLAB export succeeded for startup,
+      continuous, epoched, and multiple states. The exporter does not support a
+      <code>study</code> state and failed with
+      <code>Unknown menu inventory state: study</code>. EEGPrep's
+      <code>study</code> inventory was exported separately and shows all Study
+      menu entries enabled in the study state.</li>
+    <li>Inventory differences in supported EEGLAB states are expected
+      EEGPrep-owned labels for plugin/help/update/license/report-issue entries,
+      plus startup ICLabel viewprops enablement. No STUDY-owned missing menu
+      action was found.</li>
+    <li>Visual parity captures: <code>main_window_study</code>,
+      <code>study_menu</code>, <code>pop_study_dialog</code>, and
+      <code>pop_studydesign_dialog</code> captured both EEGLAB and EEGPrep.
+      <code>pop_precomp_dialog</code> EEGLAB capture timed out after 180s;
+      EEGPrep capture succeeded. EEGPrep-only captures succeeded for
+      <code>pop_chanplot_dialog</code>, <code>pop_preclust_dialog</code>,
+      <code>pop_clust_dialog</code>, and
+      <code>pop_clustedit_dialog</code>.</li>
+    <li>GUI Agent QA: Computer Use opened the Qt
+      <code>pop_precomp</code> dialog, verified accessible controls for target
+      mode, measure checkboxes, parameter fields, Help, Cancel, and OK, opened
+      the packaged Help dialog, closed it, edited the spectrum parameter field,
+      enabled ERSPs, pressed OK, and verified the returned dialog result.</li>
+    <li>Console QA: the new end-to-end test initializes
+      <code>EEGPrepConsoleWorkspace</code> with a loaded STUDY, calls
+      <code>pop_chanplot</code> and <code>pop_clustedit</code> through console
+      wrappers, and asserts <code>STUDY</code>,
+      <code>CURRENTSTUDY</code>, <code>LASTCOM</code>, and
+      <code>ALLCOM</code> stay synchronized.</li>
+  </ul>
+
+  <h2>Phase 6c verification</h2>
+  <ul>
+    <li><code>uv run --no-sync ruff check .</code>: passed.</li>
+    <li><code>uv run --no-sync ruff format --check .</code>: passed.</li>
+    <li><code>uv run --no-sync ty check</code>: passed after syncing the
+      optional <code>gui</code> and <code>torch</code> extras.</li>
+    <li><code>uv run --no-sync pytest tests/test_study_end_to_end.py tests/test_study_metadata.py tests/test_study_measures.py tests/test_study_clustering.py tests/test_console_workspace.py tests/test_menu_placeholder_inventory.py -q</code>:
+      119 passed, 1 skipped. The skipped test is the MATLAB-engine STUDY
+      metadata parity check.</li>
+    <li><code>uv run --no-sync pytest tests/test_study_end_to_end.py -m matlab -q</code>:
+      1 skipped, 3 deselected. Exact blocker:
+      <code>matlab.engine</code> is not installed in the uv environment.</li>
+    <li><code>EEGPREP_SKIP_MATLAB=1 uv run --no-sync pytest -m "not slow"</code>:
+      1618 passed, 229 skipped, 11 deselected, 163 warnings.</li>
+    <li><code>uv run --no-sync pytest tests/test_visual_parity.py -q</code>:
+      24 passed, 30 subtests passed.</li>
+    <li><code>uv run --no-sync python tools/visual_parity/capture.py --case main_window_study --target both --timeout 180</code>:
+      both EEGLAB and EEGPrep captures succeeded; compare
+      <code>mean_abs_delta=0.035897</code> and
+      <code>different_pixel_ratio=0.091817</code>.</li>
+    <li><code>uv run --no-sync python tools/visual_parity/capture.py --case pop_precomp_dialog --target both --timeout 180</code>:
+      EEGLAB capture timed out after 180 seconds; EEGPrep capture succeeded.
+      Remaining STUDY dialogs were captured as EEGPrep-only evidence.</li>
+  </ul>
 
   <h2>Parity references inspected</h2>
   <ul>
@@ -104,9 +214,10 @@
     <li>MATLAB parity for exact k-means labels is sensitive to implementation
       differences. Deterministic parity should compare data structures and
       component coverage unless MATLAB and sklearn seeds are explicitly aligned.</li>
-    <li>GUI visual parity captures have been generated and attached to the PR
-      as GitHub user attachments. The local artifacts remain uncommitted under
-      <code>.visual-parity/</code>.</li>
+    <li>GUI visual parity captures have been generated and attached to
+      PR #92 as GitHub user attachments at
+      <code>https://github.com/sccn/eegprep/pull/92#issuecomment-4583627220</code>.
+      The local artifacts remain uncommitted under <code>.visual-parity/</code>.</li>
   </ul>
 
   <h2>Test evidence</h2>

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -238,9 +238,9 @@ for now.
 STUDY Workflows
 ===============
 
-The current STUDY wrappers are exported for parity with EEGLAB menu workflows.
-Phase 5a owns the final STUDY data/session contracts, so avoid treating helper
-objects beyond these wrappers as stable until that phase lands.
+The STUDY wrappers and helpers below cover the integrated standalone STUDY
+workflow: metadata/design creation, study load/save, measure precompute,
+measure plotting, component preclustering, clustering, and cluster editing.
 
 .. autosummary::
    :toctree: generated/
@@ -252,24 +252,9 @@ objects beyond these wrappers as stable until that phase lands.
    eegprep.pop_savestudy
    eegprep.pop_precomp
    eegprep.pop_chanplot
-   eegprep.std_erpplot
-   eegprep.std_specplot
-   eegprep.std_erspplot
-   eegprep.std_itcplot
-
-STUDY Workflows
-===============
-
-.. autosummary::
-   :toctree: generated/
-
-   eegprep.pop_study
-   eegprep.pop_studywizard
-   eegprep.pop_studyerp
-   eegprep.pop_loadstudy
-   eegprep.pop_savestudy
-   eegprep.pop_precomp
-   eegprep.pop_chanplot
+   eegprep.pop_preclust
+   eegprep.pop_clust
+   eegprep.pop_clustedit
    eegprep.std_erpplot
    eegprep.std_specplot
    eegprep.std_erspplot

--- a/docs/source/user_guide/study_workflows.rst
+++ b/docs/source/user_guide/study_workflows.rst
@@ -4,9 +4,9 @@
 STUDY Workflows
 ===============
 
-EEGPrep includes the first standalone STUDY/session surfaces needed for
-group-level workflows. These surfaces are intentionally small on this branch so
-they can coexist with the Phase 5 STUDY workers.
+EEGPrep includes standalone STUDY/session surfaces for common group-level
+workflows. These APIs mirror EEGLAB's STUDY-facing names while storing cached
+measure data in EEGPrep-owned JSON-safe structures.
 
 Implemented Workflows
 =====================
@@ -57,8 +57,8 @@ Channel measures are stored in ``STUDY.changrp``. Component measures are stored
 on the parent ``STUDY.cluster[0]`` entry so preclustering can read the same
 cached arrays. Cached measure fields follow EEGLAB names such as ``erpdata``,
 ``specdata``, ``erspdata``, and ``itcdata``. The selected ``design`` is recorded
-in each measure group's metadata, but Phase 5b arrays are dataset-level averages
-and are not split into EEGLAB design cells yet.
+in each measure group's metadata. EEGPrep stores dataset-level averages in the
+current standalone cache rather than EEGLAB sidecar measure files.
 
 Precluster and cluster ICA components:
 
@@ -83,13 +83,15 @@ The GUI and ``eegprep-console`` share ``STUDY`` and ``CURRENTSTUDY`` through
 ``CURRENTSTUDY`` to ``1``. Retrieving a dataset from the Datasets menu returns
 ``CURRENTSTUDY`` to ``0`` and records that transition in history.
 
-Phase 5 Coordination
-====================
+Integration Notes
+=================
 
-Phase 5b precomputes component ERP, spectrum, ERSP, and ITC arrays on the
-parent ``STUDY.cluster[0]`` entry. Phase 5c preclustering reads those cached
-component arrays and can also build scalp-map features directly from loaded ICA
-maps.
+Component ERP, spectrum, ERSP, and ITC arrays are cached on the parent
+``STUDY.cluster[0]`` entry. Preclustering reads those cached component arrays
+and can also build scalp-map features directly from loaded ICA maps. MATLAB
+parity checks focus on deterministic metadata and cluster structure; exact
+numeric clustering labels can differ because EEGPrep uses deterministic
+scikit-learn k-means rather than MATLAB's implementation.
 
 See the :ref:`interactive_console` guide for mixed GUI plus console usage and
 the :ref:`gui_help_menus` guide for menu inventory behavior.

--- a/src/eegprep/functions/adminfunc/eeg_checkset.py
+++ b/src/eegprep/functions/adminfunc/eeg_checkset.py
@@ -252,7 +252,8 @@ def eeg_checkset(EEG, *checks, load_data=True):
                 scaling = np.sqrt(np.mean(EEG['icawinv'] ** 2, axis=0))
 
                 # Store original weights before scaling
-                if 'etc' not in EEG:
+                if not isinstance(EEG.get('etc'), dict):
+                    logger.debug("Replacing non-dict EEG['etc'] during ICA RMS scaling backup")
                     EEG['etc'] = {}
                 EEG['etc']['icaweights_beforerms'] = EEG['icaweights'].copy()
                 EEG['etc']['icasphere_beforerms'] = EEG['icasphere'].copy()

--- a/src/eegprep/functions/adminfunc/eeglabcompat.py
+++ b/src/eegprep/functions/adminfunc/eeglabcompat.py
@@ -17,6 +17,7 @@ from ..popfunc.pop_saveset import pop_saveset
 logger = logging.getLogger(__name__)
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 REPO_ROOT = PACKAGE_ROOT.parent.parent
+EEGLAB_ROOT_ENV = "EEGPREP_EEGLAB_ROOT"
 
 # can be either 'OCT' (for Oct2Py) or 'MAT' (MATLAB engine)
 default_runtime = 'MAT'
@@ -31,6 +32,25 @@ else:
     temp_dir = str(REPO_ROOT / 'temp')
     if not os.path.exists(temp_dir):
         os.makedirs(temp_dir, exist_ok=True)
+
+
+def _resolve_eeglab_root() -> Path:
+    """Return an external EEGLAB checkout for MATLAB/Octave parity calls."""
+    candidates = []
+    env_root = os.environ.get(EEGLAB_ROOT_ENV)
+    if env_root:
+        candidates.append(Path(env_root).expanduser())
+    candidates.append(REPO_ROOT.parent / 'eeglab')
+
+    for candidate in candidates:
+        if (candidate / 'eeglab.m').is_file():
+            return candidate
+
+    raise ImportError(
+        "EEGLAB reference checkout not found. Set EEGPREP_EEGLAB_ROOT to an "
+        "EEGLAB checkout, or place one alongside the repository, when running "
+        "MATLAB/Octave parity helpers."
+    )
 
 
 class MatlabWrapper:
@@ -225,7 +245,7 @@ def get_eeglab(runtime: str = default_runtime, *, auto_file_roundtrip: bool = Tr
     except KeyError:
         print(f"Loading {runtime} runtime...", end='', flush=True)
         # On the command line, type "octave-8.4.0" OCTAVE_EXECUTABLE or OCTAVE var
-        path2eeglab = str(PACKAGE_ROOT / 'eeglab')
+        path2eeglab = str(_resolve_eeglab_root())
         matlab_test_dir = REPO_ROOT / 'tests' / 'matlab'
         scripts_dir = str(REPO_ROOT / 'scripts')
         print("This is the path2eeglab: ", path2eeglab)

--- a/src/eegprep/functions/studyfunc/_study_utils.py
+++ b/src/eegprep/functions/studyfunc/_study_utils.py
@@ -232,7 +232,9 @@ def trialinfo_from_eeg(eeg: dict[str, Any]) -> list[dict[str, Any]]:
     trials = int(eeg.get("trials", 1) or 1)
     if trials <= 1:
         return []
-    epoch = eeg.get("epoch") or []
+    epoch = eeg.get("epoch")
+    if epoch is None:
+        epoch = []
     if isinstance(epoch, np.ndarray):
         epoch = epoch.tolist()
     if isinstance(epoch, list) and len(epoch) == trials:

--- a/src/eegprep/functions/studyfunc/pop_chanplot.py
+++ b/src/eegprep/functions/studyfunc/pop_chanplot.py
@@ -353,7 +353,7 @@ def _history_command(*, channels: Any, components: Any, measure: str, mode: str)
     }
     rendered = [python_literal(piece) if piece not in {"STUDY", "ALLEEG"} else piece for piece in pieces]
     rendered.extend(f"{key}={python_literal(value)}" for key, value in kwargs.items() if not _is_empty_arg(value))
-    return f"pop_chanplot({', '.join(rendered)})"
+    return f"STUDY = pop_chanplot({', '.join(rendered)})"
 
 
 def _is_empty_arg(value: Any) -> bool:

--- a/tests/test_study_end_to_end.py
+++ b/tests/test_study_end_to_end.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from matplotlib import pyplot as plt
+import numpy as np
+import pytest
+
+from eegprep.functions.adminfunc import eeglabcompat
+from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace
+from eegprep.functions.guifunc.menu_actions import action_kind
+from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.functions.popfunc.pop_saveset import pop_saveset
+from eegprep.functions.studyfunc.pop_chanplot import pop_chanplot
+from eegprep.functions.studyfunc.pop_clust import pop_clust
+from eegprep.functions.studyfunc.pop_clustedit import pop_clustedit
+from eegprep.functions.studyfunc.pop_loadstudy import pop_loadstudy
+from eegprep.functions.studyfunc.pop_preclust import pop_preclust
+from eegprep.functions.studyfunc.pop_precomp import pop_precomp
+from eegprep.functions.studyfunc.pop_savestudy import pop_savestudy
+from eegprep.functions.studyfunc.pop_study import pop_study
+from eegprep.functions.studyfunc.pop_studydesign import pop_studydesign
+from tests.fixtures import create_test_eeg_with_ica, matlab_engine_available
+
+
+def _study_eeg(setname: str, subject: str, condition: str, offset: float) -> dict:
+    eeg = create_test_eeg_with_ica(n_channels=4, n_samples=32, n_trials=3, srate=128, n_components=3)
+    eeg.update(
+        {
+            "setname": setname,
+            "subject": subject,
+            "condition": condition,
+            "group": "control",
+            "session": 1,
+            "run": 1,
+        }
+    )
+    eeg["data"] = np.asarray(eeg["data"], dtype=float) + offset
+    eeg["icaact"] = np.asarray(eeg["icaact"], dtype=float) + offset * 0.1
+    return eeg
+
+
+def _saved_study_datasets(tmp_path: Path) -> list[dict]:
+    np.random.seed(78)
+    datasets = [
+        _study_eeg("s01_target", "S01", "target", 0.0),
+        _study_eeg("s02_standard", "S02", "standard", 1.0),
+    ]
+    for eeg in datasets:
+        path = tmp_path / f"{eeg['setname']}.set"
+        pop_saveset(eeg, str(path))
+        eeg["filename"] = path.name
+        eeg["filepath"] = str(path.parent)
+    return datasets
+
+
+def test_study_end_to_end_workflow_roundtrips_and_syncs_console(tmp_path):
+    alleeg = _saved_study_datasets(tmp_path)
+
+    study, alleeg, create_command = pop_study(
+        None, alleeg, name="Phase 6c study", task="integration QA", return_com=True
+    )
+    study, alleeg, design_command = pop_studydesign(
+        study,
+        alleeg,
+        1,
+        variable1="condition",
+        values1=["target", "standard"],
+        return_com=True,
+    )
+    study, alleeg, channel_command = pop_precomp(
+        study,
+        alleeg,
+        "channels",
+        erp="on",
+        spec="on",
+        return_com=True,
+    )
+    study, plot_command, channel_figure = pop_chanplot(study, alleeg, channels=[1], measure="erp", return_com=True)
+    study, alleeg, component_command = pop_precomp(
+        study,
+        alleeg,
+        "components",
+        erp="on",
+        spec="on",
+        scalp="on",
+        return_com=True,
+    )
+    study, alleeg, preclust_command = pop_preclust(
+        study,
+        alleeg,
+        preproc=[{"measure": "scalp", "npca": 2}],
+        return_com=True,
+    )
+    study, clust_command = pop_clust(study, alleeg, clus_num=2, random_state=78, return_com=True)
+    study, cluster_plot_command, cluster_figure = pop_clustedit(
+        study, alleeg, action="plot", clusters=[2, 3], return_com=True
+    )
+    _saved, save_command = pop_savestudy(study, alleeg, filename="phase_6c.study", filepath=tmp_path, return_com=True)
+    loaded, loaded_alleeg, load_command = pop_loadstudy(
+        "phase_6c.study", filepath=tmp_path, load_datasets=True, return_com=True
+    )
+
+    assert loaded["name"] == "Phase 6c study"
+    assert loaded["currentdesign"] == 1
+    assert loaded["design"][0]["variable"][0]["label"] == "condition"
+    assert loaded["changrp"][0]["measureinfo"]["computed"] == ["erp", "spec"]
+    assert loaded["cluster"][0]["child"] == [cluster["name"] for cluster in loaded["cluster"][1:]]
+    assert sum(len(cluster.get("comps") or []) for cluster in loaded["cluster"][1:]) == 6
+    assert len(loaded_alleeg) == 2
+    assert all(isinstance(eeg.get("etc"), dict) for eeg in loaded_alleeg)
+    assert all(eeg.get("icaweights") is not None and np.asarray(eeg["icaweights"]).size for eeg in loaded_alleeg)
+    assert [info["subject"] for info in loaded["datasetinfo"]] == ["S01", "S02"]
+
+    session = EEGPrepSession(STUDY=loaded, ALLEEG=loaded_alleeg, CURRENTSTUDY=1)
+    workspace = EEGPrepConsoleWorkspace(
+        session,
+        exports={"pop_chanplot": pop_chanplot, "pop_clustedit": pop_clustedit},
+    )
+    console_plot = workspace.namespace["pop_chanplot"](
+        workspace.namespace["STUDY"],
+        workspace.namespace["ALLEEG"],
+        channels=[1],
+        measure="spec",
+    )
+    console_rename = workspace.namespace["pop_clustedit"](
+        workspace.namespace["STUDY"],
+        workspace.namespace["ALLEEG"],
+        action="rename",
+        cluster=2,
+        name="Console QA",
+    )
+
+    assert session.CURRENTSTUDY == 1
+    assert workspace.namespace["STUDY"] is session.STUDY
+    assert session.STUDY["etc"]["last_chanplot"] == {"measure": "spec", "mode": "channels", "channels": [1]}
+    assert session.STUDY["cluster"][1]["name"].startswith("Console QA")
+    assert console_plot.command.startswith("STUDY = pop_chanplot(")
+    assert console_rename.command.startswith("STUDY = pop_clustedit(")
+    assert session.ALLCOM[-2:] == [console_plot.command, console_rename.command]
+
+    for command in (
+        create_command,
+        design_command,
+        channel_command,
+        plot_command,
+        component_command,
+        preclust_command,
+        clust_command,
+        cluster_plot_command,
+        save_command,
+        load_command,
+    ):
+        assert command
+
+    plt.close(channel_figure)
+    plt.close(cluster_figure)
+    plt.close("all")
+
+
+def test_study_menu_actions_owned_by_epic_are_implemented():
+    study_actions = {
+        "pop_study:edit",
+        "pop_studydesign",
+        "pop_precomp:channels",
+        "pop_chanplot",
+        "pop_precomp:components",
+        "pop_preclust",
+        "pop_clust",
+        "pop_clustedit",
+        "select_study_set",
+        "clear_study",
+    }
+
+    assert {action: action_kind(action) for action in study_actions} == {
+        action: "implemented" for action in study_actions
+    }
+
+
+def test_eeglabcompat_requires_external_reference_checkout(monkeypatch, tmp_path):
+    monkeypatch.delenv(eeglabcompat.EEGLAB_ROOT_ENV, raising=False)
+    monkeypatch.setattr(eeglabcompat, "REPO_ROOT", tmp_path / "repo")
+
+    with pytest.raises(ImportError, match=eeglabcompat.EEGLAB_ROOT_ENV):
+        eeglabcompat._resolve_eeglab_root()
+
+
+@pytest.mark.matlab
+@pytest.mark.parity
+def test_study_metadata_matlab_parity_when_reference_is_available():
+    if not matlab_engine_available():
+        pytest.skip("MATLAB engine not available or skipped")
+    eeglab_root = _eeglab_reference_root()
+    if eeglab_root is None:
+        pytest.skip("EEGLAB reference checkout not available; set EEGPREP_EEGLAB_ROOT")
+
+    try:
+        import matlab.engine
+    except ImportError as exc:
+        pytest.skip(f"MATLAB engine not available: {exc}")
+
+    python_study, _python_alleeg, _command = pop_study(
+        None,
+        [
+            _study_eeg("s01_target", "S01", "target", 0.0),
+            _study_eeg("s02_standard", "S02", "standard", 1.0),
+        ],
+        name="Parity study",
+        return_com=True,
+    )
+
+    engine = matlab.engine.start_matlab()
+    try:
+        engine.addpath(engine.genpath(str(eeglab_root)), nargout=0)
+        engine.eval(_matlab_study_metadata_script(), nargout=0)
+        matlab_subjects = list(engine.workspace["parity_subjects"])
+        matlab_conditions = list(engine.workspace["parity_conditions"])
+        matlab_dataset_count = int(engine.workspace["parity_dataset_count"])
+    finally:
+        engine.quit()
+
+    assert matlab_dataset_count == len(python_study["datasetinfo"])
+    assert matlab_subjects == python_study["subject"]
+    assert matlab_conditions == python_study["condition"]
+
+
+def _eeglab_reference_root() -> Path | None:
+    candidates = []
+    if os.environ.get(eeglabcompat.EEGLAB_ROOT_ENV):
+        candidates.append(Path(os.environ[eeglabcompat.EEGLAB_ROOT_ENV]).expanduser())
+    candidates.append(Path(__file__).resolve().parents[1].parent / "eeglab")
+    for candidate in candidates:
+        if (candidate / "eeglab.m").is_file():
+            return candidate
+    return None
+
+
+def _matlab_study_metadata_script() -> str:
+    return """
+clear STUDY ALLEEG parity_subjects parity_conditions parity_dataset_count;
+ALLEEG(1).setname = 's01_target';
+ALLEEG(1).filename = 's01_target.set';
+ALLEEG(1).filepath = '';
+ALLEEG(1).subject = 'S01';
+ALLEEG(1).condition = 'target';
+ALLEEG(1).group = 'control';
+ALLEEG(1).session = 1;
+ALLEEG(1).run = 1;
+ALLEEG(1).data = zeros(4, 32, 3);
+ALLEEG(1).nbchan = 4;
+ALLEEG(1).pnts = 32;
+ALLEEG(1).trials = 3;
+ALLEEG(1).srate = 128;
+ALLEEG(1).xmin = 0;
+ALLEEG(1).xmax = (ALLEEG(1).pnts - 1) / ALLEEG(1).srate;
+ALLEEG(1).chanlocs = struct('labels', {'Ch1' 'Ch2' 'Ch3' 'Ch4'});
+ALLEEG(1).icaweights = eye(3, 4);
+ALLEEG(1).icasphere = eye(4);
+ALLEEG(1).icawinv = pinv(ALLEEG(1).icaweights * ALLEEG(1).icasphere);
+ALLEEG(2) = ALLEEG(1);
+ALLEEG(2).setname = 's02_standard';
+ALLEEG(2).filename = 's02_standard.set';
+ALLEEG(2).subject = 'S02';
+ALLEEG(2).condition = 'standard';
+[STUDY, ALLEEG] = std_editset([], ALLEEG, 'name', 'Parity study');
+[STUDY, ALLEEG] = std_checkset(STUDY, ALLEEG);
+parity_subjects = STUDY.subject;
+parity_conditions = STUDY.condition;
+parity_dataset_count = numel(STUDY.datasetinfo);
+"""


### PR DESCRIPTION
## Motivation

Phase 6c is the final integration and release-hardening pass for the STUDY/standalone epic #78. It also folds in the still-open Phase 5d end-to-end hardening scope so this PR closes both Phase 6c and Phase 5d.

Closes #82
Closes #80

## Final integration scope

- Adds an end-to-end multi-dataset STUDY workflow test covering saved ICA datasets, STUDY creation, design editing, channel and component precompute, plotting, preclustering, clustering, cluster plotting, study save/load with datasets, and console inspection.
- Fixes integration bugs found by that workflow:
  - `eeg_checkset` now normalizes non-dict `EEG["etc"]` before storing ICA RMS-scaling backups from loaded MATLAB files.
  - `trialinfo_from_eeg` handles NumPy `epoch` arrays without ambiguous truth-value checks.
  - `pop_chanplot` now records replayable `STUDY = pop_chanplot(...)` history when it updates `STUDY["etc"]["last_chanplot"]`.
- Removes installed-runtime reliance on a vendored EEGLAB checkout for MATLAB/Octave compatibility helpers. `get_eeglab()` now resolves EEGLAB from `EEGPREP_EEGLAB_ROOT` or a sibling development checkout and fails clearly otherwise.
- Updates STUDY docs/API summary and `.notes/implementation-notes.html` with final integration decisions, QA evidence, parity findings, and open risks.

## End-to-end STUDY workflow evidence

New coverage in `tests/test_study_end_to_end.py` validates:

- create/load path: two saved ICA `.set` fixtures are loaded through `pop_loadstudy(..., load_datasets=True)` after STUDY save/load;
- design path: `pop_studydesign` selects a condition design;
- precompute/plot path: `pop_precomp` computes channel and component measures and `pop_chanplot` records a replayable STUDY history command;
- clustering path: `pop_preclust`, `pop_clust`, and `pop_clustedit(action="plot")` run on the integrated STUDY;
- console sync path: `EEGPrepConsoleWorkspace` calls `pop_chanplot` and `pop_clustedit`, then asserts `STUDY`, `CURRENTSTUDY`, `LASTCOM`, and `ALLCOM` are synchronized.

## Runtime dependency and menu inventory audit

- Runtime grep/audit found no STUDY runtime path reading from `src/eegprep/eeglab`.
- `eeglabcompat` no longer assumes packaged/vendored EEGLAB files exist at runtime.
- Placeholder/menu tests pass with only the explicit EEGBrowser/eegplot exclusion remaining.
- Study-owned menu actions asserted implemented: `pop_study:edit`, `pop_studydesign`, `pop_precomp:channels`, `pop_chanplot`, `pop_precomp:components`, `pop_preclust`, `pop_clust`, `pop_clustedit`, `select_study_set`, and `clear_study`.
- EEGLAB menu inventory exported for startup/continuous/epoched/multiple states. Differences are expected EEGPrep branding/help/plugin-management labels plus startup ICLabel viewprops enablement. EEGLAB exporter does not support a `study` state; EEGPrep study-state inventory was exported separately and shows all Study menu entries enabled.

## Visual parity and GUI Agent QA

Generated local visual parity artifacts under `.visual-parity/` and did not commit them. GitHub user-attachment evidence is posted in PR comment https://github.com/sccn/eegprep/pull/92#issuecomment-4583627220.

- `main_window_study`: EEGLAB and EEGPrep captures succeeded; compare report `mean_abs_delta=0.035897`, `different_pixel_ratio=0.091817`.
- `study_menu`, `pop_study_dialog`, `pop_studydesign_dialog`: both EEGLAB and EEGPrep captures succeeded; compare metrics are dominated by macOS crop/window-size mismatch and known dialog-scope differences.
- `pop_precomp_dialog`: EEGPrep capture succeeded; EEGLAB capture timed out after 180 seconds.
- `pop_chanplot_dialog`, `pop_preclust_dialog`, `pop_clust_dialog`, `pop_clustedit_dialog`: EEGPrep-only captures succeeded after the EEGLAB timeout.

GUI Agent QA used Computer Use against the Qt `pop_precomp` dialog:

- verified accessible controls for target mode, measure checkboxes, parameter fields, Help, Cancel, and OK;
- opened and closed packaged Help for `pop_precomp`;
- edited spectrum params to `'winsize', 32`, enabled ERSPs, pressed OK, and verified the returned dialog result.

## Verification

- `uv run --no-sync ruff check .` passed.
- `uv run --no-sync ruff format --check .` passed.
- `uv run --no-sync ty check` passed after syncing optional `gui` and `torch` extras.
- `uv run --no-sync pytest tests/test_study_end_to_end.py tests/test_study_metadata.py tests/test_study_measures.py tests/test_study_clustering.py tests/test_console_workspace.py tests/test_menu_placeholder_inventory.py -q`: 119 passed, 1 skipped.
- `uv run --no-sync pytest tests/test_study_end_to_end.py -m matlab -q`: 1 skipped, 3 deselected. Exact blocker: `matlab.engine` is not installed in the uv environment.
- `EEGPREP_SKIP_MATLAB=1 uv run --no-sync pytest -m "not slow"`: 1618 passed, 229 skipped, 11 deselected, 163 warnings.
- `uv run --no-sync pytest tests/test_visual_parity.py -q`: 24 passed, 30 subtests passed.
- `./pre-commit.py`: passed on staged files.

## Remaining risks

- Exact k-means labels remain implementation-sensitive because EEGPrep uses deterministic scikit-learn k-means rather than MATLAB k-means. The integration test asserts component coverage and cluster structure rather than exact label parity.
- MATLAB-enabled STUDY metadata parity test is present but skipped locally because the MATLAB Python engine is unavailable, even though the MATLAB CLI exists.

