### PR TITLE
[Extensions] Add authoring toolkit examples

### DIFF
--- a/docs/source/api/extensions.rst
+++ b/docs/source/api/extensions.rst
@@ -60,6 +60,17 @@ inventory purposes. Their existing menus and direct public APIs are still
 provided by the current bundled plugin modules; external menu/action/console
 wiring belongs to later extension-ecosystem phases.
 
+Authoring examples
+==================
+
+Checked-in authoring packages live under
+`examples/extensions <https://github.com/sccn/eegprep/tree/develop/examples/extensions>`__.
+Start with the template package there, then compare the focused variants for
+signal transforms, file import/export, GUI dialogs, plot/browser callbacks, and
+optional dependencies. The same directory includes a developer checklist for
+GUI parity, console/history behavior, EEG data semantics, package data,
+dependencies, tests, and version compatibility.
+
 API Reference
 =============
 

--- a/examples/extensions/DEVELOPER_CHECKLIST.md
+++ b/examples/extensions/DEVELOPER_CHECKLIST.md
@@ -1,0 +1,58 @@
+# EEGPrep Extension Developer Checklist
+
+Use this checklist before sharing an extension with another EEG researcher.
+
+## GUI Parity
+
+- Match EEGLAB label text, control order, defaults, enabled states, and button behavior for ported dialogs.
+- Put renderer-independent dialog specs in code and test them with a fake renderer.
+- Return the original EEG and an empty command when the user cancels a dialog.
+- Keep Help buttons disabled until your extension runtime can route them to packaged Markdown resources.
+- When Help routing is available, point Help buttons at packaged Markdown resources, not MATLAB files or Python docstrings.
+
+## Console And History
+
+- User-facing `pop_*` functions accept `return_com=True`.
+- Mutating `pop_*` functions return `(EEG, com)` where `com` is an EEGLAB-style command string.
+- Console wrappers can replay the command after MATLAB-to-Python conversion.
+- GUI actions that mutate EEG update `LASTCOM` and `ALLCOM` through `EEGPrepSession`.
+- Treat `ExtensionMenu` entries as declarative metadata unless your target EEGPrep runtime has installed-extension menu insertion enabled.
+
+## EEG Data Semantics
+
+- Treat continuous data as channel-major `(nbchan, pnts)`.
+- Treat epoched data as channel-major `(nbchan, pnts, trials)`.
+- Preserve EEGLAB-facing 1-based event latencies and document any Python-only 0-based index inputs.
+- Deep-copy EEG dictionaries before mutating unless the function is explicitly documented as in-place.
+- Update dependent fields such as `nbchan`, `pnts`, `trials`, `xmin`, `xmax`, `times`, `event`, `history`, `icaact`, `icawinv`, `icasphere`, `icaweights`, and `icachansind` when behavior affects them.
+
+## Package Data
+
+- Declare help Markdown, sample data, model weights, montages, or lookup tables in package data.
+- Verify resources with `ExtensionResource.exists()` and `read_text()` or `read_bytes()`.
+- Keep runtime behavior independent of `src/eegprep/eeglab`.
+- Use tiny sample files in tests; do not check in large model weights unless they are essential.
+
+## Dependencies
+
+- Put required runtime dependencies in `project.dependencies`.
+- Declare optional extension capabilities with `ExtensionDependency(..., optional=True)`.
+- Fail clearly when an optional action is used without its optional dependency.
+- Avoid dependencies for small helpers that standard library, NumPy, SciPy, or EEGPrep already cover.
+
+## Tests
+
+- Test `ExtensionSpec` validation and entry-point loading.
+- Test every `pop_*` history command with `return_com=True`.
+- Test GUI cancel and invalid-input paths.
+- Test package data/model-resource availability.
+- Test sample-data workflows with realistic EEG dicts.
+- Add console/session tests when an action mutates EEG or depends on `LASTCOM`/`ALLCOM`.
+- Test `--no-plugins` behavior through `ExtensionRegistry.discover(include_plugins=False)` when discovery is relevant.
+
+## Version Compatibility
+
+- Set `api_version` to the current EEGPrep extension API version.
+- Use `eegprep_requires` for the minimum EEGPrep version your extension needs.
+- Keep private extensions on the same contract as public packages so they can be installed editable, from GitHub, or from PyPI.
+- For EEGLAB plugin ports with MATLAB-only pieces, mark unsupported paths explicitly and keep Python runtime code standalone.

--- a/examples/extensions/README.md
+++ b/examples/extensions/README.md
@@ -1,0 +1,46 @@
+# EEGPrep Extension Authoring Examples
+
+This directory contains concrete extension packages for researchers who want to build private,
+GitHub-hosted, or PyPI-published EEGPrep extensions.
+
+Start with `eegprep_ext_template`. It demonstrates:
+
+- `pyproject.toml` with `[project.entry-points."eegprep.extensions"]`
+- an `ExtensionSpec` registration function
+- one `pop_*` function that preserves EEG dict semantics and returns `(EEG, com)`
+- one declarative menu contribution for the extension runtime to place
+- one packaged help Markdown resource
+- one packaged sample-data resource
+- tests that exercise SDK registration, package data, GUI cancel, and console/history behavior
+
+Install modes:
+
+```bash
+uv add -e /path/to/eegprep_ext_template
+uv add git+https://github.com/lab/eegprep-ext-template
+uv add eegprep-ext-template
+```
+
+Run template tests after copying or adapting the package:
+
+```bash
+uv run pytest /path/to/eegprep_ext_template/tests
+```
+
+The smaller packages show focused variants:
+
+- `eegprep_ext_signal_transform`: pure EEG signal transform
+- `eegprep_ext_file_io`: file importer/exporter functions
+- `eegprep_ext_gui_dialog`: renderer-independent `inputgui` dialog and cancel path
+- `eegprep_ext_plot_browser`: plot/browser-style action with a callback boundary
+- `eegprep_ext_optional_dependency`: optional dependency plus packaged model/data file
+
+Private extensions do not need catalog submission. Keep the package in a private repository or
+install it from a local path, and use the same entry-point registration contract.
+
+The Phase 1 SDK validates menu metadata; installed-extension GUI insertion is owned by the Phase 2
+runtime integration. Until that runtime hook is present, treat `ExtensionMenu` entries as declarative
+metadata that tests can validate but the core GUI may not display.
+
+`eegprep --no-plugins` and `eegprep-console --no-plugins` should not load extension entry points.
+Use that mode when debugging core EEGPrep behavior without external contributions.

--- a/examples/extensions/eegprep_ext_file_io/pyproject.toml
+++ b/examples/extensions/eegprep_ext_file_io/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-file-io"
+version = "0.1.0"
+description = "EEGPrep extension example for file importer and exporter actions"
+requires-python = ">=3.10"
+dependencies = ["eegprep>=0.2.23", "numpy>=1.23"]
+
+[project.entry-points."eegprep.extensions"]
+file_io = "eegprep_ext_file_io.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/__init__.py
+++ b/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/__init__.py
@@ -1,0 +1,6 @@
+"""File importer/exporter EEGPrep extension example."""
+
+from .io import pop_demo_export_csv, pop_demo_import_csv
+from .registration import register
+
+__all__ = ["pop_demo_export_csv", "pop_demo_import_csv", "register"]

--- a/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/io.py
+++ b/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/io.py
@@ -1,0 +1,51 @@
+"""CSV import/export example functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def pop_demo_import_csv(filename: str | Path, *, srate: float = 1.0, return_com: bool = False):
+    """Import a channel-major CSV file into a minimal EEG dictionary."""
+    path = Path(filename)
+    data = np.loadtxt(path, delimiter=",")
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    eeg = {
+        "setname": path.stem,
+        "filename": path.name,
+        "filepath": str(path.parent),
+        "data": data,
+        "nbchan": int(data.shape[0]),
+        "pnts": int(data.shape[1]),
+        "trials": 1,
+        "srate": float(srate),
+        "xmin": 0.0,
+        "xmax": (data.shape[1] - 1) / float(srate),
+        "times": np.arange(data.shape[1]) / float(srate),
+        "chanlocs": [{"labels": f"Ch{index + 1}"} for index in range(data.shape[0])],
+        "event": [],
+        "urevent": [],
+        "epoch": [],
+        "history": "",
+        "etc": {"eegprep_ext_file_io": {"source": "csv"}},
+    }
+    command = f"EEG = pop_demo_import_csv({str(path)!r}, srate={float(srate):g});"
+    return (eeg, command) if return_com else eeg
+
+
+def pop_demo_export_csv(
+    EEG: dict[str, Any],
+    filename: str | Path,
+    *,
+    return_com: bool = False,
+):
+    """Export EEG.data to a channel-major CSV file."""
+    path = Path(filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savetxt(path, np.asarray(EEG["data"], dtype=float), delimiter=",")
+    command = f"LASTCOM = pop_demo_export_csv(EEG, {str(path)!r});"
+    return (path, command) if return_com else path

--- a/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/registration.py
+++ b/examples/extensions/eegprep_ext_file_io/src/eegprep_ext_file_io/registration.py
@@ -1,0 +1,55 @@
+"""Extension registration for the file importer/exporter example."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionDependency,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+
+def register() -> ExtensionSpec:
+    """Return the file I/O example extension spec."""
+    return ExtensionSpec(
+        name="eegprep_ext_file_io",
+        display_name="File I/O Example",
+        version="0.1.0",
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_file_io",
+        source_type=ExtensionSourceType.INSTALLED,
+        capabilities=("file-import", "file-export"),
+        dependencies=(ExtensionDependency("numpy", ">=1.23"),),
+        menus=(
+            ExtensionMenu(path=("File", "Import data"), action="pop_demo_import_csv", label="Example CSV file"),
+            ExtensionMenu(path=("File", "Export"), action="pop_demo_export_csv", label="Example CSV file"),
+        ),
+        actions=(
+            ExtensionAction(
+                name="pop_demo_import_csv",
+                target=LazyImport("eegprep_ext_file_io.io", "pop_demo_import_csv"),
+                capabilities=("imports-eeg", "history"),
+            ),
+            ExtensionAction(
+                name="pop_demo_export_csv",
+                target=LazyImport("eegprep_ext_file_io.io", "pop_demo_export_csv"),
+                capabilities=("exports-eeg", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_demo_import_csv",
+                target=LazyImport("eegprep_ext_file_io.io", "pop_demo_import_csv"),
+            ),
+            ExtensionPopFunction(
+                name="pop_demo_export_csv",
+                target=LazyImport("eegprep_ext_file_io.io", "pop_demo_export_csv"),
+            ),
+        ),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_gui_dialog/pyproject.toml
+++ b/examples/extensions/eegprep_ext_gui_dialog/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-gui-dialog"
+version = "0.1.0"
+description = "EEGPrep extension example for a GUI dialog"
+requires-python = ">=3.10"
+dependencies = ["eegprep>=0.2.23", "numpy>=1.23"]
+
+[project.entry-points."eegprep.extensions"]
+gui_dialog = "eegprep_ext_gui_dialog.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/__init__.py
+++ b/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/__init__.py
@@ -1,0 +1,6 @@
+"""GUI dialog EEGPrep extension example."""
+
+from .pop_demo_threshold import pop_demo_threshold, pop_demo_threshold_dialog_spec
+from .registration import register
+
+__all__ = ["pop_demo_threshold", "pop_demo_threshold_dialog_spec", "register"]

--- a/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/pop_demo_threshold.py
+++ b/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/pop_demo_threshold.py
@@ -1,0 +1,70 @@
+"""GUI dialog example extension."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+
+_UNSET = object()
+
+
+def pop_demo_threshold(
+    EEG: dict[str, Any] | None,
+    threshold: float | object = _UNSET,
+    *,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+):
+    """Record how many samples exceed a threshold, with an optional GUI."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    if gui is None:
+        gui = threshold is _UNSET
+    if gui:
+        result = inputgui(pop_demo_threshold_dialog_spec(), renderer=renderer)
+        if result is None:
+            return (EEG, "") if return_com else EEG
+        threshold = result.get("threshold", "0")
+    elif threshold is _UNSET:
+        threshold = 0.0
+
+    threshold_value = float(threshold)
+    output = deepcopy(EEG)
+    count = int(np.count_nonzero(np.asarray(output["data"], dtype=float) > threshold_value))
+    output.setdefault("etc", {})["eegprep_ext_gui_dialog"] = {
+        "threshold": threshold_value,
+        "samples_over_threshold": count,
+    }
+    command = f"EEG = pop_demo_threshold(EEG, {threshold_value:g});"
+    return (output, command) if return_com else output
+
+
+def pop_demo_threshold_dialog_spec() -> DialogSpec:
+    """Return the renderer-independent dialog spec for the GUI example."""
+    return DialogSpec(
+        title="Example threshold -- pop_demo_threshold()",
+        function_name="pop_demo_threshold",
+        eeglab_source="extensions/eegprep_ext_gui_dialog/pop_demo_threshold.py",
+        geometry=((1,), (1,)),
+        size=(330, 180),
+        show_help_button=False,
+        known_differences=(
+            "Extension dialog Help routing should be enabled only after the runtime "
+            "can resolve extension-packaged help resources.",
+        ),
+        controls=(
+            ControlSpec("text", "Threshold"),
+            ControlSpec(
+                "edit",
+                tag="threshold",
+                value="0",
+                callback=CallbackSpec("validate_numeric_range", params={"columns": 1}),
+            ),
+        ),
+    )

--- a/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/registration.py
+++ b/examples/extensions/eegprep_ext_gui_dialog/src/eegprep_ext_gui_dialog/registration.py
@@ -1,0 +1,43 @@
+"""Extension registration for the GUI dialog example."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionDependency,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+
+def register() -> ExtensionSpec:
+    """Return the GUI dialog example extension spec."""
+    return ExtensionSpec(
+        name="eegprep_ext_gui_dialog",
+        display_name="GUI Dialog Example",
+        version="0.1.0",
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_gui_dialog",
+        source_type=ExtensionSourceType.INSTALLED,
+        capabilities=("gui-dialog", "history"),
+        dependencies=(ExtensionDependency("numpy", ">=1.23"),),
+        menus=(ExtensionMenu(path=("Tools", "Example dialogs"), action="pop_demo_threshold", label="Threshold demo"),),
+        actions=(
+            ExtensionAction(
+                name="pop_demo_threshold",
+                target=LazyImport("eegprep_ext_gui_dialog.pop_demo_threshold", "pop_demo_threshold"),
+                capabilities=("gui-dialog", "mutates-eeg", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_demo_threshold",
+                target=LazyImport("eegprep_ext_gui_dialog.pop_demo_threshold", "pop_demo_threshold"),
+            ),
+        ),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_optional_dependency/pyproject.toml
+++ b/examples/extensions/eegprep_ext_optional_dependency/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-optional-dependency"
+version = "0.1.0"
+description = "EEGPrep extension example for optional dependencies and packaged model data"
+requires-python = ">=3.10"
+dependencies = ["eegprep>=0.2.23"]
+
+[project.optional-dependencies]
+model = ["eegprep-template-optional-model>=1.0"]
+
+[project.entry-points."eegprep.extensions"]
+optional_dependency = "eegprep_ext_optional_dependency.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"eegprep_ext_optional_dependency" = ["resources/**/*.json"]

--- a/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/__init__.py
+++ b/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/__init__.py
@@ -1,0 +1,6 @@
+"""Optional dependency EEGPrep extension example."""
+
+from .optional_model import model_card_text, pop_demo_optional_score
+from .registration import register
+
+__all__ = ["model_card_text", "pop_demo_optional_score", "register"]

--- a/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/optional_model.py
+++ b/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/optional_model.py
@@ -1,0 +1,27 @@
+"""Optional dependency and packaged model-data example."""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import Any
+
+
+def model_card_text() -> str:
+    """Return the packaged model-card resource text."""
+    return (
+        resources.files("eegprep_ext_optional_dependency")
+        .joinpath("resources/model/model-card.json")
+        .read_text(encoding="utf-8")
+    )
+
+
+def pop_demo_optional_score(EEG: dict[str, Any] | None, *, return_com: bool = False):
+    """Use an optional model dependency only when this action is called."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    try:
+        import eegprep_template_optional_model  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError("Install eegprep-ext-optional-dependency[model] to use pop_demo_optional_score.") from exc
+    command = "EEG = pop_demo_optional_score(EEG);"
+    return (EEG, command) if return_com else EEG

--- a/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/registration.py
+++ b/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/registration.py
@@ -1,0 +1,53 @@
+"""Extension registration for the optional dependency example."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionDependency,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionResource,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+
+def register() -> ExtensionSpec:
+    """Return the optional dependency example extension spec."""
+    return ExtensionSpec(
+        name="eegprep_ext_optional_dependency",
+        display_name="Optional Dependency Example",
+        version="0.1.0",
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_optional_dependency",
+        source_type=ExtensionSourceType.INSTALLED,
+        capabilities=("optional-dependency", "packaged-model"),
+        dependencies=(ExtensionDependency("eegprep-template-optional-model", ">=1.0", optional=True),),
+        menus=(
+            ExtensionMenu(
+                path=("Tools", "Example optional dependency"),
+                action="pop_demo_optional_score",
+                label="Optional model score",
+            ),
+        ),
+        actions=(
+            ExtensionAction(
+                name="pop_demo_optional_score",
+                target=LazyImport("eegprep_ext_optional_dependency.optional_model", "pop_demo_optional_score"),
+                capabilities=("optional-dependency", "mutates-eeg", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_demo_optional_score",
+                target=LazyImport("eegprep_ext_optional_dependency.optional_model", "pop_demo_optional_score"),
+            ),
+        ),
+        package_data_resources=(
+            ExtensionResource("eegprep_ext_optional_dependency", "resources/model/model-card.json"),
+        ),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/resources/model/model-card.json
+++ b/examples/extensions/eegprep_ext_optional_dependency/src/eegprep_ext_optional_dependency/resources/model/model-card.json
@@ -1,0 +1,5 @@
+{
+  "name": "Template optional model",
+  "version": "0.1.0",
+  "description": "Small packaged metadata file standing in for model weights."
+}

--- a/examples/extensions/eegprep_ext_plot_browser/pyproject.toml
+++ b/examples/extensions/eegprep_ext_plot_browser/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-plot-browser"
+version = "0.1.0"
+description = "EEGPrep extension example for plot/browser-style actions"
+requires-python = ">=3.10"
+dependencies = ["eegprep>=0.2.23"]
+
+[project.entry-points."eegprep.extensions"]
+plot_browser = "eegprep_ext_plot_browser.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/__init__.py
+++ b/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/__init__.py
@@ -1,0 +1,6 @@
+"""Plot/browser EEGPrep extension example."""
+
+from .browser import pop_demo_browser
+from .registration import register
+
+__all__ = ["pop_demo_browser", "register"]

--- a/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/browser.py
+++ b/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/browser.py
@@ -1,0 +1,26 @@
+"""Plot/browser-style example action."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def pop_demo_browser(
+    EEG: dict[str, Any] | None,
+    *,
+    command_callback: Callable[[dict[str, Any], str], None] | None = None,
+    return_com: bool = False,
+):
+    """Return a lightweight browser model and report history through a callback."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    command = "LASTCOM = pop_demo_browser(EEG);"
+    browser = {
+        "kind": "example-browser",
+        "setname": str(EEG.get("setname") or ""),
+        "nbchan": int(EEG.get("nbchan", 0) or 0),
+        "pnts": int(EEG.get("pnts", 0) or 0),
+    }
+    if command_callback is not None:
+        command_callback(EEG, command)
+    return (browser, command) if return_com else browser

--- a/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/registration.py
+++ b/examples/extensions/eegprep_ext_plot_browser/src/eegprep_ext_plot_browser/registration.py
@@ -1,0 +1,41 @@
+"""Extension registration for the plot/browser example."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+
+def register() -> ExtensionSpec:
+    """Return the plot/browser example extension spec."""
+    return ExtensionSpec(
+        name="eegprep_ext_plot_browser",
+        display_name="Plot Browser Example",
+        version="0.1.0",
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_plot_browser",
+        source_type=ExtensionSourceType.INSTALLED,
+        capabilities=("plot", "browser", "history"),
+        menus=(ExtensionMenu(path=("Plot", "Example browser"), action="pop_demo_browser", label="Browser demo"),),
+        actions=(
+            ExtensionAction(
+                name="pop_demo_browser",
+                target=LazyImport("eegprep_ext_plot_browser.browser", "pop_demo_browser"),
+                capabilities=("plot", "browser", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_demo_browser",
+                target=LazyImport("eegprep_ext_plot_browser.browser", "pop_demo_browser"),
+            ),
+        ),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_signal_transform/pyproject.toml
+++ b/examples/extensions/eegprep_ext_signal_transform/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-signal-transform"
+version = "0.1.0"
+description = "EEGPrep extension example for a pure signal transform"
+requires-python = ">=3.10"
+dependencies = ["eegprep>=0.2.23", "numpy>=1.23"]
+
+[project.entry-points."eegprep.extensions"]
+signal_transform = "eegprep_ext_signal_transform.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/__init__.py
+++ b/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/__init__.py
@@ -1,0 +1,6 @@
+"""Pure signal-transform EEGPrep extension example."""
+
+from .pop_demo_center import pop_demo_center
+from .registration import register
+
+__all__ = ["pop_demo_center", "register"]

--- a/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/pop_demo_center.py
+++ b/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/pop_demo_center.py
@@ -1,0 +1,21 @@
+"""Pure signal transform example."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+
+
+def pop_demo_center(EEG: dict[str, Any] | None, *, return_com: bool = False):
+    """Subtract each channel's mean without changing EEG dimensions."""
+    if EEG is None:
+        return (None, "") if return_com else None
+    output = deepcopy(EEG)
+    data = np.asarray(output["data"], dtype=float)
+    axis = 1 if data.ndim == 2 else (1, 2)
+    output["data"] = data - np.mean(data, axis=axis, keepdims=True)
+    output.setdefault("etc", {})["eegprep_ext_signal_transform"] = {"centered": True}
+    command = "EEG = pop_demo_center(EEG);"
+    return (output, command) if return_com else output

--- a/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/registration.py
+++ b/examples/extensions/eegprep_ext_signal_transform/src/eegprep_ext_signal_transform/registration.py
@@ -1,0 +1,44 @@
+"""Extension registration for the pure signal-transform example."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionDependency,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+
+def register() -> ExtensionSpec:
+    """Return the signal-transform example extension spec."""
+    return ExtensionSpec(
+        name="eegprep_ext_signal_transform",
+        display_name="Signal Transform Example",
+        version="0.1.0",
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_signal_transform",
+        source_type=ExtensionSourceType.INSTALLED,
+        capabilities=("signal-transform",),
+        dependencies=(ExtensionDependency("numpy", ">=1.23"),),
+        menus=(ExtensionMenu(path=("Tools", "Example transforms"), action="pop_demo_center", label="Center channels"),),
+        actions=(
+            ExtensionAction(
+                name="pop_demo_center",
+                target=LazyImport("eegprep_ext_signal_transform.pop_demo_center", "pop_demo_center"),
+                display_name="Center channels",
+                capabilities=("mutates-eeg", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_demo_center",
+                target=LazyImport("eegprep_ext_signal_transform.pop_demo_center", "pop_demo_center"),
+            ),
+        ),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_template/README.md
+++ b/examples/extensions/eegprep_ext_template/README.md
@@ -1,0 +1,33 @@
+# EEGPrep Extension Template
+
+Copy this package when starting a small EEGPrep extension.
+
+Install locally while developing:
+
+```bash
+uv add -e /path/to/eegprep_ext_template
+```
+
+Install from GitHub:
+
+```bash
+uv add git+https://github.com/lab/eegprep-ext-template
+```
+
+Install from PyPI:
+
+```bash
+uv add eegprep-ext-template
+```
+
+Run the template tests:
+
+```bash
+uv run pytest tests
+```
+
+The package contributes `pop_template_gain`, a single `pop_*` function that
+scales EEG data, records an EEGLAB-style history command, declares Tools menu
+metadata for the extension runtime, and exposes packaged help plus sample data
+resources. Current EEGPrep SDK tests can validate the menu metadata; actual GUI
+insertion depends on the Phase 2 runtime integration.

--- a/examples/extensions/eegprep_ext_template/pyproject.toml
+++ b/examples/extensions/eegprep_ext_template/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eegprep-ext-template"
+version = "0.1.0"
+description = "Minimal EEGPrep extension template package"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "eegprep>=0.2.23",
+  "numpy>=1.23",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.entry-points."eegprep.extensions"]
+template = "eegprep_ext_template.registration:register"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"eegprep_ext_template" = [
+  "resources/**/*.json",
+  "resources/**/*.md",
+]

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/__init__.py
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/__init__.py
@@ -1,0 +1,14 @@
+"""Minimal EEGPrep extension template package."""
+
+from ._version import __version__
+from .pop_template_gain import pop_template_gain, pop_template_gain_dialog_spec
+from .registration import register
+from .sample_data import load_sample_eeg
+
+__all__ = [
+    "__version__",
+    "load_sample_eeg",
+    "pop_template_gain",
+    "pop_template_gain_dialog_spec",
+    "register",
+]

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/_version.py
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/_version.py
@@ -1,0 +1,3 @@
+"""Version for the template extension package."""
+
+__version__ = "0.1.0"

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/pop_template_gain.py
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/pop_template_gain.py
@@ -1,0 +1,98 @@
+"""Template EEGLAB-style pop function."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from math import isfinite
+from typing import Any
+
+import numpy as np
+
+from eegprep.functions.guifunc.inputgui import inputgui
+from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+
+_UNSET = object()
+
+
+def pop_template_gain(
+    EEG: dict[str, Any] | list[dict[str, Any]] | None,
+    gain: float | object = _UNSET,
+    *,
+    gui: bool | None = None,
+    renderer: Any | None = None,
+    return_com: bool = False,
+):
+    """Scale EEG data by ``gain`` and optionally return an EEGLAB-style command."""
+    if EEG is None:
+        return (None, "") if return_com else None
+
+    if gui is None:
+        gui = gain is _UNSET
+    if gui:
+        result = _run_gui(renderer=renderer)
+        if result is None:
+            return (EEG, "") if return_com else EEG
+        gain = result["gain"]
+    elif gain is _UNSET:
+        gain = 1.0
+
+    gain_value = _validated_gain(gain)
+    command = _history_command(gain_value)
+    if isinstance(EEG, list):
+        output = [pop_template_gain(eeg, gain_value, gui=False) for eeg in EEG]
+        return (output, command) if return_com else output
+
+    output = deepcopy(EEG)
+    data = np.asarray(output.get("data"), dtype=float)
+    if data.size == 0:
+        raise ValueError("EEG.data must contain samples")
+    output["data"] = data * gain_value
+    output.setdefault("etc", {})["eegprep_ext_template"] = {"gain": gain_value}
+    return (output, command) if return_com else output
+
+
+def pop_template_gain_dialog_spec() -> DialogSpec:
+    """Return the renderer-independent dialog spec for ``pop_template_gain``."""
+    return DialogSpec(
+        title="Apply template gain -- pop_template_gain()",
+        function_name="pop_template_gain",
+        eeglab_source="extensions/eegprep_ext_template/pop_template_gain.py",
+        geometry=((1,), (1,)),
+        size=(330, 180),
+        show_help_button=False,
+        known_differences=(
+            "Extension-packaged help resources are declared in ExtensionSpec; "
+            "Dialog Help routing depends on extension runtime integration.",
+        ),
+        controls=(
+            ControlSpec("text", "Multiply EEG.data by this gain"),
+            ControlSpec(
+                "edit",
+                tag="gain",
+                value="1",
+                callback=CallbackSpec("validate_numeric_range", params={"columns": 1}),
+            ),
+        ),
+    )
+
+
+def _run_gui(*, renderer: Any | None = None) -> dict[str, float] | None:
+    result = inputgui(pop_template_gain_dialog_spec(), renderer=renderer)
+    if result is None:
+        return None
+    return {"gain": _validated_gain(result.get("gain", "1"))}
+
+
+def _validated_gain(value: Any) -> float:
+    gain = float(value)
+    if not isfinite(gain):
+        raise ValueError("gain must be finite")
+    return gain
+
+
+def _history_command(gain: float) -> str:
+    return f"EEG = pop_template_gain(EEG, {_format_number(gain)});"
+
+
+def _format_number(value: float) -> str:
+    return str(int(value)) if float(value).is_integer() else f"{value:g}"

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/registration.py
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/registration.py
@@ -1,0 +1,59 @@
+"""Extension registration for the template package."""
+
+from __future__ import annotations
+
+from eegprep.extensions import (
+    EXTENSION_API_VERSION,
+    ExtensionAction,
+    ExtensionDependency,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionResource,
+    ExtensionSourceType,
+    ExtensionSpec,
+    LazyImport,
+)
+
+from ._version import __version__
+
+
+def register() -> ExtensionSpec:
+    """Return the EEGPrep extension spec for this package."""
+    return ExtensionSpec(
+        name="eegprep_ext_template",
+        display_name="EEGPrep Template Extension",
+        version=__version__,
+        api_version=EXTENSION_API_VERSION,
+        package_name="eegprep_ext_template",
+        source_type=ExtensionSourceType.INSTALLED,
+        description="Minimal extension showing pop function, menu, help, tests, and sample data.",
+        maintainer="Your lab",
+        capabilities=("signal-transform", "menu", "help", "sample-data"),
+        dependencies=(ExtensionDependency("numpy", ">=1.23"),),
+        menus=(
+            ExtensionMenu(
+                path=("Tools", "Template extension"),
+                action="pop_template_gain",
+                label="Apply template gain",
+            ),
+        ),
+        actions=(
+            ExtensionAction(
+                name="pop_template_gain",
+                target=LazyImport("eegprep_ext_template.pop_template_gain", "pop_template_gain"),
+                display_name="Apply template gain",
+                description="Scale EEG.data by a numeric gain.",
+                capabilities=("mutates-eeg", "history"),
+            ),
+        ),
+        pop_functions=(
+            ExtensionPopFunction(
+                name="pop_template_gain",
+                target=LazyImport("eegprep_ext_template.pop_template_gain", "pop_template_gain"),
+                description="Scale EEG.data by a numeric gain.",
+            ),
+        ),
+        help_resources=(ExtensionResource("eegprep_ext_template", "resources/help/pop_template_gain.md"),),
+        package_data_resources=(ExtensionResource("eegprep_ext_template", "resources/sample_data/template_eeg.json"),),
+        eegprep_requires=">=0.2.23",
+    )

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/resources/help/pop_template_gain.md
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/resources/help/pop_template_gain.md
@@ -1,0 +1,12 @@
+# pop_template_gain
+
+Scale `EEG.data` by a numeric gain and return an EEGLAB-style history command.
+
+Usage:
+
+```python
+EEG, com = pop_template_gain(EEG, 2, return_com=True)
+```
+
+GUI cancel returns the original EEG and an empty command. This help file is
+packaged inside the extension; it does not depend on an EEGLAB checkout.

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/resources/sample_data/template_eeg.json
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/resources/sample_data/template_eeg.json
@@ -1,0 +1,27 @@
+{
+  "setname": "template_sample",
+  "data": [
+    [1.0, 2.0, 3.0, 4.0],
+    [0.5, 0.0, -0.5, -1.0]
+  ],
+  "nbchan": 2,
+  "pnts": 4,
+  "trials": 1,
+  "srate": 128.0,
+  "xmin": 0.0,
+  "xmax": 0.0234375,
+  "times": [0.0, 0.0078125, 0.015625, 0.0234375],
+  "chanlocs": [
+    {"labels": "Cz", "type": "EEG"},
+    {"labels": "Pz", "type": "EEG"}
+  ],
+  "event": [
+    {"type": "stim", "latency": 1, "duration": 0}
+  ],
+  "urevent": [
+    {"type": "stim", "latency": 1, "duration": 0}
+  ],
+  "epoch": [],
+  "history": "",
+  "etc": {}
+}

--- a/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/sample_data.py
+++ b/examples/extensions/eegprep_ext_template/src/eegprep_ext_template/sample_data.py
@@ -1,0 +1,24 @@
+"""Packaged sample EEG data for template tests and demos."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from importlib import resources
+import json
+from typing import Any
+
+import numpy as np
+
+
+def load_sample_eeg() -> dict[str, Any]:
+    """Return a fresh tiny EEG dictionary from this package's sample data."""
+    text = (
+        resources.files("eegprep_ext_template")
+        .joinpath("resources/sample_data/template_eeg.json")
+        .read_text(encoding="utf-8")
+    )
+    payload = json.loads(text)
+    eeg = deepcopy(payload)
+    eeg["data"] = np.asarray(payload["data"], dtype=float)
+    eeg["times"] = np.asarray(payload["times"], dtype=float)
+    return eeg

--- a/examples/extensions/eegprep_ext_template/tests/test_template_extension.py
+++ b/examples/extensions/eegprep_ext_template/tests/test_template_extension.py
@@ -1,0 +1,84 @@
+"""Tests that should pass after copying the template extension."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+import numpy as np
+
+from eegprep.extensions import ExtensionRegistry, ExtensionStatus, validate_extension_spec
+from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace, _console_python_command
+from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep_ext_template import load_sample_eeg, pop_template_gain, register
+
+
+class EntryPoint:
+    name = "template"
+    group = "eegprep.extensions"
+    dist = None
+
+    def load(self):
+        return register
+
+
+class CancelRenderer:
+    def run(self, spec, initial_values=None):
+        return None
+
+
+def test_template_spec_resources_and_entry_point() -> None:
+    spec = register()
+
+    assert validate_extension_spec(spec).ok
+    assert spec.menus[0].action == "pop_template_gain"
+    loaded_pop = spec.pop_functions[0].load()
+    assert loaded_pop.__name__ == pop_template_gain.__name__
+    assert loaded_pop.__module__ == pop_template_gain.__module__
+    assert "pop_template_gain" in spec.help_resources[0].read_text()
+    assert spec.package_data_resources[0].exists()
+
+    registry = ExtensionRegistry(include_bundled=False, entry_points_provider=lambda group: (EntryPoint(),))
+    records = registry.discover()
+    assert records[0].status == ExtensionStatus.INSTALLED
+
+
+def test_template_pop_function_sample_data_and_gui_cancel() -> None:
+    eeg = load_sample_eeg()
+
+    output, command = pop_template_gain(eeg, 2, return_com=True)
+    np.testing.assert_allclose(output["data"], eeg["data"] * 2)
+    assert command == "EEG = pop_template_gain(EEG, 2);"
+    assert _console_python_command(command) == "EEG = pop_template_gain(EEG, 2)"
+
+    cancelled, cancel_command = pop_template_gain(eeg, gui=True, renderer=CancelRenderer(), return_com=True)
+    assert cancelled is eeg
+    assert cancel_command == ""
+
+
+def test_template_console_wrapper_updates_history() -> None:
+    session = EEGPrepSession()
+    session.store_current(load_sample_eeg(), new=True, command="EEG = load_sample_eeg();")
+    workspace = EEGPrepConsoleWorkspace(session, exports={"pop_template_gain": pop_template_gain})
+
+    result = workspace.namespace["pop_template_gain"](session.EEG, 3)
+
+    assert result.command == "EEG = pop_template_gain(EEG, 3);"
+    assert session.LASTCOM == result.command
+    assert session.ALLCOM[-1] == result.command
+    np.testing.assert_allclose(session.EEG["data"], load_sample_eeg()["data"] * 3)
+    workspace.close()
+
+
+def test_no_plugins_mode_skips_template_discovery() -> None:
+    def provider(*, group: str):
+        raise AssertionError(f"entry points should not be loaded in --no-plugins mode: {group}")
+
+    assert ExtensionRegistry(entry_points_provider=provider).discover(include_plugins=False) == ()
+
+
+def test_optional_dependency_pattern_is_not_required_for_template() -> None:
+    def missing_version(name: str) -> str:
+        raise metadata.PackageNotFoundError(name)
+
+    validation = validate_extension_spec(register(), check_dependencies=False, version_provider=missing_version)
+    assert validation.ok

--- a/tests/test_extension_authoring_toolkit.py
+++ b/tests/test_extension_authoring_toolkit.py
@@ -1,0 +1,208 @@
+"""Tests for Phase 4 extension authoring assets."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+from importlib import metadata
+from pathlib import Path
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+
+from eegprep.extensions import EXTENSION_ENTRY_POINT_GROUP, ExtensionRegistry, ExtensionStatus
+from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace, _console_python_command
+from eegprep.functions.guifunc.session import EEGPrepSession
+
+EXAMPLES_ROOT = Path(__file__).resolve().parents[1] / "examples" / "extensions"
+EXAMPLE_PACKAGES = (
+    "eegprep_ext_template",
+    "eegprep_ext_signal_transform",
+    "eegprep_ext_file_io",
+    "eegprep_ext_gui_dialog",
+    "eegprep_ext_plot_browser",
+    "eegprep_ext_optional_dependency",
+)
+
+
+class ExampleEntryPoint:
+    def __init__(self, package: str) -> None:
+        self.name = package.removeprefix("eegprep_ext_")
+        self.group = EXTENSION_ENTRY_POINT_GROUP
+        self.dist = type("Distribution", (), {"metadata": {"Name": package.replace("_", "-")}})()
+        self.package = package
+
+    def load(self) -> Any:
+        return importlib.import_module(f"{self.package}.registration").register
+
+
+class Renderer:
+    def __init__(self, result: dict[str, Any] | None) -> None:
+        self.result = result
+        self.spec = None
+
+    def run(self, spec: Any, initial_values: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        self.spec = spec
+        return self.result
+
+
+def test_template_and_examples_document_install_modes_and_entry_points() -> None:
+    readme = (EXAMPLES_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "uv add -e /path/to/eegprep_ext_template" in readme
+    assert "uv add git+https://github.com/lab/eegprep-ext-template" in readme
+    assert "uv add eegprep-ext-template" in readme
+    assert "--no-plugins" in readme
+    assert "private repository" in readme
+
+    for package in EXAMPLE_PACKAGES:
+        pyproject = (EXAMPLES_ROOT / package / "pyproject.toml").read_text(encoding="utf-8")
+        assert f'[project.entry-points."{EXTENSION_ENTRY_POINT_GROUP}"]' in pyproject
+
+
+@pytest.mark.parametrize("package", EXAMPLE_PACKAGES)
+def test_example_specs_validate_and_load_lazy_targets(package: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    _add_example_package(package, monkeypatch)
+    registry = ExtensionRegistry(
+        include_bundled=False,
+        entry_points_provider=lambda group: (ExampleEntryPoint(package),),
+        version_provider=_version_provider,
+    )
+
+    records = registry.discover()
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.status == ExtensionStatus.INSTALLED
+    assert record.spec is not None
+    assert record.spec.menus
+    assert record.spec.actions
+    assert record.spec.pop_functions
+    assert record.spec.eegprep_requires
+    for action in record.spec.actions:
+        assert callable(action.load())
+    for pop_function in record.spec.pop_functions:
+        assert callable(pop_function.load())
+
+
+def test_template_resources_pop_function_and_console_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    _add_example_package("eegprep_ext_template", monkeypatch)
+    package = importlib.import_module("eegprep_ext_template")
+    spec = package.register()
+    eeg = package.load_sample_eeg()
+
+    assert spec.help_resources[0].exists()
+    assert "pop_template_gain" in spec.help_resources[0].read_text()
+    assert spec.package_data_resources[0].exists()
+    assert eeg["data"].shape == (2, 4)
+
+    output, command = package.pop_template_gain(eeg, 2, return_com=True)
+    np.testing.assert_allclose(output["data"], eeg["data"] * 2)
+    assert command == "EEG = pop_template_gain(EEG, 2);"
+    assert _console_python_command(command) == "EEG = pop_template_gain(EEG, 2)"
+    assert package.pop_template_gain_dialog_spec().show_help_button is False
+
+    cancelled, cancel_command = package.pop_template_gain(eeg, gui=True, renderer=Renderer(None), return_com=True)
+    assert cancelled is eeg
+    assert cancel_command == ""
+
+    session = EEGPrepSession()
+    session.store_current(package.load_sample_eeg(), new=True, command="EEG = load_sample_eeg();")
+    workspace = EEGPrepConsoleWorkspace(session, exports={"pop_template_gain": package.pop_template_gain})
+    try:
+        result = workspace.namespace["pop_template_gain"](session.EEG, 3)
+        assert result.command == "EEG = pop_template_gain(EEG, 3);"
+        assert session.LASTCOM == result.command
+        assert session.ALLCOM[-1] == result.command
+        np.testing.assert_allclose(session.EEG["data"], package.load_sample_eeg()["data"] * 3)
+    finally:
+        workspace.close()
+
+
+def test_no_plugins_mode_skips_example_entry_points() -> None:
+    def provider(*, group: str) -> tuple[ExampleEntryPoint, ...]:
+        raise AssertionError(f"entry point provider should not run for {group}")
+
+    registry = ExtensionRegistry(entry_points_provider=provider)
+
+    assert registry.discover(include_plugins=False) == ()
+
+
+def test_common_example_behaviors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    template = _import_example("eegprep_ext_template", monkeypatch)
+    eeg = template.load_sample_eeg()
+
+    signal = _import_example("eegprep_ext_signal_transform", monkeypatch)
+    centered, center_command = signal.pop_demo_center(eeg, return_com=True)
+    np.testing.assert_allclose(np.mean(centered["data"], axis=1), np.zeros(eeg["nbchan"]))
+    assert center_command == "EEG = pop_demo_center(EEG);"
+
+    file_io = _import_example("eegprep_ext_file_io", monkeypatch)
+    csv_path, export_command = file_io.pop_demo_export_csv(eeg, tmp_path / "template.csv", return_com=True)
+    imported, import_command = file_io.pop_demo_import_csv(csv_path, srate=eeg["srate"], return_com=True)
+    np.testing.assert_allclose(imported["data"], eeg["data"])
+    assert "pop_demo_export_csv" in export_command
+    assert "pop_demo_import_csv" in import_command
+
+    gui_dialog = _import_example("eegprep_ext_gui_dialog", monkeypatch)
+    renderer = Renderer({"threshold": "0.25"})
+    thresholded, threshold_command = gui_dialog.pop_demo_threshold(eeg, gui=True, renderer=renderer, return_com=True)
+    assert renderer.spec is not None
+    assert renderer.spec.function_name == "pop_demo_threshold"
+    assert renderer.spec.show_help_button is False
+    assert thresholded["etc"]["eegprep_ext_gui_dialog"]["samples_over_threshold"] == 5
+    assert threshold_command == "EEG = pop_demo_threshold(EEG, 0.25);"
+    cancelled, cancel_command = gui_dialog.pop_demo_threshold(eeg, gui=True, renderer=Renderer(None), return_com=True)
+    assert cancelled is eeg
+    assert cancel_command == ""
+    with pytest.raises(ValueError):
+        gui_dialog.pop_demo_threshold(eeg, gui=True, renderer=Renderer({"threshold": "bad"}), return_com=True)
+
+    plot_browser = _import_example("eegprep_ext_plot_browser", monkeypatch)
+    callback_calls = []
+    browser, browser_command = plot_browser.pop_demo_browser(
+        eeg,
+        command_callback=lambda out_eeg, command: callback_calls.append((out_eeg, command)),
+        return_com=True,
+    )
+    assert browser["kind"] == "example-browser"
+    assert callback_calls == [(eeg, browser_command)]
+
+    optional = _import_example("eegprep_ext_optional_dependency", monkeypatch)
+    optional_spec = optional.register()
+    assert optional_spec.package_data_resources[0].exists()
+    assert "Template optional model" in optional.model_card_text()
+
+    real_import = builtins.__import__
+
+    def blocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "eegprep_template_optional_model":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    with pytest.raises(RuntimeError, match=r"\[model\]"):
+        optional.pop_demo_optional_score(eeg, return_com=True)
+
+
+def _import_example(package: str, monkeypatch: pytest.MonkeyPatch) -> Any:
+    _add_example_package(package, monkeypatch)
+    return importlib.import_module(package)
+
+
+def _add_example_package(package: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    for module_name in list(sys.modules):
+        if module_name == package or module_name.startswith(f"{package}."):
+            del sys.modules[module_name]
+    monkeypatch.syspath_prepend(str(EXAMPLES_ROOT / package / "src"))
+    importlib.invalidate_caches()
+
+
+def _version_provider(name: str) -> str:
+    if name == "numpy":
+        return np.__version__
+    if name == "eegprep-template-optional-model":
+        raise metadata.PackageNotFoundError(name)
+    return "999.0"


### PR DESCRIPTION
Add a concrete extension template package, focused example extension packages, and a developer checklist for researcher-authored EEGPrep extensions. The included tests validate SDK registration, menu metadata, console/history behavior, help resources, package data, GUI cancel paths, optional dependencies, and no-plugins discovery behavior.

Closes #116