### PR TITLE
Implement pop_eegplot menu session workflows

### DIFF
--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -17,6 +17,7 @@ from typing import Any
 import eegprep
 from eegprep.functions.adminfunc.eeglab import gui
 from eegprep.functions.guifunc.session import EEGPrepSession, normalize_dataset_indices
+from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
 from eegprep.functions.popfunc.pop_newset import pop_newset
 
 
@@ -155,6 +156,20 @@ class ConsolePopFunction(LazyWorkspaceExport):
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         function = self.resolve()
         call_kwargs = dict(kwargs)
+        if self.name == "pop_eegplot" and "command_callback" not in call_kwargs:
+            source_eeg = _first_call_eeg_argument(args, call_kwargs)
+            reject = _pop_eegplot_reject_argument(args, call_kwargs)
+
+            def accept_eegplot(eeg_out: Any, command: str) -> None:
+                if not isinstance(source_eeg, dict) or not isinstance(eeg_out, dict):
+                    return
+                store_new = eegplot_accept_creates_dataset(source_eeg, eeg_out, reject)
+                store_command = "" if command == self.bridge.session.LASTCOM else command
+                self.bridge._store_eeg(eeg_out, store_command, new=store_new)
+                self.bridge.pull_from_session()
+                self.bridge._refresh()
+
+            call_kwargs["command_callback"] = accept_eegplot
         if _accepts_return_com(function) and "return_com" not in call_kwargs:
             call_kwargs["return_com"] = True
         result = function(*args, **call_kwargs)
@@ -1192,6 +1207,14 @@ def _first_call_eeg_argument(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -
     if args:
         return args[0]
     return kwargs.get("EEG")
+
+
+def _pop_eegplot_reject_argument(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> int:
+    if "reject" in kwargs:
+        return int(kwargs["reject"])
+    if len(args) >= 4:
+        return int(args[3])
+    return 1
 
 
 def _is_eeg_selection(value: Any) -> bool:

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -156,16 +156,20 @@ class ConsolePopFunction(LazyWorkspaceExport):
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         function = self.resolve()
         call_kwargs = dict(kwargs)
+        recorded_commands: set[str] = set()
         if self.name == "pop_eegplot" and "command_callback" not in call_kwargs:
             source_eeg = _first_call_eeg_argument(args, call_kwargs)
-            reject = _pop_eegplot_reject_argument(args, call_kwargs)
+            reject = _pop_eegplot_reject_argument(function, args, call_kwargs)
+            target_index = list(self.bridge.session.CURRENTSET)
 
             def accept_eegplot(eeg_out: Any, command: str) -> None:
                 if not isinstance(source_eeg, dict) or not isinstance(eeg_out, dict):
                     return
                 store_new = eegplot_accept_creates_dataset(source_eeg, eeg_out, reject)
-                store_command = "" if command == self.bridge.session.LASTCOM else command
-                self.bridge._store_eeg(eeg_out, store_command, new=store_new)
+                store_command = "" if command in recorded_commands else command
+                recorded_commands.add(command)
+                store_index = None if store_new else target_index
+                self.bridge._store_eeg(eeg_out, store_command, new=store_new, index=store_index)
                 self.bridge.pull_from_session()
                 self.bridge._refresh()
 
@@ -173,6 +177,10 @@ class ConsolePopFunction(LazyWorkspaceExport):
         if _accepts_return_com(function) and "return_com" not in call_kwargs:
             call_kwargs["return_com"] = True
         result = function(*args, **call_kwargs)
+        if self.name == "pop_eegplot":
+            _eeg, command = _extract_pop_eeg_and_command(result)
+            if command:
+                recorded_commands.add(command)
         return self.bridge.accept_pop_result(result, args, kwargs)
 
     def __repr__(self) -> str:
@@ -403,10 +411,10 @@ class EEGPrepConsoleWorkspace:
             elif export_name.startswith("pop_"):
                 self.namespace[local_name] = self.pop_wrapper(export_name)
 
-    def _store_eeg(self, eeg: Any, command: str, *, new: bool = False) -> None:
+    def _store_eeg(self, eeg: Any, command: str, *, new: bool = False, index: int | list[int] | None = None) -> None:
         self._syncing = True
         try:
-            self.session.store_current(eeg, new=new, command=command)
+            self.session.store_current(eeg, new=new, command=command, index=index)
         finally:
             self._syncing = False
 
@@ -1209,12 +1217,9 @@ def _first_call_eeg_argument(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -
     return kwargs.get("EEG")
 
 
-def _pop_eegplot_reject_argument(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> int:
-    if "reject" in kwargs:
-        return int(kwargs["reject"])
-    if len(args) >= 4:
-        return int(args[3])
-    return 1
+def _pop_eegplot_reject_argument(function: Callable[..., Any], args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> int:
+    bound = inspect.signature(function).bind_partial(*args, **kwargs)
+    return int(bound.arguments.get("reject", 1))
 
 
 def _is_eeg_selection(value: Any) -> bool:

--- a/src/eegprep/functions/guifunc/eeglab_menu.py
+++ b/src/eegprep/functions/guifunc/eeglab_menu.py
@@ -16,8 +16,10 @@ from eegprep.plugins.firfilt.menu import firfilt_filter_items
 ON = "study:on"
 ON_NO_STUDY = ""
 ON_DATA = "startup:off"
+ON_DATA_ICA = "startup:off;ica:on"
 ON_DATA_NO_ROI = "startup:off;roi:off"
 ON_EPOCH = "startup:off;continuous:off"
+ON_EPOCH_ICA = "startup:off;continuous:off;ica:on"
 ON_EPOCH_NO_ROI = "startup:off;continuous:off;roi:off"
 ON_DATA_STUDY = "startup:off;study:on"
 ON_DATA_STUDY_NO_ROI = "startup:off;study:on;roi:off"
@@ -194,7 +196,7 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
                 children=[
                     menu_item("Reject components by map", action="pop_selectcomps", userdata=ON_DATA),
                     menu_item("Reject data (all methods)", action="pop_rejmenu:ica", userdata=ON_EPOCH, separator=True),
-                    menu_item("Reject by inspection", action="pop_eegplot:reject_ica", userdata=ON_EPOCH),
+                    menu_item("Reject by inspection", action="pop_eegplot:reject_ica", userdata=ON_EPOCH_ICA),
                     menu_item("Reject extreme values", action="pop_eegthresh:ica", userdata=ON_EPOCH),
                     menu_item("Reject by linear trend/variance", action="pop_rejtrend:ica", userdata=ON_EPOCH),
                     menu_item("Reject by probability", action="pop_jointprob:ica", userdata=ON_EPOCH),
@@ -251,7 +253,10 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
             menu_item("Sum/Compare ERPs", action="pop_comperp:channels", userdata=ON_EPOCH, visibility="allmenus"),
             menu_item("Channel time-frequency", action="pop_newtimef:channels", visibility="default"),
             menu_item(
-                "Component activations (scroll)", action="pop_eegplot:components", userdata=ON_DATA, separator=True
+                "Component activations (scroll)",
+                action="pop_eegplot:components",
+                userdata=ON_DATA_ICA,
+                separator=True,
             ),
             menu_item("Component spectra and maps", action="pop_spectopo:components", userdata=ON_DATA_NO_ROI),
             menu_item(

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -1015,19 +1015,30 @@ class MenuActionDispatcher:
 
             out = pop_subcomp(selection, return_com=True)
         elif name == "pop_eegplot":
-            from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
+            from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset, pop_eegplot
+
+            icacomp, superpose, reject = _pop_eegplot_variant_options(variant)
 
             def accept_eegplot(eeg_out: Any, command: str) -> None:
                 with self.session.gui_action("pop_eegplot"):
                     if command:
-                        self._store_current_from_gui(eeg_out, command=command)
+                        store_new = eegplot_accept_creates_dataset(selection, eeg_out, reject)
+                        store_command = "" if command == self.session.LASTCOM else command
+                        self._store_current_from_gui(eeg_out, new=store_new, command=store_command)
                         self._refresh()
 
-            pop_eegplot(
+            out = pop_eegplot(
                 selection,
-                icacomp=0 if variant in {"components", "reject_ica"} else 1,
+                icacomp=icacomp,
+                superpose=superpose,
+                reject=reject,
                 command_callback=accept_eegplot,
+                return_com=True,
             )
+            command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
+            if command:
+                self._add_history_from_gui(command)
+                self._refresh()
             return
         elif name == "pop_autorej":
             from eegprep.functions.popfunc.pop_autorej import pop_autorej
@@ -1464,6 +1475,16 @@ def _currentset_list(value: Any) -> list[int]:
         return [int(item) for item in value if int(item) > 0]
     current = int(value)
     return [current] if current > 0 else []
+
+
+def _pop_eegplot_variant_options(variant: str) -> tuple[int, int, int]:
+    if variant == "components":
+        return 0, 1, 1
+    if variant == "reject_ica":
+        return 0, 0, 1
+    if variant == "channels":
+        return 1, 1, 1
+    return 1, 0, 1
 
 
 def _apply_save_metadata(eeg: dict[str, Any], filename: str) -> None:

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -1018,13 +1018,22 @@ class MenuActionDispatcher:
             from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset, pop_eegplot
 
             icacomp, superpose, reject = _pop_eegplot_variant_options(variant)
+            target_index = list(self.session.CURRENTSET)
+            recorded_commands: set[str] = set()
 
             def accept_eegplot(eeg_out: Any, command: str) -> None:
                 with self.session.gui_action("pop_eegplot"):
                     if command:
                         store_new = eegplot_accept_creates_dataset(selection, eeg_out, reject)
-                        store_command = "" if command == self.session.LASTCOM else command
-                        self._store_current_from_gui(eeg_out, new=store_new, command=store_command)
+                        store_command = "" if command in recorded_commands else command
+                        recorded_commands.add(command)
+                        store_index = None if store_new else target_index
+                        self._store_current_from_gui(
+                            eeg_out,
+                            new=store_new,
+                            command=store_command,
+                            index=store_index,
+                        )
                         self._refresh()
 
             out = pop_eegplot(
@@ -1038,6 +1047,7 @@ class MenuActionDispatcher:
             command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
             if command:
                 self._add_history_from_gui(command)
+                recorded_commands.add(command)
                 self._refresh()
             return
         elif name == "pop_autorej":
@@ -1478,6 +1488,8 @@ def _currentset_list(value: Any) -> list[int]:
 
 
 def _pop_eegplot_variant_options(variant: str) -> tuple[int, int, int]:
+    # Mirrors eeglab.m callbacks: cb_eegplot/cb_eegplotrej* omit optional args,
+    # while Plot scroll actions explicitly call pop_eegplot(EEG, icacomp, 1, 1).
     if variant == "components":
         return 0, 1, 1
     if variant == "reject_ica":

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -178,18 +178,31 @@ class EEGPrepSession:
         new: bool = False,
         command: str = "",
         mark_saved: bool = False,
+        index: int | list[int] | None = None,
     ) -> int | list[int]:
         """Store ``eeg`` in ALLEEG and select it."""
-        if isinstance(eeg, list):
+        if index is not None:
             if new:
-                index: int | list[int] | None = [0] * len(eeg)
-            elif len(self.CURRENTSET) == len(eeg):
-                index = list(self.CURRENTSET)
+                raise ValueError("new and index cannot both be set")
+            normalized_index = normalize_dataset_indices(index, allow_empty=False)
+            if isinstance(eeg, list):
+                if len(normalized_index) != len(eeg):
+                    raise ValueError("Length of EEG list must equal length of index")
+                store_index: int | list[int] = normalized_index
             else:
-                index = None
+                if len(normalized_index) != 1:
+                    raise ValueError("A single EEG dataset must be stored to one index")
+                store_index = normalized_index[0]
+        elif isinstance(eeg, list):
+            if new:
+                store_index = [0] * len(eeg)
+            elif len(self.CURRENTSET) == len(eeg):
+                store_index = list(self.CURRENTSET)
+            else:
+                store_index = None
         else:
-            index = 0 if new or not self.CURRENTSET else self.CURRENTSET[0]
-        self.ALLEEG, checked, stored_index = eeg_store(self.ALLEEG, eeg, index)
+            store_index = 0 if new or not self.CURRENTSET else self.CURRENTSET[0]
+        self.ALLEEG, checked, stored_index = eeg_store(self.ALLEEG, eeg, store_index)
         self.EEG = checked
         self.CURRENTSET = normalize_dataset_indices(stored_index, allow_empty=False)
         if mark_saved:

--- a/src/eegprep/functions/popfunc/pop_eegplot.py
+++ b/src/eegprep/functions/popfunc/pop_eegplot.py
@@ -100,7 +100,13 @@ def pop_eegplot(
 
 
 def eegplot_accept_creates_dataset(input_eeg: dict[str, Any], output_eeg: dict[str, Any], reject: int = 1) -> bool:
-    """Return whether an accepted ``pop_eegplot`` result should be stored as a new dataset."""
+    """Return whether accepted ``pop_eegplot`` output should be a new dataset.
+
+    Rejection accepts that remove continuous samples or epochs create a new
+    EEGLAB-style dataset. Mark-only updates and no-op rejects update in place.
+    For example, ``(pnts=100, pnts=80, reject=1)`` returns true, while
+    ``(pnts=100, pnts=100, reject=1)`` and any ``reject=0`` call return false.
+    """
     if not int(bool(reject)):
         return False
     input_trials = int(input_eeg.get("trials", 1) or 1)

--- a/src/eegprep/functions/popfunc/pop_eegplot.py
+++ b/src/eegprep/functions/popfunc/pop_eegplot.py
@@ -56,6 +56,8 @@ def pop_eegplot(
         return (None, "") if return_com else None
     if icacomp not in {0, 1}:
         raise ValueError("icacomp must be 1 for data channels or 0 for components")
+    if int(bool(icacomp)) == 0:
+        _require_ica(EEG)
     options = dict(kwargs)
     options.setdefault("srate", EEG.get("srate", 256))
     options.setdefault(
@@ -95,6 +97,17 @@ def pop_eegplot(
         window = eegplot(EEG, *args, show=show, **options)
     command = history_command("pop_eegplot", icacomp, superpose, reject)
     return (EEG, command) if return_com else window
+
+
+def eegplot_accept_creates_dataset(input_eeg: dict[str, Any], output_eeg: dict[str, Any], reject: int = 1) -> bool:
+    """Return whether an accepted ``pop_eegplot`` result should be stored as a new dataset."""
+    if not int(bool(reject)):
+        return False
+    input_trials = int(input_eeg.get("trials", 1) or 1)
+    output_trials = int(output_eeg.get("trials", 1) or 1)
+    if input_trials > 1:
+        return output_trials < input_trials
+    return _dataset_pnts(output_eeg) < _dataset_pnts(input_eeg)
 
 
 def apply_eegplot_rejections(
@@ -289,6 +302,27 @@ def _row_count(EEG: dict[str, Any], icacomp: int) -> int:
     return int(weights.shape[0]) if weights.ndim == 2 else 0
 
 
+def _require_ica(EEG: dict[str, Any]) -> None:
+    if _nonempty_array(EEG.get("icaact")):
+        return
+    if _nonempty_array(EEG.get("icaweights")) and _nonempty_array(EEG.get("icasphere")):
+        return
+    raise ValueError("You must run ICA before browsing component activations with pop_eegplot.")
+
+
+def _nonempty_array(value: Any) -> bool:
+    return value is not None and np.asarray(value).size > 0
+
+
+def _dataset_pnts(EEG: dict[str, Any]) -> int:
+    if "pnts" in EEG:
+        return int(EEG.get("pnts", 0) or 0)
+    data = np.asarray(EEG.get("data"))
+    if data.ndim >= 2:
+        return int(data.shape[1])
+    return 0
+
+
 def _displayed_rejection_families(reject: dict[str, Any]) -> tuple[str, ...]:
     disprej = reject.get("disprej")
     if disprej is None or np.asarray(disprej, dtype=object).size == 0:
@@ -320,4 +354,4 @@ def _reject_color(
     return tuple(float(item) for item in values[:3])
 
 
-__all__ = ["apply_eegplot_rejections", "pop_eegplot"]
+__all__ = ["apply_eegplot_rejections", "eegplot_accept_creates_dataset", "pop_eegplot"]

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -12,6 +12,7 @@ import pytest
 
 from eegprep.functions.adminfunc import console as console_module
 from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace
+from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.session import EEGPrepSession
 
 
@@ -46,6 +47,23 @@ def _fake_pop_without_command(eeg, *, return_com=False):
 def _fake_pop_topoplot(eeg, *, return_com=False):
     command = "pop_topoplot(EEG, typeplot=1, items=[0])"
     return (["figure"], command) if return_com else ["figure"]
+
+
+def _fake_pop_eegplot(
+    eeg,
+    icacomp=1,
+    superpose=0,
+    reject=1,
+    *,
+    command_callback=None,
+    return_com=False,
+):
+    _fake_pop_eegplot.command_callback = command_callback
+    command = f"pop_eegplot(EEG, {icacomp}, {superpose}, {reject})"
+    return (eeg, command) if return_com else "window"
+
+
+_fake_pop_eegplot.command_callback = None
 
 
 def _fake_pop_copyset(ALLEEG, set_in, set_out=None, *, return_com=False):
@@ -625,6 +643,76 @@ def test_non_mutating_pop_plot_call_records_history_without_storing_dataset():
     assert result == (["figure"], "pop_topoplot(EEG, typeplot=1, items=[0])")
     assert session.EEG is original_eeg
     assert session.ALLCOM == ["pop_topoplot(EEG, typeplot=1, items=[0])"]
+
+
+def test_gui_pop_eegplot_accept_updates_console_namespace_without_duplicate_history():
+    session = EEGPrepSession()
+    eeg = _demo_eeg()
+    eeg["data"] = np.arange(8, dtype=float).reshape(2, 4)
+    eeg["pnts"] = 4
+    eeg["xmax"] = 0.03
+    session.store_current(eeg, new=True)
+    refresh = mock.Mock()
+    workspace = EEGPrepConsoleWorkspace(session, refresh=refresh, exports={})
+    dispatcher = MenuActionDispatcher(session)
+    captured = {}
+    command = "pop_eegplot(EEG, 1, 0, 1)"
+
+    def fake_pop_eegplot(eeg_in, *, command_callback=None, return_com=False, **_kwargs):
+        captured["callback"] = command_callback
+        assert eeg_in is session.EEG
+        assert return_com is True
+        return eeg_in, command
+
+    with mock.patch("eegprep.functions.popfunc.pop_eegplot.pop_eegplot", side_effect=fake_pop_eegplot):
+        dispatcher.dispatch("pop_eegplot:data")
+
+    assert workspace.namespace["LASTCOM"] == command
+    assert workspace.namespace["CURRENTSET"] == 1
+    assert session.ALLCOM == [command]
+
+    out = dict(session.EEG)
+    out["data"] = np.asarray(out["data"])[:, :2]
+    out["pnts"] = 2
+    out["xmax"] = 0.01
+    captured["callback"](out, command)
+
+    assert workspace.namespace["CURRENTSET"] == 2
+    assert workspace.namespace["EEG"]["pnts"] == 2
+    assert len(workspace.namespace["ALLEEG"]) == 2
+    assert session.ALLCOM == [command]
+
+
+def test_console_pop_eegplot_accept_callback_refreshes_session_after_browser_accept():
+    session = EEGPrepSession()
+    eeg = _demo_eeg()
+    eeg["data"] = np.arange(8, dtype=float).reshape(2, 4)
+    eeg["pnts"] = 4
+    eeg["xmax"] = 0.03
+    session.store_current(eeg, new=True)
+    refresh = mock.Mock()
+    workspace = EEGPrepConsoleWorkspace(session, refresh=refresh, exports={"pop_eegplot": _fake_pop_eegplot})
+
+    result = workspace.namespace["pop_eegplot"](workspace.namespace["EEG"])
+    workspace.after_execute("pop_eegplot(EEG)")
+
+    eeg_out, command = result
+    assert eeg_out is session.EEG
+    assert command == "pop_eegplot(EEG, 1, 0, 1)"
+    assert session.ALLCOM == [command]
+    assert callable(_fake_pop_eegplot.command_callback)
+
+    out = dict(session.EEG)
+    out["data"] = np.asarray(out["data"])[:, :2]
+    out["pnts"] = 2
+    out["xmax"] = 0.01
+    _fake_pop_eegplot.command_callback(out, command)
+
+    assert session.CURRENTSET == [2]
+    assert session.EEG["pnts"] == 2
+    assert len(session.ALLEEG) == 2
+    assert session.ALLCOM == [command]
+    assert refresh.call_count >= 2
 
 
 def test_bare_dataset_pop_call_updates_alleeg_eeg_currentset_and_history():

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -715,6 +715,32 @@ def test_console_pop_eegplot_accept_callback_refreshes_session_after_browser_acc
     assert refresh.call_count >= 2
 
 
+def test_console_pop_eegplot_positional_reject_argument_controls_accept_storage():
+    session = EEGPrepSession()
+    eeg = _demo_eeg()
+    eeg["data"] = np.arange(8, dtype=float).reshape(2, 4)
+    eeg["pnts"] = 4
+    eeg["xmax"] = 0.03
+    session.store_current(eeg, new=True)
+    workspace = EEGPrepConsoleWorkspace(session, exports={"pop_eegplot": _fake_pop_eegplot})
+
+    result = workspace.namespace["pop_eegplot"](workspace.namespace["EEG"], 1, 0, 0)
+    workspace.after_execute("pop_eegplot(EEG, 1, 0, 0)")
+
+    _eeg_out, command = result
+    assert command == "pop_eegplot(EEG, 1, 0, 0)"
+    out = dict(session.EEG)
+    out["data"] = np.asarray(out["data"])[:, :2]
+    out["pnts"] = 2
+    out["xmax"] = 0.01
+    _fake_pop_eegplot.command_callback(out, command)
+
+    assert session.CURRENTSET == [1]
+    assert session.EEG["pnts"] == 2
+    assert len(session.ALLEEG) == 1
+    assert session.ALLCOM == [command]
+
+
 def test_bare_dataset_pop_call_updates_alleeg_eeg_currentset_and_history():
     session = EEGPrepSession()
     session.store_current(_demo_eeg(), new=True)

--- a/tests/test_eegplot.py
+++ b/tests/test_eegplot.py
@@ -9,6 +9,7 @@ import eegprep.functions.sigprocfunc.eegplot as eegplot_module
 import eegprep.functions.popfunc.pop_eegplot as pop_eegplot_module
 from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
 from eegprep.functions.popfunc.pop_eegplot import apply_eegplot_rejections
+from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.sigprocfunc.eegplot import (
     add_winrej_region,
@@ -411,6 +412,8 @@ def test_pop_eegplot_loads_continuous_mark_only_rows_when_updating_or_superposin
 
 def test_pop_eegplot_component_mode_computes_activations_once(monkeypatch: pytest.MonkeyPatch) -> None:
     eeg = create_test_eeg(n_channels=2, n_samples=10, n_trials=1, srate=10)
+    eeg["icaweights"] = np.eye(2)
+    eeg["icasphere"] = np.eye(2)
     calls = 0
 
     def fake_component_activations(dataset: dict) -> np.ndarray:
@@ -428,6 +431,25 @@ def test_pop_eegplot_component_mode_computes_activations_once(monkeypatch: pytes
     assert command == "pop_eegplot(EEG, 0, 0, 1)"
 
 
+def test_pop_eegplot_component_mode_requires_ica() -> None:
+    eeg = create_test_eeg(n_channels=2, n_samples=10, n_trials=1, srate=10)
+
+    with pytest.raises(ValueError, match="run ICA"):
+        pop_eegplot(eeg, icacomp=0, show=False)
+
+
+def test_eegplot_accept_creates_dataset_only_when_reject_removes_data() -> None:
+    continuous = create_test_eeg(n_channels=1, n_samples=10, n_trials=1, srate=10)
+    continuous_out = dict(continuous, pnts=7, data=np.zeros((1, 7)))
+    epoched = create_test_eeg(n_channels=1, n_samples=4, n_trials=3, srate=10)
+    epoched_out = dict(epoched, trials=2, data=np.zeros((1, 4, 2)))
+
+    assert eegplot_accept_creates_dataset(continuous, continuous_out, reject=1) is True
+    assert eegplot_accept_creates_dataset(epoched, epoched_out, reject=1) is True
+    assert eegplot_accept_creates_dataset(continuous, continuous_out, reject=0) is False
+    assert eegplot_accept_creates_dataset(continuous, continuous, reject=1) is False
+
+
 def test_sample_data_eeglab_set_builds_non_mutating_model() -> None:
     eeg = pop_loadset(str(SAMPLE_DATASET))
     data_before = np.array(eeg["data"], copy=True)
@@ -436,4 +458,16 @@ def test_sample_data_eeglab_set_builds_non_mutating_model() -> None:
 
     assert model.data.n_channels == int(eeg["nbchan"])
     assert model.state.srate == float(eeg["srate"])
+    np.testing.assert_array_equal(eeg["data"], data_before)
+
+
+def test_sample_data_pop_eegplot_channel_api_flow_returns_browser_model() -> None:
+    eeg = pop_loadset(str(SAMPLE_DATASET))
+    data_before = np.array(eeg["data"], copy=True)
+
+    model = pop_eegplot(eeg, superpose=1, show=False, winlength=1)
+
+    assert model.data.mode == "continuous"
+    assert model.data.n_channels == int(eeg["nbchan"])
+    assert model.state.title.startswith("Scroll channel activities -- eegplot()")
     np.testing.assert_array_equal(eeg["data"], data_before)

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -632,6 +632,7 @@ class MenuActionDispatcherTests(unittest.TestCase):
             dispatcher.dispatch("pop_eegplot:data")
 
         self.assertEqual(session.ALLCOM, [command])
+        session.add_history("EEG = pop_reref(EEG);")
         out = dict(session.EEG)
         out["data"] = np.asarray(out["data"])[:, :20]
         out["pnts"] = 20
@@ -641,8 +642,39 @@ class MenuActionDispatcherTests(unittest.TestCase):
         self.assertEqual(len(session.ALLEEG), 2)
         self.assertEqual(session.CURRENTSET, [2])
         self.assertEqual(session.EEG["pnts"], 20)
-        self.assertEqual(session.ALLCOM, [command])
+        self.assertEqual(session.ALLCOM, [command, "EEG = pop_reref(EEG);"])
         self.assertGreaterEqual(refresh.call_count, 2)
+
+    def test_pop_eegplot_accept_updates_original_dataset_after_selection_changes(self):
+        session = EEGPrepSession()
+        first = _demo_eeg()
+        second = _demo_eeg()
+        second["setname"] = "second"
+        session.store_current(first, new=True)
+        session.store_current(second, new=True)
+        session.retrieve(1)
+        dispatcher = MenuActionDispatcher(session)
+        captured = {}
+        command = "pop_eegplot(EEG, 1, 0, 1)"
+
+        def fake_pop_eegplot(eeg, *, command_callback=None, return_com=False, **_kwargs):
+            captured["callback"] = command_callback
+            self.assertEqual(eeg["setname"], "demo")
+            self.assertTrue(return_com)
+            return eeg, command
+
+        with mock.patch("eegprep.functions.popfunc.pop_eegplot.pop_eegplot", side_effect=fake_pop_eegplot):
+            dispatcher.dispatch("pop_eegplot:data")
+
+        session.retrieve(2)
+        out = dict(first, setname="accepted first")
+        captured["callback"](out, command)
+
+        self.assertEqual(session.CURRENTSET, [1])
+        self.assertEqual(session.EEG["setname"], "accepted first")
+        self.assertEqual(session.ALLEEG[0]["setname"], "accepted first")
+        self.assertEqual(session.ALLEEG[1]["setname"], "second")
+        self.assertEqual(session.ALLCOM, [command])
 
     def test_pop_eegplot_component_menu_error_does_not_mutate_session_when_ica_missing(self):
         session = EEGPrepSession()

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -572,6 +572,118 @@ class MenuActionDispatcherTests(unittest.TestCase):
         self.assertEqual(session.ALLCOM[-1], "CURRENTSTUDY = 1")
         self.assertEqual(session.menu_statuses(), {"study"})
 
+    def test_pop_eegplot_menu_variants_use_eeglab_parity_arguments(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(epoched=True, ica=True), new=True)
+        dispatcher = MenuActionDispatcher(session)
+        calls = []
+
+        def fake_pop_eegplot(
+            eeg,
+            *,
+            icacomp=1,
+            superpose=0,
+            reject=1,
+            command_callback=None,
+            return_com=False,
+        ):
+            self.assertIs(eeg, session.EEG)
+            self.assertTrue(callable(command_callback))
+            self.assertTrue(return_com)
+            calls.append((icacomp, superpose, reject))
+            return eeg, f"pop_eegplot(EEG, {icacomp}, {superpose}, {reject})"
+
+        with mock.patch("eegprep.functions.popfunc.pop_eegplot.pop_eegplot", side_effect=fake_pop_eegplot):
+            for action in (
+                "pop_eegplot:data",
+                "pop_eegplot:channels",
+                "pop_eegplot:components",
+                "pop_eegplot:reject_data",
+                "pop_eegplot:reject_ica",
+            ):
+                dispatcher.dispatch(action)
+
+        self.assertEqual(calls, [(1, 0, 1), (1, 1, 1), (0, 1, 1), (1, 0, 1), (0, 0, 1)])
+        self.assertEqual(
+            session.ALLCOM,
+            [
+                "pop_eegplot(EEG, 1, 0, 1)",
+                "pop_eegplot(EEG, 1, 1, 1)",
+                "pop_eegplot(EEG, 0, 1, 1)",
+                "pop_eegplot(EEG, 1, 0, 1)",
+                "pop_eegplot(EEG, 0, 0, 1)",
+            ],
+        )
+
+    def test_pop_eegplot_accept_stores_rejected_continuous_data_as_new_dataset_without_duplicate_history(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(), new=True)
+        refresh = mock.Mock()
+        dispatcher = MenuActionDispatcher(session, refresh=refresh)
+        captured = {}
+        command = "pop_eegplot(EEG, 1, 0, 1)"
+
+        def fake_pop_eegplot(eeg, *, command_callback=None, return_com=False, **_kwargs):
+            captured["callback"] = command_callback
+            self.assertTrue(return_com)
+            return eeg, command
+
+        with mock.patch("eegprep.functions.popfunc.pop_eegplot.pop_eegplot", side_effect=fake_pop_eegplot):
+            dispatcher.dispatch("pop_eegplot:data")
+
+        self.assertEqual(session.ALLCOM, [command])
+        out = dict(session.EEG)
+        out["data"] = np.asarray(out["data"])[:, :20]
+        out["pnts"] = 20
+        out["xmax"] = 0.19
+        captured["callback"](out, command)
+
+        self.assertEqual(len(session.ALLEEG), 2)
+        self.assertEqual(session.CURRENTSET, [2])
+        self.assertEqual(session.EEG["pnts"], 20)
+        self.assertEqual(session.ALLCOM, [command])
+        self.assertGreaterEqual(refresh.call_count, 2)
+
+    def test_pop_eegplot_component_menu_error_does_not_mutate_session_when_ica_missing(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(ica=False), new=True)
+        original_history = list(session.ALLCOM)
+        original_currentset = list(session.CURRENTSET)
+        dispatcher = MenuActionDispatcher(session)
+
+        with self.assertRaisesRegex(ValueError, "run ICA"):
+            dispatcher.dispatch("pop_eegplot:components")
+
+        self.assertEqual(session.CURRENTSET, original_currentset)
+        self.assertEqual(session.ALLCOM, original_history)
+        self.assertEqual(session.EEG["setname"], "demo")
+
+    def test_pop_eegplot_menu_enabled_states_follow_dataset_and_ica_status(self):
+        pytest.importorskip("PySide6")
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+        from eegprep.functions.guifunc.main_window import build_main_window
+
+        continuous_no_ica = EEGPrepSession()
+        continuous_no_ica.store_current(_demo_eeg(ica=False), new=True)
+        window = build_main_window(continuous_no_ica, all_menus=True)
+        actions = {action.data(): action for action in _qt_actions(window.window.menuBar().actions()) if action.data()}
+
+        self.assertTrue(actions["pop_eegplot:data"].isEnabled())
+        self.assertTrue(actions["pop_eegplot:channels"].isEnabled())
+        self.assertFalse(actions["pop_eegplot:components"].isEnabled())
+        self.assertFalse(actions["pop_eegplot:reject_data"].isEnabled())
+        self.assertFalse(actions["pop_eegplot:reject_ica"].isEnabled())
+        window.window.close()
+
+        epoched_no_ica = EEGPrepSession()
+        epoched_no_ica.store_current(_demo_eeg(epoched=True, ica=False), new=True)
+        window = build_main_window(epoched_no_ica, all_menus=True)
+        actions = {action.data(): action for action in _qt_actions(window.window.menuBar().actions()) if action.data()}
+
+        self.assertTrue(actions["pop_eegplot:reject_data"].isEnabled())
+        self.assertFalse(actions["pop_eegplot:reject_ica"].isEnabled())
+        window.window.close()
+
     def test_multiple_dataset_reref_preserves_selection(self):
         session = EEGPrepSession()
         first = _demo_eeg()

--- a/tests/test_menu_placeholder_inventory.py
+++ b/tests/test_menu_placeholder_inventory.py
@@ -71,3 +71,5 @@ def test_eegbrowser_scrolling_actions_are_implemented():
     assert action_kind("pop_eegplot:data") == "implemented"
     assert action_kind("pop_eegplot:channels") == "implemented"
     assert action_kind("pop_eegplot:components") == "implemented"
+    assert action_kind("pop_eegplot:reject_data") == "implemented"
+    assert action_kind("pop_eegplot:reject_ica") == "implemented"


### PR DESCRIPTION
Wire pop_eegplot into the EEGBrowser menu workflows with EEGLAB-style variant arguments, command echo, history, and session synchronization. Add ICA gating and regression coverage for GUI, console, and menu state behavior.\n\nFixes #98