### PR TITLE
Implement advanced EEGBrowser display modes

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -162,6 +162,7 @@ Visualization
 
    eegprep.cart2topo
    eegprep.eegplot
+   eegprep.eeg_multieegplot
    eegprep.pop_topoplot
    eegprep.topoplot
 

--- a/docs/source/api/signal_processing.rst
+++ b/docs/source/api/signal_processing.rst
@@ -37,6 +37,8 @@ Browser
 
 .. autofunction:: eegprep.eegplot
 
+.. autofunction:: eegprep.eeg_multieegplot
+
 Resampling
 ==========
 

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -50,6 +50,7 @@ _LAZY_EXPORTS = {
     "eeg_eeg2mne": ("eegprep.functions.miscfunc.eeg_eeg2mne", "eeg_eeg2mne"),
     "eeg_eegrej": ("eegprep.functions.popfunc.eeg_eegrej", "eeg_eegrej"),
     "eeg_emptyset": ("eegprep.functions.popfunc.eeg_emptyset", "eeg_emptyset"),
+    "eeg_multieegplot": ("eegprep.functions.popfunc.eeg_multieegplot", "eeg_multieegplot"),
     "eegplot": ("eegprep.functions.sigprocfunc.eegplot", "eegplot"),
     "eeg_findboundaries": ("eegprep.functions.popfunc.eeg_findboundaries", "eeg_findboundaries"),
     "eeg_interp": ("eegprep.functions.popfunc.eeg_interp", "eeg_interp"),

--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -186,6 +186,10 @@ class EEGBrowserWindow(_QMainWindow):
             self.controls.hide()
             self.menuBar().hide()
             return
+        self.channel_slider.show()
+        self.scale_indicator.show()
+        self.controls.show()
+        self.menuBar().show()
         axes_geometry = _rect_from_normalized(_AXES_POSITION, width, height)
         self.canvas.setGeometry(
             axes_geometry.adjusted(
@@ -477,6 +481,8 @@ class EEGBrowserWindow(_QMainWindow):
             self.controls.hide()
             self.menuBar().hide()
             return
+        self.controls.show()
+        self.menuBar().show()
         maximum_offset = max(0, self.model.data.n_channels - self.model.state.dispchans)
         self.channel_slider.blockSignals(True)
         self.channel_slider.setRange(0, maximum_offset)

--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -44,6 +44,7 @@ _SCALE_STEP = 0.1
 _MIN_SPACING = 0.001
 _TRACE_SCALE = 0.72
 _AXES_POSITION = (0.0964286, 0.15, 0.842, 0.75)
+_NOUI_AXES_POSITION = (0.055, 0.075, 0.90, 0.87)
 _CONTROL_POSITIONS = {
     "back_page": (0.2464, 0.0254, 0.0385, 0.0339),
     "back_step": (0.2924, 0.0254, 0.0288, 0.0339),
@@ -118,6 +119,14 @@ def open_eegbrowser(model: BrowserModel, accept_callback: Callable[[np.ndarray],
     return window
 
 
+def link_eegbrowser_windows(parent: Any, children: Any) -> tuple[Any, ...]:
+    """Link child browser windows so scrolling changes stay synchronized."""
+    child_windows = _normalize_child_windows(children)
+    for child in child_windows:
+        parent.link_child(child)
+    return child_windows
+
+
 class EEGBrowserWindow(_QMainWindow):
     """Basic EEGLAB-like scrolling browser window."""
 
@@ -129,6 +138,9 @@ class EEGBrowserWindow(_QMainWindow):
         self._pre_normalize_spacing: float | None = None
         self._legend_window: Any = None
         self._message_window: Any = None
+        self._linked_windows: list[Any] = []
+        self._child_windows: list[Any] = []
+        self._syncing_link = False
         self.setObjectName("eegbrowser")
         self.setWindowTitle(model.state.title)
         self.setStyleSheet(_BUTTON_STYLE)
@@ -148,14 +160,32 @@ class EEGBrowserWindow(_QMainWindow):
         self._build_shortcuts()
         self._layout_children()
         self._sync_controls()
+        if model.state.noui:
+            self.set_publication_view(True)
 
     def resizeEvent(self, event: Any) -> None:  # noqa: N802 - Qt API name
         super().resizeEvent(event)
         self._layout_children()
 
+    def closeEvent(self, event: Any) -> None:  # noqa: N802 - Qt API name
+        for child in list(self._child_windows):
+            child.close()
+        for linked in list(self._linked_windows):
+            linked._unlink_window(self)
+        self._linked_windows.clear()
+        self._child_windows.clear()
+        super().closeEvent(event)
+
     def _layout_children(self) -> None:
         width = max(1, self._content.width())
         height = max(1, self._content.height())
+        if self.model.state.noui:
+            self.canvas.setGeometry(_rect_from_normalized(_NOUI_AXES_POSITION, width, height))
+            self.channel_slider.hide()
+            self.scale_indicator.hide()
+            self.controls.hide()
+            self.menuBar().hide()
+            return
         axes_geometry = _rect_from_normalized(_AXES_POSITION, width, height)
         self.canvas.setGeometry(
             axes_geometry.adjusted(
@@ -371,6 +401,12 @@ class EEGBrowserWindow(_QMainWindow):
         self.model.state.zoom_enabled = bool(enabled)
         self.canvas.plot.setMouseEnabled(x=enabled, y=enabled)
 
+    def set_publication_view(self, enabled: bool = True) -> None:
+        """Toggle EEGLAB ``noui``-style publication display."""
+        self.model.state.noui = bool(enabled)
+        self._layout_children()
+        self._sync_controls()
+
     def toggle_stack(self) -> None:
         self.model.state.stacked = not self.model.state.stacked
         self._redraw()
@@ -422,6 +458,11 @@ class EEGBrowserWindow(_QMainWindow):
         self._redraw()
 
     def _redraw(self) -> None:
+        self._redraw_local()
+        if not self._syncing_link:
+            self._sync_linked_windows({id(self)})
+
+    def _redraw_local(self) -> None:
         self.model.state.clamp_to_data(self.model.data)
         self.canvas.redraw()
         self.scale_indicator.update()
@@ -430,6 +471,12 @@ class EEGBrowserWindow(_QMainWindow):
 
     def _sync_controls(self) -> None:
         self.model.state.clamp_to_data(self.model.data)
+        if self.model.state.noui:
+            self.channel_slider.setVisible(False)
+            self.scale_indicator.setVisible(False)
+            self.controls.hide()
+            self.menuBar().hide()
+            return
         maximum_offset = max(0, self.model.data.n_channels - self.model.state.dispchans)
         self.channel_slider.blockSignals(True)
         self.channel_slider.setRange(0, maximum_offset)
@@ -485,8 +532,51 @@ class EEGBrowserWindow(_QMainWindow):
             self.model.state.mark_color = (color.redF(), color.greenF(), color.blueF())
 
     def _edit_figure(self) -> None:
-        self.controls.hide()
-        self.menuBar().hide()
+        self.set_publication_view(True)
+
+    def link_window(self, other: Any) -> None:
+        """Link this browser with another browser for synchronized scrolling."""
+        if other is self:
+            return
+        self._add_linked_window(other)
+        other._add_linked_window(self)
+        other._apply_linked_scroll(self)
+
+    def link_child(self, child: Any) -> None:
+        """Link and register a child browser window."""
+        self.link_window(child)
+        if child not in self._child_windows:
+            self._child_windows.append(child)
+
+    def _add_linked_window(self, other: Any) -> None:
+        if other not in self._linked_windows:
+            self._linked_windows.append(other)
+
+    def _unlink_window(self, other: Any) -> None:
+        if other in self._linked_windows:
+            self._linked_windows.remove(other)
+        if other in self._child_windows:
+            self._child_windows.remove(other)
+
+    def _sync_linked_windows(self, visited: set[int]) -> None:
+        for linked in list(self._linked_windows):
+            if id(linked) in visited:
+                continue
+            linked._apply_linked_scroll(self, visited)
+
+    def _apply_linked_scroll(self, source: Any, visited: set[int] | None = None) -> None:
+        if visited is None:
+            visited = {id(source)}
+        visited.add(id(self))
+        self._syncing_link = True
+        try:
+            self.model.state.time = source.model.state.time
+            self.model.state.winlength = source.model.state.winlength
+            self.model.state.channel_offset = source.model.state.channel_offset
+            self._redraw_local()
+        finally:
+            self._syncing_link = False
+        self._sync_linked_windows(visited)
 
     def _show_status_message(self, text: str) -> None:
         qt_widgets, _pg = _require_gui()
@@ -903,7 +993,10 @@ class EEGBrowserCanvas(_QWidget):
     def _event_sample(self, scene_point: Any) -> int:
         view_point = self.plot.getPlotItem().vb.mapSceneToView(scene_point)
         x_value = float(view_point.x())
-        if self.model.data.epoched or self.model.data.x_values is not None:
+        if self.model.data.x_values is not None:
+            sample = int(np.argmin(np.abs(self.model.data.x_values - x_value)))
+            max_sample = self.model.data.total_samples - 1
+        elif self.model.data.epoched:
             sample = int(round(x_value))
             max_sample = self.model.data.total_samples - 1
         else:
@@ -1216,6 +1309,16 @@ def _winrej_frame_to_index(value: float) -> int:
     return frame - 1
 
 
+def _normalize_child_windows(children: Any) -> tuple[Any, ...]:
+    if isinstance(children, EEGBrowserWindow):
+        return (children,)
+    if isinstance(children, (list, tuple, set)):
+        out = tuple(children)
+        if all(isinstance(item, EEGBrowserWindow) for item in out):
+            return out
+    raise TypeError("children must be an EEGBrowserWindow or a sequence of EEGBrowserWindow objects")
+
+
 def _require_gui() -> tuple[Any, Any]:
     if QtWidgets is None or QtCore is None or QtGui is None or pg is None:
         raise RuntimeError(
@@ -1225,4 +1328,4 @@ def _require_gui() -> tuple[Any, Any]:
     return QtWidgets, pg
 
 
-__all__ = ["EEGBrowserCanvas", "EEGBrowserWindow", "open_eegbrowser"]
+__all__ = ["EEGBrowserCanvas", "EEGBrowserWindow", "link_eegbrowser_windows", "open_eegbrowser"]

--- a/src/eegprep/functions/popfunc/_property_browser.py
+++ b/src/eegprep/functions/popfunc/_property_browser.py
@@ -1,0 +1,70 @@
+"""Shared browser-backed activity views for property plots."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.popfunc._plot_utils import channel_labels, component_activations
+from eegprep.functions.sigprocfunc.eegplot import eegplot
+
+
+def property_activity_browser(
+    EEG: dict[str, Any],
+    typecomp: int | bool,
+    index: int,
+    *,
+    scroll_event: int | bool = 1,
+    show: bool = False,
+) -> Any:
+    """Build or open the scrolling activity browser for one property item."""
+    if int(bool(typecomp)):
+        data, eloc_file, title = _channel_activity(EEG, int(index))
+    else:
+        data, eloc_file, title = _component_activity(EEG, int(index))
+    return eegplot(
+        data,
+        srate=float(EEG.get("srate", 256) or 256),
+        limits=[float(EEG.get("xmin", 0.0) or 0.0) * 1000.0, float(EEG.get("xmax", 0.0) or 0.0) * 1000.0],
+        events=EEG.get("event", []) if int(bool(scroll_event)) else [],
+        eloc_file=eloc_file,
+        title=title,
+        dispchans=1,
+        spacing=_activity_spacing(data),
+        show=show,
+    )
+
+
+def _channel_activity(EEG: dict[str, Any], index: int) -> tuple[np.ndarray, Any, str]:
+    data = np.asarray(EEG.get("data"), dtype=float)
+    if index < 1 or index > data.shape[0]:
+        raise ValueError("channel index is outside available channels")
+    chanlocs = EEG.get("chanlocs", [])
+    if isinstance(chanlocs, np.ndarray):
+        chanlocs = chanlocs.tolist()
+    eloc_file = [chanlocs[index - 1]] if isinstance(chanlocs, list) and index - 1 < len(chanlocs) else [index]
+    labels = channel_labels(EEG)
+    label = labels[index - 1] if index - 1 < len(labels) else str(index)
+    return np.array(data[index - 1 : index], copy=True), eloc_file, f"Channel {label} activity -- eegplot()"
+
+
+def _component_activity(EEG: dict[str, Any], index: int) -> tuple[np.ndarray, Any, str]:
+    acts = component_activations(EEG)
+    if index < 1 or index > acts.shape[0]:
+        raise ValueError("component index is outside available ICA components")
+    return np.array(acts[index - 1 : index], copy=True), [index], f"Scrolling IC{index} Activity -- eegplot()"
+
+
+def _activity_spacing(data: np.ndarray) -> float:
+    flat = np.asarray(data, dtype=float).reshape(1, -1)
+    sample = flat[:, : min(1000, flat.shape[1])]
+    spacing = float(np.nanstd(sample) * 3.0)
+    if not np.isfinite(spacing) or spacing <= 0:
+        return 1.0
+    if spacing > 10:
+        return float(round(spacing))
+    return spacing
+
+
+__all__ = ["property_activity_browser"]

--- a/src/eegprep/functions/popfunc/eeg_multieegplot.py
+++ b/src/eegprep/functions/popfunc/eeg_multieegplot.py
@@ -1,0 +1,180 @@
+"""EEGLAB-style multi-epoch eegplot helper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.sigprocfunc.eegplot import eegplot, trial2eegplot
+
+
+NEW_REJECTION_COLOR = (0.8, 0.8, 1.0)
+OLD_REJECTION_COLOR = (0.8, 1.0, 0.8)
+
+
+def eeg_multieegplot(
+    data: Any,
+    rej: Any = None,
+    rejE: Any = None,
+    oldrej: Any = None,
+    oldrejE: Any = None,
+    *args: Any,
+    oldcolor: Any = OLD_REJECTION_COLOR,
+    newcolor: Any = NEW_REJECTION_COLOR,
+    show: bool = True,
+    **kwargs: Any,
+) -> Any:
+    """Open ``eegplot`` with current and previous rejection marks.
+
+    ``rej``/``rejE`` and ``oldrej``/``oldrejE`` follow EEGLAB's convention:
+    trial vectors are sweeps-length arrays of 0/1 marks and electrode marks
+    are ``channels x sweeps`` boolean arrays. For continuous data, rejection
+    rows may be ``[start end]`` or EEGLAB event-like rows whose start/end are
+    in columns 3 and 4.
+    """
+    array = np.asarray(data, dtype=float)
+    if array.ndim not in {2, 3}:
+        raise ValueError("eeg_multieegplot data must be 2-D or 3-D channel-major data")
+    n_channels = int(array.shape[0])
+    pnts = int(array.shape[1])
+    if array.ndim == 3:
+        winrej = _epoched_winrej(
+            rej,
+            rejE,
+            oldrej,
+            oldrejE,
+            n_channels=n_channels,
+            pnts=pnts,
+            trials=int(array.shape[2]),
+            oldcolor=_rgb(oldcolor, "oldcolor"),
+            newcolor=_rgb(newcolor, "newcolor"),
+        )
+    else:
+        winrej = _continuous_winrej(
+            rej,
+            oldrej,
+            n_channels=n_channels,
+            oldcolor=_rgb(oldcolor, "oldcolor"),
+            newcolor=_rgb(newcolor, "newcolor"),
+        )
+    if not _option_supplied(args, kwargs, "winlength"):
+        kwargs["winlength"] = 5
+    if not _option_supplied(args, kwargs, "winrej"):
+        kwargs["winrej"] = winrej
+    if not _option_supplied(args, kwargs, "xgrid"):
+        kwargs["xgrid"] = "off"
+    return eegplot(array, *args, show=show, **kwargs)
+
+
+def _epoched_winrej(
+    rej: Any,
+    rejE: Any,
+    oldrej: Any,
+    oldrejE: Any,
+    *,
+    n_channels: int,
+    pnts: int,
+    trials: int,
+    oldcolor: tuple[float, float, float],
+    newcolor: tuple[float, float, float],
+) -> np.ndarray:
+    rows = []
+    old_rows = trial2eegplot(
+        _trial_marks(oldrej, trials),
+        _electrode_marks(oldrejE, n_channels, trials),
+        pnts,
+        oldcolor,
+    )
+    if old_rows.size:
+        rows.append(old_rows)
+    new_rows = trial2eegplot(
+        _trial_marks(rej, trials),
+        _electrode_marks(rejE, n_channels, trials),
+        pnts,
+        newcolor,
+    )
+    if new_rows.size:
+        rows.append(new_rows)
+    return np.vstack(rows) if rows else np.zeros((0, 5 + n_channels), dtype=float)
+
+
+def _continuous_winrej(
+    rej: Any,
+    oldrej: Any,
+    *,
+    n_channels: int,
+    oldcolor: tuple[float, float, float],
+    newcolor: tuple[float, float, float],
+) -> np.ndarray:
+    rows = []
+    new_rows = _continuous_rows(rej, n_channels, newcolor)
+    if new_rows.size:
+        rows.append(new_rows)
+    old_rows = _continuous_rows(oldrej, n_channels, oldcolor)
+    if old_rows.size:
+        rows.append(old_rows)
+    return np.vstack(rows) if rows else np.zeros((0, 5 + n_channels), dtype=float)
+
+
+def _continuous_rows(
+    value: Any,
+    n_channels: int,
+    color: tuple[float, float, float],
+) -> np.ndarray:
+    rows = np.asarray(value if value is not None else [], dtype=float)
+    if rows.size == 0:
+        return np.zeros((0, 5 + n_channels), dtype=float)
+    if rows.ndim == 1:
+        rows = rows.reshape(1, -1)
+    if rows.ndim != 2 or rows.shape[1] < 2:
+        raise ValueError("continuous rejection rows must contain at least start and end columns")
+    start_end = rows[:, 2:4] if rows.shape[1] >= 4 else rows[:, 0:2]
+    out = np.zeros((rows.shape[0], 5 + n_channels), dtype=float)
+    out[:, 0:2] = start_end
+    out[:, 2:5] = np.asarray(color, dtype=float)
+    return out
+
+
+def _trial_marks(value: Any, trials: int) -> np.ndarray:
+    marks = np.zeros(int(trials), dtype=bool)
+    arr = np.asarray(value if value is not None else [], dtype=float).ravel()
+    if arr.size == 0:
+        return marks
+    if arr.size == trials:
+        return arr > 0
+    for trial in arr.astype(int):
+        if 1 <= trial <= trials:
+            marks[trial - 1] = True
+    return marks
+
+
+def _electrode_marks(value: Any, n_channels: int, trials: int) -> np.ndarray:
+    out = np.zeros((int(n_channels), int(trials)), dtype=bool)
+    arr = np.asarray(value if value is not None else [], dtype=bool)
+    if arr.size == 0:
+        return out
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.ndim != 2:
+        raise ValueError("electrode rejection marks must be a 2-D channels x trials array")
+    rows = min(out.shape[0], arr.shape[0])
+    cols = min(out.shape[1], arr.shape[1])
+    out[:rows, :cols] = arr[:rows, :cols]
+    return out
+
+
+def _option_supplied(args: tuple[Any, ...], kwargs: dict[str, Any], name: str) -> bool:
+    if name in kwargs:
+        return True
+    return any(isinstance(args[index], str) and args[index] == name for index in range(0, len(args), 2))
+
+
+def _rgb(value: Any, name: str) -> tuple[float, float, float]:
+    values = tuple(float(item) for item in value)
+    if len(values) != 3 or any(item < 0.0 or item > 1.0 for item in values):
+        raise ValueError(f"{name} must contain three RGB values between 0 and 1")
+    return values
+
+
+__all__ = ["eeg_multieegplot"]

--- a/src/eegprep/functions/popfunc/eeg_multieegplot.py
+++ b/src/eegprep/functions/popfunc/eeg_multieegplot.py
@@ -108,12 +108,12 @@ def _continuous_winrej(
     newcolor: tuple[float, float, float],
 ) -> np.ndarray:
     rows = []
-    new_rows = _continuous_rows(rej, n_channels, newcolor)
-    if new_rows.size:
-        rows.append(new_rows)
     old_rows = _continuous_rows(oldrej, n_channels, oldcolor)
     if old_rows.size:
         rows.append(old_rows)
+    new_rows = _continuous_rows(rej, n_channels, newcolor)
+    if new_rows.size:
+        rows.append(new_rows)
     return np.vstack(rows) if rows else np.zeros((0, 5 + n_channels), dtype=float)
 
 

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+from eegprep.functions.popfunc._property_browser import property_activity_browser
 from eegprep.functions.popfunc._plot_utils import (
     channel_labels,
     component_activations,
@@ -32,6 +33,8 @@ def pop_prop(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
+    scroll_event: int | bool = 1,
+    show_activity: bool = False,
     return_com: bool = False,
 ):
     """Plot properties of one channel or independent component."""
@@ -48,6 +51,14 @@ def pop_prop(
         spec_opt = result["spec_opt"]
     indices = numeric_vector(chanorcomp if chanorcomp is not None else 1, dtype=int)
     figures = [_plot_one_property(EEG, typecomp, int(index), spec_opt) for index in indices]
+    for figure, index in zip(figures, indices):
+        figure.eegprep_activity_view = property_activity_browser(
+            EEG,
+            typecomp,
+            int(index),
+            scroll_event=scroll_event,
+            show=show_activity,
+        )
     command = history_command("pop_prop", typecomp, indices.astype(int).tolist(), winhandle, spec_opt)
     return (
         (figures[0] if len(figures) == 1 else figures, command)

--- a/src/eegprep/functions/popfunc/pop_subcomp.py
+++ b/src/eegprep/functions/popfunc/pop_subcomp.py
@@ -139,17 +139,26 @@ def _remove_components(EEG: dict, components: Any, keepcomp: int | bool) -> tupl
 
 def _plot_subcomp_confirmation(input_eeg: dict, output_eeg: dict) -> None:
     icachansind = _icachansind(input_eeg)
-    preview = copy.deepcopy(input_eeg)
     input_data = np.asarray(input_eeg["data"])
     output_data = np.asarray(output_eeg["data"])
-    preview["data"] = np.array(input_data[icachansind], dtype=float, copy=True)
-    preview["nbchan"] = int(icachansind.size)
-    preview["chanlocs"] = _selected_chanlocs(input_eeg, icachansind)
+    preview_data = np.array(input_data[icachansind], dtype=float, copy=True)
+    preview = {
+        "data": preview_data,
+        "nbchan": int(icachansind.size),
+        "pnts": int(input_eeg.get("pnts", preview_data.shape[1]) or preview_data.shape[1]),
+        "trials": int(input_eeg.get("trials", preview_data.shape[2] if preview_data.ndim == 3 else 1) or 1),
+        "srate": float(input_eeg.get("srate", 256) or 256),
+        "xmin": float(input_eeg.get("xmin", 0.0) or 0.0),
+        "xmax": float(input_eeg.get("xmax", 0.0) or 0.0),
+        "chanlocs": _selected_chanlocs(input_eeg, icachansind),
+        "event": input_eeg.get("event", []),
+        "setname": input_eeg.get("setname", ""),
+    }
     eegplot(
         preview,
-        srate=float(input_eeg.get("srate", 256) or 256),
+        srate=preview["srate"],
         title="Black = channel before rejection; red = after rejection -- eegplot()",
-        limits=[float(input_eeg.get("xmin", 0.0) or 0.0) * 1000.0, float(input_eeg.get("xmax", 0.0) or 0.0) * 1000.0],
+        limits=[preview["xmin"] * 1000.0, preview["xmax"] * 1000.0],
         data2=np.array(output_data[icachansind], dtype=float, copy=True),
     )
 

--- a/src/eegprep/functions/popfunc/pop_subcomp.py
+++ b/src/eegprep/functions/popfunc/pop_subcomp.py
@@ -13,6 +13,7 @@ from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.miscfunc.misc import finite_matmul, finite_pinv
 from eegprep.functions.popfunc._pop_utils import format_history_value, is_on as _is_on
+from eegprep.functions.sigprocfunc.eegplot import eegplot
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +37,6 @@ def pop_subcomp(
     """
     if EEG is None:
         return (None, "") if return_com else None
-    if _is_on(plotag):
-        raise NotImplementedError(
-            "pop_subcomp plot confirmation depends on EEGBrowser/component plotting workflows "
-            "that are not part of this Phase 3 PR."
-        )
     if gui is None:
         gui = components is None
     if gui:
@@ -57,6 +53,8 @@ def pop_subcomp(
         return (outputs, command) if return_com else outputs
 
     output, removed = _remove_components(EEG, components, keepcomp)
+    if removed and _is_on(plotag):
+        _plot_subcomp_confirmation(EEG, output)
     command = _history_command(components if components is not None else [], plotag, keepcomp) if removed else ""
     return (output, command) if return_com else output
 
@@ -137,6 +135,34 @@ def _remove_components(EEG: dict, components: Any, keepcomp: int | bool) -> tupl
     _trim_iclabel_classifications(output, keep_mask)
     _trim_dipfit_model(output, keep_mask)
     return output, True
+
+
+def _plot_subcomp_confirmation(input_eeg: dict, output_eeg: dict) -> None:
+    icachansind = _icachansind(input_eeg)
+    preview = copy.deepcopy(input_eeg)
+    input_data = np.asarray(input_eeg["data"])
+    output_data = np.asarray(output_eeg["data"])
+    preview["data"] = np.array(input_data[icachansind], dtype=float, copy=True)
+    preview["nbchan"] = int(icachansind.size)
+    preview["chanlocs"] = _selected_chanlocs(input_eeg, icachansind)
+    eegplot(
+        preview,
+        srate=float(input_eeg.get("srate", 256) or 256),
+        title="Black = channel before rejection; red = after rejection -- eegplot()",
+        limits=[float(input_eeg.get("xmin", 0.0) or 0.0) * 1000.0, float(input_eeg.get("xmax", 0.0) or 0.0) * 1000.0],
+        data2=np.array(output_data[icachansind], dtype=float, copy=True),
+    )
+
+
+def _selected_chanlocs(EEG: dict, indices: np.ndarray) -> list[Any]:
+    chanlocs = EEG.get("chanlocs", [])
+    if chanlocs is None:
+        chanlocs = []
+    if isinstance(chanlocs, np.ndarray):
+        chanlocs = chanlocs.tolist()
+    if not isinstance(chanlocs, (list, tuple)):
+        return []
+    return [copy.deepcopy(chanlocs[int(index)]) for index in indices if 0 <= int(index) < len(chanlocs)]
 
 
 def _components_to_remove(EEG: dict, components: Any, keepcomp: int | bool, n_comps: int) -> list[int]:

--- a/src/eegprep/functions/sigprocfunc/eegplot.py
+++ b/src/eegprep/functions/sigprocfunc/eegplot.py
@@ -31,6 +31,7 @@ _OPTION_NAMES = {
     "xgrid",
     "ygrid",
     "data2",
+    "plotdata2",
     "command",
     "command_callback",
     "butlabel",
@@ -46,6 +47,8 @@ _OPTION_NAMES = {
     "freqlimits",
     "component",
     "setelectrode",
+    "children",
+    "noui",
     "show",
 }
 
@@ -129,6 +132,7 @@ class BrowserState:
     accept_label: str | None = None
     mark_color: tuple[float, float, float] = DEFAULT_WINREJ_COLOR
     setelectrode: bool = False
+    noui: bool = False
     accepted: bool = False
     cancelled: bool = False
 
@@ -176,7 +180,13 @@ def eegplot(data: Any, *args: Any, **kwargs: Any) -> Any:
     command_callback = options.get("command_callback")
     if command_callback is None and callable(options.get("command")):
         command_callback = options.get("command")
-    return open_eegbrowser(model, accept_callback=command_callback)
+    window = open_eegbrowser(model, accept_callback=command_callback)
+    children = options.get("children")
+    if children:
+        from eegprep.functions.guifunc.eegbrowser import link_eegbrowser_windows
+
+        link_eegbrowser_windows(window, children)
+    return window
 
 
 def parse_eegplot_options(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -236,6 +246,7 @@ def build_eegplot_model(data: Any, **kwargs: Any) -> BrowserModel:
         ),
         mark_color=_normalize_rgb(options["wincolor"], "wincolor"),
         setelectrode=bool(options["setelectrode"]),
+        noui=_on_off(options["noui"], "noui"),
     )
     state.clamp_to_data(browser_data)
     return BrowserModel(browser_data, state)
@@ -599,6 +610,7 @@ def _model_options(source_eeg: dict[str, Any] | None, kwargs: dict[str, Any]) ->
     options.setdefault("xgrid", "off")
     options.setdefault("ygrid", "off")
     options.setdefault("data2", None)
+    options.setdefault("plotdata2", "off")
     options.setdefault("command", None)
     options.setdefault("command_callback", None)
     options.setdefault("butlabel", "REJECT")
@@ -614,6 +626,8 @@ def _model_options(source_eeg: dict[str, Any] | None, kwargs: dict[str, Any]) ->
     options.setdefault("freqlimits", None)
     options.setdefault("component", False)
     options.setdefault("setelectrode", False)
+    options.setdefault("children", ())
+    options.setdefault("noui", "off")
     if options["spacing"] is None or float(options["spacing"]) == 0:
         options["spacing"] = _default_spacing(source_eeg, options)
     if options["time"] is None:
@@ -715,7 +729,7 @@ def _channel_labels(
     component: bool,
 ) -> tuple[str, ...]:
     if component:
-        return tuple(f"Comp {index}" for index in range(1, n_channels + 1))
+        return tuple(str(index) for index in range(1, n_channels + 1))
     if isinstance(eloc_file, np.ndarray):
         eloc_file = eloc_file.tolist()
     if eloc_file is None or eloc_file == 0:

--- a/src/eegprep/functions/sigprocfunc/eegplot.py
+++ b/src/eegprep/functions/sigprocfunc/eegplot.py
@@ -31,7 +31,6 @@ _OPTION_NAMES = {
     "xgrid",
     "ygrid",
     "data2",
-    "plotdata2",
     "command",
     "command_callback",
     "butlabel",
@@ -610,7 +609,6 @@ def _model_options(source_eeg: dict[str, Any] | None, kwargs: dict[str, Any]) ->
     options.setdefault("xgrid", "off")
     options.setdefault("ygrid", "off")
     options.setdefault("data2", None)
-    options.setdefault("plotdata2", "off")
     options.setdefault("command", None)
     options.setdefault("command_callback", None)
     options.setdefault("butlabel", "REJECT")

--- a/src/eegprep/plugins/ICLabel/pop_viewprops.py
+++ b/src/eegprep/plugins/ICLabel/pop_viewprops.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._property_browser import property_activity_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import one_based_indices
 from eegprep.functions.popfunc.pop_topoplot import pop_topoplot
@@ -30,9 +31,10 @@ def pop_viewprops(
     gui: bool | None = None,
     renderer: Any | None = None,
     plot: bool = True,
+    show_activity: bool = False,
     return_com: bool = False,
 ):
-    """Render a non-scrolling channel/component property overview."""
+    """Render channel/component property overview figures and activity views."""
     if EEG is None:
         return ([], "") if return_com else []
     if gui is None:
@@ -51,7 +53,7 @@ def pop_viewprops(
     indices = one_based_indices(chanorcomp, limit=limit, default_all=True)
     figures = []
     if plot:
-        figures = _plot_props(EEG, int(bool(typecomp)), indices, classifier_name)
+        figures = _plot_props(EEG, int(bool(typecomp)), indices, classifier_name, scroll_event, show_activity)
     command = _history_command(typecomp, indices, spec_opt, erp_opt, scroll_event, classifier_name)
     return (figures, command) if return_com else figures
 
@@ -95,30 +97,46 @@ def pop_viewprops_dialog_spec(EEG: dict[str, Any], typecomp: int | bool = 1) -> 
         size=(600, 318 if classifiers else 288),
         geometry=tuple(geometry),
         controls=tuple(controls),
-        known_differences=(
-            "EEGPrep omits EEGBrowser/eegplot scrolling activity from the property overview.",
-            "Channel mode renders a non-scrolling overview so the GUI and console remain usable without EEGBrowser.",
-        ),
     )
 
 
-def _plot_props(EEG: dict[str, Any], typecomp: int, indices: list[int], classifier_name: str) -> list[Any]:
+def _plot_props(
+    EEG: dict[str, Any],
+    typecomp: int,
+    indices: list[int],
+    classifier_name: str,
+    scroll_event: int | bool,
+    show_activity: bool,
+) -> list[Any]:
     if not indices:
         return []
+    visible_indices = indices[:PLOTS_PER_FIGURE]
+    activity_views = [
+        property_activity_browser(EEG, typecomp, index, scroll_event=scroll_event, show=show_activity)
+        for index in visible_indices
+    ]
     if not typecomp:
-        return pop_topoplot(
-            EEG, 0, indices[:PLOTS_PER_FIGURE], "View components properties - pop_viewprops()", [], 0, gui=False
+        figures = pop_topoplot(
+            EEG, 0, visible_indices, "View components properties - pop_viewprops()", [], 0, gui=False
         )
+        _attach_activity_views(figures, activity_views)
+        return figures
     fig_obj, axes = plt.subplots(1, min(len(indices), PLOTS_PER_FIGURE), squeeze=False)
     labels = _channel_labels(EEG)
-    for axis, index in zip(axes.ravel(), indices[:PLOTS_PER_FIGURE]):
+    for axis, index in zip(axes.ravel(), visible_indices):
         axis.axis("off")
         label = labels[index - 1] if index - 1 < len(labels) else str(index)
         axis.text(0.5, 0.5, label, ha="center", va="center", fontsize=10)
         axis.set_title(str(index))
     fig_obj.suptitle("View channels properties - pop_viewprops()")
     fig_obj.tight_layout()
+    _attach_activity_views([fig_obj], activity_views)
     return [fig_obj]
+
+
+def _attach_activity_views(figures: list[Any], activity_views: list[Any]) -> None:
+    for figure in figures:
+        figure.eegprep_activity_views = activity_views
 
 
 def _history_command(
@@ -184,6 +202,11 @@ def _classifier_name_from_gui(EEG: dict[str, Any], value: Any) -> str:
 
 def _channel_labels(EEG: dict[str, Any]) -> list[str]:
     labels = []
-    for index, chanloc in enumerate(EEG.get("chanlocs", []) or []):
+    chanlocs = EEG.get("chanlocs", [])
+    if chanlocs is None:
+        chanlocs = []
+    if isinstance(chanlocs, np.ndarray):
+        chanlocs = chanlocs.tolist()
+    for index, chanloc in enumerate(chanlocs):
         labels.append(str(chanloc.get("labels", index + 1)) if isinstance(chanloc, dict) else str(index + 1))
     return labels or [str(index + 1) for index in range(int(EEG.get("nbchan", 0) or 0))]

--- a/src/eegprep/resources/help/eeg_multieegplot.md
+++ b/src/eegprep/resources/help/eeg_multieegplot.md
@@ -1,0 +1,15 @@
+# eeg_multieegplot
+
+`eeg_multieegplot` opens `eegplot` with current and previous rejection marks
+already converted to browser `winrej` rows.
+
+Usage:
+
+```python
+window = eeg_multieegplot(data, rej, rejE, oldrej, oldrejE)
+model = eeg_multieegplot(data, rej, rejE, oldrej, oldrejE, show=False)
+```
+
+For epoched data, `rej` and `oldrej` are trial-length 0/1 vectors and `rejE`
+and `oldrejE` are `channels x trials` electrode mark matrices. Previous marks
+use EEGLAB's light green color by default; new marks use light blue.

--- a/src/eegprep/resources/help/eegplot.md
+++ b/src/eegprep/resources/help/eegplot.md
@@ -21,6 +21,10 @@ Core options:
 - `title` and `plottitle`: window and plot titles.
 - `xgrid`, `ygrid`, `submean`, and `scale`: `"on"` or `"off"` toggles.
 - `data2`: overlay data with the same normalized shape as the primary data.
+- `children`: one browser window or a sequence of browser windows to link for
+  synchronized scrolling.
+- `noui`: `"on"` hides menus and controls for a cleaner publication-style
+  browser view.
 - `winrej`: rejection-mark rows `[start end R G B channel_mask...]` in
   EEGLAB eegplot frame coordinates. Continuous rows use one-based sample
   latencies for rejection through `eeg_eegrej`; epoched rows use EEGLAB's

--- a/src/eegprep/resources/help/pop_subcomp.md
+++ b/src/eegprep/resources/help/pop_subcomp.md
@@ -23,4 +23,6 @@ Behavior:
 - ICA weights and sphere matrices must already be present.
 - Data are projected back using the remaining components.
 - ICA activations and rejection flags are cleared after removal, matching EEGLAB's component-removal workflow.
-- Component plotting and scrolling confirmation flows are outside this phase.
+- With `plotag=1`, EEGPrep opens a before/after scrolling browser: black traces
+  show the original channel data and red `data2` traces show the data after
+  removing the selected components.

--- a/src/eegprep/resources/help/pop_viewprops.md
+++ b/src/eegprep/resources/help/pop_viewprops.md
@@ -8,5 +8,6 @@ Usage:
 Set `typecomp=1` for channels and `typecomp=0` for ICA components. Indices are
 EEGLAB-facing 1-based values.
 
-EEGPrep provides non-scrolling property overview figures. EEGBrowser/eegplot
-activity scrolling is intentionally excluded.
+Property overview figures include browser-backed activity views for each
+visible channel or component. The dialog's event checkbox controls whether
+events are included in those scrolling activity views.

--- a/tests/test_eegplot.py
+++ b/tests/test_eegplot.py
@@ -10,6 +10,7 @@ import eegprep.functions.popfunc.pop_eegplot as pop_eegplot_module
 from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
 from eegprep.functions.popfunc.pop_eegplot import apply_eegplot_rejections
 from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
+from eegprep.functions.popfunc.eeg_multieegplot import eeg_multieegplot
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.sigprocfunc.eegplot import (
     add_winrej_region,
@@ -75,7 +76,7 @@ def test_component_mode_uses_ica_activation_labels_without_mutating_eeg() -> Non
     model = build_eegplot_model(eeg, component=True, spacing=1, show=False)
 
     assert model.data.mode == "component"
-    assert model.data.channel_labels == ("Comp 1", "Comp 2")
+    assert model.data.channel_labels == ("1", "2")
     np.testing.assert_array_equal(model.data.flat_data, eeg["icaact"])
     np.testing.assert_array_equal(eeg["data"], data_before)
     np.testing.assert_array_equal(eeg["icaact"], ica_before)
@@ -101,6 +102,12 @@ def test_spectral_and_overlay_inputs_are_normalized_together() -> None:
     assert model.state.limits == (3.0, 7.0)
     np.testing.assert_array_equal(model.data.x_values, freqs[2:7])
     np.testing.assert_array_equal(model.data.flat_data2, overlay[:, 2:7])
+
+
+def test_noui_option_sets_publication_state_without_showing_qt() -> None:
+    model = build_eegplot_model(np.zeros((2, 10)), spacing=1, noui="on", show=False)
+
+    assert model.state.noui is True
 
 
 def test_event_latency_conversion_uses_eeglab_one_based_samples() -> None:
@@ -438,6 +445,34 @@ def test_pop_eegplot_component_mode_requires_ica() -> None:
         pop_eegplot(eeg, icacomp=0, show=False)
 
 
+def test_eeg_multieegplot_epoched_combines_old_and_new_rejection_colors() -> None:
+    data = np.zeros((2, 4, 3), dtype=float)
+    rej = np.array([False, True, False])
+    rej_e = np.array([[False, True, False], [False, False, False]])
+    oldrej = np.array([True, False, False])
+    oldrej_e = np.array([[True, False, False], [False, False, False]])
+
+    model = eeg_multieegplot(data, rej, rej_e, oldrej, oldrej_e, show=False)
+    rows = winrej_to_array(model.state.winrej, 2)
+
+    np.testing.assert_array_equal(rows[:, :2], [[0, 3], [4, 7]])
+    np.testing.assert_allclose(rows[:, 2:5], [[0.8, 1.0, 0.8], [0.8, 0.8, 1.0]])
+    np.testing.assert_array_equal(rows[:, 5:], [[1, 0], [1, 0]])
+
+
+def test_eeg_multieegplot_continuous_uses_old_and_new_colors() -> None:
+    model = eeg_multieegplot(
+        np.zeros((2, 20), dtype=float),
+        [[3, 5]],
+        oldrej=[[1, 2, 8, 10]],
+        show=False,
+    )
+    rows = winrej_to_array(model.state.winrej, 2)
+
+    np.testing.assert_array_equal(rows[:, :2], [[3, 5], [8, 10]])
+    np.testing.assert_allclose(rows[:, 2:5], [[0.8, 0.8, 1.0], [0.8, 1.0, 0.8]])
+
+
 def test_eegplot_accept_creates_dataset_only_when_reject_removes_data() -> None:
     continuous = create_test_eeg(n_channels=1, n_samples=10, n_trials=1, srate=10)
     continuous_out = dict(continuous, pnts=7, data=np.zeros((1, 7)))
@@ -470,4 +505,22 @@ def test_sample_data_pop_eegplot_channel_api_flow_returns_browser_model() -> Non
     assert model.data.mode == "continuous"
     assert model.data.n_channels == int(eeg["nbchan"])
     assert model.state.title.startswith("Scroll channel activities -- eegplot()")
+    np.testing.assert_array_equal(eeg["data"], data_before)
+
+
+def test_sample_data_pop_eegplot_component_api_flow_with_ica_fields() -> None:
+    eeg = pop_loadset(str(SAMPLE_DATASET))
+    n_channels = int(eeg["nbchan"])
+    eeg["icaweights"] = np.eye(n_channels)
+    eeg["icasphere"] = np.eye(n_channels)
+    eeg["icawinv"] = np.eye(n_channels)
+    eeg["icachansind"] = np.arange(n_channels)
+    eeg["icaact"] = np.array(eeg["data"], dtype=float, copy=True)
+    data_before = np.array(eeg["data"], copy=True)
+
+    model = pop_eegplot(eeg, icacomp=0, show=False, winlength=1)
+
+    assert model.data.mode == "component"
+    assert model.data.n_channels == n_channels
+    assert model.state.title.startswith("Scroll component activities -- eegplot()")
     np.testing.assert_array_equal(eeg["data"], data_before)

--- a/tests/test_eegplot.py
+++ b/tests/test_eegplot.py
@@ -44,6 +44,11 @@ def test_parse_eegplot_options_rejects_unknown_options() -> None:
         parse_eegplot_options((), {"bogus": 1})
 
 
+def test_eegplot_rejects_internal_plotdata2_option() -> None:
+    with pytest.raises(ValueError, match="plotdata2"):
+        eegplot(np.zeros((1, 10)), plotdata2="on", show=False)
+
+
 def test_continuous_data_normalization_defaults_and_bounds() -> None:
     data = np.arange(20, dtype=float).reshape(2, 10)
     model = build_eegplot_model(data, srate=10, winlength=0.4, spacing=2, show=False)
@@ -469,8 +474,17 @@ def test_eeg_multieegplot_continuous_uses_old_and_new_colors() -> None:
     )
     rows = winrej_to_array(model.state.winrej, 2)
 
-    np.testing.assert_array_equal(rows[:, :2], [[3, 5], [8, 10]])
-    np.testing.assert_allclose(rows[:, 2:5], [[0.8, 0.8, 1.0], [0.8, 1.0, 0.8]])
+    np.testing.assert_array_equal(rows[:, :2], [[8, 10], [3, 5]])
+    np.testing.assert_allclose(rows[:, 2:5], [[0.8, 1.0, 0.8], [0.8, 0.8, 1.0]])
+
+
+def test_eeg_multieegplot_epoched_accepts_one_based_trial_indices() -> None:
+    model = eeg_multieegplot(np.zeros((1, 4, 4), dtype=float), rej=[2, 4], rejE=np.ones((1, 4)), show=False)
+    rows = winrej_to_array(model.state.winrej, 1)
+
+    np.testing.assert_array_equal(rows[:, :2], [[4, 7], [12, 15]])
+    np.testing.assert_allclose(rows[:, 2:5], [[0.8, 0.8, 1.0], [0.8, 0.8, 1.0]])
+    np.testing.assert_array_equal(rows[:, 5:], [[1], [1]])
 
 
 def test_eegplot_accept_creates_dataset_only_when_reject_removes_data() -> None:

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
-from eegprep.functions.sigprocfunc.eegplot import build_eegplot_model
+from eegprep.functions.sigprocfunc.eegplot import build_eegplot_model, eegplot
 
 
 SAMPLE_DATASET = Path(__file__).resolve().parents[1] / "sample_data" / "eeglab_data.set"
@@ -400,10 +400,23 @@ def test_gui_linked_child_windows_synchronize_time_and_channels(qapp) -> None:
     parent.close()
 
 
-def test_gui_noui_publication_view_hides_browser_controls(qapp) -> None:
+def test_gui_eegplot_children_option_links_opened_browser(qapp) -> None:
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 
-    model = build_eegplot_model(np.zeros((3, 100)), srate=10, winlength=2, spacing=1, noui="on")
+    child_model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1)
+    child = EEGBrowserWindow(child_model)
+
+    parent = eegplot(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1, children=child)
+
+    assert child in parent._linked_windows
+    assert parent in child._linked_windows
+    parent.close()
+
+
+def test_gui_noui_publication_view_hides_and_restores_browser_controls(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    model = build_eegplot_model(np.zeros((3, 100)), srate=10, winlength=2, dispchans=2, spacing=1, noui="on")
     window = EEGBrowserWindow(model)
     window.show()
     qapp.processEvents()
@@ -413,6 +426,14 @@ def test_gui_noui_publication_view_hides_browser_controls(qapp) -> None:
     assert window.controls.cancel_button.isHidden() is True
     assert window.scale_indicator.isHidden() is True
     assert window.canvas.isVisible() is True
+
+    window.set_publication_view(False)
+    qapp.processEvents()
+
+    assert window.menuBar().isHidden() is False
+    assert window.channel_slider.isHidden() is False
+    assert window.controls.cancel_button.isHidden() is False
+    assert window.scale_indicator.isHidden() is False
     window.close()
 
 

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -360,6 +360,85 @@ def test_gui_channel_specific_marks_draw_red_trace_overlay(qapp) -> None:
     window.close()
 
 
+def test_gui_data2_overlay_draws_second_trace_per_channel(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    data = np.vstack([np.arange(20, dtype=float), np.arange(20, dtype=float)])
+    model = build_eegplot_model(data, data2=data + 10.0, srate=10, spacing=10, dispchans=2, show=False)
+    window = EEGBrowserWindow(model)
+
+    curves = [item for item in window.canvas._items if hasattr(item, "getData")]
+
+    assert len(curves) == 4
+    np.testing.assert_allclose(curves[0].getData()[0], curves[1].getData()[0])
+    window.close()
+
+
+def test_gui_linked_child_windows_synchronize_time_and_channels(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    parent_model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1)
+    child_model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1)
+    sibling_model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1)
+    parent = EEGBrowserWindow(parent_model)
+    child = EEGBrowserWindow(child_model)
+    sibling = EEGBrowserWindow(sibling_model)
+    parent.link_child(child)
+    parent.link_child(sibling)
+
+    parent.scroll_time(1.0)
+    qapp.processEvents()
+
+    assert child_model.state.time == pytest.approx(parent_model.state.time)
+    assert sibling_model.state.time == pytest.approx(parent_model.state.time)
+
+    child.scroll_channels(1)
+    qapp.processEvents()
+
+    assert parent_model.state.channel_offset == child_model.state.channel_offset
+    assert sibling_model.state.channel_offset == child_model.state.channel_offset
+    parent.close()
+
+
+def test_gui_noui_publication_view_hides_browser_controls(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    model = build_eegplot_model(np.zeros((3, 100)), srate=10, winlength=2, spacing=1, noui="on")
+    window = EEGBrowserWindow(model)
+    window.show()
+    qapp.processEvents()
+
+    assert window.menuBar().isHidden() is True
+    assert window.channel_slider.isHidden() is True
+    assert window.controls.cancel_button.isHidden() is True
+    assert window.scale_indicator.isHidden() is True
+    assert window.canvas.isVisible() is True
+    window.close()
+
+
+def test_gui_spectral_mode_uses_frequency_axis_and_labels(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    freqs = np.arange(1, 11, dtype=float)
+    model = build_eegplot_model(
+        np.arange(10, dtype=float).reshape(1, 10),
+        freqs=freqs,
+        freqlimits=[4, 6],
+        spacing=1,
+        winlength=2,
+        show=False,
+    )
+    window = EEGBrowserWindow(model)
+
+    curve = next(item for item in window.canvas._items if hasattr(item, "getData"))
+    x_values, _y_values = curve.getData()
+
+    np.testing.assert_allclose(x_values, [4.0, 5.0, 6.0])
+    assert window.controls.time_label.text() == "Freq"
+    assert window.controls.value_label.text() == "Power"
+    window.close()
+
+
 def test_gui_accept_callback_receives_winrej_and_cancel_does_not(qapp) -> None:
     qt_widgets = pytest.importorskip("PySide6.QtWidgets")
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow

--- a/tests/test_gui_pop_subcomp.py
+++ b/tests/test_gui_pop_subcomp.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest import mock
 
 import numpy as np
 
+import eegprep.functions.popfunc.pop_subcomp as pop_subcomp_module
 from eegprep.functions.adminfunc.console import _console_python_command
 from eegprep.functions.guifunc.spec import controls_by_tag
 from eegprep.functions.popfunc.pop_subcomp import pop_subcomp, pop_subcomp_dialog_spec
@@ -117,6 +119,25 @@ class PopSubcompGuiTests(unittest.TestCase):
 
         self.assertEqual(out["icaweights"].shape, (2, 3))
         self.assertEqual(_console_python_command(com), "EEG = pop_subcomp(EEG, components=[], plotag=0)")
+
+    def test_plot_confirmation_opens_before_after_data2_browser(self):
+        captured = {}
+
+        def fake_eegplot(preview, **kwargs):
+            captured["preview"] = preview
+            captured["kwargs"] = kwargs
+            return "window"
+
+        with mock.patch.object(pop_subcomp_module, "eegplot", side_effect=fake_eegplot):
+            out, com = pop_subcomp(_eeg(), [2], plotag=True, return_com=True)
+
+        self.assertEqual(out["icaweights"].shape, (2, 3))
+        self.assertEqual(captured["preview"]["data"].shape, (3, 8))
+        self.assertEqual(
+            captured["kwargs"]["title"], "Black = channel before rejection; red = after rejection -- eegplot()"
+        )
+        np.testing.assert_array_equal(captured["kwargs"]["data2"][1], np.zeros(8))
+        self.assertEqual(_console_python_command(com), "EEG = pop_subcomp(EEG, components=[2], plotag=1)")
 
     def test_multiple_datasets_with_no_flags_can_enter_components_in_gui(self):
         eegs = [_eeg(), _eeg()]

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -35,11 +35,13 @@ def test_all_lists_public_exports_once() -> None:
 
 def test_eegrej_export_matches_eeglab_low_level_function() -> None:
     from eegprep.functions.popfunc.eeg_eegrej import eeg_eegrej
+    from eegprep.functions.popfunc.eeg_multieegplot import eeg_multieegplot
     from eegprep.functions.sigprocfunc.eegplot import eegplot as sigproc_eegplot
     from eegprep.functions.sigprocfunc.eegrej import eegrej as sigproc_eegrej
     from eegprep.functions.sigprocfunc.rmbase import rmbase as sigproc_rmbase
 
     assert eegprep.eegplot is sigproc_eegplot
+    assert eegprep.eeg_multieegplot is eeg_multieegplot
     assert eegprep.eegrej is sigproc_eegrej
     assert eegprep.eeg_eegrej is eeg_eegrej
     assert eegprep.eegrej is not eegprep.eeg_eegrej

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -43,6 +43,7 @@ from eegprep.functions.sigprocfunc.coregister import (
     read_electrode_file,
     traditional_transform_matrix,
 )
+from eegprep.plugins.ICLabel.pop_viewprops import pop_viewprops
 from eegprep.functions.sigprocfunc.headplot import (
     MAPLIMIT_PADDING,
     default_headplot_mesh_transform,
@@ -595,6 +596,32 @@ def test_component_plot_wrappers_work_when_ica_fields_exist(ica_epoch):
     plt.close(plotdata_fig)
     plt.close(envtopo_fig)
     plt.close(erpimage_result["figure"])
+
+
+def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):
+    figure, command = pop_prop(ica_epoch, typecomp=0, chanorcomp=1, return_com=True)
+
+    activity = figure.eegprep_activity_view
+
+    assert activity.data.mode == "epoched"
+    assert activity.data.n_channels == 1
+    assert activity.state.title == "Scrolling IC1 Activity -- eegplot()"
+    assert "pop_prop(EEG" in command
+    plt.close(figure)
+
+
+def test_pop_viewprops_attaches_channel_activity_browser_models(ica_epoch):
+    eeg = deepcopy(ica_epoch)
+    eeg["event"] = [{"type": "stim", "latency": 2}]
+
+    figures, command = pop_viewprops(eeg, typecomp=1, chanorcomp=[1], scroll_event=0, return_com=True)
+    activity = figures[0].eegprep_activity_views[0]
+
+    assert activity.data.mode == "epoched"
+    assert activity.data.channel_labels == ("Ch1",)
+    assert activity.state.events == []
+    assert "pop_viewprops(EEG" in command
+    plt.close(figures[0])
 
 
 def test_pop_erpimage_projects_components_to_selected_channel(ica_epoch):


### PR DESCRIPTION
Add EEGBrowser data2 overlays, linked/noui/frequency modes, eeg_multieegplot, and browser-backed property activity views. This also enables pop_subcomp(plotag=True) to show a before/after data2 browser and expands tests for advanced channel/component display behavior.

Fixes #100
Part of #94