### PR TITLE
[EEGBrowser] Complete Phase 7 closeout

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -174,10 +174,9 @@ and console code should append each successful command once through
 ``EEGPrepSession.add_history`` or storage helpers.
 
 Menu placeholders are machine-readable. Each placeholder action has either a
-target epic phase or an explicit exclusion reason such as ``eegbrowser`` for
-EEGBrowser/eegplot-style scrolling workflows. Runtime package code must not
-read, import, or shell out to ``src/eegprep/eeglab``; that tree is only a
-development parity reference.
+target epic phase or an explicit exclusion reason for workflows that cannot be
+packaged in EEGPrep. Runtime package code must not read, import, or shell out
+to ``src/eegprep/eeglab``; that tree is only a development parity reference.
 
 GUI Help buttons and Help-menu topics must resolve to packaged Markdown files
 under ``src/eegprep/resources/help``. Do not fall back to the vendored EEGLAB

--- a/docs/source/user_guide/eegbrowser.rst
+++ b/docs/source/user_guide/eegbrowser.rst
@@ -1,0 +1,51 @@
+.. _eegbrowser:
+
+====================
+EEGBrowser Workflows
+====================
+
+EEGPrep includes an EEGLAB-style scrolling browser for inspecting continuous,
+epoched, component, spectral, and overlay data. The browser is available from
+the Plot menu, rejection workflows, Python APIs, and ``eegprep-console``.
+
+Opening The Browser
+===================
+
+From the GUI, load or select a dataset and use the Plot menu entries for
+channel data, component activity, or visual rejection. The rejection dialogs can
+also open browser-backed review windows before updating marks or removing data.
+
+From Python or ``eegprep-console``:
+
+.. code-block:: python
+
+   from eegprep import eegplot, pop_eegplot
+
+   window = eegplot(EEG)
+   EEG, com = pop_eegplot(EEG, return_com=True)
+
+Use ``show=False`` when testing or scripting normalization without opening Qt:
+
+.. code-block:: python
+
+   model = eegplot(EEG, winlength=5, dispchans=16, show=False)
+
+Marks And Rejection
+===================
+
+Dragging across the browser marks a time range. On continuous data, accepted
+marks can be stored in ``EEG.reject.rejmanualwinrej`` for later review or
+converted through ``eeg_eegrej`` to remove samples. On epoched data, accepted
+marks update ``EEG.reject.rejmanual`` and ``EEG.reject.rejmanualE`` or remove
+marked epochs through ``pop_rejepoch``.
+
+Component mode uses ICA activations and writes ICA-prefixed rejection fields
+where applicable. Event overlays use EEGLAB one-based event latencies; Python
+array indexing remains zero-based internally.
+
+Performance
+===========
+
+The browser draws only the visible time range and applies min/max decimation to
+large traces, preserving endpoints and extrema while keeping UI redraw work
+bounded by the displayed pixel width.

--- a/docs/source/user_guide/gui_help_menus.rst
+++ b/docs/source/user_guide/gui_help_menus.rst
@@ -28,8 +28,9 @@ can select one or more loaded datasets.
 
 Actions that are not implemented yet are marked as coming soon and are backed
 by machine-readable placeholder metadata. EEGBrowser/eegplot-style scrolling
-workflows are explicitly excluded from the current parity scope rather than
-being treated as ordinary pending work.
+workflows are implemented as packaged EEGPrep runtime code and are covered by
+the same menu inventory, help-resource, and visual parity checks as other GUI
+actions.
 
 Help Resources
 ==============

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -37,6 +37,7 @@ Getting Started
    installation
    quickstart
    gui_help_menus
+   eegbrowser
    interactive_console
 
 Core Concepts

--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -206,6 +206,7 @@ class EEGBrowserWindow(_QMainWindow):
             _rect_from_normalized((scale_x, _AXES_POSITION[1], scale_width, _AXES_POSITION[3]), width, height)
         )
         self.controls.set_geometry(width, height)
+        self.controls.sync_from_state()
 
     def _build_menus(self) -> None:
         figure_menu = self.menuBar().addMenu("Figure")

--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -43,6 +43,8 @@ _EVENT_COLORS = (
 _SCALE_STEP = 0.1
 _MIN_SPACING = 0.001
 _TRACE_SCALE = 0.72
+_WINREJ_BRUSH_ALPHA = 210
+_WINREJ_EDGE_ALPHA = 230
 _AXES_POSITION = (0.0964286, 0.15, 0.842, 0.75)
 _NOUI_AXES_POSITION = (0.055, 0.075, 0.90, 0.87)
 _CONTROL_POSITIONS = {
@@ -755,11 +757,11 @@ class EEGBrowserCanvas(_QWidget):
                     self._sample_edge_to_x_value(min(region_stop, stop)),
                 ),
                 orientation=plot_graphics.LinearRegionItem.Vertical,
-                brush=(*color, 70),
+                brush=(*color, _WINREJ_BRUSH_ALPHA),
                 movable=False,
             )
-            item.lines[0].setPen(plot_graphics.mkPen((*color, 120), width=1))
-            item.lines[1].setPen(plot_graphics.mkPen((*color, 120), width=1))
+            item.lines[0].setPen(plot_graphics.mkPen((*color, _WINREJ_EDGE_ALPHA), width=1))
+            item.lines[1].setPen(plot_graphics.mkPen((*color, _WINREJ_EDGE_ALPHA), width=1))
             item.setZValue(-20)
             self.plot.addItem(item)
             self._items.append(item)

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -2,7 +2,7 @@
 
 Each placeholder carries either an implementation phase or an exclusion reason
 so later phase agents can distinguish planned work from intentionally excluded
-browser/external-plugin workflows.
+external-plugin workflows.
 """
 
 from __future__ import annotations
@@ -40,12 +40,6 @@ def is_placeholder_action(action: str) -> bool:
 
 def placeholder_message(action: str) -> str:
     """Build the shared EEGLAB-style placeholder message for ``action``."""
-    metadata = placeholder_metadata(action)
-    if metadata is not None and metadata.excluded_reason == "eegbrowser":
-        return (
-            f"{action} depends on EEGBrowser/eegplot-style scrolling browser workflows, "
-            "which are outside the current EEGPrep parity scope."
-        )
     return (
         f"{action} is not yet available in EEGPrep.\n\n"
         "Track progress or request this workflow at https://github.com/sccn/eegprep/issues."

--- a/src/eegprep/functions/guifunc/menu_placeholders.py
+++ b/src/eegprep/functions/guifunc/menu_placeholders.py
@@ -2,7 +2,8 @@
 
 Each placeholder carries either an implementation phase or an exclusion reason
 so later phase agents can distinguish planned work from intentionally excluded
-external-plugin workflows.
+external-plugin workflows. The inventory can be empty after a phase completes;
+keep these helpers as stable hooks for menu checks and future phases.
 """
 
 from __future__ import annotations

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -277,6 +277,10 @@ class EEGPrepSession:
 
     def add_history(self, command: str | None, *, notify: bool = True) -> None:
         """Append an EEGLAB-style command to session history."""
+        if not command:
+            if notify:
+                self.notify_changed()
+            return
         self.LASTCOM = eegh(command, self.ALLCOM)
         if notify:
             self.notify_changed()

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -308,8 +308,24 @@ def _demo_eegbrowser_eeg(*, epoched: bool = False, events: bool = True) -> dict:
     }
 
 
+def _demo_eegbrowser_ica_eeg() -> dict:
+    eeg = _demo_eegbrowser_eeg(events=False)
+    channel_count = int(eeg["nbchan"])
+    times = np.arange(int(eeg["pnts"]), dtype=float) / float(eeg["srate"])
+    eeg["icaweights"] = np.eye(channel_count)
+    eeg["icasphere"] = np.eye(channel_count)
+    eeg["icawinv"] = np.eye(channel_count)
+    eeg["icachansind"] = np.arange(channel_count)
+    icaact = np.vstack(
+        [np.cos(2 * np.pi * (component + 1) * times) + 0.08 * component for component in range(channel_count)]
+    )
+    eeg["data"] = icaact.copy()
+    eeg["icaact"] = icaact
+    return eeg
+
+
 def _demo_eegbrowser_winrej(variant: str) -> np.ndarray | None:
-    if variant == "continuous_marked":
+    if variant in {"continuous_marked", "pop_eegplot_reject_data"}:
         return np.array(
             [
                 [125, 260, 0.7, 1.0, 0.9, 1, 1, 1, 1, 1, 1, 1, 1],
@@ -317,11 +333,27 @@ def _demo_eegbrowser_winrej(variant: str) -> np.ndarray | None:
             ],
             dtype=float,
         )
-    if variant == "epoched_marked":
+    if variant in {"epoched_marked", "rejection_epochs"}:
         return np.array(
             [
                 [250, 499, 0.7, 1.0, 0.9, 1, 1, 1, 1, 1, 1, 1, 1],
                 [500, 749, 1.0, 0.9, 0.9, 0, 0, 1, 0, 0, 0, 0, 0],
+            ],
+            dtype=float,
+        )
+    if variant == "component_activity":
+        return np.array(
+            [
+                [180, 310, 1.0, 0.9, 0.9, 1, 0, 0, 0, 0, 0, 0, 0],
+                [520, 640, 0.7, 1.0, 0.9, 0, 1, 1, 0, 0, 0, 0, 0],
+            ],
+            dtype=float,
+        )
+    if variant == "rejcont_continuous":
+        return np.array(
+            [
+                [160, 260, 0.0, 0.9, 0.0, 1, 1, 1, 1],
+                [620, 760, 0.0, 0.9, 0.0, 1, 0, 1, 0],
             ],
             dtype=float,
         )
@@ -411,20 +443,83 @@ def capture_eegbrowser(output: pathlib.Path, *, variant: str = "continuous") -> 
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
-    epoched = variant in {"epoched", "epoched_marked"}
-    has_events = variant in {"events", "labels"}
-    winrej = _demo_eegbrowser_winrej(variant)
-    model = build_eegplot_model(
-        _demo_eegbrowser_eeg(epoched=epoched, events=has_events),
-        winlength=3.0 if variant == "epoched_marked" else 1.0 if epoched else 2.0,
-        dispchans=6,
-        spacing=1.2,
-        xgrid="on" if variant != "grid_off" else "off",
-        ygrid="on" if variant != "grid_off" else "off",
-        winrej=winrej,
-        command="TMPREJ=[];" if winrej is not None else None,
-        butlabel="Reject",
-    )
+    if variant == "component_activity":
+        model = build_eegplot_model(
+            _demo_eegbrowser_ica_eeg(),
+            component=True,
+            winlength=2.0,
+            dispchans=6,
+            spacing=1.2,
+            xgrid="on",
+            ygrid="on",
+            winrej=_demo_eegbrowser_winrej(variant),
+            command="TMPREJ=[];",
+            butlabel="Update Marks",
+            title="Scroll component activities -- eegplot() -- eegbrowser demo",
+        )
+    elif variant == "data2_overlay":
+        eeg = _demo_eegbrowser_eeg(events=True)
+        data = np.asarray(eeg["data"], dtype=float)
+        overlay = data + 0.35 * np.cos(np.arange(data.shape[1], dtype=float)[None, :] / 12.0)
+        model = build_eegplot_model(
+            eeg,
+            data2=overlay,
+            winlength=2.0,
+            dispchans=6,
+            spacing=1.2,
+            xgrid="on",
+            ygrid="on",
+            title="Scroll channel activities -- eegplot() -- data2 overlay demo",
+        )
+    elif variant == "spectral_overlay":
+        freqs = np.linspace(1.0, 45.0, 90)
+        data = np.vstack([np.log1p(freqs) + 0.12 * channel + np.sin(freqs / (channel + 2)) for channel in range(6)])
+        overlay = data + 0.25 * np.cos(freqs / 4.0)
+        model = build_eegplot_model(
+            data,
+            data2=overlay,
+            freqs=freqs,
+            freqlimits=[4, 32],
+            winlength=12.0,
+            dispchans=6,
+            spacing=1.0,
+            xgrid="on",
+            ygrid="on",
+            title="Scroll spectral activities -- eegplot() -- overlay demo",
+        )
+    else:
+        epoched = variant in {"epoched", "epoched_marked", "rejection_epochs"}
+        has_events = variant in {"events", "labels", "pop_eegplot_reject_data", "rejection_epochs"}
+        winrej = _demo_eegbrowser_winrej(variant)
+        eeg = _demo_eegbrowser_eeg(epoched=epoched, events=has_events)
+        data = eeg
+        if variant == "rejcont_continuous":
+            selected_rows = [0, 1, 2, 3]
+            data = np.asarray(eeg["data"], dtype=float)[selected_rows, :]
+            eeg["chanlocs"] = [eeg["chanlocs"][index] for index in selected_rows]
+            winrej = _demo_eegbrowser_winrej(variant)
+        title = "Scroll channel activities -- eegplot() -- eegbrowser demo"
+        if variant == "pop_eegplot_reject_data":
+            title = "Scroll channel activities -- eegplot() -- pop_eegplot reject demo"
+        elif variant == "rejection_epochs":
+            title = "Trial rejection using data activity -- pop_eegthresh()"
+        elif variant == "rejcont_continuous":
+            title = "Scroll channel activities -- eegplot() -- pop_rejcont demo"
+        model = build_eegplot_model(
+            data,
+            srate=float(eeg["srate"]),
+            winlength=3.0 if variant in {"epoched_marked", "rejection_epochs"} else 1.0 if epoched else 2.0,
+            dispchans=4 if variant == "rejcont_continuous" else 6,
+            spacing=1.2,
+            xgrid="off" if variant == "grid_off" or variant == "rejcont_continuous" else "on",
+            ygrid="off" if variant == "grid_off" else "on",
+            winrej=winrej,
+            wincolor=(0.0, 0.9, 0.0) if variant == "rejcont_continuous" else None,
+            command="TMPREJ=[];" if winrej is not None else None,
+            butlabel="Reject",
+            eloc_file=eeg.get("chanlocs", []) if variant == "rejcont_continuous" else None,
+            title=title,
+        )
     if variant != "labels":
         model.state.channel_label_mode = "numbers"
     window = EEGBrowserWindow(model)
@@ -1231,6 +1326,18 @@ def main(argv: list[str] | None = None) -> int:
         capture_eegbrowser(args.output, variant="grid_off")
     elif args.case == "eegbrowser_labels":
         capture_eegbrowser(args.output, variant="labels")
+    elif args.case == "eegbrowser_component_activity":
+        capture_eegbrowser(args.output, variant="component_activity")
+    elif args.case == "eegbrowser_data2_overlay":
+        capture_eegbrowser(args.output, variant="data2_overlay")
+    elif args.case == "eegbrowser_spectral_overlay":
+        capture_eegbrowser(args.output, variant="spectral_overlay")
+    elif args.case == "eegbrowser_pop_eegplot_reject_data":
+        capture_eegbrowser(args.output, variant="pop_eegplot_reject_data")
+    elif args.case == "eegbrowser_rejcont_continuous":
+        capture_eegbrowser(args.output, variant="rejcont_continuous")
+    elif args.case == "eegbrowser_rejection_epochs":
+        capture_eegbrowser(args.output, variant="rejection_epochs")
     elif args.case == "file_menu":
         capture_main_window(args.output, menu_label="File")
     elif args.case == "edit_menu":

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -497,7 +497,6 @@ def capture_eegbrowser(output: pathlib.Path, *, variant: str = "continuous") -> 
             selected_rows = [0, 1, 2, 3]
             data = np.asarray(eeg["data"], dtype=float)[selected_rows, :]
             eeg["chanlocs"] = [eeg["chanlocs"][index] for index in selected_rows]
-            winrej = _demo_eegbrowser_winrej(variant)
         title = "Scroll channel activities -- eegplot() -- eegbrowser demo"
         if variant == "pop_eegplot_reject_data":
             title = "Scroll channel activities -- eegplot() -- pop_eegplot reject demo"

--- a/src/eegprep/resources/help/eeg_helpmenu.md
+++ b/src/eegprep/resources/help/eeg_helpmenu.md
@@ -13,15 +13,13 @@ Top-level menus:
   component removal, epoching, and baseline removal workflows.
 - Plot: channel, component, ERP, spectra, time-frequency, statistics, DIPFIT,
   ICLabel, and viewprops plotting surfaces implemented in this repository.
-- Study: Phase 5 STUDY/group-level workflows. Implemented actions are enabled;
-  pending design, precompute, and clustering actions remain explicit
-  placeholders until their phase lands.
+- Study: STUDY/group-level workflows for design, measure precompute, plotting,
+  clustering, and study metadata.
 - Datasets: current dataset retrieval and multi-dataset selection.
 - Help: packaged EEGPrep help resources, docs links, update links, issue
   reporting, and contact actions.
 
 Menu placeholders are machine-readable and carry a target phase or an explicit
-exclusion reason. EEGBrowser/eegplot-style scrolling workflows are excluded
-from the current parity scope.
+exclusion reason for workflows that cannot be packaged in EEGPrep.
 
 See also: EEGPREP, EEG_HELPHELP

--- a/src/eegprep/resources/help/eeg_rejsuperpose.md
+++ b/src/eegprep/resources/help/eeg_rejsuperpose.md
@@ -8,5 +8,6 @@ Usage:
 combines ICA-component rejection fields. The combined result is written to
 `EEG.reject.rejglobal` and `EEG.reject.rejglobalE`.
 
-EEGPrep uses this helper from the non-browser rejection menus. EEGBrowser
-scrolling inspection remains outside the current scope.
+EEGPrep uses this helper from rejection menus and browser-backed review flows
+to keep data-channel and ICA-component rejection marks synchronized with
+EEGLAB-compatible fields.

--- a/src/eegprep/resources/help/pop_autorej.md
+++ b/src/eegprep/resources/help/pop_autorej.md
@@ -6,8 +6,9 @@ Usage:
     EEG, command = pop_autorej(EEG, return_com=True)
 
 `pop_autorej` applies EEGLAB-style large-amplitude, probability, and kurtosis
-epoch rejection to epoched data. It does not open EEGPlot/EEGBrowser scrolling
-inspection windows.
+epoch rejection to epoched data. The GUI path opens EEGPlot/EEGBrowser
+inspection by default so users can review and update marks before accepting
+rejection.
 
 Important options include `threshold`, `startprob`, `maxrej`, `electrodes`, and
 `icacomps`. Rejected epoch numbers are EEGLAB-facing 1-based indices.

--- a/src/eegprep/resources/help/pop_rejepoch.md
+++ b/src/eegprep/resources/help/pop_rejepoch.md
@@ -8,5 +8,5 @@ Usage:
 `tmprej` may be a boolean vector over epochs or a list of EEGLAB-facing 1-based
 epoch numbers. If omitted, `EEG.reject.rejglobal` is used.
 
-EEGBrowser confirmation is not opened in EEGPrep; use the GUI rejection dialogs
-to review marks before removing epochs.
+Review marks with EEGPrep rejection dialogs or the scrolling EEGPlot/EEGBrowser
+workflows before removing epochs.

--- a/src/eegprep/resources/help/pop_rejmenu.md
+++ b/src/eegprep/resources/help/pop_rejmenu.md
@@ -9,4 +9,5 @@ The EEGPrep dialog combines non-browser rejection marks into
 `EEG.reject.rejglobal` using `eeg_rejsuperpose`. It can then remove the marked
 epochs with `pop_rejepoch`.
 
-Interactive EEGPlot/EEGBrowser scrolling inspection is intentionally excluded.
+Use the scrolling EEGPlot/EEGBrowser buttons to review data or component marks
+interactively before updating marks or rejecting epochs.

--- a/src/eegprep/resources/help/pop_selectcomps.md
+++ b/src/eegprep/resources/help/pop_selectcomps.md
@@ -5,8 +5,8 @@ Usage:
     EEG = pop_selectcomps(EEG, compnum, reject=[...])
     EEG, command = pop_selectcomps(EEG, return_com=True)
 
-This EEGPrep implementation provides the component-selection and marking path
-without launching EEGBrowser scrolling views. Marked components are stored in
-`EEG.reject.gcompreject`.
+This EEGPrep implementation provides the component-selection and marking path.
+Marked components are stored in `EEG.reject.gcompreject` and can be inspected
+alongside component activity in the scrolling EEGPlot/EEGBrowser workflows.
 
 Use `pop_subcomp` to remove marked components from the data.

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -46,11 +46,14 @@ def test_gui_display_menu_labels_refresh_after_toggle(qapp) -> None:
 
     model = build_eegplot_model(np.zeros((1, 20)), srate=10, spacing=1, xgrid="off", ygrid="on", scale="on")
     window = EEGBrowserWindow(model)
+    window.show()
+    qapp.processEvents()
 
     assert window.xgrid_action.text() == "X grid on"
     assert window.ygrid_action.text() == "Y grid off"
     assert window.scale_action.text() == "Show scale"
     assert window.scale_action.isChecked() is True
+    assert window.controls.event_button.isHidden() is True
 
     window.xgrid_action.trigger()
     window.ygrid_action.trigger()
@@ -371,6 +374,36 @@ def test_gui_data2_overlay_draws_second_trace_per_channel(qapp) -> None:
 
     assert len(curves) == 4
     np.testing.assert_allclose(curves[0].getData()[0], curves[1].getData()[0])
+    window.close()
+
+
+def test_gui_large_continuous_data_decimates_visible_traces(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    samples = 120_000
+    srate = 512
+    times = np.arange(samples, dtype=np.float32) / float(srate)
+    data = np.vstack([np.sin(2 * np.pi * (channel + 1) * times) + channel * 0.01 for channel in range(16)]).astype(
+        np.float32
+    )
+    model = build_eegplot_model(data, srate=srate, winlength=30, dispchans=12, spacing=1, show=False)
+    window = EEGBrowserWindow(model)
+    window.resize(960, 560)
+    window.show()
+    qapp.processEvents()
+    window.canvas.redraw()
+
+    curves = [item for item in window.canvas._items if hasattr(item, "getData")]
+    max_points = max(len(curve.getData()[0]) for curve in curves)
+
+    assert model.data.total_samples == samples
+    assert len(curves) >= 12
+    assert max_points <= window.canvas.width() * 2 + 2
+
+    window.scroll_time(1.5)
+    qapp.processEvents()
+
+    assert model.state.time == pytest.approx(45.0)
     window.close()
 
 

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -204,6 +204,24 @@ def test_gui_menus_toggle_events_marks_scale_and_channel_labels(qapp) -> None:
     window.close()
 
 
+def test_gui_winrej_regions_are_visibly_saturated(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    model = build_eegplot_model(
+        np.zeros((2, 30)),
+        srate=10,
+        spacing=1,
+        winrej=[[1, 10, 0.7, 1.0, 0.9, 1, 1]],
+    )
+    window = EEGBrowserWindow(model)
+
+    regions = [item for item in window.canvas._items if item.__class__.__name__ == "LinearRegionItem"]
+
+    assert len(regions) == 1
+    assert regions[0].brush.color().alpha() >= 200
+    window.close()
+
+
 def test_gui_event_lines_stay_visible_and_labels_sit_above_plot_box(qapp) -> None:
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 

--- a/tests/test_gui_rejection_dialogs.py
+++ b/tests/test_gui_rejection_dialogs.py
@@ -257,6 +257,7 @@ class RejectionDialogTests(unittest.TestCase):
 
         self.assertEqual(session.EEG["setname"], "accepted")
         self.assertEqual(session.ALLCOM[-1], "pop_eegplot(EEG, 1, 0, 1)")
+        self.assertEqual(session.LASTCOM, "pop_eegplot(EEG, 1, 0, 1)")
 
     def test_rejcont_dispatch_defers_history_until_browser_accept(self):
         session = EEGPrepSession()

--- a/tests/test_menu_placeholder_inventory.py
+++ b/tests/test_menu_placeholder_inventory.py
@@ -26,6 +26,7 @@ def test_placeholder_inventory_has_phase_or_exclusion_metadata():
 
     assert set(inventory) == PLACEHOLDER_ACTIONS
     assert not any(metadata.phase == "2" for metadata in inventory.values())
+    assert not any(metadata.excluded_reason == "eegbrowser" for metadata in inventory.values())
     for action, metadata in inventory.items():
         assert bool(metadata.phase) ^ bool(metadata.excluded_reason), action
 

--- a/tests/test_public_api_examples.py
+++ b/tests/test_public_api_examples.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import runpy
 from importlib.resources import files
 from pathlib import Path
@@ -27,9 +28,39 @@ def test_package_resources_cover_public_workflows() -> None:
     assert package.joinpath("resources/help/pop_clean_rawdata.md").is_file()
     assert package.joinpath("resources/help/eegplot.md").is_file()
     assert package.joinpath("resources/help/pop_eegplot.md").is_file()
+    assert package.joinpath("resources/help/eeg_multieegplot.md").is_file()
     assert package.joinpath("resources/headplot/colin27headmesh.mat").is_file()
     assert package.joinpath("resources/montages/standard-10-5-342ch.locs").is_file()
     assert package.joinpath("plugins/ICLabel/netICL.mat").is_file()
+
+
+def test_browser_help_and_docs_do_not_describe_eegbrowser_as_excluded() -> None:
+    stale_patterns = (
+        r"excluded_reason\s*=\s*[\"']eegbrowser[\"']",
+        r"EEGBrowser.*excluded",
+        r"excluded.*EEGBrowser",
+        r"outside the current .*scope",
+        r"without launching EEGBrowser",
+        r"does not open EEGPlot/EEGBrowser",
+        r"not opened in EEGPrep",
+        r"scrolling inspection remains",
+        r"current parity scope",
+        r"``eegbrowser``",
+    )
+    checked_paths = [
+        *sorted((REPO_ROOT / "src/eegprep/resources/help").glob("*.md")),
+        *sorted((REPO_ROOT / "docs/source").rglob("*.rst")),
+        REPO_ROOT / "src/eegprep/functions/guifunc/menu_placeholders.py",
+    ]
+
+    stale = []
+    for path in checked_paths:
+        text = path.read_text(encoding="utf-8")
+        for pattern in stale_patterns:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                stale.append(f"{path.relative_to(REPO_ROOT)}: {pattern}")
+
+    assert stale == []
 
 
 def test_project_entry_points_cover_gui_and_console() -> None:

--- a/tests/test_visual_parity.py
+++ b/tests/test_visual_parity.py
@@ -34,6 +34,23 @@ class VisualParityConfigTests(unittest.TestCase):
         self.assertEqual(cases["reref_dialog"].targets["eeglab"].action, "pop_reref")
         self.assertEqual(cases["reref_dialog_channel_ref"].targets["eeglab"].action, "pop_reref:channels")
         self.assertEqual(cases["reref_dialog_huber_ref"].targets["eeglab"].action, "pop_reref:huber")
+        for case_id in (
+            "eegbrowser_continuous",
+            "eegbrowser_continuous_marked",
+            "eegbrowser_epoched",
+            "eegbrowser_epoched_marked",
+            "eegbrowser_events",
+            "eegbrowser_grid_off",
+            "eegbrowser_labels",
+            "eegbrowser_component_activity",
+            "eegbrowser_data2_overlay",
+            "eegbrowser_pop_eegplot_reject_data",
+            "eegbrowser_rejcont_continuous",
+            "eegbrowser_rejection_epochs",
+        ):
+            with self.subTest(case_id=case_id):
+                self.assertEqual(cases[case_id].targets["eeglab"].type, "matlab_figure")
+                self.assertIn("eegprep.functions.guifunc.visual_capture", cases[case_id].targets["eegprep"].command)
         self.assertIn("pop_interp_dialog", cases)
         self.assertEqual(cases["pop_interp_dialog"].targets["eeglab"].action, "pop_interp:continuous")
         self.assertEqual(cases["pop_interp_epoched_dialog"].targets["eeglab"].action, "pop_interp:epoched")

--- a/tools/visual_parity/cases.json
+++ b/tools/visual_parity/cases.json
@@ -312,6 +312,136 @@
       }
     },
     {
+      "id": "eegbrowser_component_activity",
+      "description": "EEGLAB/EEGPrep eegplot browser with component activity scroll and component marks.",
+      "window_size": [960, 560],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_figure",
+          "action": "eegbrowser",
+          "matlab_command": "eeglab; close(findobj('tag','EEGLAB')); t = 0:999; data = zeros(8,1000); for c = 1:8, data(c,:) = cos(2*pi*c*t/250)+0.08*(c-1); end; winrej = [180 310 1.0 0.9 0.9 1 0 0 0 0 0 0 0; 520 640 0.7 1.0 0.9 0 1 1 0 0 0 0 0]; eegplot(data, 'srate', 250, 'winlength', 2, 'dispchans', 6, 'spacing', 1.2, 'xgrid', 'on', 'ygrid', 'on', 'winrej', winrej, 'command', 'TMPREJ=[];', 'butlabel', 'Update Marks', 'title', 'Scroll component activities -- eegplot() -- eegbrowser demo');"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "eegbrowser_component_activity",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "eegbrowser_data2_overlay",
+      "description": "EEGLAB/EEGPrep eegplot browser with data2 overlay traces.",
+      "window_size": [1058, 560],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_figure",
+          "action": "eegbrowser",
+          "matlab_command": "eeglab; close(findobj('tag','EEGLAB')); t = 0:999; data = zeros(8,1000); for c = 1:8, data(c,:) = sin(2*pi*c*t/250)+0.05*c; end; data2 = data + 0.35*cos(t/12); events = struct('type', {'stim','resp','boundary'}, 'latency', {80,350,610}, 'duration', {0,0,25}); eegplot(data, 'srate', 250, 'data2', data2, 'events', events, 'winlength', 2, 'dispchans', 6, 'spacing', 1.2, 'xgrid', 'on', 'ygrid', 'on', 'title', 'Scroll channel activities -- eegplot() -- data2 overlay demo');"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "eegbrowser_data2_overlay",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "eegbrowser_pop_eegplot_reject_data",
+      "description": "EEGLAB/EEGPrep pop_eegplot reject-data browser path with accepted marks.",
+      "window_size": [960, 560],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_figure",
+          "action": "eegbrowser",
+          "matlab_command": "eeglab; close(findobj('tag','EEGLAB')); t = 0:999; data = zeros(8,1000); for c = 1:8, data(c,:) = sin(2*pi*c*t/250)+0.05*c; end; events = struct('type', {'stim','resp','boundary'}, 'latency', {80,350,610}, 'duration', {0,0,25}); winrej = [125 260 0.7 1.0 0.9 1 1 1 1 1 1 1 1; 340 460 1.0 0.9 0.9 0 1 0 0 0 0 0 0]; eegplot(data, 'srate', 250, 'events', events, 'winlength', 2, 'dispchans', 6, 'spacing', 1.2, 'xgrid', 'on', 'ygrid', 'on', 'winrej', winrej, 'command', 'TMPREJ=[];', 'butlabel', 'Reject', 'title', 'Scroll channel activities -- eegplot() -- pop_eegplot reject demo');"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "eegbrowser_pop_eegplot_reject_data",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "eegbrowser_rejcont_continuous",
+      "description": "EEGLAB/EEGPrep browser-backed continuous rejection review path.",
+      "window_size": [960, 560],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_figure",
+          "action": "eegbrowser",
+          "matlab_command": "eeglab; close(findobj('tag','EEGLAB')); t = 0:999; data = zeros(4,1000); for c = 1:4, data(c,:) = sin(2*pi*c*t/250)+0.05*c; end; winrej = [160 260 0.0 0.9 0.0 1 1 1 1; 620 760 0.0 0.9 0.0 1 0 1 0]; eegplot(data, 'srate', 250, 'winlength', 2, 'dispchans', 4, 'spacing', 1.2, 'xgrid', 'off', 'ygrid', 'on', 'winrej', winrej, 'wincolor', [0 0.9 0], 'command', 'TMPREJ=[];', 'butlabel', 'Reject', 'title', 'Scroll channel activities -- eegplot() -- pop_rejcont demo');"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "eegbrowser_rejcont_continuous",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
+      "id": "eegbrowser_rejection_epochs",
+      "description": "EEGLAB/EEGPrep browser-backed epoched rejection review path.",
+      "window_size": [960, 560],
+      "timeout_seconds": 120,
+      "targets": {
+        "eeglab": {
+          "type": "matlab_figure",
+          "action": "eegbrowser",
+          "matlab_command": "eeglab; close(findobj('tag','EEGLAB')); t = 0:249; data = zeros(8,250,3); for c = 1:8, for e = 1:3, data(c,:,e) = sin(2*pi*c*t/250)+0.2*cos(2*pi*e*t/250)+0.05*c; end; end; events = struct('type', {'stim','resp','boundary'}, 'latency', {80,350,610}, 'duration', {0,0,25}); winrej = [250 499 0.7 1.0 0.9 1 1 1 1 1 1 1 1; 500 749 1.0 0.9 0.9 0 0 1 0 0 0 0 0]; eegplot(data, 'srate', 250, 'events', events, 'winlength', 3, 'dispchans', 6, 'spacing', 1.2, 'xgrid', 'on', 'ygrid', 'on', 'winrej', winrej, 'command', 'TMPREJ=[];', 'butlabel', 'Reject', 'title', 'Trial rejection using data activity -- pop_eegthresh()');"
+        },
+        "eegprep": {
+          "type": "command",
+          "action": "eegbrowser_rejection_epochs",
+          "command": [
+            "{python}",
+            "-m",
+            "eegprep.functions.guifunc.visual_capture",
+            "--case",
+            "{case_id}",
+            "--output",
+            "{output}"
+          ]
+        }
+      }
+    },
+    {
       "id": "adjust_events_dialog",
       "description": "Adjust event latencies dialog opened from pop_adjustevents.",
       "window_size": [858, 169],


### PR DESCRIPTION
Remove stale EEGBrowser exclusion docs/placeholders, add packaged help and user-guide coverage, expand browser visual parity inventory, and harden session, resize, and large-data smoke coverage.

Evidence: ruff check, ruff format --check, ty check, focused pytest 217 passed/2 skipped, non-slow pytest 1548 passed/230 skipped/11 deselected, MATLAB parity attempt 1 passed/1 skipped, 12 visual compares, mixed console/GUI QA, and clean autoreview.

Residual risk: MATLAB Engine was unavailable for the conversion-helper parity test; visual differences are native rendering and antialiasing.

Closes #101
