### PR TITLE
[EEGBrowser] Integrate rejection workflows

### DIFF
--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -32,6 +32,15 @@ _TUPLE_ASSIGNMENT_TARGET_PATTERN = re.compile(
 _POP_INTERP_CHANNELS_PATTERN = re.compile(r"(pop_interp\s*\(\s*EEG\s*,\s*)\[([0-9,\s]+)\]")
 _PYTHON_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _CONSOLE_COMMAND_EXPORTS = {"pop_newset": pop_newset}
+_BROWSER_ACCEPT_POP_FUNCTIONS = {
+    "pop_autorej",
+    "pop_eegthresh",
+    "pop_jointprob",
+    "pop_rejcont",
+    "pop_rejkurt",
+    "pop_rejspec",
+    "pop_rejtrend",
+}
 
 
 class ConsolePopResult:
@@ -174,10 +183,26 @@ class ConsolePopFunction(LazyWorkspaceExport):
                 self.bridge._refresh()
 
             call_kwargs["command_callback"] = accept_eegplot
+        elif self.name in _BROWSER_ACCEPT_POP_FUNCTIONS and "command_callback" not in call_kwargs:
+            source_eeg = _first_call_eeg_argument(args, call_kwargs)
+            target_index = list(self.bridge.session.CURRENTSET)
+
+            def accept_browser_result(eeg_out: Any, command: str) -> None:
+                if not isinstance(source_eeg, dict) or not isinstance(eeg_out, dict):
+                    return
+                store_new = eegplot_accept_creates_dataset(source_eeg, eeg_out, reject=1)
+                store_command = "" if command in recorded_commands else command
+                recorded_commands.add(command)
+                store_index = None if store_new else target_index
+                self.bridge._store_eeg(eeg_out, store_command, new=store_new, index=store_index)
+                self.bridge.pull_from_session()
+                self.bridge._refresh()
+
+            call_kwargs["command_callback"] = accept_browser_result
         if _accepts_return_com(function) and "return_com" not in call_kwargs:
             call_kwargs["return_com"] = True
         result = function(*args, **call_kwargs)
-        if self.name == "pop_eegplot":
+        if self.name == "pop_eegplot" or self.name in _BROWSER_ACCEPT_POP_FUNCTIONS:
             _eeg, command = _extract_pop_eeg_and_command(result)
             if command:
                 recorded_commands.add(command)

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -1065,6 +1065,14 @@ class MenuActionDispatcher:
 
             target_index = list(self.session.CURRENTSET)
             recorded_commands: set[str] = set()
+            if isinstance(selection, list):
+                out = self._run_browser_accept_pop_action(name, selection, variant, command_callback=None)
+                command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
+                eeg_out = out[0] if isinstance(out, tuple) and out else out
+                if command:
+                    self._store_current_from_gui(eeg_out, command=command, index=target_index)
+                    self._refresh()
+                return
 
             def accept_browser_result(eeg_out: Any, command: str) -> None:
                 with self.session.gui_action(name):
@@ -1081,59 +1089,7 @@ class MenuActionDispatcher:
                         )
                         self._refresh()
 
-            if name == "pop_autorej":
-                from eegprep.functions.popfunc.pop_autorej import pop_autorej
-
-                out = pop_autorej(selection, command_callback=accept_browser_result, return_com=True)
-            elif name == "pop_eegthresh":
-                from eegprep.functions.popfunc.pop_eegthresh import pop_eegthresh
-
-                out = pop_eegthresh(
-                    selection,
-                    _icacomp_from_variant(variant),
-                    command_callback=accept_browser_result,
-                    return_com=True,
-                )
-            elif name == "pop_jointprob":
-                from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
-
-                out = pop_jointprob(
-                    selection,
-                    _icacomp_from_variant(variant),
-                    command_callback=accept_browser_result,
-                    return_com=True,
-                )
-            elif name == "pop_rejcont":
-                from eegprep.functions.popfunc.pop_rejcont import pop_rejcont
-
-                out = pop_rejcont(selection, command_callback=accept_browser_result, return_com=True)
-            elif name == "pop_rejkurt":
-                from eegprep.functions.popfunc.pop_rejkurt import pop_rejkurt
-
-                out = pop_rejkurt(
-                    selection,
-                    _icacomp_from_variant(variant),
-                    command_callback=accept_browser_result,
-                    return_com=True,
-                )
-            elif name == "pop_rejspec":
-                from eegprep.functions.popfunc.pop_rejspec import pop_rejspec
-
-                out = pop_rejspec(
-                    selection,
-                    _icacomp_from_variant(variant),
-                    command_callback=accept_browser_result,
-                    return_com=True,
-                )
-            else:
-                from eegprep.functions.popfunc.pop_rejtrend import pop_rejtrend
-
-                out = pop_rejtrend(
-                    selection,
-                    _icacomp_from_variant(variant),
-                    command_callback=accept_browser_result,
-                    return_com=True,
-                )
+            out = self._run_browser_accept_pop_action(name, selection, variant, command_callback=accept_browser_result)
             command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
             eeg_out = out[0] if isinstance(out, tuple) and out else out
             if name == "pop_rejcont":
@@ -1181,6 +1137,43 @@ class MenuActionDispatcher:
         if command:
             self._store_current_from_gui(eeg_out, command=command)
             self._refresh()
+
+    def _run_browser_accept_pop_action(
+        self,
+        name: str,
+        selection: Any,
+        variant: str,
+        *,
+        command_callback: Any | None,
+    ) -> Any:
+        callback_kwargs = {"command_callback": command_callback} if command_callback is not None else {}
+        if name == "pop_autorej":
+            from eegprep.functions.popfunc.pop_autorej import pop_autorej
+
+            return pop_autorej(selection, **callback_kwargs, return_com=True)
+        if name == "pop_eegthresh":
+            from eegprep.functions.popfunc.pop_eegthresh import pop_eegthresh
+
+            return pop_eegthresh(selection, _icacomp_from_variant(variant), **callback_kwargs, return_com=True)
+        if name == "pop_jointprob":
+            from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
+
+            return pop_jointprob(selection, _icacomp_from_variant(variant), **callback_kwargs, return_com=True)
+        if name == "pop_rejcont":
+            from eegprep.functions.popfunc.pop_rejcont import pop_rejcont
+
+            return pop_rejcont(selection, **callback_kwargs, return_com=True)
+        if name == "pop_rejkurt":
+            from eegprep.functions.popfunc.pop_rejkurt import pop_rejkurt
+
+            return pop_rejkurt(selection, _icacomp_from_variant(variant), **callback_kwargs, return_com=True)
+        if name == "pop_rejspec":
+            from eegprep.functions.popfunc.pop_rejspec import pop_rejspec
+
+            return pop_rejspec(selection, _icacomp_from_variant(variant), **callback_kwargs, return_com=True)
+        from eegprep.functions.popfunc.pop_rejtrend import pop_rejtrend
+
+        return pop_rejtrend(selection, _icacomp_from_variant(variant), **callback_kwargs, return_com=True)
 
     def _select_multiple_datasets(self, parent: Any | None) -> None:
         if not self.session.ALLEEG:

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -180,6 +180,16 @@ _DIPFIT_ACTIONS = {
     "pop_multifit",
 }
 
+_BROWSER_ACCEPT_POP_ACTIONS = {
+    "pop_autorej",
+    "pop_eegthresh",
+    "pop_jointprob",
+    "pop_rejcont",
+    "pop_rejkurt",
+    "pop_rejspec",
+    "pop_rejtrend",
+}
+
 
 class MenuActionDispatcher:
     """Dispatch menu action identifiers to real functions or placeholders."""
@@ -1050,26 +1060,91 @@ class MenuActionDispatcher:
                 recorded_commands.add(command)
                 self._refresh()
             return
-        elif name == "pop_autorej":
-            from eegprep.functions.popfunc.pop_autorej import pop_autorej
+        elif name in _BROWSER_ACCEPT_POP_ACTIONS:
+            from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
 
-            out = pop_autorej(selection, return_com=True)
-        elif name == "pop_eegthresh":
-            from eegprep.functions.popfunc.pop_eegthresh import pop_eegthresh
+            target_index = list(self.session.CURRENTSET)
+            recorded_commands: set[str] = set()
 
-            out = pop_eegthresh(selection, _icacomp_from_variant(variant), return_com=True)
-        elif name == "pop_jointprob":
-            from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
+            def accept_browser_result(eeg_out: Any, command: str) -> None:
+                with self.session.gui_action(name):
+                    if command:
+                        store_new = eegplot_accept_creates_dataset(selection, eeg_out, reject=1)
+                        store_command = "" if command in recorded_commands else command
+                        recorded_commands.add(command)
+                        store_index = None if store_new else target_index
+                        self._store_current_from_gui(
+                            eeg_out,
+                            new=store_new,
+                            command=store_command,
+                            index=store_index,
+                        )
+                        self._refresh()
 
-            out = pop_jointprob(selection, _icacomp_from_variant(variant), return_com=True)
+            if name == "pop_autorej":
+                from eegprep.functions.popfunc.pop_autorej import pop_autorej
+
+                out = pop_autorej(selection, command_callback=accept_browser_result, return_com=True)
+            elif name == "pop_eegthresh":
+                from eegprep.functions.popfunc.pop_eegthresh import pop_eegthresh
+
+                out = pop_eegthresh(
+                    selection,
+                    _icacomp_from_variant(variant),
+                    command_callback=accept_browser_result,
+                    return_com=True,
+                )
+            elif name == "pop_jointprob":
+                from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
+
+                out = pop_jointprob(
+                    selection,
+                    _icacomp_from_variant(variant),
+                    command_callback=accept_browser_result,
+                    return_com=True,
+                )
+            elif name == "pop_rejcont":
+                from eegprep.functions.popfunc.pop_rejcont import pop_rejcont
+
+                out = pop_rejcont(selection, command_callback=accept_browser_result, return_com=True)
+            elif name == "pop_rejkurt":
+                from eegprep.functions.popfunc.pop_rejkurt import pop_rejkurt
+
+                out = pop_rejkurt(
+                    selection,
+                    _icacomp_from_variant(variant),
+                    command_callback=accept_browser_result,
+                    return_com=True,
+                )
+            elif name == "pop_rejspec":
+                from eegprep.functions.popfunc.pop_rejspec import pop_rejspec
+
+                out = pop_rejspec(
+                    selection,
+                    _icacomp_from_variant(variant),
+                    command_callback=accept_browser_result,
+                    return_com=True,
+                )
+            else:
+                from eegprep.functions.popfunc.pop_rejtrend import pop_rejtrend
+
+                out = pop_rejtrend(
+                    selection,
+                    _icacomp_from_variant(variant),
+                    command_callback=accept_browser_result,
+                    return_com=True,
+                )
+            command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
+            eeg_out = out[0] if isinstance(out, tuple) and out else out
+            if command:
+                self._store_current_from_gui(eeg_out, command=command)
+                recorded_commands.add(command)
+                self._refresh()
+            return
         elif name == "pop_rejchan":
             from eegprep.functions.popfunc.pop_rejchan import pop_rejchan
 
             out = pop_rejchan(selection, return_com=True)
-        elif name == "pop_rejcont":
-            from eegprep.functions.popfunc.pop_rejcont import pop_rejcont
-
-            out = pop_rejcont(selection, return_com=True)
         elif name == "pop_rejepoch":
             from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 
@@ -1078,22 +1153,10 @@ class MenuActionDispatcher:
                 return
             marks = (selection.get("reject") or {}).get("rejglobal", [])
             out = pop_rejepoch(selection, marks, return_com=True)
-        elif name == "pop_rejkurt":
-            from eegprep.functions.popfunc.pop_rejkurt import pop_rejkurt
-
-            out = pop_rejkurt(selection, _icacomp_from_variant(variant), return_com=True)
         elif name == "pop_rejmenu":
             from eegprep.functions.popfunc.pop_rejmenu import pop_rejmenu
 
             out = pop_rejmenu(selection, _icacomp_from_variant(variant), return_com=True)
-        elif name == "pop_rejspec":
-            from eegprep.functions.popfunc.pop_rejspec import pop_rejspec
-
-            out = pop_rejspec(selection, _icacomp_from_variant(variant), return_com=True)
-        elif name == "pop_rejtrend":
-            from eegprep.functions.popfunc.pop_rejtrend import pop_rejtrend
-
-            out = pop_rejtrend(selection, _icacomp_from_variant(variant), return_com=True)
         elif name == "pop_selectcomps":
             from eegprep.functions.popfunc.pop_selectcomps import pop_selectcomps
 

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -1136,6 +1136,8 @@ class MenuActionDispatcher:
                 )
             command = out[1] if isinstance(out, tuple) and len(out) > 1 else ""
             eeg_out = out[0] if isinstance(out, tuple) and out else out
+            if name == "pop_rejcont":
+                return
             if command:
                 self._store_current_from_gui(eeg_out, command=command)
                 recorded_commands.add(command)

--- a/src/eegprep/functions/guifunc/qt.py
+++ b/src/eegprep/functions/guifunc/qt.py
@@ -7,8 +7,12 @@ import math
 import re
 from typing import Any
 
+import numpy as np
+
 from eegprep.functions.guifunc.pophelp import pophelp
 from eegprep.functions.popfunc.pop_chansel import pop_chansel
+from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
+from eegprep.functions.sigprocfunc.eegplot import eegplot
 
 from .spec import CallbackSpec, ControlSpec, DialogSpec
 
@@ -451,6 +455,14 @@ class QtDialogRenderer:
             source = widgets.get(params["button"])
             if source is not None:
                 source.clicked.connect(lambda: self._show_callback_message(source, params))
+        elif callback.name == "open_eegplot":
+            source = widgets.get(params["button"])
+            if source is not None:
+                source.clicked.connect(lambda: self._open_eegplot(source, params))
+        elif callback.name == "open_rejection_browser":
+            source = widgets.get(params["button"])
+            if source is not None:
+                source.clicked.connect(lambda: self._open_rejection_browser(source, widgets, params))
         elif callback.name == "set_value":
             source = widgets.get(params["source"])
             target = widgets.get(params["target"])
@@ -716,6 +728,59 @@ class QtDialogRenderer:
         transform_target = widgets.get(params.get("transform_target", ""))
         if transform_target is not None and params.get("custom_transform") is not None:
             transform_target.setText(str(params["custom_transform"]))
+
+    @staticmethod
+    def _open_eegplot(parent: Any, params: Mapping[str, Any]) -> None:
+        eeg = params.get("eeg")
+        if not isinstance(eeg, dict):
+            return
+        try:
+            eegplot(
+                eeg,
+                srate=eeg.get("srate", 256),
+                limits=[
+                    float(eeg.get("xmin", 0.0) or 0.0) * 1000.0,
+                    float(eeg.get("xmax", 0.0) or 0.0) * 1000.0,
+                ],
+                events=eeg.get("event", []),
+                winlength=5,
+                xgrid="off",
+                eloc_file=eeg.get("chanlocs", []),
+                title=f"Scroll channel activities -- eegplot() -- {eeg.get('setname', '')}".rstrip(),
+            )
+        except (RuntimeError, ValueError) as exc:
+            _qt_core, qt_widgets = _require_qt()
+            qt_widgets.QMessageBox.warning(parent, "Warning", str(exc))
+
+    @staticmethod
+    def _open_rejection_browser(parent: Any, widgets: Mapping[str, Any], params: Mapping[str, Any]) -> None:
+        eeg = params.get("eeg")
+        if not isinstance(eeg, dict):
+            return
+        try:
+            status_widget = widgets.get("rejstatus")
+            status = int(QtDialogRenderer._read_widget(status_widget) if status_widget is not None else 1)
+            superpose = max(0, min(status - 1, 2))
+
+            def accept(eeg_out: dict[str, Any], _command: str) -> None:
+                eeg.clear()
+                eeg.update(eeg_out)
+                for tag in params.get("count_tags", ()):
+                    widget = widgets.get(tag)
+                    field = params.get("count_fields", {}).get(tag)
+                    if widget is not None and field is not None and hasattr(widget, "setText"):
+                        widget.setText(str(int(np.asarray((eeg.get("reject") or {}).get(field, []), dtype=bool).sum())))
+
+            pop_eegplot(
+                eeg,
+                icacomp=int(params.get("icacomp", 1)),
+                superpose=superpose,
+                reject=0,
+                command_callback=accept,
+            )
+        except (RuntimeError, ValueError) as exc:
+            _qt_core, qt_widgets = _require_qt()
+            qt_widgets.QMessageBox.warning(parent, "Warning", str(exc))
 
     @staticmethod
     def _set_headplot_setup_mode(widgets: Mapping[str, Any], params: Mapping[str, Any], checked: bool) -> None:

--- a/src/eegprep/functions/popfunc/_eegplot_rejection.py
+++ b/src/eegprep/functions/popfunc/_eegplot_rejection.py
@@ -14,6 +14,7 @@ from eegprep.functions.sigprocfunc.eegplot import eegplot, eegplot2trial, trial2
 
 
 DISPLAY_REJECTION_FAMILIES = ("manual", "thresh", "const", "jp", "kurt", "freq")
+# Autorej shares manual-color browser marks and is not superposed as a separate EEGLAB family.
 _AUTO_REJECTION_COLOR = MANUAL_REJECTION_COLOR
 
 

--- a/src/eegprep/functions/popfunc/_eegplot_rejection.py
+++ b/src/eegprep/functions/popfunc/_eegplot_rejection.py
@@ -1,0 +1,367 @@
+"""Shared EEGBrowser integration for rejection pop functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.popfunc._chanutils import chanlocs_as_list
+from eegprep.functions.popfunc._rejection import copy_eeg, reject_field_names, update_reject_fields
+from eegprep.functions.popfunc.pop_eegplot import DEFAULT_REJECTION_COLORS, MANUAL_REJECTION_COLOR
+from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
+from eegprep.functions.sigprocfunc.eegplot import eegplot, eegplot2trial, trial2eegplot
+
+
+DISPLAY_REJECTION_FAMILIES = ("manual", "thresh", "const", "jp", "kurt", "freq")
+_AUTO_REJECTION_COLOR = MANUAL_REJECTION_COLOR
+
+
+def open_epoched_rejection_browser(
+    EEG: dict[str, Any],
+    *,
+    data: np.ndarray,
+    icacomp: int | bool,
+    elecrange: list[int],
+    kind: str,
+    superpose: int | bool,
+    reject: int | bool,
+    command: str,
+    command_callback: Any | None = None,
+    show: bool = True,
+) -> Any:
+    """Open EEGBrowser with method-specific epoched rejection marks."""
+    row_count = int(data.shape[0])
+    selected_rows = _selected_row_indices(elecrange, row_count)
+    selected_data = np.asarray(data, dtype=float)[selected_rows, :, :]
+    ensure_rejection_defaults(EEG)
+    winrej = initial_epoched_rejection_winrej(
+        EEG,
+        icacomp=icacomp,
+        elecrange=elecrange,
+        kind=kind,
+        superpose=superpose,
+        row_count=row_count,
+    )
+
+    def _accept(winrej_rows: np.ndarray) -> None:
+        eeg_out, accept_command = apply_epoched_rejection_browser(
+            EEG,
+            winrej_rows,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind=kind,
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            row_count=row_count,
+            return_com=True,
+        )
+        if command_callback is not None:
+            command_callback(eeg_out, accept_command)
+
+    options: dict[str, Any] = {
+        "srate": EEG.get("srate", 256),
+        "limits": [
+            float(EEG.get("xmin", 0.0) or 0.0) * 1000.0,
+            float(EEG.get("xmax", 0.0) or 0.0) * 1000.0,
+        ],
+        "events": EEG.get("event", []),
+        "winlength": 5,
+        "xgrid": "off",
+        "winrej": winrej,
+        "wincolor": _kind_color(EEG, kind),
+        "butlabel": "Reject" if int(bool(reject)) else "Update Marks",
+        "show": show,
+    }
+    if show:
+        options["command_callback"] = _accept
+    if int(bool(icacomp)):
+        options["eloc_file"] = _selected_chanlocs(EEG, selected_rows)
+        options["title"] = f"Scroll channel activities -- eegplot() -- {EEG.get('setname', '')}".rstrip()
+    else:
+        options["component"] = True
+        options["title"] = f"Scroll component activities -- eegplot() -- {EEG.get('setname', '')}".rstrip()
+    return eegplot(selected_data, **options)
+
+
+def initial_epoched_rejection_winrej(
+    EEG: dict[str, Any],
+    *,
+    icacomp: int | bool,
+    elecrange: list[int],
+    kind: str,
+    superpose: int | bool,
+    row_count: int,
+) -> np.ndarray:
+    """Build selected-channel ``winrej`` rows for a rejection-family browser."""
+    reject = EEG.get("reject") or {}
+    trials = int(EEG.get("trials", 1) or 1)
+    pnts = int(EEG.get("pnts", np.asarray(EEG.get("data")).shape[1]))
+    selected_rows = _selected_row_indices(elecrange, row_count)
+    rows: list[np.ndarray] = []
+    current_rows = _family_rows(
+        reject,
+        kind,
+        icacomp=icacomp,
+        trials=trials,
+        row_count=row_count,
+        pnts=pnts,
+        selected_rows=selected_rows,
+        color=_kind_color(EEG, kind),
+    )
+    if int(superpose) == 2:
+        for family in _displayed_families(reject):
+            family_kind = f"rej{family}"
+            if family_kind == kind:
+                continue
+            family_rows = _family_rows(
+                reject,
+                family_kind,
+                icacomp=icacomp,
+                trials=trials,
+                row_count=row_count,
+                pnts=pnts,
+                selected_rows=selected_rows,
+                color=_family_color(reject, family),
+            )
+            if family_rows.size:
+                rows.append(family_rows)
+    if int(superpose) == 1:
+        old_rows = _family_rows(
+            reject,
+            kind,
+            icacomp=icacomp,
+            trials=trials,
+            row_count=row_count,
+            pnts=pnts,
+            selected_rows=selected_rows,
+            color=_lighter_color(_kind_color(EEG, kind)),
+        )
+        if old_rows.size:
+            rows.append(old_rows)
+    if current_rows.size:
+        rows.append(current_rows)
+    return np.vstack(rows) if rows else np.zeros((0, 5 + len(selected_rows)), dtype=float)
+
+
+def apply_epoched_rejection_browser(
+    EEG: dict[str, Any],
+    winrej: Any,
+    *,
+    icacomp: int | bool,
+    elecrange: list[int],
+    kind: str,
+    superpose: int | bool,
+    reject: int | bool,
+    command: str,
+    row_count: int | None = None,
+    return_com: bool = False,
+) -> Any:
+    """Apply accepted EEGBrowser rejection rows to method-specific fields."""
+    out = copy_eeg(EEG)
+    ensure_rejection_defaults(out)
+    trials = int(out.get("trials", 1) or 1)
+    pnts = int(out.get("pnts", np.asarray(out.get("data")).shape[1]))
+    if row_count is None:
+        row_count = _row_count(out, icacomp)
+    selected_rows = _selected_row_indices(elecrange, row_count)
+    rows = _as_winrej_rows(winrej)
+    if int(superpose) == 2:
+        _apply_superposed_family_rows(
+            out,
+            rows,
+            icacomp=icacomp,
+            kind=kind,
+            trials=trials,
+            row_count=row_count,
+            selected_rows=selected_rows,
+            pnts=pnts,
+        )
+        trial_marks, row_marks = _all_rows_to_trial_marks(rows, pnts, trials, row_count, selected_rows)
+    else:
+        trial_marks, selected_marks = eegplot2trial(rows, pnts, trials, _kind_color(out, kind), None)
+        row_marks = _expand_selected_row_marks(selected_marks, row_count, selected_rows, trials)
+        update_reject_fields(out, icacomp=icacomp, kind=kind, reject=trial_marks, reject_e=row_marks)
+        _store_manual_marks(out, trial_marks, row_marks, icacomp=icacomp)
+    if int(bool(reject)) and np.asarray(trial_marks, dtype=bool).any():
+        out, _reject_command = pop_rejepoch(out, np.asarray(trial_marks, dtype=bool), 1, return_com=True)
+    return (out, command) if return_com else out
+
+
+def ensure_rejection_defaults(EEG: dict[str, Any]) -> None:
+    """Ensure EEGLAB-compatible rejection color fields exist."""
+    reject = EEG.setdefault("reject", {})
+    reject.setdefault("rejmanualcol", np.asarray(MANUAL_REJECTION_COLOR, dtype=float))
+    for family, color in DEFAULT_REJECTION_COLORS.items():
+        reject.setdefault(f"rej{family}col", np.asarray(color, dtype=float))
+
+
+def _apply_superposed_family_rows(
+    EEG: dict[str, Any],
+    rows: np.ndarray,
+    *,
+    icacomp: int | bool,
+    kind: str,
+    trials: int,
+    row_count: int,
+    selected_rows: np.ndarray,
+    pnts: int,
+) -> None:
+    reject = EEG.setdefault("reject", {})
+    families = set(_displayed_families(reject))
+    families.add(_family_from_kind(kind))
+    for family in sorted(families):
+        family_kind = f"rej{family}"
+        trial_marks, selected_marks = eegplot2trial(rows, pnts, trials, _family_color(reject, family), None)
+        row_marks = _expand_selected_row_marks(selected_marks, row_count, selected_rows, trials)
+        update_reject_fields(EEG, icacomp=icacomp, kind=family_kind, reject=trial_marks, reject_e=row_marks)
+
+
+def _all_rows_to_trial_marks(
+    rows: np.ndarray,
+    pnts: int,
+    trials: int,
+    row_count: int,
+    selected_rows: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    trial_marks, selected_marks = eegplot2trial(rows, pnts, trials, None, None)
+    return trial_marks, _expand_selected_row_marks(selected_marks, row_count, selected_rows, trials)
+
+
+def _family_rows(
+    reject: dict[str, Any],
+    kind: str,
+    *,
+    icacomp: int | bool,
+    trials: int,
+    row_count: int,
+    pnts: int,
+    selected_rows: np.ndarray,
+    color: tuple[float, float, float],
+) -> np.ndarray:
+    field, field_e = reject_field_names(icacomp, kind)
+    marks = _trial_marks(reject.get(field), trials)
+    row_marks = _row_marks(reject.get(field_e), row_count, trials)[selected_rows, :]
+    return trial2eegplot(marks, row_marks, pnts, color)
+
+
+def _store_manual_marks(
+    EEG: dict[str, Any],
+    trial_marks: np.ndarray,
+    row_marks: np.ndarray,
+    *,
+    icacomp: int | bool,
+) -> None:
+    field, field_e = reject_field_names(icacomp, "rejmanual")
+    reject = EEG.setdefault("reject", {})
+    current = _trial_marks(reject.get(field), np.asarray(trial_marks).size)
+    current_e = _row_marks(reject.get(field_e), row_marks.shape[0], np.asarray(trial_marks).size)
+    reject[field] = current | np.asarray(trial_marks, dtype=bool)
+    reject[field_e] = current_e | np.asarray(row_marks, dtype=bool)
+    reject.setdefault("rejmanualcol", np.asarray(MANUAL_REJECTION_COLOR, dtype=float))
+
+
+def _selected_row_indices(elecrange: list[int], row_count: int) -> np.ndarray:
+    selected = np.asarray(elecrange, dtype=int).ravel() - 1
+    if selected.size == 0:
+        selected = np.arange(row_count, dtype=int)
+    if np.any(selected < 0) or np.any(selected >= row_count):
+        raise ValueError("Index out of range")
+    return selected
+
+
+def _expand_selected_row_marks(
+    selected_marks: np.ndarray,
+    row_count: int,
+    selected_rows: np.ndarray,
+    trials: int,
+) -> np.ndarray:
+    out = np.zeros((row_count, trials), dtype=bool)
+    marks = np.asarray(selected_marks, dtype=bool)
+    if marks.ndim == 1 and marks.size:
+        marks = marks.reshape(1, -1)
+    if marks.ndim != 2 or marks.size == 0:
+        return out
+    rows = min(selected_rows.size, marks.shape[0])
+    cols = min(trials, marks.shape[1])
+    out[selected_rows[:rows], :cols] = marks[:rows, :cols]
+    return out
+
+
+def _trial_marks(value: Any, trials: int) -> np.ndarray:
+    out = np.zeros(trials, dtype=bool)
+    marks = np.asarray(value if value is not None else [], dtype=bool).ravel()
+    out[: min(trials, marks.size)] = marks[:trials]
+    return out
+
+
+def _row_marks(value: Any, row_count: int, trials: int) -> np.ndarray:
+    out = np.zeros((row_count, trials), dtype=bool)
+    marks = np.asarray(value if value is not None else [], dtype=bool)
+    if marks.ndim == 1 and marks.size:
+        marks = marks.reshape(1, -1)
+    if marks.ndim == 2:
+        rows = min(row_count, marks.shape[0])
+        cols = min(trials, marks.shape[1])
+        out[:rows, :cols] = marks[:rows, :cols]
+    return out
+
+
+def _row_count(EEG: dict[str, Any], icacomp: int | bool) -> int:
+    if int(bool(icacomp)):
+        return int(EEG.get("nbchan", np.asarray(EEG.get("data")).shape[0]) or 0)
+    weights = np.asarray(EEG.get("icaweights", []))
+    return int(weights.shape[0]) if weights.ndim == 2 else 0
+
+
+def _displayed_families(reject: dict[str, Any]) -> tuple[str, ...]:
+    disprej = reject.get("disprej")
+    if disprej is not None and np.asarray(disprej, dtype=object).size:
+        return tuple(
+            str(item) for item in np.asarray(disprej, dtype=object).ravel() if str(item) in DISPLAY_REJECTION_FAMILIES
+        )
+    return tuple(family for family in DISPLAY_REJECTION_FAMILIES if _has_family_marks(reject, family))
+
+
+def _has_family_marks(reject: dict[str, Any], family: str) -> bool:
+    return any(np.asarray(reject.get(field, [])).size for field in (f"rej{family}", f"icarej{family}"))
+
+
+def _kind_color(EEG: dict[str, Any], kind: str) -> tuple[float, float, float]:
+    reject = EEG.get("reject") or {}
+    family = _family_from_kind(kind)
+    if family == "auto":
+        return _AUTO_REJECTION_COLOR
+    return _family_color(reject, family)
+
+
+def _family_color(reject: dict[str, Any], family: str) -> tuple[float, float, float]:
+    default = DEFAULT_REJECTION_COLORS.get(family, MANUAL_REJECTION_COLOR)
+    values = np.asarray(reject.get(f"rej{family}col", default), dtype=float).ravel()
+    if values.size < 3:
+        return default
+    return tuple(float(item) for item in values[:3])
+
+
+def _family_from_kind(kind: str) -> str:
+    family = kind[3:] if kind.startswith("rej") else kind
+    return family or "manual"
+
+
+def _lighter_color(color: tuple[float, float, float]) -> tuple[float, float, float]:
+    return tuple(min(float(component) + 0.15, 1.0) for component in color)
+
+
+def _selected_chanlocs(EEG: dict[str, Any], selected_rows: np.ndarray) -> list[dict[str, Any]]:
+    chanlocs = chanlocs_as_list(EEG.get("chanlocs", []))
+    return [chanlocs[index] for index in selected_rows if index < len(chanlocs)]
+
+
+def _as_winrej_rows(winrej: Any) -> np.ndarray:
+    rows = np.asarray(winrej if winrej is not None else [], dtype=float)
+    if rows.ndim == 1:
+        rows = rows.reshape(1, -1)
+    if rows.size == 0:
+        return np.zeros((0, 5), dtype=float)
+    return rows

--- a/src/eegprep/functions/popfunc/pop_autorej.py
+++ b/src/eegprep/functions/popfunc/pop_autorej.py
@@ -8,8 +8,15 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value, parse_key_value_args
-from eegprep.functions.popfunc._rejection import one_based_indices, parse_numeric_sequence
+from eegprep.functions.popfunc._rejection import (
+    copy_eeg,
+    one_based_indices,
+    parse_numeric_sequence,
+    rejection_data,
+    update_reject_fields,
+)
 from eegprep.functions.popfunc.pop_eegthresh import pop_eegthresh
 from eegprep.functions.popfunc.pop_jointprob import pop_jointprob
 from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
@@ -22,9 +29,11 @@ def pop_autorej(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
     **kwargs: Any,
 ):
-    """Run EEGLAB's automatic epoch rejection protocol without EEGPlot."""
+    """Run EEGLAB's automatic epoch rejection protocol."""
     if EEG is None:
         return (None, "") if return_com else (None, [])
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
@@ -35,8 +44,15 @@ def pop_autorej(
         if gui_options is None:
             return (EEG, "") if return_com else (EEG, [])
         options.update(gui_options)
-    out, rejected = _apply_one(EEG, options)
     command = _history_command(options)
+    out, rejected = _apply_one(
+        EEG,
+        options,
+        display=str(options.get("eegplot", "off")).lower() == "on",
+        command=command,
+        command_callback=command_callback,
+        show=show,
+    )
     return (out, command) if return_com else (out, rejected)
 
 
@@ -65,7 +81,7 @@ def pop_autorej_dialog_spec(EEG: dict[str, Any]) -> DialogSpec:
             ControlSpec("edit", tag="maxrej", value="5"),
             ControlSpec("spacer"),
             ControlSpec("text", "Check box for visual inspection of results"),
-            ControlSpec("checkbox", tag="eegplot", value=False, enabled=False),
+            ControlSpec("checkbox", tag="eegplot", value=True, enabled=True),
         ),
     )
 
@@ -86,10 +102,20 @@ def _run_gui(EEG: dict[str, Any], renderer: Any | None) -> dict[str, Any] | None
         options["startprob"] = result.get("startprob")
     if result.get("maxrej", "5") != "5":
         options["maxrej"] = result.get("maxrej")
+    if result.get("eegplot"):
+        options["eegplot"] = "on"
     return options
 
 
-def _apply_one(EEG: dict[str, Any], options: dict[str, Any]) -> tuple[dict[str, Any], list[int]]:
+def _apply_one(
+    EEG: dict[str, Any],
+    options: dict[str, Any],
+    *,
+    display: bool = False,
+    command: str = "",
+    command_callback: Any | None = None,
+    show: bool = True,
+) -> tuple[dict[str, Any], list[int]]:
     if int(EEG.get("trials", 1) or 1) <= 1:
         raise ValueError("pop_autorej requires epoched data")
     threshold = float(parse_numeric_sequence(options.get("threshold", 1000), dtype=float)[0])
@@ -137,12 +163,52 @@ def _apply_one(EEG: dict[str, Any], options: dict[str, Any]) -> tuple[dict[str, 
         rejected.update(remaining[index - 1] for index in current)
         if current:
             work = pop_rejepoch(work, current, 0)
-    return work, sorted(rejected)
+    rejected_sorted = sorted(rejected)
+    if display:
+        marked = _autorej_marked_dataset(EEG, rejected_sorted, process_data=process_data, rows=rows)
+        browser_data, _row_count = rejection_data(marked, int(process_data))
+        open_epoched_rejection_browser(
+            marked,
+            data=browser_data,
+            icacomp=int(process_data),
+            elecrange=rows,
+            kind="rejauto",
+            superpose=0,
+            reject=1,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+        return marked, rejected_sorted
+    return work, rejected_sorted
+
+
+def _autorej_marked_dataset(
+    EEG: dict[str, Any],
+    rejected: list[int],
+    *,
+    process_data: bool,
+    rows: list[int],
+) -> dict[str, Any]:
+    out = copy_eeg(EEG)
+    trials = int(out.get("trials", 1) or 1)
+    row_count = int(out.get("nbchan", 0) or 0) if process_data else int(np.asarray(out.get("icaweights", [])).shape[0])
+    marks = np.zeros(trials, dtype=bool)
+    for index in rejected:
+        if 1 <= int(index) <= trials:
+            marks[int(index) - 1] = True
+    row_marks = np.zeros((row_count, trials), dtype=bool)
+    selected = np.asarray(rows, dtype=int) - 1
+    selected = selected[(selected >= 0) & (selected < row_count)]
+    if selected.size:
+        row_marks[np.ix_(selected, np.flatnonzero(marks))] = True
+    update_reject_fields(out, icacomp=int(process_data), kind="rejauto", reject=marks, reject_e=row_marks)
+    return out
 
 
 def _history_command(options: dict[str, Any]) -> str:
     values: list[Any] = []
-    for key in ("startprob", "electrodes", "icacomps", "maxrej", "nogui", "threshold"):
+    for key in ("startprob", "electrodes", "icacomps", "maxrej", "nogui", "threshold", "eegplot"):
         if key in options:
             values.extend([key, options[key]])
     return (

--- a/src/eegprep/functions/popfunc/pop_eegthresh.py
+++ b/src/eegprep/functions/popfunc/pop_eegthresh.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import (
     copy_eeg,
@@ -35,6 +36,8 @@ def pop_eegthresh(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ):
     """Mark or reject epochs using EEGLAB ``pop_eegthresh`` semantics."""
     if EEG is None:
@@ -51,7 +54,16 @@ def pop_eegthresh(
             elecrange, negthresh, posthresh, starttime, endtime, superpose, reject = result
         for dataset in EEG:
             out, inds, _command = _apply_one(
-                dataset, icacomp, elecrange, negthresh, posthresh, starttime, endtime, superpose, reject
+                dataset,
+                icacomp,
+                elecrange,
+                negthresh,
+                posthresh,
+                starttime,
+                endtime,
+                superpose,
+                reject,
+                display=False,
             )
             outputs.append(out)
             rejected.append(inds)
@@ -63,7 +75,18 @@ def pop_eegthresh(
             return (EEG, "") if return_com else (EEG, [])
         elecrange, negthresh, posthresh, starttime, endtime, superpose, reject = result
     out, rejected, command = _apply_one(
-        EEG, icacomp, elecrange, negthresh, posthresh, starttime, endtime, superpose, reject
+        EEG,
+        icacomp,
+        elecrange,
+        negthresh,
+        posthresh,
+        starttime,
+        endtime,
+        superpose,
+        reject,
+        display=bool(gui or topcommand is not None),
+        command_callback=command_callback,
+        show=show,
     )
     return (out, command) if return_com else (out, rejected)
 
@@ -138,6 +161,10 @@ def _apply_one(
     endtime: Any,
     superpose: int | bool,
     reject: int | bool,
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ) -> tuple[dict[str, Any], list[int], str]:
     out = copy_eeg(EEG)
     data, row_count = rejection_data(out, icacomp)
@@ -160,11 +187,24 @@ def _apply_one(
     )
     update_reject_fields(out, icacomp=icacomp, kind="rejthresh", reject=marks, reject_e=marks_e)
     rejected = (np.flatnonzero(marks) + 1).tolist()
-    if int(bool(reject)) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
     command = _history_command(
         icacomp, elecrange, negthresh, posthresh, starttime, endtime, superpose, int(bool(reject))
     )
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind="rejthresh",
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(reject)) and rejected:
+        out = pop_rejepoch(out, rejected, 0)
     return out, rejected, command
 
 
@@ -185,7 +225,7 @@ def _history_command(
         parse_numeric_sequence(posthresh, dtype=float),
         parse_numeric_sequence(starttime, dtype=float),
         parse_numeric_sequence(endtime, dtype=float),
-        int(bool(superpose)),
+        int(superpose),
         int(bool(reject)),
     ]
     return (

--- a/src/eegprep/functions/popfunc/pop_jointprob.py
+++ b/src/eegprep/functions/popfunc/pop_jointprob.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import (
     copy_eeg,
@@ -35,6 +36,8 @@ def pop_jointprob(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ):
     """Mark or reject epochs by local/global joint probability."""
     if EEG is None:
@@ -48,7 +51,17 @@ def pop_jointprob(
                 return (EEG, "") if return_com else (EEG, [], [], 0)
             elecrange, locthresh, globthresh, superpose, reject, vistype = result
         outputs = [
-            _apply_one(dataset, icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype)[0]
+            _apply_one(
+                dataset,
+                icacomp,
+                elecrange,
+                locthresh,
+                globthresh,
+                superpose,
+                reject,
+                vistype,
+                display=False,
+            )[0]
             for dataset in EEG
         ]
         command = _history_command(icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype, plotflag)
@@ -59,7 +72,17 @@ def pop_jointprob(
             return (EEG, "") if return_com else (EEG, [], [], 0)
         elecrange, locthresh, globthresh, superpose, reject, vistype = result
     out, local_threshold, global_threshold, rejected, command = _apply_one(
-        EEG, icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype
+        EEG,
+        icacomp,
+        elecrange,
+        locthresh,
+        globthresh,
+        superpose,
+        reject,
+        vistype,
+        display=bool(int(vistype) == 1 or topcommand is not None),
+        command_callback=command_callback,
+        show=show,
     )
     return (out, command) if return_com else (out, local_threshold, global_threshold, len(rejected))
 
@@ -145,6 +168,10 @@ def _apply_one(
     superpose: int | bool,
     reject: int | bool,
     vistype: int,
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ) -> tuple[dict[str, Any], list[float], list[float], list[int], str]:
     out = copy_eeg(EEG)
     data, row_count = rejection_data(out, icacomp)
@@ -161,9 +188,22 @@ def _apply_one(
         out["stats"]["icajp"] = global_scores
     update_reject_fields(out, icacomp=icacomp, kind="rejjp", reject=marks, reject_e=marks_e)
     rejected = (np.flatnonzero(marks) + 1).tolist()
-    if int(bool(reject)) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
     command = _history_command(icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype, 0)
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind="rejjp",
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(reject)) and rejected:
+        out = pop_rejepoch(out, rejected, 0)
     return (
         out,
         parse_numeric_sequence(locthresh, dtype=float),
@@ -188,7 +228,7 @@ def _history_command(
         parse_numeric_sequence(elecrange, dtype=int),
         parse_numeric_sequence(locthresh, dtype=float),
         parse_numeric_sequence(globthresh, dtype=float),
-        int(bool(superpose)),
+        int(superpose),
         int(bool(reject)),
         int(vistype),
         [],

--- a/src/eegprep/functions/popfunc/pop_rejcont.py
+++ b/src/eegprep/functions/popfunc/pop_rejcont.py
@@ -11,6 +11,10 @@ from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.popfunc._pop_utils import format_history_value, parse_key_value_args
 from eegprep.functions.popfunc._rejection import copy_eeg, one_based_indices, parse_numeric_sequence
 from eegprep.functions.popfunc.pop_select import pop_select
+from eegprep.functions.sigprocfunc.eegplot import eegplot
+
+
+_REJCONT_WINREJ_COLOR = (0.0, 0.9, 0.0)
 
 
 def pop_rejcont(
@@ -19,6 +23,8 @@ def pop_rejcont(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
     **kwargs: Any,
 ):
     """Reject continuous data portions based on high-frequency power."""
@@ -32,7 +38,13 @@ def pop_rejcont(
         if gui_options is None:
             return (EEG, "") if return_com else (EEG, [])
         options.update(gui_options)
-    out, selected, command = _apply_one(EEG, options)
+    out, selected, command = _apply_one(
+        EEG,
+        options,
+        display=bool(gui or str(options.get("eegplot", "off")).lower() == "on"),
+        command_callback=command_callback,
+        show=show,
+    )
     return (out, command) if return_com else (out, selected)
 
 
@@ -76,10 +88,18 @@ def _run_gui(EEG: dict[str, Any], renderer: Any | None) -> dict[str, Any] | None
         "contiguous": result.get("contiguous", "4"),
         "addlength": result.get("addlength", "0.25"),
         "taper": "hamming" if result.get("taper", False) else "none",
+        "eegplot": "on",
     }
 
 
-def _apply_one(EEG: dict[str, Any], options: dict[str, Any]) -> tuple[dict[str, Any], np.ndarray, str]:
+def _apply_one(
+    EEG: dict[str, Any],
+    options: dict[str, Any],
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
+) -> tuple[dict[str, Any], np.ndarray, str]:
     out = copy_eeg(EEG)
     if int(out.get("trials", 1) or 1) != 1:
         raise ValueError("pop_rejcont requires continuous data")
@@ -110,15 +130,120 @@ def _apply_one(EEG: dict[str, Any], options: dict[str, Any]) -> tuple[dict[str, 
         addlength,
         options,
     )
-    if selected.size and str(options.get("onlyreturnselection", "off")).lower() != "on":
+    command = _history_command(options)
+    if display and str(options.get("onlyreturnselection", "off")).lower() != "on":
+        _open_rejcont_browser(
+            out,
+            data,
+            selected,
+            elecrange,
+            options,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif selected.size and str(options.get("onlyreturnselection", "off")).lower() != "on":
         if str(options.get("correct", "remove")).lower() == "blank":
             for start, stop in selected.astype(int):
                 data[np.asarray(elecrange, dtype=int) - 1, start - 1 : stop] = 0
             out["data"] = data
         else:
             out = pop_select(out, "nopoint", selected.tolist(), gui=False)
-    command = _history_command(options)
     return out, selected, command
+
+
+def _open_rejcont_browser(
+    EEG: dict[str, Any],
+    data: np.ndarray,
+    selected: np.ndarray,
+    elecrange: list[int],
+    options: dict[str, Any],
+    *,
+    command: str,
+    command_callback: Any | None,
+    show: bool,
+) -> Any:
+    selected_rows = np.asarray(elecrange, dtype=int) - 1
+    selected_data = np.asarray(data, dtype=float)[selected_rows, :]
+    winrej = _rejcont_winrej(selected, len(elecrange))
+
+    def _accept(winrej_rows: np.ndarray) -> None:
+        eeg_out = _apply_rejcont_winrej(EEG, winrej_rows, elecrange, options)
+        if command_callback is not None:
+            command_callback(eeg_out, command)
+
+    kwargs: dict[str, Any] = {
+        "srate": EEG.get("srate", 256),
+        "limits": [
+            float(EEG.get("xmin", 0.0) or 0.0) * 1000.0,
+            float(EEG.get("xmax", 0.0) or 0.0) * 1000.0,
+        ],
+        "events": EEG.get("event", []),
+        "winlength": 50,
+        "xgrid": "off",
+        "winrej": winrej,
+        "wincolor": _REJCONT_WINREJ_COLOR,
+        "butlabel": "Reject",
+        "eloc_file": _selected_chanlocs(EEG, selected_rows),
+        "title": f"Scroll channel activities -- eegplot() -- {EEG.get('setname', '')}".rstrip(),
+        "show": show,
+    }
+    if show:
+        kwargs["command_callback"] = _accept
+    return eegplot(selected_data, **kwargs)
+
+
+def _apply_rejcont_winrej(
+    EEG: dict[str, Any],
+    winrej_rows: np.ndarray,
+    elecrange: list[int],
+    options: dict[str, Any],
+) -> dict[str, Any]:
+    out = copy_eeg(EEG)
+    selected = _continuous_rows_to_regions(winrej_rows, int(out.get("pnts", np.asarray(out.get("data")).shape[1])))
+    if selected.size == 0:
+        return out
+    if str(options.get("correct", "remove")).lower() == "blank":
+        data = np.asarray(out.get("data"), dtype=float)
+        if data.ndim == 3:
+            data = data[:, :, 0]
+        for start, stop in selected.astype(int):
+            data[np.asarray(elecrange, dtype=int) - 1, start - 1 : stop] = 0
+        out["data"] = data
+        return out
+    return pop_select(out, "nopoint", selected.tolist(), gui=False)
+
+
+def _continuous_rows_to_regions(winrej_rows: np.ndarray, pnts: int) -> np.ndarray:
+    rows = np.asarray(winrej_rows if winrej_rows is not None else [], dtype=float)
+    if rows.ndim == 1:
+        rows = rows.reshape(1, -1)
+    if rows.size == 0:
+        return np.empty((0, 2), dtype=int)
+    regions = []
+    for row in rows:
+        start = max(1, min(int(round(float(row[0]))), pnts))
+        stop = max(1, min(int(round(float(row[1]))), pnts))
+        if stop < start:
+            start, stop = stop, start
+        if stop > start:
+            regions.append([start, stop])
+    return _merge_regions(np.asarray(regions, dtype=int)) if regions else np.empty((0, 2), dtype=int)
+
+
+def _rejcont_winrej(selected: np.ndarray, channel_count: int) -> np.ndarray:
+    if selected.size == 0:
+        return np.zeros((0, 5 + channel_count), dtype=float)
+    rows = np.zeros((selected.shape[0], 5 + channel_count), dtype=float)
+    rows[:, 0:2] = selected[:, 0:2]
+    rows[:, 2:5] = np.asarray(_REJCONT_WINREJ_COLOR, dtype=float)
+    rows[:, 5:] = 1
+    return rows
+
+
+def _selected_chanlocs(EEG: dict[str, Any], selected_rows: np.ndarray) -> list[dict[str, Any]]:
+    chanlocs = list(EEG.get("chanlocs", []) or [])
+    return [chanlocs[index] for index in selected_rows if index < len(chanlocs)]
 
 
 def _selected_regions(
@@ -203,6 +328,7 @@ def _history_command(options: dict[str, Any]) -> str:
         "taper",
         "correct",
         "onlyreturnselection",
+        "eegplot",
     ):
         if key in options:
             values.extend([key, options[key]])

--- a/src/eegprep/functions/popfunc/pop_rejcont.py
+++ b/src/eegprep/functions/popfunc/pop_rejcont.py
@@ -131,7 +131,8 @@ def _apply_one(
         options,
     )
     command = _history_command(options)
-    if display and str(options.get("onlyreturnselection", "off")).lower() != "on":
+    browser_display = display and str(options.get("onlyreturnselection", "off")).lower() != "on"
+    if browser_display:
         _open_rejcont_browser(
             out,
             data,
@@ -149,7 +150,7 @@ def _apply_one(
             out["data"] = data
         else:
             out = pop_select(out, "nopoint", selected.tolist(), gui=False)
-    return out, selected, command
+    return out, selected, "" if browser_display else command
 
 
 def _open_rejcont_browser(

--- a/src/eegprep/functions/popfunc/pop_rejcont.py
+++ b/src/eegprep/functions/popfunc/pop_rejcont.py
@@ -15,6 +15,7 @@ from eegprep.functions.sigprocfunc.eegplot import eegplot
 
 
 _REJCONT_WINREJ_COLOR = (0.0, 0.9, 0.0)
+_REJCONT_TAPER = "hamming"
 
 
 def pop_rejcont(
@@ -70,6 +71,7 @@ def pop_rejcont_dialog_spec(EEG: dict[str, Any]) -> DialogSpec:
             ControlSpec("edit", tag="contiguous", value="4"),
             ControlSpec("text", "Add trails before and after regions (s)"),
             ControlSpec("edit", tag="addlength", value="0.25"),
+            # EEGLAB labels this "hanning" but maps the checked option to a Hamming taper.
             ControlSpec("text", "Use hanning window before computing FFT"),
             ControlSpec("checkbox", tag="taper", value=True),
         ),
@@ -87,7 +89,7 @@ def _run_gui(EEG: dict[str, Any], renderer: Any | None) -> dict[str, Any] | None
         "epochlength": result.get("epochlength", "0.5"),
         "contiguous": result.get("contiguous", "4"),
         "addlength": result.get("addlength", "0.25"),
-        "taper": "hamming" if result.get("taper", False) else "none",
+        "taper": _REJCONT_TAPER if result.get("taper", False) else "none",
         "eegplot": "on",
     }
 
@@ -150,7 +152,7 @@ def _apply_one(
             out["data"] = data
         else:
             out = pop_select(out, "nopoint", selected.tolist(), gui=False)
-    return out, selected, "" if browser_display else command
+    return (EEG if browser_display else out), selected, "" if browser_display else command
 
 
 def _open_rejcont_browser(
@@ -265,7 +267,7 @@ def _selected_regions(
         return np.empty((0, 2), dtype=int)
     starts = list(range(0, data.shape[1] - window + 1, step))
     flagged = np.zeros(len(starts), dtype=bool)
-    taper = np.hamming(window) if str(options.get("taper", "none")).lower() == "hamming" else np.ones(window)
+    taper = np.hamming(window) if str(options.get("taper", "none")).lower() == _REJCONT_TAPER else np.ones(window)
     freqs = np.fft.rfftfreq(window, d=1 / srate)
     if len(freqlimit) < 2:
         freqlimit = [35, min(128, srate / 2)]

--- a/src/eegprep/functions/popfunc/pop_rejkurt.py
+++ b/src/eegprep/functions/popfunc/pop_rejkurt.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import (
     copy_eeg,
@@ -35,6 +36,8 @@ def pop_rejkurt(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ):
     """Mark or reject epochs by local/global kurtosis."""
     if EEG is None:
@@ -48,7 +51,17 @@ def pop_rejkurt(
                 return (EEG, "") if return_com else (EEG, [], [], 0)
             elecrange, locthresh, globthresh, superpose, reject, vistype = result
         outputs = [
-            _apply_one(dataset, icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype)[0]
+            _apply_one(
+                dataset,
+                icacomp,
+                elecrange,
+                locthresh,
+                globthresh,
+                superpose,
+                reject,
+                vistype,
+                display=False,
+            )[0]
             for dataset in EEG
         ]
         command = _history_command(icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype, plotflag)
@@ -59,7 +72,17 @@ def pop_rejkurt(
             return (EEG, "") if return_com else (EEG, [], [], 0)
         elecrange, locthresh, globthresh, superpose, reject, vistype = result
     out, local_threshold, global_threshold, rejected, command = _apply_one(
-        EEG, icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype
+        EEG,
+        icacomp,
+        elecrange,
+        locthresh,
+        globthresh,
+        superpose,
+        reject,
+        vistype,
+        display=bool(int(vistype) == 1 or topcommand is not None),
+        command_callback=command_callback,
+        show=show,
     )
     return (out, command) if return_com else (out, local_threshold, global_threshold, len(rejected))
 
@@ -149,6 +172,10 @@ def _apply_one(
     superpose: int | bool,
     reject: int | bool,
     vistype: int,
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ) -> tuple[dict[str, Any], list[float], list[float], list[int], str]:
     out = copy_eeg(EEG)
     data, row_count = rejection_data(out, icacomp)
@@ -165,9 +192,22 @@ def _apply_one(
         out["stats"]["icakurt"] = global_scores
     update_reject_fields(out, icacomp=icacomp, kind="rejkurt", reject=marks, reject_e=marks_e)
     rejected = (np.flatnonzero(marks) + 1).tolist()
-    if int(bool(reject)) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
     command = _history_command(icacomp, elecrange, locthresh, globthresh, superpose, reject, vistype, 0)
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind="rejkurt",
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(reject)) and rejected:
+        out = pop_rejepoch(out, rejected, 0)
     return (
         out,
         parse_numeric_sequence(locthresh, dtype=float),
@@ -192,7 +232,7 @@ def _history_command(
         parse_numeric_sequence(elecrange, dtype=int),
         parse_numeric_sequence(locthresh, dtype=float),
         parse_numeric_sequence(globthresh, dtype=float),
-        int(bool(superpose)),
+        int(superpose),
         int(bool(reject)),
         int(vistype),
         [],

--- a/src/eegprep/functions/popfunc/pop_rejmenu.py
+++ b/src/eegprep/functions/popfunc/pop_rejmenu.py
@@ -7,7 +7,8 @@ from typing import Any
 import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
-from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+from eegprep.functions.popfunc._rejection import copy_eeg
 from eegprep.functions.popfunc.eeg_rejsuperpose import eeg_rejsuperpose
 from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 
@@ -25,8 +26,10 @@ def pop_rejmenu(
         return (None, "") if return_com else None
     if gui is None:
         gui = True
+    source = EEG
     if gui:
-        result = inputgui(pop_rejmenu_dialog_spec(EEG, icacomp), renderer=renderer)
+        source = copy_eeg(EEG)
+        result = inputgui(pop_rejmenu_dialog_spec(source, icacomp), renderer=renderer)
         if result is None:
             return (EEG, "") if return_com else EEG
         flags = [
@@ -36,7 +39,7 @@ def pop_rejmenu(
     else:
         flags = [1, 1, 1, 1, 1, 1, 1]
         reject = 0
-    out, command = eeg_rejsuperpose(EEG, icacomp, *flags, return_com=True)
+    out, command = eeg_rejsuperpose(source, icacomp, *flags, return_com=True)
     if reject and np.asarray((out.get("reject") or {}).get("rejglobal", [])).any():
         out, reject_command = pop_rejepoch(out, out["reject"]["rejglobal"], 0, return_com=True)
         command = f"{command} {reject_command}"
@@ -73,6 +76,19 @@ def pop_rejmenu_dialog_spec(EEG: dict[str, Any], icacomp: int | bool = 1) -> Dia
             ControlSpec("text", title_text, font_weight="bold"),
             ControlSpec("pushbutton", tag=swatch_tag, enabled=False),
             ControlSpec("spacer"),
+        )
+
+    def scroll_callback(button: str) -> CallbackSpec:
+        return CallbackSpec(
+            "open_rejection_browser",
+            params={
+                "button": button,
+                "eeg": EEG,
+                "icacomp": 1 if is_data else 0,
+                "count_tags": ("mantrial",),
+                "count_fields": {"mantrial": prefix + "rejmanual"},
+            },
+            matlab_callback="pop_eegplot(EEG, icacomp, rejstatus, 0)",
         )
 
     def threshold_rows(
@@ -128,7 +144,7 @@ def pop_rejmenu_dialog_spec(EEG: dict[str, Any], icacomp: int | bool = 1) -> Dia
         ControlSpec("text", "Mark trials by appearance", font_weight="bold"),
         ControlSpec("pushbutton", tag="butmanual", enabled=False),
         ControlSpec("spacer"),
-        ControlSpec("pushbutton", activity, enabled=False),
+        ControlSpec("pushbutton", activity, tag="scrollmanual", enabled=True, callback=scroll_callback("scrollmanual")),
         ControlSpec("text", "Marked trials"),
         ControlSpec("text", str(_count(reject.get(prefix + "rejmanual"))), tag="mantrial"),
     )
@@ -190,7 +206,13 @@ def pop_rejmenu_dialog_spec(EEG: dict[str, Any], icacomp: int | bool = 1) -> Dia
         add_row(
             (0.8, 0.8, 0.8, 0.8),
             ControlSpec("pushbutton", "Calculate", enabled=False),
-            ControlSpec("pushbutton", activity, enabled=False),
+            ControlSpec(
+                "pushbutton",
+                activity,
+                tag=f"scroll{edit_prefix}",
+                enabled=True,
+                callback=scroll_callback(f"scroll{edit_prefix}"),
+            ),
             ControlSpec("pushbutton", "PLOT", enabled=False),
             ControlSpec("pushbutton", "HELP", enabled=False),
         )
@@ -260,9 +282,6 @@ def pop_rejmenu_dialog_spec(EEG: dict[str, Any], icacomp: int | bool = 1) -> Dia
                 color: #777777;
             }
         """,
-        known_differences=(
-            "EEGPrep disables EEGBrowser/eegplot scrolling buttons; use the individual rejection dialogs to compute marks.",
-        ),
     )
 
 

--- a/src/eegprep/functions/popfunc/pop_rejspec.py
+++ b/src/eegprep/functions/popfunc/pop_rejspec.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value, parse_key_value_args
 from eegprep.functions.popfunc._rejection import (
     copy_eeg,
@@ -27,6 +28,8 @@ def pop_rejspec(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
     **kwargs: Any,
 ):
     """Mark or reject epochs by spectral power thresholds."""
@@ -41,7 +44,7 @@ def pop_rejspec(
             if gui_options is None:
                 return (EEG, "") if return_com else (EEG, [])
             options.update(gui_options)
-        outputs = [_apply_one(dataset, icacomp, options)[0] for dataset in EEG]
+        outputs = [_apply_one(dataset, icacomp, options, display=False)[0] for dataset in EEG]
         command = _history_command(icacomp, options)
         return (outputs, command) if return_com else (outputs, [])
     if gui:
@@ -49,7 +52,14 @@ def pop_rejspec(
         if gui_options is None:
             return (EEG, "") if return_com else (EEG, [])
         options.update(gui_options)
-    out, rejected, command = _apply_one(EEG, icacomp, options)
+    out, rejected, command = _apply_one(
+        EEG,
+        icacomp,
+        options,
+        display=bool(gui or _int_option(options.get("eegplotplotallrej", 0)) == 2),
+        command_callback=command_callback,
+        show=show,
+    )
     return (out, command) if return_com else (out, rejected)
 
 
@@ -151,7 +161,13 @@ def _run_gui(EEG: dict[str, Any], icacomp: int, renderer: Any | None) -> dict[st
 
 
 def _apply_one(
-    EEG: dict[str, Any], icacomp: int | bool, options: dict[str, Any]
+    EEG: dict[str, Any],
+    icacomp: int | bool,
+    options: dict[str, Any],
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ) -> tuple[dict[str, Any], list[int], str]:
     out = copy_eeg(EEG)
     data, row_count = rejection_data(out, icacomp)
@@ -170,8 +186,6 @@ def _apply_one(
         out["specicaact"] = spectra
     update_reject_fields(out, icacomp=icacomp, kind="rejfreq", reject=marks, reject_e=marks_e)
     rejected = (np.flatnonzero(marks) + 1).tolist()
-    if int(bool(options.get("eegplotreject", 0))) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
     normalized_options = dict(options)
     normalized_options["elecrange"] = elecrange
     normalized_options["method"] = method
@@ -179,7 +193,23 @@ def _apply_one(
     normalized_options.setdefault("freqlimits", freqlimits)
     normalized_options.setdefault("eegplotplotallrej", 0)
     normalized_options.setdefault("eegplotreject", 0)
-    return out, rejected, _history_command(icacomp, normalized_options)
+    command = _history_command(icacomp, normalized_options)
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind="rejfreq",
+            superpose=_int_option(normalized_options.get("eegplotplotallrej", 0)),
+            reject=int(bool(_int_option(normalized_options.get("eegplotreject", 0)))),
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(options.get("eegplotreject", 0))) and rejected:
+        out = pop_rejepoch(out, rejected, 0)
+    return out, rejected, command
 
 
 def _history_command(icacomp: int | bool, options: dict[str, Any]) -> str:
@@ -194,12 +224,24 @@ def _history_command(icacomp: int | bool, options: dict[str, Any]) -> str:
         "freqlimits",
         options.get("freqlimits", [15, 30]),
         "eegplotplotallrej",
-        int(bool(options.get("eegplotplotallrej", 0))),
+        _int_option(options.get("eegplotplotallrej", 0)),
         "eegplotreject",
-        int(bool(options.get("eegplotreject", 0))),
+        int(bool(_int_option(options.get("eegplotreject", 0)))),
     ]
     return (
         "EEG = pop_rejspec(EEG, "
         + ", ".join(format_history_value(item, cell_for_sequence=None) for item in values)
         + ");"
     )
+
+
+def _int_option(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"on", "yes", "true"}:
+            return 1
+        if lowered in {"off", "no", "false", ""}:
+            return 0
+    return int(value)

--- a/src/eegprep/functions/popfunc/pop_rejtrend.py
+++ b/src/eegprep/functions/popfunc/pop_rejtrend.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import (
     copy_eeg,
@@ -34,6 +35,8 @@ def pop_rejtrend(
     gui: bool | None = None,
     renderer: Any | None = None,
     return_com: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ):
     """Mark or reject epochs containing line-like trends."""
     if EEG is None:
@@ -47,7 +50,18 @@ def pop_rejtrend(
                 return (EEG, "") if return_com else EEG
             elecrange, winsize, minslope, minstd, superpose, reject = result
         outputs = [
-            _apply_one(dataset, icacomp, elecrange, winsize, minslope, minstd, superpose, reject)[0] for dataset in EEG
+            _apply_one(
+                dataset,
+                icacomp,
+                elecrange,
+                winsize,
+                minslope,
+                minstd,
+                superpose,
+                reject,
+                display=False,
+            )[0]
+            for dataset in EEG
         ]
         command = _history_command(icacomp, elecrange, winsize, minslope, minstd, superpose, reject)
         return (outputs, command) if return_com else outputs
@@ -56,7 +70,19 @@ def pop_rejtrend(
         if result is None:
             return (EEG, "") if return_com else EEG
         elecrange, winsize, minslope, minstd, superpose, reject = result
-    out, command = _apply_one(EEG, icacomp, elecrange, winsize, minslope, minstd, superpose, reject)
+    out, command = _apply_one(
+        EEG,
+        icacomp,
+        elecrange,
+        winsize,
+        minslope,
+        minstd,
+        superpose,
+        reject,
+        display=bool(gui or calldisp),
+        command_callback=command_callback,
+        show=show,
+    )
     return (out, command) if return_com else out
 
 
@@ -120,6 +146,10 @@ def _apply_one(
     minstd: Any,
     superpose: int | bool,
     reject: int | bool,
+    *,
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
 ) -> tuple[dict[str, Any], str]:
     out = copy_eeg(EEG)
     data, row_count = rejection_data(out, icacomp)
@@ -132,9 +162,23 @@ def _apply_one(
     marks, marks_e = trend_marks(data, elecrange, winsize, minslope, minstd)
     update_reject_fields(out, icacomp=icacomp, kind="rejconst", reject=marks, reject_e=marks_e)
     rejected = (np.flatnonzero(marks) + 1).tolist()
-    if int(bool(reject)) and rejected:
+    command = _history_command(icacomp, elecrange, winsize, minslope, minstd, superpose, reject)
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind="rejconst",
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(reject)) and rejected:
         out = pop_rejepoch(out, rejected, 0)
-    return out, _history_command(icacomp, elecrange, winsize, minslope, minstd, superpose, reject)
+    return out, command
 
 
 def _history_command(
@@ -152,7 +196,7 @@ def _history_command(
         int(parse_numeric_sequence(winsize, dtype=float)[0]),
         float(parse_numeric_sequence(minslope, dtype=float)[0]),
         float(parse_numeric_sequence(minstd, dtype=float)[0]),
-        int(bool(superpose)),
+        int(superpose),
         int(bool(reject)),
     ]
     return (

--- a/src/eegprep/functions/popfunc/pop_select.py
+++ b/src/eegprep/functions/popfunc/pop_select.py
@@ -659,11 +659,25 @@ def pop_select_dialog_spec(EEG) -> DialogSpec:
             ),
             ControlSpec("spacer"),
             ControlSpec("spacer"),
-            # TODO: re-enable when an EEGPrep equivalent of EEGLAB's eegplot scrolling viewer is available.
-            ControlSpec("pushbutton", "Scroll dataset", tag="scroll", enabled=False),
+            ControlSpec(
+                "pushbutton",
+                "Scroll dataset",
+                tag="scroll",
+                enabled=_scroll_dataset_enabled(EEG),
+                callback=CallbackSpec(
+                    "open_eegplot",
+                    params={"button": "scroll", "eeg": EEG},
+                    matlab_callback="eegplot(EEG.data,'srate',EEG.srate,'winlength',5)",
+                ),
+            ),
             ControlSpec("spacer"),
         ),
     )
+
+
+def _scroll_dataset_enabled(EEG) -> bool:
+    data = EEG.get("data") if isinstance(EEG, dict) else None
+    return data is not None and np.asarray(data).size > 0
 
 
 def _run_gui(EEG, renderer=None):

--- a/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
+++ b/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import re
 from typing import Any
@@ -15,11 +16,14 @@ from eegprep.functions.popfunc._pop_utils import (
     parse_key_value_args,
     parse_text_tokens,
 )
+from eegprep.functions.sigprocfunc.eegplot import eegplot
 from eegprep.plugins.clean_rawdata.clean_artifacts import clean_artifacts
+from eegprep.plugins.clean_rawdata.private.masks import mask_to_intervals
 
 
 logger = logging.getLogger(__name__)
 _SHOW_VIS_ARTIFACTS_KEY = "_show_vis_artifacts"
+_CLEAN_RAWDATA_REJECT_COLOR = (1.0, 0.95, 0.25)
 
 _OPTION_ALIASES = {
     "channelcriterion": "ChannelCriterion",
@@ -60,14 +64,15 @@ def pop_clean_rawdata(
         output = [pop_clean_rawdata(item, gui=False, **options) for item in EEG]
         command = _history_command(options)
         if show_vis_artifacts:
-            _notify_vis_artifacts_unavailable()
+            logger.warning("clean_rawdata visual rejected-data browser is disabled for multiple datasets.")
         return (output, command) if return_com else output
     if int(EEG.get("trials", 1) or 1) > 1 or np.asarray(EEG.get("data")).ndim == 3:
         raise ValueError("Input data must be continuous. This data seems epoched.")
+    original_eeg = copy.deepcopy(EEG) if show_vis_artifacts else None
     clean_eeg, _hp, _bur, _removed_channels = clean_artifacts(EEG, **options)
     command = _history_command(options)
-    if show_vis_artifacts:
-        _notify_vis_artifacts_unavailable()
+    if show_vis_artifacts and original_eeg is not None:
+        _show_vis_artifacts(original_eeg, clean_eeg)
     return (clean_eeg, command) if return_com else clean_eeg
 
 
@@ -175,7 +180,7 @@ def pop_clean_rawdata_dialog_spec(EEG) -> DialogSpec:
             ControlSpec("edit", tag="rejwinval2", value="25"),
             ControlSpec("spacer"),
             ControlSpec(
-                "checkbox", "Pop up scrolling data window with rejected data highlighted", tag="vis", value=False
+                "checkbox", "Pop up scrolling data window with rejected data highlighted", tag="vis", value=True
             ),
         ),
     )
@@ -274,18 +279,33 @@ def _clean_rawdata_history_value(value):
     return format_history_value(value, bool_style="onoff", empty_sequence="{}")
 
 
-def _notify_vis_artifacts_unavailable():
-    message = (
-        "The clean_rawdata rejected-data scrolling viewer is not yet available in EEGPrep. "
-        "The dataset was still cleaned."
-    )
+def _show_vis_artifacts(original_eeg: dict[str, Any], clean_eeg: dict[str, Any]) -> Any:
+    mask = np.asarray((clean_eeg.get("etc") or {}).get("clean_sample_mask", []), dtype=bool).ravel()
+    pnts = int(original_eeg.get("pnts", np.asarray(original_eeg.get("data")).shape[1]) or 0)
+    nbchan = int(original_eeg.get("nbchan", np.asarray(original_eeg.get("data")).shape[0]) or 0)
+    winrej = np.zeros((0, 5 + nbchan), dtype=float)
+    if mask.size == pnts:
+        rejected = mask_to_intervals(mask, value=False)
+        winrej = _clean_rawdata_winrej(rejected, nbchan)
     try:
-        from PySide6 import QtWidgets
-    except ImportError:
-        logger.warning(message)
-        return
-    app = QtWidgets.QApplication.instance()
-    if app is None:
-        logger.warning(message)
-        return
-    QtWidgets.QMessageBox.information(QtWidgets.QApplication.activeWindow(), "EEGPrep", message)
+        return eegplot(
+            original_eeg,
+            winrej=winrej,
+            wincolor=_CLEAN_RAWDATA_REJECT_COLOR,
+            events=original_eeg.get("event", []),
+            xgrid="off",
+            title=f"Rejected data highlighted -- eegplot() -- {original_eeg.get('setname', '')}".rstrip(),
+        )
+    except RuntimeError as exc:
+        logger.warning("Could not open clean_rawdata rejected-data browser: %s", exc)
+        return None
+
+
+def _clean_rawdata_winrej(rejected: np.ndarray, nbchan: int) -> np.ndarray:
+    if rejected.size == 0:
+        return np.zeros((0, 5 + nbchan), dtype=float)
+    rows = np.zeros((rejected.shape[0], 5 + nbchan), dtype=float)
+    rows[:, 0:2] = rejected[:, 0:2]
+    rows[:, 2:5] = np.asarray(_CLEAN_RAWDATA_REJECT_COLOR, dtype=float)
+    rows[:, 5:] = 1
+    return rows

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -76,6 +76,15 @@ def _fake_pop_jointprob_browser(eeg, *args, command_callback=None, return_com=Fa
 _fake_pop_jointprob_browser.command_callback = None
 
 
+def _fake_pop_rejcont_browser(eeg, *args, command_callback=None, return_com=False, **kwargs):
+    del args, kwargs
+    _fake_pop_rejcont_browser.command_callback = command_callback
+    return (eeg, "") if return_com else eeg
+
+
+_fake_pop_rejcont_browser.command_callback = None
+
+
 def _fake_pop_copyset(ALLEEG, set_in, set_out=None, *, return_com=False):
     copied = dict(ALLEEG[int(set_in) - 1], setname="copied")
     output = list(ALLEEG)
@@ -783,6 +792,43 @@ def test_console_rejection_browser_accept_callback_refreshes_session_after_accep
     assert len(session.ALLEEG) == 2
     assert session.ALLCOM == [command]
     assert refresh.call_count >= 2
+
+
+def test_console_rejcont_browser_defers_store_until_accept():
+    session = EEGPrepSession()
+    eeg = _demo_eeg()
+    eeg["data"] = np.arange(8, dtype=float).reshape(2, 4)
+    eeg["pnts"] = 4
+    eeg["xmax"] = 0.03
+    session.store_current(eeg, new=True)
+    refresh = mock.Mock()
+    workspace = EEGPrepConsoleWorkspace(
+        session,
+        refresh=refresh,
+        exports={"pop_rejcont": _fake_pop_rejcont_browser},
+    )
+
+    result = workspace.namespace["pop_rejcont"](workspace.namespace["EEG"])
+    workspace.after_execute("pop_rejcont(EEG)")
+
+    eeg_out, command = result
+    assert eeg_out is session.EEG
+    assert command == ""
+    assert session.ALLCOM == []
+    assert len(session.ALLEEG) == 1
+    assert callable(_fake_pop_rejcont_browser.command_callback)
+
+    accepted = dict(session.EEG)
+    accepted["data"] = np.asarray(session.EEG["data"])[:, :2]
+    accepted["pnts"] = 2
+    accept_command = "EEG = pop_rejcont(EEG, 'eegplot', 'on');"
+    _fake_pop_rejcont_browser.command_callback(accepted, accept_command)
+
+    assert session.CURRENTSET == [2]
+    assert session.EEG["pnts"] == 2
+    assert len(session.ALLEEG) == 2
+    assert session.ALLCOM == [accept_command]
+    assert refresh.call_count >= 1
 
 
 def test_bare_dataset_pop_call_updates_alleeg_eeg_currentset_and_history():

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -66,6 +66,16 @@ def _fake_pop_eegplot(
 _fake_pop_eegplot.command_callback = None
 
 
+def _fake_pop_jointprob_browser(eeg, *args, command_callback=None, return_com=False, **kwargs):
+    del args, kwargs
+    _fake_pop_jointprob_browser.command_callback = command_callback
+    command = "EEG = pop_jointprob(EEG, 1, [1], 4, 4, 0, 1, 1);"
+    return (eeg, command) if return_com else eeg
+
+
+_fake_pop_jointprob_browser.command_callback = None
+
+
 def _fake_pop_copyset(ALLEEG, set_in, set_out=None, *, return_com=False):
     copied = dict(ALLEEG[int(set_in) - 1], setname="copied")
     output = list(ALLEEG)
@@ -738,6 +748,41 @@ def test_console_pop_eegplot_positional_reject_argument_controls_accept_storage(
     assert session.CURRENTSET == [1]
     assert session.EEG["pnts"] == 2
     assert len(session.ALLEEG) == 1
+
+
+def test_console_rejection_browser_accept_callback_refreshes_session_after_accept():
+    session = EEGPrepSession()
+    eeg = _demo_eeg()
+    eeg["data"] = np.arange(24, dtype=float).reshape(2, 4, 3)
+    eeg["pnts"] = 4
+    eeg["trials"] = 3
+    eeg["xmax"] = 0.03
+    session.store_current(eeg, new=True)
+    refresh = mock.Mock()
+    workspace = EEGPrepConsoleWorkspace(
+        session,
+        refresh=refresh,
+        exports={"pop_jointprob": _fake_pop_jointprob_browser},
+    )
+
+    result = workspace.namespace["pop_jointprob"](workspace.namespace["EEG"])
+    workspace.after_execute("pop_jointprob(EEG)")
+
+    _eeg_out, command = result
+    assert command == "EEG = pop_jointprob(EEG, 1, [1], 4, 4, 0, 1, 1);"
+    assert session.ALLCOM == [command]
+    assert callable(_fake_pop_jointprob_browser.command_callback)
+
+    accepted = dict(session.EEG)
+    accepted["data"] = np.asarray(session.EEG["data"])[:, :, :2]
+    accepted["trials"] = 2
+    _fake_pop_jointprob_browser.command_callback(accepted, command)
+
+    assert session.CURRENTSET == [2]
+    assert session.EEG["trials"] == 2
+    assert len(session.ALLEEG) == 2
+    assert session.ALLCOM == [command]
+    assert refresh.call_count >= 2
     assert session.ALLCOM == [command]
 
 

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -783,7 +783,6 @@ def test_console_rejection_browser_accept_callback_refreshes_session_after_accep
     assert len(session.ALLEEG) == 2
     assert session.ALLCOM == [command]
     assert refresh.call_count >= 2
-    assert session.ALLCOM == [command]
 
 
 def test_bare_dataset_pop_call_updates_alleeg_eeg_currentset_and_history():

--- a/tests/test_gui_pop_clean_rawdata.py
+++ b/tests/test_gui_pop_clean_rawdata.py
@@ -44,7 +44,7 @@ class PopCleanRawdataGuiTests(unittest.TestCase):
         self.assertEqual(controls["chanrm"].font_weight, "bold")
         self.assertEqual(controls["asr"].font_weight, "bold")
         self.assertEqual(controls["rejwin"].font_weight, "bold")
-        self.assertFalse(controls["vis"].value)
+        self.assertTrue(controls["vis"].value)
 
     def test_gui_channel_callbacks_expose_labels(self):
         controls = controls_by_tag(pop_clean_rawdata_dialog_spec(_eeg()))
@@ -102,7 +102,7 @@ class PopCleanRawdataGuiTests(unittest.TestCase):
         self.assertIn("'BurstCriterion', 20", com)
         self.assertIn("'BurstRejection', 'on'", com)
 
-    def test_gui_vis_checkbox_notifies_when_checked(self):
+    def test_gui_vis_checkbox_opens_rejected_data_browser_when_checked(self):
         class Renderer:
             def run(self, spec, initial_values=None):
                 return {
@@ -133,14 +133,24 @@ class PopCleanRawdataGuiTests(unittest.TestCase):
         with (
             mock.patch(
                 "eegprep.plugins.clean_rawdata.pop_clean_rawdata.clean_artifacts",
-                return_value=(dict(eeg, setname="cleaned"), eeg, eeg, np.zeros(2, dtype=bool)),
+                return_value=(
+                    dict(
+                        eeg,
+                        setname="cleaned",
+                        etc={"clean_sample_mask": np.r_[np.ones(10, dtype=bool), np.zeros(30, dtype=bool)]},
+                    ),
+                    eeg,
+                    eeg,
+                    np.zeros(2, dtype=bool),
+                ),
             ) as clean,
-            mock.patch("eegprep.plugins.clean_rawdata.pop_clean_rawdata._notify_vis_artifacts_unavailable") as notify,
+            mock.patch("eegprep.plugins.clean_rawdata.pop_clean_rawdata.eegplot") as eegplot,
         ):
             out, com = pop_clean_rawdata(eeg, gui=True, renderer=Renderer(), return_com=True)
 
         clean.assert_called_once()
-        notify.assert_called_once()
+        eegplot.assert_called_once()
+        np.testing.assert_array_equal(eegplot.call_args.kwargs["winrej"][:, :2], [[11, 40]])
         self.assertEqual(out["setname"], "cleaned")
         self.assertNotIn("_show_vis_artifacts", com)
 

--- a/tests/test_gui_pop_select.py
+++ b/tests/test_gui_pop_select.py
@@ -75,7 +75,9 @@ class PopSelectGuiTests(unittest.TestCase):
             ],
         )
         self.assertEqual([control.font_weight for control in spec.controls[:3]], ["bold", "bold", "bold"])
-        self.assertFalse(controls_by_tag(spec)["scroll"].enabled)
+        scroll = controls_by_tag(spec)["scroll"]
+        self.assertTrue(scroll.enabled)
+        self.assertEqual(scroll.callback.name, "open_eegplot")
 
     def test_gui_channel_picker_exposes_labels_and_types(self):
         controls = controls_by_tag(pop_select_dialog_spec(_eeg()))

--- a/tests/test_gui_rejection_dialogs.py
+++ b/tests/test_gui_rejection_dialogs.py
@@ -63,6 +63,10 @@ class RejectionDialogTests(unittest.TestCase):
         self.assertTrue(controls_by_tag(specs[1])["superpose"].value)
         self.assertEqual(controls_by_tag(specs[2])["vistype"].value, 2)
         self.assertTrue(controls_by_tag(specs[2])["superpose"].value)
+        self.assertTrue(controls_by_tag(specs[7])["eegplot"].enabled)
+        self.assertTrue(controls_by_tag(specs[7])["eegplot"].value)
+        self.assertTrue(controls_by_tag(specs[8])["scrollmanual"].enabled)
+        self.assertEqual(controls_by_tag(specs[8])["scrollmanual"].callback.name, "open_rejection_browser")
         self.assertTrue(controls_by_tag(specs[10])["scroll_event"].enabled)
 
     def test_viewprops_component_dialog_includes_classifier_dropdown(self):
@@ -117,7 +121,7 @@ class RejectionDialogTests(unittest.TestCase):
 
         eeg = _epoched_ica_eeg()
         eeg["data"][0, 2, 1] = 10
-        _out, com = pop_eegthresh(eeg, gui=True, renderer=Renderer(), return_com=True)
+        _out, com = pop_eegthresh(eeg, gui=True, renderer=Renderer(), return_com=True, show=False)
 
         self.assertEqual(
             _console_python_command(com),
@@ -138,8 +142,8 @@ class RejectionDialogTests(unittest.TestCase):
                 }
 
         eeg = _epoched_ica_eeg()
-        _joint_out, joint_com = pop_jointprob(eeg, gui=True, renderer=Renderer(), return_com=True)
-        _kurt_out, kurt_com = pop_rejkurt(eeg, gui=True, renderer=Renderer(), return_com=True)
+        _joint_out, joint_com = pop_jointprob(eeg, gui=True, renderer=Renderer(), return_com=True, show=False)
+        _kurt_out, kurt_com = pop_rejkurt(eeg, gui=True, renderer=Renderer(), return_com=True, show=False)
 
         self.assertEqual(
             _console_python_command(joint_com),
@@ -223,12 +227,43 @@ class RejectionDialogTests(unittest.TestCase):
             dispatcher.dispatch("pop_eegplot:reject_data")
 
         self.assertEqual(session.ALLCOM, [])
-        self.assertIs(captured["selection"], session.EEG)
+        self.assertEqual(captured["selection"]["setname"], "test_dataset")
         updated = dict(eeg, setname="accepted")
         captured["callback"](updated, "pop_eegplot(EEG, 1, 0, 1)")
 
         self.assertEqual(session.EEG["setname"], "accepted")
         self.assertEqual(session.ALLCOM[-1], "pop_eegplot(EEG, 1, 0, 1)")
+
+    def test_rejection_browser_accept_callback_creates_dataset_without_duplicate_history(self):
+        session = EEGPrepSession()
+        eeg = _epoched_ica_eeg()
+        session.store_current(eeg, new=True)
+        dispatcher = MenuActionDispatcher(session)
+        captured = {}
+        command = "EEG = pop_jointprob(EEG, 1, [1], 4, 4, 0, 1, 1);"
+
+        def fake_pop_jointprob(selection, icacomp, **kwargs):
+            captured["selection"] = selection
+            captured["icacomp"] = icacomp
+            captured["callback"] = kwargs["command_callback"]
+            return selection, command
+
+        with mock.patch("eegprep.functions.popfunc.pop_jointprob.pop_jointprob", side_effect=fake_pop_jointprob):
+            dispatcher.dispatch("pop_jointprob:data")
+
+        self.assertEqual(session.ALLCOM, [command])
+        self.assertEqual(captured["selection"]["setname"], "test_dataset")
+        self.assertEqual(captured["icacomp"], 1)
+
+        accepted = dict(eeg)
+        accepted["data"] = np.asarray(eeg["data"])[:, :, :2]
+        accepted["trials"] = 2
+        captured["callback"](accepted, command)
+
+        self.assertEqual(session.CURRENTSET, [2])
+        self.assertEqual(session.EEG["trials"], 2)
+        self.assertEqual(len(session.ALLEEG), 2)
+        self.assertEqual(session.ALLCOM, [command])
 
 
 if __name__ == "__main__":

--- a/tests/test_gui_rejection_dialogs.py
+++ b/tests/test_gui_rejection_dialogs.py
@@ -264,6 +264,37 @@ class RejectionDialogTests(unittest.TestCase):
         self.assertEqual(len(session.ALLEEG), 2)
         self.assertEqual(session.ALLCOM, [command])
 
+    def test_rejection_dispatch_stores_multi_dataset_results_without_browser_callback(self):
+        session = EEGPrepSession()
+        first = _epoched_ica_eeg()
+        first["setname"] = "first"
+        second = _epoched_ica_eeg()
+        second["setname"] = "second"
+        session.store_current(first, new=True)
+        session.store_current(second, new=True)
+        session.retrieve([1, 2])
+        dispatcher = MenuActionDispatcher(session)
+        captured = {}
+        command = "EEG = pop_jointprob(EEG, 1, [1], 4, 4, 0, 1, 1);"
+
+        def fake_pop_jointprob(selection, icacomp, **kwargs):
+            captured["selection"] = selection
+            captured["icacomp"] = icacomp
+            captured["kwargs"] = kwargs
+            output = [dict(item, setname=f"{item['setname']}-marked") for item in selection]
+            return output, command
+
+        with mock.patch("eegprep.functions.popfunc.pop_jointprob.pop_jointprob", side_effect=fake_pop_jointprob):
+            dispatcher.dispatch("pop_jointprob:data")
+
+        self.assertEqual([item["setname"] for item in captured["selection"]], ["first", "second"])
+        self.assertEqual(captured["icacomp"], 1)
+        self.assertTrue(captured["kwargs"]["return_com"])
+        self.assertNotIn("command_callback", captured["kwargs"])
+        self.assertEqual(session.CURRENTSET, [1, 2])
+        self.assertEqual([item["setname"] for item in session.ALLEEG], ["first-marked", "second-marked"])
+        self.assertEqual(session.ALLCOM, [command])
+
     def test_rejection_browser_accept_callback_creates_dataset_without_duplicate_history(self):
         session = EEGPrepSession()
         eeg = _epoched_ica_eeg()

--- a/tests/test_gui_rejection_dialogs.py
+++ b/tests/test_gui_rejection_dialogs.py
@@ -234,6 +234,36 @@ class RejectionDialogTests(unittest.TestCase):
         self.assertEqual(session.EEG["setname"], "accepted")
         self.assertEqual(session.ALLCOM[-1], "pop_eegplot(EEG, 1, 0, 1)")
 
+    def test_rejcont_dispatch_defers_history_until_browser_accept(self):
+        session = EEGPrepSession()
+        eeg = create_test_eeg(n_channels=1, n_samples=10, n_trials=1, srate=10)
+        session.store_current(eeg, new=True)
+        dispatcher = MenuActionDispatcher(session)
+        captured = {}
+        command = "EEG = pop_rejcont(EEG, 'eegplot', 'on');"
+
+        def fake_pop_rejcont(selection, **kwargs):
+            captured["selection"] = selection
+            captured["callback"] = kwargs["command_callback"]
+            return selection, command
+
+        with mock.patch("eegprep.functions.popfunc.pop_rejcont.pop_rejcont", side_effect=fake_pop_rejcont):
+            dispatcher.dispatch("pop_rejcont")
+
+        self.assertEqual(session.ALLCOM, [])
+        self.assertEqual(len(session.ALLEEG), 1)
+        self.assertEqual(captured["selection"]["setname"], "test_dataset")
+
+        accepted = dict(eeg)
+        accepted["data"] = np.asarray(eeg["data"])[:, :5]
+        accepted["pnts"] = 5
+        captured["callback"](accepted, command)
+
+        self.assertEqual(session.CURRENTSET, [2])
+        self.assertEqual(session.EEG["pnts"], 5)
+        self.assertEqual(len(session.ALLEEG), 2)
+        self.assertEqual(session.ALLCOM, [command])
+
     def test_rejection_browser_accept_callback_creates_dataset_without_duplicate_history(self):
         session = EEGPrepSession()
         eeg = _epoched_ica_eeg()

--- a/tests/test_rejection_workflows.py
+++ b/tests/test_rejection_workflows.py
@@ -354,7 +354,7 @@ def test_pop_rejcont_display_defers_history_command_until_browser_accept(monkeyp
 
     monkeypatch.setattr(pop_rejcont_module, "eegplot", fake_eegplot)
 
-    _out, command = pop_rejcont(
+    out, command = pop_rejcont(
         eeg,
         "elecrange",
         [1],
@@ -372,6 +372,7 @@ def test_pop_rejcont_display_defers_history_command_until_browser_accept(monkeyp
         return_com=True,
     )
 
+    assert out is eeg
     assert command == ""
     assert accepted[0][1].startswith("EEG = pop_rejcont(EEG, ")
 

--- a/tests/test_rejection_workflows.py
+++ b/tests/test_rejection_workflows.py
@@ -341,6 +341,41 @@ def test_pop_rejcont_display_accept_removes_continuous_regions(monkeypatch):
     assert accepted[0][0]["pnts"] < eeg["pnts"]
 
 
+def test_pop_rejcont_display_defers_history_command_until_browser_accept(monkeypatch):
+    accepted = []
+    eeg = create_test_eeg(n_channels=2, n_samples=120, n_trials=1, srate=100)
+    time = np.arange(120) / 100
+    eeg["data"][0] = 100 * np.sin(2 * np.pi * 30 * time)
+
+    def fake_eegplot(_data, *args, **kwargs):
+        del args
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(pop_rejcont_module, "eegplot", fake_eegplot)
+
+    _out, command = pop_rejcont(
+        eeg,
+        "elecrange",
+        [1],
+        "freqlimit",
+        [20, 40],
+        "threshold",
+        0,
+        "epochlength",
+        0.2,
+        "contiguous",
+        1,
+        "eegplot",
+        "on",
+        command_callback=lambda eeg_out, accept_command: accepted.append((eeg_out, accept_command)),
+        return_com=True,
+    )
+
+    assert command == ""
+    assert accepted[0][1].startswith("EEG = pop_rejcont(EEG, ")
+
+
 def test_pop_autorej_display_marks_original_epochs_before_browser_accept(monkeypatch):
     calls = []
     accepted = []

--- a/tests/test_rejection_workflows.py
+++ b/tests/test_rejection_workflows.py
@@ -9,7 +9,10 @@ import numpy as np
 import pytest
 import scipy.io
 
+import eegprep.functions.popfunc._eegplot_rejection as eegplot_rejection_module
+import eegprep.functions.popfunc.pop_rejcont as pop_rejcont_module
 from eegprep.functions.adminfunc.console import _console_python_command
+from eegprep.functions.popfunc.pop_eegplot import DEFAULT_REJECTION_COLORS
 from eegprep.functions.popfunc.eeg_rejsuperpose import eeg_rejsuperpose
 from eegprep.functions.popfunc._rejection import (
     jointprob,
@@ -132,6 +135,246 @@ def test_rejection_statistics_store_data_and_component_marks():
     assert not np.allclose(fft_spec_out["specdata"], spec_out["specdata"])
     assert comp_count >= 1
     assert "icarejjp" in comp_out["reject"]
+
+
+@pytest.mark.parametrize(
+    ("runner", "field"),
+    [
+        (
+            lambda eeg, callback: pop_eegthresh(
+                eeg,
+                1,
+                [1],
+                -10,
+                10,
+                0,
+                0.79,
+                0,
+                0,
+                topcommand="update",
+                command_callback=callback,
+                return_com=True,
+            ),
+            "rejthresh",
+        ),
+        (
+            lambda eeg, callback: pop_jointprob(
+                eeg, 1, [1, 2, 3, 4], 1.2, 1.2, 0, 0, 1, command_callback=callback, return_com=True
+            ),
+            "rejjp",
+        ),
+        (
+            lambda eeg, callback: pop_rejkurt(
+                eeg, 1, [1, 2, 3, 4], 1.2, 1.2, 0, 0, 1, command_callback=callback, return_com=True
+            ),
+            "rejkurt",
+        ),
+        (
+            lambda eeg, callback: pop_rejtrend(
+                eeg, 1, [2], 80, 0.2, 0.3, 0, 0, 1, command_callback=callback, return_com=True
+            ),
+            "rejconst",
+        ),
+        (
+            lambda eeg, callback: pop_rejspec(
+                eeg,
+                1,
+                "method",
+                "fft",
+                "elecrange",
+                [3],
+                "threshold",
+                [-10, 10],
+                "freqlimits",
+                [20, 30],
+                "eegplotplotallrej",
+                2,
+                "eegplotreject",
+                0,
+                command_callback=callback,
+                return_com=True,
+            ),
+            "rejfreq",
+        ),
+    ],
+)
+def test_epoched_rejection_display_paths_open_browser_and_accept_marks(monkeypatch, runner, field):
+    calls = []
+    accepted = []
+
+    def fake_eegplot(data, *args, **kwargs):
+        del args
+        calls.append((np.asarray(data), kwargs))
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(eegplot_rejection_module, "eegplot", fake_eegplot)
+    eeg = _epoched_eeg()
+
+    out, command = runner(eeg, lambda eeg_out, accept_command: accepted.append((eeg_out, accept_command)))
+
+    assert command
+    assert out["trials"] == eeg["trials"]
+    assert calls
+    assert calls[0][0].ndim == 3
+    assert accepted
+    assert accepted[0][1] == command
+    assert accepted[0][0]["reject"][field].shape == (eeg["trials"],)
+
+
+def test_component_rejection_browser_accept_updates_ica_marks(monkeypatch):
+    calls = []
+    accepted = []
+
+    def fake_eegplot(data, *args, **kwargs):
+        del args
+        calls.append((np.asarray(data), kwargs))
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(eegplot_rejection_module, "eegplot", fake_eegplot)
+    eeg = _epoched_eeg()
+
+    out, _command = pop_jointprob(
+        eeg,
+        0,
+        [1],
+        1.2,
+        1.2,
+        0,
+        0,
+        1,
+        command_callback=lambda eeg_out, command: accepted.append((eeg_out, command)),
+        return_com=True,
+    )
+
+    assert calls[0][0].shape[0] == 1
+    assert out["trials"] == eeg["trials"]
+    assert "icarejjp" in accepted[0][0]["reject"]
+    assert accepted[0][0]["reject"]["icarejjpE"].shape == (4, 5)
+
+
+def test_reject_on_browser_accept_removes_epochs_without_immediate_rejection(monkeypatch):
+    accepted = []
+
+    def fake_eegplot(_data, *args, **kwargs):
+        del args
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(eegplot_rejection_module, "eegplot", fake_eegplot)
+    eeg = _epoched_eeg()
+
+    out, _command = pop_eegthresh(
+        eeg,
+        1,
+        [1],
+        -10,
+        10,
+        0,
+        0.79,
+        0,
+        1,
+        topcommand="reject",
+        command_callback=lambda eeg_out, command: accepted.append(eeg_out),
+        return_com=True,
+    )
+
+    assert out["trials"] == eeg["trials"]
+    assert accepted[0]["trials"] == eeg["trials"] - 1
+
+
+def test_superposed_browser_winrej_includes_existing_family_marks(monkeypatch):
+    calls = []
+
+    def fake_eegplot(_data, *args, **kwargs):
+        del args
+        calls.append(kwargs)
+        return "window"
+
+    monkeypatch.setattr(eegplot_rejection_module, "eegplot", fake_eegplot)
+    eeg = _epoched_eeg()
+    eeg["reject"]["rejthresh"] = np.array([True, False, False, False, False])
+    eeg["reject"]["rejthreshE"] = np.zeros((4, 5), dtype=bool)
+    eeg["reject"]["rejthreshE"][0, 0] = True
+    eeg["reject"]["disprej"] = ["thresh"]
+
+    pop_jointprob(eeg, 1, [1, 2, 3, 4], 1.2, 1.2, 2, 0, 1)
+
+    rows = calls[0]["winrej"]
+    assert any(np.allclose(row[2:5], DEFAULT_REJECTION_COLORS["thresh"]) for row in rows)
+
+
+def test_pop_rejcont_display_accept_removes_continuous_regions(monkeypatch):
+    accepted = []
+    eeg = create_test_eeg(n_channels=2, n_samples=120, n_trials=1, srate=100)
+    time = np.arange(120) / 100
+    eeg["data"][0] = 100 * np.sin(2 * np.pi * 30 * time)
+
+    def fake_eegplot(data, *args, **kwargs):
+        del args
+        assert np.asarray(data).shape[0] == 1
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(pop_rejcont_module, "eegplot", fake_eegplot)
+
+    out, selected = pop_rejcont(
+        eeg,
+        "elecrange",
+        [1],
+        "freqlimit",
+        [20, 40],
+        "threshold",
+        0,
+        "epochlength",
+        0.2,
+        "contiguous",
+        1,
+        "eegplot",
+        "on",
+        command_callback=lambda eeg_out, command: accepted.append((eeg_out, command)),
+    )
+
+    assert selected.size
+    assert out["pnts"] == eeg["pnts"]
+    assert accepted[0][0]["pnts"] < eeg["pnts"]
+
+
+def test_pop_autorej_display_marks_original_epochs_before_browser_accept(monkeypatch):
+    calls = []
+    accepted = []
+
+    def fake_eegplot(_data, *args, **kwargs):
+        del args
+        calls.append(kwargs)
+        kwargs["command_callback"](kwargs["winrej"])
+        return "window"
+
+    monkeypatch.setattr(eegplot_rejection_module, "eegplot", fake_eegplot)
+    eeg = _epoched_eeg()
+
+    out, command = pop_autorej(
+        eeg,
+        "threshold",
+        10,
+        "startprob",
+        20,
+        "maxrej",
+        40,
+        "nogui",
+        "on",
+        "eegplot",
+        "on",
+        command_callback=lambda eeg_out, accept_command: accepted.append((eeg_out, accept_command)),
+        return_com=True,
+    )
+
+    assert command
+    assert calls
+    assert out["trials"] == eeg["trials"]
+    assert out["reject"]["rejauto"].shape == (eeg["trials"],)
+    assert accepted[0][1] == command
 
 
 def test_jointprob_global_marks_match_eeglab_trial_rows_for_duplicate_channels():


### PR DESCRIPTION
Wire EEGBrowser into selection, rejection, and clean_rawdata workflows so display paths show EEGLAB-style marks and accepted browser edits update session and console state. Adds focused regression coverage for data/ICA marks, reject-on-close, cancel, superpose, continuous and epoched behavior.

Fixes #99