### PR TITLE
Document external extension workflow

### DIFF
--- a/.agents/skills/eegprep-extension-development/SKILL.md
+++ b/.agents/skills/eegprep-extension-development/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: eegprep-extension-development
+description: Build EEGPrep external extension packages with SDK registration, declarative menus, pop_* console/history behavior, packaged help/data, distribution choices, tests, GUI visual parity, and catalog-readiness. Use when Codex or a researcher needs to create, port, review, package, or submit an EEGPrep extension outside the core package.
+---
+
+# EEGPrep Extension Development
+
+Use this skill to build extension packages that work as standalone Python
+packages and feel natural to EEGLAB users inside EEGPrep.
+
+## Start Here
+
+1. Read `AGENTS.md` and follow `.agents/skills/eegprep-feature-development/SKILL.md`
+   for repo workflow, notes, tests, and PR expectations.
+2. Inspect `src/eegprep/extensions.py` and `docs/source/api/extensions.rst` before
+   writing registration code. Use real SDK symbols, especially
+   `ExtensionSpec`, `ExtensionAction`, `ExtensionMenu`, `ExtensionPopFunction`,
+   `ExtensionResource`, `ExtensionDependency`, `LazyImport`,
+   `validate_extension_spec`, and the `eegprep.extensions` entry-point group.
+3. If porting an EEGLAB plugin or workflow, inspect the matching EEGLAB MATLAB
+   source during development. Do not make runtime extension code depend on a
+   local EEGLAB checkout.
+4. Check whether Phase 4 templates, scaffolding, or examples exist in the
+   current branch. Reference or use them where available; do not duplicate their
+   full implementation inside custom extension code.
+
+## Plan the Extension
+
+Define:
+
+- Distribution path: local/private editable, GitHub-only, PyPI, or private
+  package index.
+- Trust posture: experimental, private lab use, public uncurated, or catalog
+  submission. Curated means catalog-reviewed and mechanically validated, not
+  scientific endorsement.
+- Contributions: actions, menus, `pop_*` functions, help resources, package
+  data, console aliases, optional dependencies, and large model files.
+- EEGPrep version contract through `eegprep_requires` and extension API version.
+- Tests that prove discovery, validation, lazy imports, resources, history,
+  console behavior, and GUI behavior where applicable.
+
+Prefer the smallest SDK surface that expresses the feature. If the extension
+needs to mutate EEGPrep internals directly, stop and add or request an SDK
+surface instead.
+
+## Register Through the SDK
+
+Create a normal Python package with `pyproject.toml`:
+
+```toml
+[project]
+name = "eegprep-ext-foo"
+version = "0.1.0"
+dependencies = ["eegprep"]
+
+[project.entry-points."eegprep.extensions"]
+foo = "eegprep_ext_foo.register:register"
+```
+
+Keep `register()` lightweight:
+
+```python
+from eegprep import ExtensionAction, ExtensionMenu, ExtensionPopFunction, ExtensionSpec, LazyImport
+
+
+def register():
+    return ExtensionSpec(
+        name="foo",
+        display_name="Foo",
+        version="0.1.0",
+        package_name="eegprep_ext_foo",
+        eegprep_requires=">=0.2",
+        actions=(
+            ExtensionAction("foo.run", LazyImport("eegprep_ext_foo.actions", "run")),
+        ),
+        menus=(ExtensionMenu(("Tools", "Foo"), "foo.run", "Run Foo"),),
+        pop_functions=(
+            ExtensionPopFunction("pop_foo", LazyImport("eegprep_ext_foo.pop_foo", "pop_foo")),
+        ),
+    )
+```
+
+Use `LazyImport` for processing modules, dialogs, models, and optional
+dependencies. A registration function may import the SDK and small metadata; it
+must not import heavy code, start Qt, read data files, or call EEGLAB.
+
+## Menus, Help, Console, and History
+
+- Declare menus with `ExtensionMenu`; do not mutate Qt menu objects or patch
+  EEGPrep menu builders.
+- Keep user-facing actions compatible with `EEGPrepSession`. GUI actions should
+  store datasets, add history, and notify changes through session helpers.
+- Implement user-facing `pop_*` functions with `return_com=True`; return
+  `(EEG, com)` when history should be recorded.
+- Preserve EEGLAB-facing command strings and indexing semantics while using
+  Python indexing internally.
+- Package GUI Help and `pophelp` text as Markdown resources and declare them
+  with `ExtensionResource`.
+- Put data/model resources in the package and access them with
+  `importlib.resources` or declared `ExtensionResource` records. Do not read
+  from `src/eegprep/eeglab` at runtime.
+
+## Dependencies and Large Files
+
+- Declare required Python packages normally in `pyproject.toml`.
+- Use `ExtensionDependency(package, version_spec, optional=True)` only for
+  optional behavior. Required missing dependencies should produce
+  `missing_dependency`, not a late crash.
+- For large models, choose an explicit path: package extra, private index,
+  Git LFS-backed package source, or an extension-owned first-run download.
+  Document the choice and never imply EEGPrep hosts model artifacts.
+
+## GUI Extensions
+
+For dialogs, windows, or menu UX:
+
+1. Use `.agents/skills/eeglab-gui-visual-parity/SKILL.md` to compare labels,
+   alignment, order, defaults, enabled states, buttons, and workflow against
+   EEGLAB where an EEGLAB reference exists.
+2. Exercise mixed GUI plus `eegprep-console` flows: GUI action, inspect `EEG`,
+   `ALLEEG`, `CURRENTSET`, `LASTCOM`, and `ALLCOM`; then run the `pop_*`
+   function from the console and verify GUI/history refresh.
+3. Use `.agents/skills/gui-agent-flow-qa/SKILL.md` only when explicitly asked
+   for full GUI agent QA or when the project workflow requires it.
+
+## Tests and Checks
+
+Write focused tests for:
+
+- Entry-point discovery through `ExtensionRegistry` or `discover_extensions`.
+- `validate_extension_spec` success and failure cases.
+- Lazy imports remaining unloaded during discovery.
+- Missing help/data resources and missing required dependencies.
+- Duplicate action or `pop_*` names when relevant.
+- `pop_*` return values, `return_com=True`, history strings, and console
+  auto-store behavior.
+- GUI visual parity and user-flow behavior for GUI extensions.
+- Wheel or source distribution contents when packaged resources matter.
+
+Run the narrowest relevant pytest files first, then `./pre-commit.py --fix`,
+focused tests, and broader ruff/format/ty checks when the change affects
+imports, docs, packaging, or public APIs.
+
+## Distribution Decision
+
+- Local/private lab only: `uv add --editable /path/to/eegprep-ext-foo`.
+- GitHub-only: `uv add git+https://github.com/lab/eegprep-ext-foo`; pin tags
+  or commits for reproducibility.
+- PyPI: `uv add eegprep-ext-foo` after normal package publishing.
+- Private index: `uv add --index https://packages.lab.example/simple
+  eegprep-ext-foo` or `uv add --default-index ...` when the private index
+  replaces PyPI.
+
+EEGPrep does not host extension zips, install arbitrary archives, or treat
+curation as scientific endorsement.
+
+## Catalog Submission
+
+Before proposing curation, verify:
+
+- The package installs from a standard path and the entry point returns a valid
+  `ExtensionSpec`.
+- The extension passes validation in a clean environment.
+- Menus, help, package data, `pop_*` history, and console behavior are covered.
+- Optional dependencies and large files are documented and do not block startup.
+- Experimental status is explicit in docs and metadata.
+- Governance/catalog checks from Phase 5, if present in the branch, pass.

--- a/.agents/skills/eegprep-extension-development/agents/openai.yaml
+++ b/.agents/skills/eegprep-extension-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "EEGPrep Extension Development"
+  short_description: "Build EEGPrep extension packages"
+  default_prompt: "Use $eegprep-extension-development to plan, implement, test, and package an EEGPrep extension."

--- a/docs/source/user_guide/extensions.rst
+++ b/docs/source/user_guide/extensions.rst
@@ -1,0 +1,291 @@
+.. _extensions:
+
+===================
+External Extensions
+===================
+
+EEGPrep extensions are normal Python packages. Install them with standard
+Python package tooling, then start ``eegprep-gui`` or ``eegprep-console`` in
+the same environment. EEGPrep discovers installed extensions through the
+``eegprep.extensions`` entry-point group and validates their declarative
+``ExtensionSpec`` records before they contribute menus, actions, help, or
+``pop_*`` functions.
+
+Installing an extension installs third-party Python code into your environment.
+Use the same review standards you would use for any Python package. EEGPrep
+does not host arbitrary extension zip files, download extension code from a
+catalog, or unzip user-provided archives as part of normal runtime.
+
+Installing Extensions
+=====================
+
+Install EEGPrep first, then add extension packages to the same project or
+virtual environment.
+
+Local or private editable extension
+-----------------------------------
+
+Use an editable install while developing an extension or keeping a lab-only
+extension on disk:
+
+.. code-block:: bash
+
+   uv add --editable /path/to/eegprep-ext-foo
+
+This is the best path for private lab workflows, prototype methods, and
+extensions that should never leave a controlled environment. If the extension
+uses optional dependencies, install the extra declared by that package:
+
+.. code-block:: bash
+
+   uv add --editable "/path/to/eegprep-ext-foo[models]"
+
+GitHub extension
+----------------
+
+A researcher does not need to publish to PyPI to share an extension. A GitHub
+repository can be installed directly:
+
+.. code-block:: bash
+
+   uv add git+https://github.com/lab/eegprep-ext-foo
+
+Pin a branch, tag, or commit when reproducibility matters:
+
+.. code-block:: bash
+
+   uv add git+https://github.com/lab/eegprep-ext-foo --tag v0.3.0
+
+PyPI extension
+--------------
+
+Use the package name when the extension is published on PyPI:
+
+.. code-block:: bash
+
+   uv add eegprep-ext-foo
+
+PyPI is useful when an extension is public, versioned, and meant for broad
+reuse. It is not required for GitHub-only or private lab distribution.
+
+Private package index
+---------------------
+
+For a private package index, point uv at the lab or institution index:
+
+.. code-block:: bash
+
+   uv add --index https://packages.lab.example/simple eegprep-ext-foo
+
+When the private index should replace PyPI rather than supplement it, use:
+
+.. code-block:: bash
+
+   uv add --default-index https://packages.lab.example/simple eegprep-ext-foo
+
+Configure authentication through uv-supported environment variables, keyring
+configuration, or your institution's package-index instructions. Do not put
+passwords in committed ``pyproject.toml`` files.
+
+Using Installed Extensions
+==========================
+
+After installation, launch EEGPrep from the same environment:
+
+.. code-block:: bash
+
+   uv run eegprep-gui --full
+   uv run eegprep-console --full
+
+Extension menus and actions appear automatically when the extension record is
+active. In ``eegprep-console``, extension ``pop_*`` functions should behave like
+EEGPrep ``pop_*`` functions: GUI actions and console calls share one
+``EEGPrepSession``, update ``EEG`` and ``ALLEEG`` when data changes, and append
+the returned command to ``LASTCOM`` and ``ALLCOM``.
+
+For example, a user-facing extension function should support:
+
+.. code-block:: python
+
+   EEG, LASTCOM = pop_my_extension(EEG, return_com=True)
+   pop_my_extension(EEG)
+
+Normal Python imports still use standard Python semantics. The automatic
+session storage behavior is specific to ``eegprep-console`` and registered GUI
+actions.
+
+Required Package Format
+=======================
+
+An EEGPrep extension package must provide:
+
+* A ``pyproject.toml`` project.
+* A ``[project.entry-points."eegprep.extensions"]`` entry point.
+* A lightweight ``register()`` function that returns ``ExtensionSpec``.
+* Declarative ``ExtensionAction``, ``ExtensionMenu``, and
+  ``ExtensionPopFunction`` records where applicable.
+* ``LazyImport`` targets for heavy modules, GUI modules, processing code, and
+  model code.
+* Packaged Markdown help and package data declared through
+  ``ExtensionResource`` when those files are user-facing or required at
+  validation time.
+* ``pop_*`` functions that support ``return_com=True`` when the call is
+  user-facing or history-relevant.
+* No runtime dependency on ``src/eegprep/eeglab`` or any local EEGLAB checkout.
+
+Minimal ``pyproject.toml`` metadata:
+
+.. code-block:: toml
+
+   [project]
+   name = "eegprep-ext-foo"
+   version = "0.1.0"
+   dependencies = ["eegprep"]
+
+   [project.entry-points."eegprep.extensions"]
+   foo = "eegprep_ext_foo.register:register"
+
+Minimal registration:
+
+.. code-block:: python
+
+   from eegprep import (
+       ExtensionAction,
+       ExtensionMenu,
+       ExtensionPopFunction,
+       ExtensionResource,
+       ExtensionSpec,
+       LazyImport,
+   )
+
+   def register():
+       return ExtensionSpec(
+           name="foo",
+           display_name="Foo",
+           version="0.1.0",
+           package_name="eegprep_ext_foo",
+           eegprep_requires=">=0.2",
+           actions=(
+               ExtensionAction(
+                   name="foo.run",
+                   target=LazyImport("eegprep_ext_foo.actions", "run"),
+               ),
+           ),
+           menus=(
+               ExtensionMenu(path=("Tools", "Foo"), action="foo.run", label="Run Foo"),
+           ),
+           pop_functions=(
+               ExtensionPopFunction(
+                   name="pop_foo",
+                   target=LazyImport("eegprep_ext_foo.pop_foo", "pop_foo"),
+               ),
+           ),
+           help_resources=(
+               ExtensionResource("eegprep_ext_foo", "help/pop_foo.md"),
+           ),
+       )
+
+``register()`` should import only the SDK and small metadata. Import processing
+functions, Qt dialogs, and model loaders lazily through ``LazyImport`` so a
+broken optional module does not slow or break EEGPrep startup.
+
+Menus must be declarative. Do not mutate EEGPrep Qt objects, monkeypatch menu
+builders, or write directly to ``EEGPrepSession`` internals from an extension.
+If an extension needs a new integration surface, add or request SDK support
+instead of reaching into private EEGPrep modules.
+
+``pop_*`` History and Console Rules
+===================================
+
+Extension ``pop_*`` functions should follow EEGPrep and EEGLAB-facing
+conventions:
+
+* Accept an EEG dict or EEG-like object explicitly.
+* Return the updated EEG object for data-changing calls.
+* Support ``return_com=True`` and return ``(EEG, com)`` when the call should be
+  recorded in history.
+* Use EEGLAB-facing 1-based values in command strings when users provide
+  EEGLAB-style indices, and convert to Python 0-based indexing internally.
+* Keep GUI and console workflows synchronized through the registered action and
+  ``EEGPrepSession`` helpers instead of mutating GUI-only state.
+* Add packaged help resources for GUI Help buttons and ``pophelp`` surfaces.
+
+Package Data, Optional Dependencies, and Large Files
+====================================================
+
+Use package resources for help text, small calibration files, montages, and
+other data that must ship with the extension. Declare required runtime files
+with ``ExtensionResource`` so ``validate_extension_spec`` can catch missing
+resources before users click the action.
+
+For optional dependencies, declare ``ExtensionDependency(..., optional=True)``
+when the dependency unlocks optional behavior. Declare required dependencies
+without ``optional=True`` so missing packages appear as
+``missing_dependency`` rather than a runtime crash.
+
+Large model files need an explicit distribution choice. Prefer package extras,
+an institution-controlled package index, or an explicit first-run download
+implemented by the extension. Do not imply that a curated catalog entry hosts
+or downloads large model artifacts for EEGPrep.
+
+Trust Levels and States
+=======================
+
+The Extension Manager and registry use these user-facing meanings:
+
+Bundled/Core
+  Ships with EEGPrep and is covered by the EEGPrep CI and release process.
+  Registry value: ``bundled``.
+
+Curated
+  Appears in an EEGPrep catalog that has been reviewed for metadata quality,
+  package-format requirements, and mechanical validation. Curated does not mean
+  SCCN, EEGLAB, or EEGPrep scientifically endorses the method, results, claims,
+  or clinical suitability. Registry value: ``curated``.
+
+Installed
+  Present in the user's Python environment and discovered through
+  ``eegprep.extensions``. Installed does not imply catalog review. Registry
+  value: ``installed``.
+
+Disabled
+  Present but intentionally turned off by the user or configuration. Disabled
+  extensions remain visible so users can re-enable them or inspect why they are
+  inactive. Registry value: ``disabled``.
+
+Failed or incompatible
+  Present but not active because import, registration, validation, dependency,
+  or version checks failed. Registry values include ``failed_import``,
+  ``invalid_spec``, ``missing_dependency``, ``incompatible``, and ``unknown``.
+  The user action is to update, reinstall with missing dependencies, disable,
+  or contact the extension maintainer.
+
+The important combinations are:
+
+* Curated but not installed: visible as reviewed catalog metadata only; it does
+  not run until the user installs the package.
+* Installed but not curated: usable if valid, but not reviewed by the catalog.
+* Curated and installed: both reviewed in the catalog and present locally.
+* Installed then broken after an EEGPrep update: visible as incompatible or
+  failed, with errors preserved so the user can update or disable it.
+* Experimental: can be installed or curated as experimental, but the docs and
+  UI must not imply scientific endorsement.
+
+Catalog Submission Checks
+=========================
+
+Catalog submission and governance automation are maintained separately from
+runtime extension loading. Before submitting an extension for curation, check
+that:
+
+* The package installs from a normal Python distribution path.
+* The entry point returns a valid ``ExtensionSpec``.
+* ``validate_extension_spec`` passes in a clean environment.
+* Menus and ``pop_*`` functions are declarative and use ``LazyImport`` targets.
+* Help and package data are included in the built wheel or source distribution.
+* GUI extensions pass the relevant visual parity and user-flow checks.
+* The README or package metadata states whether the method is experimental.
+* Large files, optional dependencies, and private indexes are documented.
+* No runtime code imports from the vendored EEGLAB reference checkout.
+
+See :ref:`api_extensions` for the SDK API reference.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -39,6 +39,7 @@ Getting Started
    gui_help_menus
    eegbrowser
    interactive_console
+   extensions
 
 Core Concepts
 =============
@@ -76,6 +77,7 @@ Quick Reference
 - :ref:`quickstart` - Load, preprocess, and save EEG data
 - :ref:`gui_help_menus` - Use GUI menus, packaged help, and menu inventory checks
 - :ref:`interactive_console` - Use the GUI and Python console together
+- :ref:`extensions` - Install, trust, and use external EEGPrep extensions
 - :ref:`preprocessing_pipeline` - Understand preprocessing steps
 - :ref:`bids_workflow` - Process BIDS datasets
 - :ref:`study_workflows` - Use current STUDY creation, save/load, and plotting surfaces

--- a/tests/test_extension_docs.py
+++ b/tests/test_extension_docs.py
@@ -1,0 +1,71 @@
+"""Checks for external extension docs and agent skill references."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import eegprep
+from eegprep import extensions
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOC_PATHS = (
+    REPO_ROOT / "docs/source/api/extensions.rst",
+    REPO_ROOT / "docs/source/user_guide/extensions.rst",
+    REPO_ROOT / ".agents/skills/eegprep-extension-development/SKILL.md",
+)
+
+SDK_SYMBOLS = (
+    "ExtensionAction",
+    "ExtensionDependency",
+    "ExtensionMenu",
+    "ExtensionPopFunction",
+    "ExtensionRegistry",
+    "ExtensionResource",
+    "ExtensionSpec",
+    "ExtensionStatus",
+    "LazyImport",
+    "discover_extensions",
+    "validate_extension_spec",
+)
+
+INSTALL_COMMANDS = (
+    "uv add --editable /path/to/eegprep-ext-foo",
+    "uv add git+https://github.com/lab/eegprep-ext-foo",
+    "uv add eegprep-ext-foo",
+    "uv add --index https://packages.lab.example/simple eegprep-ext-foo",
+    "uv add --default-index https://packages.lab.example/simple eegprep-ext-foo",
+)
+
+
+def test_extension_docs_and_skill_reference_importable_sdk_symbols() -> None:
+    text = _extension_text()
+    sdk_module = importlib.import_module("eegprep.extensions")
+
+    assert extensions.EXTENSION_ENTRY_POINT_GROUP == "eegprep.extensions"
+    assert "eegprep.extensions" in text
+    for symbol in SDK_SYMBOLS:
+        assert hasattr(sdk_module, symbol), symbol
+        assert hasattr(eegprep, symbol), symbol
+        assert symbol in text
+
+
+def test_extension_docs_cover_supported_install_paths() -> None:
+    text = _extension_text()
+
+    for command in INSTALL_COMMANDS:
+        assert command in text
+
+
+def test_extension_docs_cover_registry_status_language() -> None:
+    text = _extension_text()
+
+    for status in extensions.ExtensionStatus:
+        assert status.value in text
+    assert "scientific endorsement" in text
+    assert "does not host extension zips" in text
+    assert "does not host arbitrary extension zip files" in text
+
+
+def _extension_text() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)

--- a/tests/test_extension_docs.py
+++ b/tests/test_extension_docs.py
@@ -68,4 +68,8 @@ def test_extension_docs_cover_registry_status_language() -> None:
 
 
 def _extension_text() -> str:
-    return "\n".join(path.read_text(encoding="utf-8") for path in DOC_PATHS)
+    text_parts = []
+    for path in DOC_PATHS:
+        assert path.is_file(), f"Expected extension documentation path to exist: {path}"
+        text_parts.append(path.read_text(encoding="utf-8"))
+    return "\n".join(text_parts)


### PR DESCRIPTION
Document external extension installation, package format, trust states, and no zip-hosting policy. Add the eegprep-extension-development skill and a lightweight check tying docs and skill text to real extension SDK symbols and install commands.

Closes #119