### PR TITLE
[Extensions] Integrate runtime contributions

### DIFF
--- a/src/eegprep/extension_runtime.py
+++ b/src/eegprep/extension_runtime.py
@@ -1,0 +1,265 @@
+"""Runtime adapters for registered EEGPrep extensions."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from eegprep.extensions import (
+    ExtensionAction,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionRecord,
+    ExtensionRegistry,
+    ExtensionResource,
+)
+from eegprep.functions.guifunc.menu_spec import MenuItemSpec, menu_item
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExtensionMenuContribution:
+    """A resolved extension menu item plus its insertion target."""
+
+    owner: str
+    path: tuple[str, ...]
+    item: MenuItemSpec
+    insert_after: str = ""
+    insert_before: str = ""
+
+
+@dataclass(frozen=True)
+class ExtensionRuntime:
+    """Active extension contributions prepared for GUI, help, and console use."""
+
+    records: tuple[ExtensionRecord, ...] = ()
+    actions: Mapping[str, ExtensionAction] | None = None
+    pop_functions: Mapping[str, ExtensionPopFunction] | None = None
+    help_resources: Mapping[str, ExtensionResource] | None = None
+    menu_contributions: tuple[ExtensionMenuContribution, ...] = ()
+
+    @classmethod
+    def discover(
+        cls,
+        *,
+        include_plugins: bool = True,
+        registry: ExtensionRegistry | None = None,
+    ) -> "ExtensionRuntime":
+        """Discover active extensions and prepare their runtime contributions."""
+        if not include_plugins:
+            return cls.empty()
+        registry = registry or ExtensionRegistry()
+        return cls.from_records(registry.discover(include_plugins=True))
+
+    @classmethod
+    def from_records(cls, records: tuple[ExtensionRecord, ...]) -> "ExtensionRuntime":
+        """Build runtime maps from registry records."""
+        actions: dict[str, ExtensionAction] = {}
+        pop_functions: dict[str, ExtensionPopFunction] = {}
+        help_resources: dict[str, ExtensionResource] = {}
+        menu_contributions: list[ExtensionMenuContribution] = []
+
+        for record in records:
+            if not record.is_active or record.spec is None:
+                continue
+            origin = f"extension:{record.name}"
+            for action in record.spec.actions:
+                actions[_key(action.name)] = action
+            for pop_function in record.spec.pop_functions:
+                pop_functions[_key(pop_function.name)] = pop_function
+            for resource in record.spec.help_resources:
+                stem = _resource_stem(resource)
+                if stem in help_resources:
+                    logger.warning(
+                        "EEGPrep extension %s help resource %s duplicates an earlier help topic",
+                        record.name,
+                        resource.path,
+                    )
+                    continue
+                help_resources[stem] = resource
+            for menu in record.spec.menus:
+                menu_contributions.append(_menu_contribution(record.name, origin, menu))
+
+        return cls(
+            records=records,
+            actions=actions,
+            pop_functions=pop_functions,
+            help_resources=help_resources,
+            menu_contributions=tuple(menu_contributions),
+        )
+
+    @classmethod
+    def empty(cls) -> "ExtensionRuntime":
+        """Return a runtime with no active extension contributions."""
+        return cls(actions={}, pop_functions={}, help_resources={})
+
+    def action(self, name: str) -> ExtensionAction | ExtensionPopFunction | None:
+        """Return the registered action or pop callable descriptor for ``name``."""
+        key = _key(name)
+        actions = self.actions or {}
+        pop_functions = self.pop_functions or {}
+        return actions.get(key) or pop_functions.get(key)
+
+    def pop_function(self, name: str) -> ExtensionPopFunction | None:
+        """Return a registered extension ``pop_*`` descriptor."""
+        return (self.pop_functions or {}).get(_key(name))
+
+    def pop_function_resolvers(self) -> dict[str, Callable[[], object]]:
+        """Return lazy callables keyed by extension ``pop_*`` name."""
+        return {pop_function.name: pop_function.load for pop_function in (self.pop_functions or {}).values()}
+
+    def help_resource(self, function_name: str) -> ExtensionResource | None:
+        """Return an extension help resource for ``function_name`` if one exists."""
+        return (self.help_resources or {}).get(_key(function_name))
+
+    def has_action(self, name: str) -> bool:
+        """Return whether an action is registered by an active extension."""
+        return self.action(name) is not None
+
+
+def apply_extension_menus(
+    menus: tuple[MenuItemSpec, ...],
+    runtime: ExtensionRuntime,
+) -> tuple[MenuItemSpec, ...]:
+    """Insert registered extension menu items into the core menu tree."""
+    output = menus
+    for contribution in runtime.menu_contributions:
+        output, inserted = _insert_contribution(output, contribution)
+        if not inserted:
+            logger.warning(
+                "EEGPrep extension %s menu path %s was not found for %s",
+                contribution.owner,
+                " > ".join(contribution.path),
+                contribution.item.label,
+            )
+    return output
+
+
+def _menu_contribution(owner: str, origin: str, menu: ExtensionMenu) -> ExtensionMenuContribution:
+    return ExtensionMenuContribution(
+        owner=owner,
+        path=tuple(str(part) for part in menu.path),
+        item=_menu_item_from_extension_menu(menu, origin),
+        insert_after=menu.insert_after,
+        insert_before=menu.insert_before,
+    )
+
+
+def _menu_item_from_extension_menu(menu: ExtensionMenu, origin: str) -> MenuItemSpec:
+    label = menu.label or menu.action
+    return menu_item(
+        label,
+        action=menu.action or None,
+        tag=menu.tag or None,
+        userdata=menu.userdata,
+        separator=menu.separator,
+        enabled=menu.enabled,
+        checked=menu.checked,
+        visibility=menu.visibility,
+        origin=origin,
+        children=tuple(_menu_item_from_extension_menu(child, origin) for child in menu.children),
+    )
+
+
+def _insert_contribution(
+    items: tuple[MenuItemSpec, ...],
+    contribution: ExtensionMenuContribution,
+) -> tuple[tuple[MenuItemSpec, ...], bool]:
+    return _insert_at_path(items, contribution.path, contribution)
+
+
+def _insert_at_path(
+    items: tuple[MenuItemSpec, ...],
+    path: tuple[str, ...],
+    contribution: ExtensionMenuContribution,
+) -> tuple[tuple[MenuItemSpec, ...], bool]:
+    if not path:
+        return _insert_child(items, contribution), True
+    updated: list[MenuItemSpec] = []
+    inserted = False
+    for item in items:
+        if not inserted and _matches_menu_token(item, path[0]):
+            if len(path) == 1:
+                children = _insert_child(item.children, contribution)
+                updated.append(item.with_children(children))
+                inserted = True
+                continue
+            children, inserted = _insert_at_path(item.children, path[1:], contribution)
+            updated.append(item.with_children(children) if inserted else item)
+            continue
+        updated.append(item)
+    return tuple(updated), inserted
+
+
+def _insert_child(
+    children: tuple[MenuItemSpec, ...],
+    contribution: ExtensionMenuContribution,
+) -> tuple[MenuItemSpec, ...]:
+    item = contribution.item
+    if any(_key(child.label) == _key(item.label) for child in children):
+        logger.warning(
+            "EEGPrep extension %s menu %s duplicates an existing item",
+            contribution.owner,
+            item.label,
+        )
+        return children
+    output = list(children)
+    if contribution.insert_before:
+        index = _anchor_index(children, contribution.insert_before)
+        if index is not None:
+            output.insert(index, item)
+            return tuple(output)
+        _log_missing_anchor(contribution)
+    if contribution.insert_after:
+        index = _anchor_index(children, contribution.insert_after)
+        if index is not None:
+            output.insert(index + 1, item)
+            return tuple(output)
+        _log_missing_anchor(contribution)
+    output.append(item)
+    return tuple(output)
+
+
+def _anchor_index(children: tuple[MenuItemSpec, ...], anchor: str) -> int | None:
+    for index, child in enumerate(children):
+        if _matches_menu_token(child, anchor):
+            return index
+    return None
+
+
+def _matches_menu_token(item: MenuItemSpec, token: str) -> bool:
+    normalized = _key(token)
+    return normalized in {
+        _key(item.label),
+        _key(item.tag or ""),
+        _key(item.action or ""),
+    }
+
+
+def _log_missing_anchor(contribution: ExtensionMenuContribution) -> None:
+    anchor = contribution.insert_before or contribution.insert_after
+    logger.warning(
+        "EEGPrep extension %s menu anchor %s was not found under %s for %s",
+        contribution.owner,
+        anchor,
+        " > ".join(contribution.path),
+        contribution.item.label,
+    )
+
+
+def _resource_stem(resource: ExtensionResource) -> str:
+    name = resource.path.rsplit("/", 1)[-1]
+    return _key(name.rsplit(".", 1)[0])
+
+
+def _key(value: str) -> str:
+    return str(value).strip().lower()
+
+
+__all__ = [
+    "ExtensionMenuContribution",
+    "ExtensionRuntime",
+    "apply_extension_menus",
+]

--- a/src/eegprep/extensions.py
+++ b/src/eegprep/extensions.py
@@ -132,14 +132,24 @@ class ExtensionPopFunction:
 
 @dataclass(frozen=True)
 class ExtensionMenu:
-    """Future menu placement for an extension action."""
+    """Declarative menu contribution for an extension action."""
 
-    path: tuple[str, ...]
-    action: str
+    path: tuple[str, ...] = field(default_factory=tuple)
+    action: str = ""
     label: str = ""
+    tag: str = ""
+    userdata: str = ""
+    separator: bool = False
+    enabled: bool = True
+    checked: bool = False
+    visibility: str = "always"
+    insert_after: str = ""
+    insert_before: str = ""
+    children: tuple["ExtensionMenu", ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "path", _as_tuple(self.path))
+        object.__setattr__(self, "children", _as_tuple(self.children))
 
 
 @dataclass(frozen=True)
@@ -279,45 +289,203 @@ class ExtensionRegistry:
         return None
 
     def _bundled_records(self) -> list[ExtensionRecord]:
-        from eegprep.functions.adminfunc.plugin_menu import bundled_plugins
+        from eegprep.plugins.EEG_BIDS.menu import (
+            eeg_bids_export_items,
+            eeg_bids_import_items,
+            eeg_bids_tools_menu,
+        )
+        from eegprep.plugins.ICLabel.menu import iclabel_menu, viewprops_plot_menus
+        from eegprep.plugins.clean_rawdata.menu import clean_rawdata_menu
+        from eegprep.plugins.dipfit.menu import dipfit_menu
+        from eegprep.plugins.firfilt.menu import firfilt_filter_items
 
-        records = []
-        for plugin in bundled_plugins():
-            plugin_name = str(plugin["plugin"])
-            folder_name = str(plugin.get("foldername") or plugin_name)
-            funcname = str(plugin.get("funcname") or "")
-            pop_functions = ()
-            if funcname:
-                pop_functions = (
-                    ExtensionPopFunction(
-                        name=funcname,
-                        target=LazyImport(f"eegprep.plugins.{folder_name}.{funcname}", funcname),
-                        description=str(plugin.get("description") or ""),
-                    ),
-                )
-            menus = ()
-            if plugin.get("menu") and funcname:
-                menus = (
-                    ExtensionMenu(
-                        path=tuple(part.strip() for part in str(plugin["menu"]).split(">")),
-                        action=funcname,
-                        label=str(plugin.get("name") or plugin_name),
-                    ),
-                )
-            spec = ExtensionSpec(
-                name=plugin_name,
-                display_name=str(plugin.get("name") or plugin_name),
-                version=str(plugin.get("version") or "bundled"),
-                api_version=EXTENSION_API_VERSION,
-                package_name=f"eegprep.plugins.{folder_name}",
+        specs = (
+            ExtensionSpec(
+                name="clean_rawdata",
+                display_name="clean_rawdata",
+                version="bundled",
+                package_name="eegprep.plugins.clean_rawdata",
                 source_type=ExtensionSourceType.BUNDLED,
-                description=str(plugin.get("description") or ""),
-                capabilities=tuple(str(tag) for tag in plugin.get("tags", ())),
-                menus=menus,
-                pop_functions=pop_functions,
-            )
-            records.append(self._record_from_spec(spec))
-        return records
+                description="Artifact Subspace Reconstruction and related channel/window cleaning workflows.",
+                capabilities=("artifact", "preprocessing"),
+                menus=(
+                    _extension_menu_from_spec(
+                        clean_rawdata_menu(),
+                        path=("tools",),
+                        insert_after="pop_eegplot:data",
+                    ),
+                ),
+                pop_functions=(
+                    ExtensionPopFunction(
+                        name="pop_clean_rawdata",
+                        target=LazyImport(
+                            "eegprep.plugins.clean_rawdata.pop_clean_rawdata",
+                            "pop_clean_rawdata",
+                        ),
+                    ),
+                ),
+            ),
+            ExtensionSpec(
+                name="ICLabel",
+                display_name="ICLabel",
+                version="bundled",
+                package_name="eegprep.plugins.ICLabel",
+                source_type=ExtensionSourceType.BUNDLED,
+                description="Independent-component classification, flagging, and extended component properties.",
+                capabilities=("ica", "classification"),
+                menus=(
+                    _extension_menu_from_spec(
+                        iclabel_menu(),
+                        path=("tools",),
+                        insert_after="pop_selectcomps",
+                    ),
+                    *(_extension_menu_from_spec(item, path=("plot",)) for item in viewprops_plot_menus()),
+                ),
+                pop_functions=(
+                    ExtensionPopFunction(
+                        name="pop_iclabel",
+                        target=LazyImport("eegprep.plugins.ICLabel.pop_iclabel", "pop_iclabel"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_icflag",
+                        target=LazyImport("eegprep.plugins.ICLabel.pop_icflag", "pop_icflag"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_viewprops",
+                        target=LazyImport("eegprep.plugins.ICLabel.pop_viewprops", "pop_viewprops"),
+                    ),
+                ),
+            ),
+            ExtensionSpec(
+                name="firfilt",
+                display_name="firfilt",
+                version="bundled",
+                package_name="eegprep.plugins.firfilt",
+                source_type=ExtensionSourceType.BUNDLED,
+                description="Windowed-sinc, Parks-McClellan, moving-average, and new default FIR filtering.",
+                capabilities=("filter", "preprocessing"),
+                menus=tuple(
+                    _extension_menu_from_spec(
+                        item,
+                        path=("tools", "filter"),
+                        insert_before="pop_eegfilt",
+                    )
+                    for item in firfilt_filter_items()
+                ),
+                pop_functions=(
+                    ExtensionPopFunction(
+                        name="pop_eegfiltnew",
+                        target=LazyImport("eegprep.plugins.firfilt.pop_eegfiltnew", "pop_eegfiltnew"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_firws",
+                        target=LazyImport("eegprep.plugins.firfilt.pop_firws", "pop_firws"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_firpm",
+                        target=LazyImport("eegprep.plugins.firfilt.pop_firpm", "pop_firpm"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_firma",
+                        target=LazyImport("eegprep.plugins.firfilt.pop_firma", "pop_firma"),
+                    ),
+                ),
+            ),
+            ExtensionSpec(
+                name="dipfit",
+                display_name="DIPFIT",
+                version="bundled",
+                package_name="eegprep.plugins.dipfit",
+                source_type=ExtensionSourceType.BUNDLED,
+                description="Source-localization menu surfaces and FieldTrip-backed DIPFIT workflows.",
+                capabilities=("source", "localization"),
+                menus=(
+                    _extension_menu_from_spec(
+                        dipfit_menu(),
+                        path=("tools",),
+                        insert_after="pop_rmbase",
+                    ),
+                ),
+                pop_functions=(
+                    ExtensionPopFunction(
+                        name="pop_dipfit_settings",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_dipfit_settings", "pop_dipfit_settings"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_dipfit_headmodel",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_dipfit_headmodel", "pop_dipfit_headmodel"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_dipfit_gridsearch",
+                        target=LazyImport(
+                            "eegprep.plugins.dipfit.pop_dipfit_gridsearch",
+                            "pop_dipfit_gridsearch",
+                        ),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_dipfit_nonlinear",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_dipfit_nonlinear", "pop_dipfit_nonlinear"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_dipplot",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_dipplot", "pop_dipplot"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_multifit",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_multifit", "pop_multifit"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_leadfield",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_leadfield", "pop_leadfield"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_dipfit_loreta",
+                        target=LazyImport("eegprep.plugins.dipfit.pop_dipfit_loreta", "pop_dipfit_loreta"),
+                    ),
+                ),
+            ),
+            ExtensionSpec(
+                name="EEG_BIDS",
+                display_name="EEG-BIDS",
+                version="bundled",
+                package_name="eegprep.plugins.EEG_BIDS",
+                source_type=ExtensionSourceType.BUNDLED,
+                description="BIDS import, export, validation, and metadata helpers for EEG datasets.",
+                capabilities=("import", "export", "bids", "study"),
+                menus=(
+                    *(
+                        _extension_menu_from_spec(
+                            item,
+                            path=("File", "Import data", "import data"),
+                        )
+                        for item in eeg_bids_import_items()
+                    ),
+                    *(
+                        _extension_menu_from_spec(
+                            item,
+                            path=("File", "export"),
+                        )
+                        for item in eeg_bids_export_items()
+                    ),
+                    _extension_menu_from_spec(
+                        eeg_bids_tools_menu(),
+                        path=("File",),
+                        insert_after="export",
+                    ),
+                ),
+                pop_functions=(
+                    ExtensionPopFunction(
+                        name="pop_importbids",
+                        target=LazyImport("eegprep.plugins.EEG_BIDS.pop_importbids", "pop_importbids"),
+                    ),
+                    ExtensionPopFunction(
+                        name="pop_exportbids",
+                        target=LazyImport("eegprep.plugins.EEG_BIDS.pop_exportbids", "pop_exportbids"),
+                    ),
+                ),
+            ),
+        )
+        return [self._record_from_spec(spec) for spec in specs]
 
     def _entry_point_records(self) -> list[ExtensionRecord]:
         records = []
@@ -400,6 +568,7 @@ class ExtensionRegistry:
         extension_names: set[str] = set()
         action_names: dict[str, str] = {}
         pop_names: dict[str, str] = {}
+        menu_names: dict[tuple[tuple[str, ...], str], str] = {}
         final_records: list[ExtensionRecord] = []
 
         for record in records:
@@ -424,6 +593,10 @@ class ExtensionRegistry:
                     owner = pop_names.get(pop_name)
                     if owner is not None:
                         errors.append(f"Duplicate pop function {pop_function.name!r} already provided by {owner!r}")
+                for menu_key, menu_label in _extension_menu_keys(spec.menus):
+                    owner = menu_names.get(menu_key)
+                    if owner is not None:
+                        errors.append(f"Duplicate menu {menu_label!r} already provided by {owner!r}")
 
             if errors:
                 final_records.append(_invalid_record(record, tuple(errors)))
@@ -435,6 +608,8 @@ class ExtensionRegistry:
                     action_names[_normalize_name(action.name)] = record.name
                 for pop_function in spec.pop_functions:
                     pop_names[_normalize_name(pop_function.name)] = record.name
+                for menu_key, _menu_label in _extension_menu_keys(spec.menus):
+                    menu_names[menu_key] = record.name
             final_records.append(record)
         return final_records
 
@@ -514,7 +689,19 @@ def validate_extension_spec(
         missing_dependency.extend(dependency_missing)
 
     if check_resources:
-        for resource in (*spec.help_resources, *spec.package_data_resources):
+        for resource in spec.help_resources:
+            if not isinstance(resource, ExtensionResource):
+                invalid.append(f"Extension resource {resource!r} is not an ExtensionResource")
+                continue
+            if not resource.package or not resource.path:
+                invalid.append("Extension resources must include package and path")
+                continue
+            if not resource.path.endswith(".md"):
+                invalid.append(f"Extension help resource {resource.package}:{resource.path} must be a Markdown file")
+                continue
+            if not resource.exists():
+                invalid.append(f"Extension resource {resource.package}:{resource.path} is missing")
+        for resource in spec.package_data_resources:
             if not isinstance(resource, ExtensionResource):
                 invalid.append(f"Extension resource {resource!r} is not an ExtensionResource")
                 continue
@@ -568,14 +755,35 @@ def _validate_pop_functions(pop_functions: tuple[Any, ...], invalid: list[str]) 
 
 
 def _validate_menus(menus: tuple[Any, ...], invalid: list[str]) -> None:
+    names: set[tuple[tuple[str, ...], str]] = set()
     for menu in menus:
-        if not isinstance(menu, ExtensionMenu):
-            invalid.append(f"Extension menu {menu!r} is not an ExtensionMenu")
-            continue
-        if not menu.path:
-            invalid.append("Extension menus must include a path")
-        if not menu.action:
-            invalid.append("Extension menus must reference an action")
+        _validate_menu(menu, invalid, names, root=True)
+
+
+def _validate_menu(
+    menu: Any,
+    invalid: list[str],
+    names: set[tuple[tuple[str, ...], str]],
+    *,
+    root: bool,
+) -> None:
+    if not isinstance(menu, ExtensionMenu):
+        invalid.append(f"Extension menu {menu!r} is not an ExtensionMenu")
+        return
+    if root and not menu.path:
+        invalid.append("Extension menus must include a path")
+    if menu.insert_before and menu.insert_after:
+        invalid.append("Extension menus cannot set both insert_before and insert_after")
+    if not menu.action and not menu.children:
+        invalid.append("Extension menus must reference an action or include children")
+    label = menu.label or menu.action
+    if label:
+        key = (_normalize_menu_path(menu.path), _normalize_name(label))
+        if root and key in names:
+            invalid.append(f"Duplicate menu {label!r} within extension")
+        names.add(key)
+    for child in menu.children:
+        _validate_menu(child, invalid, names, root=False)
 
 
 def _dependency_errors(dependencies: tuple[Any, ...], version_provider: VersionProvider) -> tuple[list[str], list[str]]:
@@ -783,6 +991,42 @@ def _version_parts(version: str) -> tuple[int, ...]:
 
 def _normalize_name(name: str) -> str:
     return str(name).strip().lower()
+
+
+def _normalize_menu_path(path: tuple[Any, ...]) -> tuple[str, ...]:
+    return tuple(_normalize_name(str(part)) for part in path)
+
+
+def _extension_menu_from_spec(
+    spec: Any,
+    *,
+    path: tuple[str, ...] = (),
+    insert_after: str = "",
+    insert_before: str = "",
+) -> ExtensionMenu:
+    return ExtensionMenu(
+        path=path,
+        action=spec.action or "",
+        label=spec.label,
+        tag=spec.tag or "",
+        userdata=spec.userdata,
+        separator=spec.separator,
+        enabled=spec.enabled,
+        checked=spec.checked,
+        visibility=spec.visibility,
+        insert_after=insert_after,
+        insert_before=insert_before,
+        children=tuple(_extension_menu_from_spec(child) for child in spec.children),
+    )
+
+
+def _extension_menu_keys(menus: tuple[ExtensionMenu, ...]) -> tuple[tuple[tuple[tuple[str, ...], str], str], ...]:
+    keys = []
+    for menu in menus:
+        label = menu.label or menu.action
+        if label:
+            keys.append(((_normalize_menu_path(menu.path), _normalize_name(label)), label))
+    return tuple(keys)
 
 
 def _as_tuple(value: Any) -> tuple[Any, ...]:

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
 import eegprep
+from eegprep.extension_runtime import ExtensionRuntime
 from eegprep.functions.adminfunc.eeglab import gui
 from eegprep.functions.guifunc.session import EEGPrepSession, normalize_dataset_indices
 from eegprep.functions.popfunc.pop_eegplot import eegplot_accept_creates_dataset
@@ -136,13 +137,19 @@ class ConsoleStudyResult:
 class LazyWorkspaceExport:
     """Lazy proxy for public EEGPrep exports in the console namespace."""
 
-    def __init__(self, name: str, value: Any | None = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        value: Any | None = None,
+        resolver: Callable[[], Any] | None = None,
+    ) -> None:
         self.name = name
         self._value = value
+        self._resolver = resolver
 
     def resolve(self) -> Any:
         if self._value is None:
-            self._value = getattr(eegprep, self.name)
+            self._value = self._resolver() if self._resolver is not None else getattr(eegprep, self.name)
         return self._value
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -158,8 +165,14 @@ class LazyWorkspaceExport:
 class ConsolePopFunction(LazyWorkspaceExport):
     """Console wrapper that stores ``pop_*`` EEG outputs back into the session."""
 
-    def __init__(self, name: str, bridge: EEGPrepConsoleWorkspace, value: Any | None = None) -> None:
-        super().__init__(name, value=value)
+    def __init__(
+        self,
+        name: str,
+        bridge: EEGPrepConsoleWorkspace,
+        value: Any | None = None,
+        resolver: Callable[[], Any] | None = None,
+    ) -> None:
+        super().__init__(name, value=value, resolver=resolver)
         self.bridge = bridge
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -246,11 +259,13 @@ class EEGPrepConsoleWorkspace:
         refresh: Callable[[], None] | None = None,
         command_echo: Callable[[str], Any] | None = None,
         exports: Mapping[str, Any] | None = None,
+        extension_runtime: ExtensionRuntime | None = None,
     ) -> None:
         self.session = session
         self.window = window
         self.refresh = refresh or getattr(window, "refresh", None)
         self.command_echo = command_echo
+        self.extension_runtime = extension_runtime or ExtensionRuntime.empty()
         self.namespace: dict[str, Any] = {}
         self._eegprep_proxy = ConsoleEEGPrepModule(self)
         self._wrapped_pop_exports: dict[str, ConsolePopFunction] = {}
@@ -262,6 +277,7 @@ class EEGPrepConsoleWorkspace:
         self._terminal_buffer_token: contextvars.Token | None = None
         self._bind_base_namespace()
         self._bind_exports(exports)
+        self._bind_extension_exports()
         self.pull_from_session()
         self.session.add_change_listener(self._session_changed)
         self.session.add_command_echo_listener(self._echo_session_command)
@@ -411,11 +427,21 @@ class EEGPrepConsoleWorkspace:
             else:
                 self.namespace[name] = LazyWorkspaceExport(name, None if exports is None else exports[name])
 
+    def _bind_extension_exports(self) -> None:
+        for name, resolver in self.extension_runtime.pop_function_resolvers().items():
+            if name in self._wrapped_pop_exports:
+                continue
+            wrapped = ConsolePopFunction(name, self, resolver=resolver)
+            self._wrapped_pop_exports[name] = wrapped
+            self.namespace[name] = wrapped
+
     def pop_wrapper(self, name: str) -> ConsolePopFunction:
         """Return the console-aware wrapper for a public ``pop_*`` function."""
         wrapped = self._wrapped_pop_exports.get(name)
         if wrapped is None:
-            wrapped = ConsolePopFunction(name, self)
+            pop_function = self.extension_runtime.pop_function(name)
+            resolver = pop_function.load if pop_function is not None else None
+            wrapped = ConsolePopFunction(name, self, resolver=resolver)
             self._wrapped_pop_exports[name] = wrapped
         return wrapped
 
@@ -526,7 +552,10 @@ def run_console(
             ) from exc
         raise
 
-    workspace = EEGPrepConsoleWorkspace(session, window=window)
+    extension_runtime = getattr(window, "extension_runtime", None)
+    if extension_runtime is None:
+        extension_runtime = ExtensionRuntime.discover(include_plugins=not args.no_plugins)
+    workspace = EEGPrepConsoleWorkspace(session, window=window, extension_runtime=extension_runtime)
     banner = _console_banner()
     shell = (
         _IPythonShellAdapter(shell_factory(workspace.namespace, banner), workspace)

--- a/src/eegprep/functions/adminfunc/plugin_menu.py
+++ b/src/eegprep/functions/adminfunc/plugin_menu.py
@@ -6,83 +6,58 @@ import importlib
 from copy import deepcopy
 from typing import Any
 
+from eegprep.extensions import ExtensionRecord, ExtensionRegistry, ExtensionStatus
+
 EXTERNAL_PLUGIN_NOTICE = (
     "EEGPrep currently manages only extensions bundled inside this Python package. "
     "External EEGLAB plugin repositories are not installed, updated, or removed from this dialog."
 )
 
-_BUNDLED_PLUGINS: tuple[dict[str, Any], ...] = (
-    {
-        "plugin": "clean_rawdata",
-        "name": "clean_rawdata",
-        "version": "bundled",
-        "foldername": "clean_rawdata",
-        "funcname": "pop_clean_rawdata",
-        "status": "ok",
-        "installed": True,
-        "source": "bundled",
-        "menu": "Tools > Reject data using Clean Rawdata and ASR",
-        "description": "Artifact Subspace Reconstruction and related channel/window cleaning workflows.",
-        "tags": ("artifact", "preprocessing"),
-    },
-    {
-        "plugin": "ICLabel",
-        "name": "ICLabel",
-        "version": "bundled",
-        "foldername": "ICLabel",
-        "funcname": "pop_iclabel",
-        "status": "ok",
-        "installed": True,
-        "source": "bundled",
-        "menu": "Tools > Classify components using ICLabel",
-        "description": "Independent-component classification, flagging, and extended component properties.",
-        "tags": ("ica", "classification"),
-    },
-    {
-        "plugin": "firfilt",
-        "name": "firfilt",
-        "version": "bundled",
-        "foldername": "firfilt",
-        "funcname": "pop_eegfiltnew",
-        "status": "ok",
-        "installed": True,
-        "source": "bundled",
-        "menu": "Tools > Filter the data",
-        "description": "Windowed-sinc, Parks-McClellan, moving-average, and new default FIR filtering.",
-        "tags": ("filter", "preprocessing"),
-    },
-    {
-        "plugin": "dipfit",
-        "name": "DIPFIT",
-        "version": "bundled",
-        "foldername": "dipfit",
-        "funcname": "pop_dipfit_settings",
-        "status": "ok",
-        "installed": True,
-        "source": "bundled",
-        "menu": "Tools > Source localization using DIPFIT",
-        "description": "Source-localization menu surfaces and FieldTrip-backed DIPFIT workflows.",
-        "tags": ("source", "localization"),
-    },
-    {
-        "plugin": "EEG_BIDS",
-        "name": "EEG-BIDS",
-        "version": "bundled",
-        "foldername": "EEG_BIDS",
-        "funcname": "pop_importbids",
-        "status": "ok",
-        "installed": True,
-        "source": "bundled",
-        "menu": "File > Import data / Export / BIDS tools",
-        "description": "BIDS import, export, validation, and metadata helpers for EEG datasets.",
-        "tags": ("import", "export", "bids", "study"),
-    },
-)
+_MENU_SUMMARIES = {
+    "clean_rawdata": "Tools > Reject data using Clean Rawdata and ASR",
+    "ICLabel": "Tools > Classify components using ICLabel",
+    "firfilt": "Tools > Filter the data",
+    "dipfit": "Tools > Source localization using DIPFIT",
+    "EEG_BIDS": "File > Import data / Export / BIDS tools",
+}
 
 
 def bundled_plugins() -> tuple[dict[str, Any], ...]:
     """Return metadata for EEGPrep extensions bundled in the installed package."""
-    return tuple(deepcopy(plugin) for plugin in _BUNDLED_PLUGINS)
+    records = ExtensionRegistry(include_entry_points=False).discover()
+    return tuple(_plugin_from_record(record) for record in records)
+
+
+def _plugin_from_record(record: ExtensionRecord) -> dict[str, Any]:
+    spec = record.spec
+    name = record.name if spec is None else spec.name
+    display_name = name if spec is None else spec.display_name or spec.name
+    package_name = "" if spec is None else spec.package_name
+    foldername = package_name.rsplit(".", 1)[-1] if package_name else name
+    funcname = "" if spec is None or not spec.pop_functions else spec.pop_functions[0].name
+    source_type = record.source_type.value if hasattr(record.source_type, "value") else str(record.source_type)
+    return {
+        "plugin": name,
+        "name": display_name,
+        "version": "bundled" if spec is None else spec.version or "bundled",
+        "foldername": foldername,
+        "funcname": funcname,
+        "status": "ok" if record.status == ExtensionStatus.BUNDLED else record.status.value,
+        "installed": record.is_active,
+        "source": source_type,
+        "menu": _MENU_SUMMARIES.get(name, _menu_summary(record)),
+        "description": "" if spec is None else spec.description,
+        "tags": () if spec is None else tuple(spec.capabilities),
+    }
+
+
+def _menu_summary(record: ExtensionRecord) -> str:
+    spec = record.spec
+    if spec is None or not spec.menus:
+        return ""
+    menu = spec.menus[0]
+    label = menu.label or menu.action
+    return " > ".join((*menu.path, label))
 
 
 def plugin_status(

--- a/src/eegprep/functions/guifunc/eeglab_menu.py
+++ b/src/eegprep/functions/guifunc/eeglab_menu.py
@@ -2,16 +2,8 @@
 
 from __future__ import annotations
 
+from eegprep.extension_runtime import ExtensionRuntime, apply_extension_menus
 from eegprep.functions.guifunc.menu_spec import MenuItemSpec, menu_item, visible_menu_items
-from eegprep.plugins.EEG_BIDS.menu import (
-    eeg_bids_export_items,
-    eeg_bids_import_items,
-    eeg_bids_tools_menu,
-)
-from eegprep.plugins.ICLabel.menu import iclabel_menu, viewprops_plot_menus
-from eegprep.plugins.clean_rawdata.menu import clean_rawdata_menu
-from eegprep.plugins.dipfit.menu import dipfit_menu
-from eegprep.plugins.firfilt.menu import firfilt_filter_items
 
 ON = "study:on"
 ON_NO_STUDY = ""
@@ -373,23 +365,17 @@ def eeglab_core_menus() -> tuple[MenuItemSpec, ...]:
     return (file_menu, edit_menu, tools_menu, plot_menu, study_menu, datasets_menu, help_menu)
 
 
-def eeglab_plugin_menus() -> tuple[MenuItemSpec, ...]:
-    """Return plugin menu additions represented in the sibling EEGLAB checkout."""
-    return (
-        clean_rawdata_menu(),
-        iclabel_menu(),
-        dipfit_menu(),
-    )
-
-
-def eeglab_menus(*, all_menus: bool = False, include_plugins: bool = True) -> tuple[MenuItemSpec, ...]:
+def eeglab_menus(
+    *,
+    all_menus: bool = False,
+    include_plugins: bool = True,
+    extension_runtime: ExtensionRuntime | None = None,
+) -> tuple[MenuItemSpec, ...]:
     """Return the complete visible menu tree for the configured menu mode."""
-    menus = list(eeglab_core_menus())
+    menus = eeglab_core_menus()
     if include_plugins:
-        menus[0] = _insert_file_plugins(menus[0])
-        menus[2] = _insert_tools_plugins(menus[2])
-        menus[2] = _insert_firfilt(menus[2])
-        menus[3] = _insert_plot_plugins(menus[3])
+        runtime = extension_runtime or ExtensionRuntime.discover(include_plugins=True)
+        menus = apply_extension_menus(menus, runtime)
     return visible_menu_items(tuple(menus), all_menus=all_menus)
 
 
@@ -401,59 +387,3 @@ def menu_actions(items: tuple[MenuItemSpec, ...]) -> set[str]:
             actions.add(item.action)
         actions.update(menu_actions(item.children))
     return actions
-
-
-def _insert_tools_plugins(tools_menu: MenuItemSpec) -> MenuItemSpec:
-    children = []
-    clean_rawdata, iclabel, dipfit = eeglab_plugin_menus()
-    for item in tools_menu.children:
-        children.append(item)
-        if item.action == "pop_eegplot:data":
-            children.append(clean_rawdata)
-        if item.action == "pop_selectcomps":
-            children.append(iclabel)
-        if item.action == "pop_rmbase":
-            children.append(dipfit)
-    return tools_menu.with_children(tuple(children))
-
-
-def _insert_firfilt(tools_menu: MenuItemSpec) -> MenuItemSpec:
-    children = []
-    for item in tools_menu.children:
-        if item.tag != "filter":
-            children.append(item)
-            continue
-        filter_children = (
-            *firfilt_filter_items(),
-            *item.children,
-        )
-        children.append(item.with_children(filter_children))
-    return tools_menu.with_children(tuple(children))
-
-
-def _insert_plot_plugins(plot_menu: MenuItemSpec) -> MenuItemSpec:
-    return plot_menu.with_children((*plot_menu.children, *viewprops_plot_menus()))
-
-
-def _insert_file_plugins(file_menu: MenuItemSpec) -> MenuItemSpec:
-    children: list[MenuItemSpec] = []
-    for item in file_menu.children:
-        if item.label == "Import data":
-            children.append(_insert_import_plugins(item))
-            continue
-        if item.tag == "export":
-            children.append(item.with_children((*item.children, *eeg_bids_export_items())))
-            children.append(eeg_bids_tools_menu())
-            continue
-        children.append(item)
-    return file_menu.with_children(tuple(children))
-
-
-def _insert_import_plugins(import_menu: MenuItemSpec) -> MenuItemSpec:
-    children: list[MenuItemSpec] = []
-    for item in import_menu.children:
-        if item.tag == "import data":
-            children.append(item.with_children((*item.children, *eeg_bids_import_items())))
-            continue
-        children.append(item)
-    return import_menu.with_children(tuple(children))

--- a/src/eegprep/functions/guifunc/main_window.py
+++ b/src/eegprep/functions/guifunc/main_window.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 
+from eegprep.extension_runtime import ExtensionRuntime
 from eegprep.functions.adminfunc.eeg_options import EEG_OPTIONS
 from eegprep.functions.guifunc.eeglab_menu import eeglab_menus
 from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
@@ -51,6 +52,7 @@ class EEGPrepMainWindow:
         *,
         all_menus: bool | None = None,
         include_plugins: bool = True,
+        extension_runtime: ExtensionRuntime | None = None,
         native_menu_bar: bool | None = None,
         native_file_dialogs: bool = True,
     ) -> None:
@@ -65,6 +67,11 @@ class EEGPrepMainWindow:
         self.session = session or EEGPrepSession()
         self.all_menus = bool(EEG_OPTIONS.get("option_allmenus", 0)) if all_menus is None else bool(all_menus)
         self.include_plugins = include_plugins
+        self.extension_runtime = (
+            extension_runtime
+            if include_plugins and extension_runtime is not None
+            else ExtensionRuntime.discover(include_plugins=include_plugins)
+        )
         self.window = qt_widgets.QMainWindow()
         self.window.setObjectName(APP_NAME)
         self.window.setWindowTitle(APP_NAME)
@@ -77,6 +84,7 @@ class EEGPrepMainWindow:
             self.session,
             refresh=self.refresh,
             native_file_dialogs=native_file_dialogs,
+            extension_runtime=self.extension_runtime,
         )
         self._build_central_widget()
         self.refresh()
@@ -218,7 +226,11 @@ class EEGPrepMainWindow:
 
     def _current_menu_specs(self) -> tuple[MenuItemSpec, ...]:
         specs = []
-        for spec in eeglab_menus(all_menus=self.all_menus, include_plugins=self.include_plugins):
+        for spec in eeglab_menus(
+            all_menus=self.all_menus,
+            include_plugins=self.include_plugins,
+            extension_runtime=self.extension_runtime,
+        ):
             if spec.label == "Datasets":
                 spec = spec.with_children(self._dataset_menu_items())
             specs.append(spec)
@@ -322,6 +334,7 @@ def build_main_window(
     *,
     all_menus: bool | None = None,
     include_plugins: bool = True,
+    extension_runtime: ExtensionRuntime | None = None,
     native_menu_bar: bool | None = None,
     native_file_dialogs: bool = True,
 ) -> EEGPrepMainWindow:
@@ -330,6 +343,7 @@ def build_main_window(
         session=session,
         all_menus=all_menus,
         include_plugins=include_plugins,
+        extension_runtime=extension_runtime,
         native_menu_bar=native_menu_bar,
         native_file_dialogs=native_file_dialogs,
     )

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import webbrowser
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
+from eegprep.extension_runtime import ExtensionRuntime
 from eegprep.functions.guifunc.menu_placeholders import PLACEHOLDER_ACTIONS, is_placeholder_action, placeholder_message
 from eegprep.functions.guifunc.pophelp import pophelp
 from eegprep.functions.guifunc.session import EEGPrepSession, has_eeg_data
@@ -200,10 +202,12 @@ class MenuActionDispatcher:
         refresh: Callable[[], None] | None = None,
         *,
         native_file_dialogs: bool = True,
+        extension_runtime: ExtensionRuntime | None = None,
     ):
         self.session = session
         self.refresh = refresh
         self.native_file_dialogs = native_file_dialogs
+        self.extension_runtime = extension_runtime or ExtensionRuntime.empty()
 
     def dispatch_gui(self, action: str, parent: Any | None = None) -> None:
         """Run a menu action from Qt and show user-facing errors."""
@@ -446,6 +450,10 @@ class MenuActionDispatcher:
             return
         if base == "pop_chanplot":
             self._run_chanplot(parent)
+            return
+        extension_action = self.extension_runtime.action(base)
+        if extension_action is not None:
+            self._run_extension_action(extension_action, base, variant, parent)
             return
         self.show_coming_soon(action, parent)
 
@@ -922,6 +930,80 @@ class MenuActionDispatcher:
 
         show_dialog = parent is not None and _qt_widgets() is not None
         plugin_menu(parent=parent if show_dialog else None, session=self.session, show=show_dialog)
+
+    def _run_extension_action(self, action: Any, name: str, variant: str, parent: Any | None) -> None:
+        target = action.load()
+        result = self._call_extension_target(target, name, variant, parent)
+        self._apply_extension_result(result)
+
+    def _call_extension_target(self, target: Callable[..., Any], name: str, variant: str, parent: Any | None) -> Any:
+        try:
+            parameters = inspect.signature(target).parameters
+        except (TypeError, ValueError):
+            parameters = {}
+        kwargs: dict[str, Any] = {}
+        if "return_com" in parameters:
+            kwargs["return_com"] = True
+        if "variant" in parameters:
+            kwargs["variant"] = variant
+        if "session" in parameters:
+            kwargs["session"] = self.session
+        if "parent" in parameters:
+            kwargs["parent"] = parent
+        for eeg_name in ("EEG", "eeg"):
+            if eeg_name in parameters:
+                selection = self._current_selection_or_warn(parent, allow_multiple=True)
+                if selection is None:
+                    return None
+                kwargs[eeg_name] = selection
+                return target(**kwargs)
+        if name.startswith("pop_"):
+            selection = self._current_selection_or_warn(parent, allow_multiple=True)
+            if selection is None:
+                return None
+            return target(selection, **kwargs)
+        required = [
+            parameter
+            for parameter in parameters.values()
+            if parameter.default is inspect.Signature.empty
+            and parameter.kind
+            in {
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            }
+            and parameter.name not in kwargs
+        ]
+        if not required:
+            return target(**kwargs)
+        first = required[0]
+        if first.name == "session":
+            return target(self.session, **kwargs)
+        if first.name == "parent":
+            return target(parent, **kwargs)
+        selection = self._current_selection_or_warn(parent, allow_multiple=True)
+        if selection is None:
+            return None
+        return target(selection, **kwargs)
+
+    def _apply_extension_result(self, result: Any) -> None:
+        dataset_state = _extension_dataset_state(result)
+        if dataset_state is not None:
+            alleeg, eeg_out, currentset, command = dataset_state
+            self.session.ALLEEG = alleeg
+            self.session.EEG = eeg_out
+            self.session.CURRENTSET = _currentset_list(currentset)
+            self._add_history_from_gui(command)
+            self.session.notify_changed()
+            self._refresh()
+            return
+        eeg_out, command = _extension_eeg_and_command(result)
+        if eeg_out is not None:
+            self._store_current_from_gui(eeg_out, command=command)
+            self._refresh()
+            return
+        if command:
+            self._add_history_from_gui(command)
+            self._refresh()
 
     def _run_pop_function(self, name: str, parent: Any | None, *, variant: str = "") -> None:
         selection = self._current_selection_or_warn(parent, allow_multiple=name in _MULTIPLE_DATASET_ACTIONS)
@@ -1423,7 +1505,7 @@ class MenuActionDispatcher:
         self._refresh()
 
     def _show_help(self, function_name: str, parent: Any | None) -> None:
-        pophelp(function_name, parent=parent)
+        pophelp(function_name, parent=parent, extension_runtime=self.extension_runtime)
 
     def _current_selection_or_warn(
         self,
@@ -1557,6 +1639,34 @@ def _currentset_list(value: Any) -> list[int]:
     return [current] if current > 0 else []
 
 
+def _extension_dataset_state(result: Any) -> tuple[list[dict[str, Any]], Any, Any, str] | None:
+    if not isinstance(result, tuple) or len(result) < 4:
+        return None
+    alleeg, eeg, currentset, command = result[0], result[1], result[2], result[3]
+    if not isinstance(alleeg, list) or not _is_eeg_selection(eeg) or not isinstance(command, str):
+        return None
+    return alleeg, eeg, currentset, command.strip()
+
+
+def _extension_eeg_and_command(result: Any) -> tuple[Any | None, str]:
+    if isinstance(result, tuple):
+        command = str(result[1]).strip() if len(result) > 1 and isinstance(result[1], str) else ""
+        if result and _is_eeg_selection(result[0]):
+            return result[0], command
+        return None, command
+    if _is_eeg_selection(result):
+        return result, ""
+    if isinstance(result, str):
+        return None, result.strip()
+    return None, ""
+
+
+def _is_eeg_selection(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(key in value for key in ("data", "nbchan", "setname"))
+    return isinstance(value, list) and all(isinstance(item, dict) for item in value)
+
+
 def _pop_eegplot_variant_options(variant: str) -> tuple[int, int, int]:
     # Mirrors eeglab.m callbacks: cb_eegplot/cb_eegplotrej* omit optional args,
     # while Plot scroll actions explicitly call pop_eegplot(EEG, icacomp, 1, 1).
@@ -1585,12 +1695,14 @@ def _tutorial_url() -> str:
     return _docs_url("user_guide/quickstart.html")
 
 
-def action_kind(action: str) -> str:
+def action_kind(action: str, extension_runtime: ExtensionRuntime | None = None) -> str:
     """Return ``implemented``, ``placeholder``, or ``unknown`` for an action id."""
     base = action.partition(":")[0]
     if action in PLACEHOLDER_ACTIONS:
         return "placeholder"
     if base in IMPLEMENTED_ACTIONS:
+        return "implemented"
+    if extension_runtime is not None and extension_runtime.has_action(base):
         return "implemented"
     if is_placeholder_action(action):
         return "placeholder"

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -223,7 +223,7 @@ class MenuActionDispatcher:
     def dispatch(self, action: str, parent: Any | None = None) -> None:
         """Run a menu action."""
         base, _sep, variant = action.partition(":")
-        if action_kind(action) == "placeholder":
+        if action_kind(action, extension_runtime=self.extension_runtime) == "placeholder":
             self.show_coming_soon(action, parent)
             return
         if base == "quit":
@@ -941,6 +941,7 @@ class MenuActionDispatcher:
             parameters = inspect.signature(target).parameters
         except (TypeError, ValueError):
             parameters = {}
+        allow_multiple = name in _MULTIPLE_DATASET_ACTIONS
         kwargs: dict[str, Any] = {}
         if "return_com" in parameters:
             kwargs["return_com"] = True
@@ -952,13 +953,13 @@ class MenuActionDispatcher:
             kwargs["parent"] = parent
         for eeg_name in ("EEG", "eeg"):
             if eeg_name in parameters:
-                selection = self._current_selection_or_warn(parent, allow_multiple=True)
+                selection = self._current_selection_or_warn(parent, allow_multiple=allow_multiple)
                 if selection is None:
                     return None
                 kwargs[eeg_name] = selection
                 return target(**kwargs)
         if name.startswith("pop_"):
-            selection = self._current_selection_or_warn(parent, allow_multiple=True)
+            selection = self._current_selection_or_warn(parent, allow_multiple=allow_multiple)
             if selection is None:
                 return None
             return target(selection, **kwargs)
@@ -980,7 +981,7 @@ class MenuActionDispatcher:
             return target(self.session, **kwargs)
         if first.name == "parent":
             return target(parent, **kwargs)
-        selection = self._current_selection_or_warn(parent, allow_multiple=True)
+        selection = self._current_selection_or_warn(parent, allow_multiple=allow_multiple)
         if selection is None:
             return None
         return target(selection, **kwargs)

--- a/src/eegprep/functions/guifunc/pophelp.py
+++ b/src/eegprep/functions/guifunc/pophelp.py
@@ -8,11 +8,19 @@ from importlib import resources
 import re
 from typing import Any
 
+from eegprep.extension_runtime import ExtensionRuntime
+from eegprep.extensions import ExtensionResource
+
 
 HELP_PACKAGE = "eegprep.resources.help"
 
 
-def pophelp(function_name: str, nonmatlab: bool = False, parent: Any | None = None) -> Any:
+def pophelp(
+    function_name: str,
+    nonmatlab: bool = False,
+    parent: Any | None = None,
+    extension_runtime: ExtensionRuntime | None = None,
+) -> Any:
     """Open an EEGLAB-like help browser for a function."""
     try:
         from PySide6 import QtWidgets
@@ -23,7 +31,7 @@ def pophelp(function_name: str, nonmatlab: bool = False, parent: Any | None = No
         ) from exc
 
     function_name = _normalise_function_name(function_name)
-    text, source_path = pophelp_text(function_name, nonmatlab=nonmatlab)
+    text, source_path = pophelp_text(function_name, nonmatlab=nonmatlab, extension_runtime=extension_runtime)
     title = f"{function_name} - {function_name.upper()}"
     dialog = QtWidgets.QDialog(parent)
     dialog.setObjectName("pophelp")
@@ -44,14 +52,18 @@ def pophelp(function_name: str, nonmatlab: bool = False, parent: Any | None = No
     return dialog
 
 
-def pophelp_text(function_name: str, nonmatlab: bool = False) -> tuple[str, str]:
+def pophelp_text(
+    function_name: str,
+    nonmatlab: bool = False,
+    extension_runtime: ExtensionRuntime | None = None,
+) -> tuple[str, str]:
     """Return EEGLAB-style help text and source path for ``function_name``."""
     function_name = _normalise_function_name(function_name)
-    source_path = _find_source(function_name)
+    source_path = _find_source(function_name, extension_runtime=extension_runtime)
     doc = _read_help_source(source_path, nonmatlab=nonmatlab)
     if function_name.startswith("pop_"):
         called_name = function_name[4:]
-        called_source = _find_source(called_name, missing_ok=True)
+        called_source = _find_source(called_name, missing_ok=True, extension_runtime=extension_runtime)
         if called_source is not None:
             called_doc = _read_help_source(called_source, nonmatlab=False)
             doc = _append_called_help(doc, called_doc)
@@ -69,10 +81,19 @@ def _normalise_function_name(function_name: str) -> str:
     return function_name
 
 
-def _find_source(function_name: str, *, missing_ok: bool = False) -> Traversable | None:
+def _find_source(
+    function_name: str,
+    *,
+    missing_ok: bool = False,
+    extension_runtime: ExtensionRuntime | None = None,
+) -> Traversable | ExtensionResource | None:
     direct = resources.files(HELP_PACKAGE).joinpath(f"{function_name}.md")
     if direct.is_file():
         return direct
+    if extension_runtime is not None:
+        extension_resource = extension_runtime.help_resource(function_name)
+        if extension_resource is not None:
+            return extension_resource
     if missing_ok:
         return None
     raise FileNotFoundError(
@@ -82,14 +103,19 @@ def _find_source(function_name: str, *, missing_ok: bool = False) -> Traversable
     )
 
 
-def _read_help_source(path: Traversable | None, *, nonmatlab: bool) -> str:
+def _read_help_source(path: Traversable | ExtensionResource | None, *, nonmatlab: bool) -> str:
     if path is None:
         return ""
+    if isinstance(path, ExtensionResource):
+        function_name = path.path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        return path.read_text(encoding="utf-8").strip() or f"No help found for {function_name}."
     function_name = path.name.rsplit(".", 1)[0]
     return path.read_text(encoding="utf-8").strip() or f"No help found for {function_name}."
 
 
-def _resource_source_name(path: Traversable) -> str:
+def _resource_source_name(path: Traversable | ExtensionResource) -> str:
+    if isinstance(path, ExtensionResource):
+        return f"{path.package}:{path.path}"
     return f"eegprep/resources/help/{path.name}"
 
 

--- a/tests/test_extension_runtime.py
+++ b/tests/test_extension_runtime.py
@@ -123,6 +123,44 @@ def test_include_plugins_false_hides_bundled_plugins_without_hiding_core_menus()
     assert "From BIDS folder structure" not in [item.label for item in import_functions.children]
 
 
+def test_bundled_plugin_menus_land_at_expected_anchors() -> None:
+    menus = eeglab_menus(all_menus=True)
+    default_menus = eeglab_menus(all_menus=False)
+    tools = _child(menus, "Tools")
+    default_tools = _child(default_menus, "Tools")
+    file_menu = _child(menus, "File")
+    plot_menu = _child(menus, "Plot")
+
+    tools_labels = [item.label for item in tools.children]
+    default_tools_labels = [item.label for item in default_tools.children]
+    filter_labels = [item.label for item in _child(tools.children, "Filter the data").children]
+    import_menu = _child(file_menu.children, "Import data")
+    import_functions = _child(import_menu.children, "Using EEGPrep functions and plugins")
+    export_menu = _child(file_menu.children, "Export")
+    file_labels = [item.label for item in file_menu.children]
+    plot_labels = [item.label for item in plot_menu.children]
+
+    assert (
+        tools_labels[tools_labels.index("Inspect/reject data by eye") + 1] == "Reject data using Clean Rawdata and ASR"
+    )
+    assert (
+        default_tools_labels[default_tools_labels.index("Inspect/label components by map") + 1]
+        == "Classify components using ICLabel"
+    )
+    assert tools_labels[tools_labels.index("Remove epoch baseline") + 1] == "Source localization using DIPFIT"
+    assert filter_labels == [
+        "Basic FIR filter (new, default)",
+        "Windowed sinc FIR filter",
+        "Parks-McClellan (equiripple) FIR filter",
+        "Moving average FIR filter",
+        "Basic FIR filter (legacy)",
+    ]
+    assert "From BIDS folder structure" in [item.label for item in import_functions.children]
+    assert "To BIDS folder structure" in [item.label for item in export_menu.children]
+    assert file_labels[file_labels.index("Export") + 1] == "BIDS tools"
+    assert plot_labels[-2:] == ["View extended channel properties", "View extended component properties"]
+
+
 def test_missing_extension_menu_path_is_logged_and_skipped(caplog: pytest.LogCaptureFixture) -> None:
     runtime = _runtime(
         ExtensionSpec(
@@ -304,6 +342,54 @@ def test_registered_extension_pop_function_dispatches_as_gui_action(
     assert echoed == ["EEG = pop_gui_ext(EEG);"]
 
 
+def test_extension_pop_function_uses_single_dataset_selection_rule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_single_selection"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "pop_functions.py": """
+                calls = []
+
+                def pop_single_ext(EEG, *, return_com=False):
+                    calls.append(EEG)
+                    output = dict(EEG, setname="single-extension")
+                    command = "EEG = pop_single_ext(EEG);"
+                    return (output, command) if return_com else output
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="single_selection_extension",
+            pop_functions=(
+                ExtensionPopFunction(
+                    "pop_single_ext",
+                    LazyImport(f"{package}.pop_functions", "pop_single_ext"),
+                ),
+            ),
+        )
+    )
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg("one"), new=True)
+    session.store_current(_demo_eeg("two"), new=True)
+    session.retrieve([1, 2])
+    dispatcher = MenuActionDispatcher(session, extension_runtime=runtime)
+    module = importlib.import_module(f"{package}.pop_functions")
+
+    with mock.patch.object(dispatcher, "_warn") as warn:
+        dispatcher.dispatch("pop_single_ext", parent="window")
+
+    warn.assert_called_once_with("window", "This action is not available for multiple selected datasets")
+    assert module.calls == []
+    assert session.CURRENTSET == [1, 2]
+    assert session.ALLCOM == []
+
+
 def test_extension_action_error_after_menu_click_is_reported_without_mutation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -463,9 +549,9 @@ def _child(items, label):
     raise AssertionError(f"missing menu item {label!r}")
 
 
-def _demo_eeg():
+def _demo_eeg(setname: str = "demo"):
     return {
-        "setname": "demo",
+        "setname": setname,
         "data": np.array([[1.0, 2.0], [3.0, 4.0]]),
         "nbchan": 2,
         "pnts": 2,

--- a/tests/test_extension_runtime.py
+++ b/tests/test_extension_runtime.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from eegprep.extension_runtime import ExtensionRuntime
+from eegprep.extensions import (
+    EXTENSION_ENTRY_POINT_GROUP,
+    ExtensionAction,
+    ExtensionMenu,
+    ExtensionPopFunction,
+    ExtensionRecord,
+    ExtensionRegistry,
+    ExtensionResource,
+    ExtensionSourceType,
+    ExtensionSpec,
+    ExtensionStatus,
+    LazyImport,
+    validate_extension_spec,
+)
+from eegprep.functions.adminfunc.console import EEGPrepConsoleWorkspace
+from eegprep.functions.guifunc.eeglab_menu import eeglab_menus, menu_actions
+from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher, action_kind
+from eegprep.functions.guifunc.menu_spec import menu_enabled
+from eegprep.functions.guifunc.pophelp import pophelp_text
+from eegprep.functions.guifunc.session import EEGPrepSession
+
+
+class FakeDistribution:
+    def __init__(self, name: str) -> None:
+        self.metadata = {"Name": name}
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, value: str, *, group: str = EXTENSION_ENTRY_POINT_GROUP) -> None:
+        self.name = name
+        self.value = value
+        self.group = group
+        self.dist = FakeDistribution(name)
+
+    def load(self):
+        module_name, _, attr_name = self.value.partition(":")
+        module = importlib.import_module(module_name)
+        return getattr(module, attr_name)
+
+
+def test_extension_menu_enabled_state_matrix() -> None:
+    runtime = _runtime(
+        ExtensionSpec(
+            name="state_extension",
+            menus=(
+                ExtensionMenu(
+                    path=("tools",),
+                    action="pop_continuous_only",
+                    label="Continuous extension",
+                    userdata="startup:off;epoch:off",
+                ),
+                ExtensionMenu(
+                    path=("tools",),
+                    action="pop_epoched_only",
+                    label="Epoched extension",
+                    userdata="startup:off;continuous:off",
+                ),
+                ExtensionMenu(
+                    path=("tools",),
+                    action="pop_requires_ica",
+                    label="ICA extension",
+                    userdata="startup:off;ica:on",
+                ),
+                ExtensionMenu(
+                    path=("tools",),
+                    action="pop_study_or_multi",
+                    label="Study extension",
+                    userdata="startup:off;study:on",
+                ),
+            ),
+        )
+    )
+
+    tools = _child(eeglab_menus(all_menus=True, extension_runtime=runtime), "Tools")
+    items = {item.label: item for item in tools.children}
+
+    assert not menu_enabled(items["Continuous extension"], {"startup"})
+    assert menu_enabled(items["Continuous extension"], {"continuous_dataset"})
+    assert not menu_enabled(items["Continuous extension"], {"epoched_dataset"})
+    assert menu_enabled(items["Epoched extension"], {"epoched_dataset"})
+    assert not menu_enabled(items["Epoched extension"], {"continuous_dataset"})
+    assert not menu_enabled(items["ICA extension"], {"continuous_dataset", "ica_absent"})
+    assert menu_enabled(items["ICA extension"], {"continuous_dataset"})
+    assert menu_enabled(items["Study extension"], {"study"})
+    assert menu_enabled(items["Study extension"], {"multiple_datasets"})
+
+
+def test_include_plugins_false_hides_extension_menu_contributions() -> None:
+    runtime = _runtime(
+        ExtensionSpec(
+            name="hidden_extension",
+            menus=(ExtensionMenu(path=("tools",), action="pop_hidden_extension", label="Hidden extension"),),
+        )
+    )
+
+    actions = menu_actions(eeglab_menus(all_menus=True, include_plugins=False, extension_runtime=runtime))
+
+    assert "pop_hidden_extension" not in actions
+
+
+def test_include_plugins_false_hides_bundled_plugins_without_hiding_core_menus() -> None:
+    menus = eeglab_menus(all_menus=False, include_plugins=False)
+    tools = _child(menus, "Tools")
+    file_menu = _child(menus, "File")
+    import_menu = _child(file_menu.children, "Import data")
+    import_functions = _child(import_menu.children, "Using EEGPrep functions and plugins")
+
+    assert [menu.label for menu in menus] == ["File", "Edit", "Tools", "Plot", "Study", "Datasets", "Help"]
+    assert "Change sampling rate" in [item.label for item in tools.children]
+    assert "Reject data using Clean Rawdata and ASR" not in [item.label for item in tools.children]
+    assert "From BIDS folder structure" not in [item.label for item in import_functions.children]
+
+
+def test_missing_extension_menu_path_is_logged_and_skipped(caplog: pytest.LogCaptureFixture) -> None:
+    runtime = _runtime(
+        ExtensionSpec(
+            name="missing_path_extension",
+            menus=(
+                ExtensionMenu(
+                    path=("missing menu",),
+                    action="pop_missing_path",
+                    label="Missing path extension",
+                ),
+            ),
+        )
+    )
+    caplog.set_level("WARNING", logger="eegprep.extension_runtime")
+
+    actions = menu_actions(eeglab_menus(all_menus=True, extension_runtime=runtime))
+
+    assert "pop_missing_path" not in actions
+    assert "menu path missing menu was not found" in caplog.text
+
+
+def test_duplicate_extension_menu_names_mark_later_record_invalid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_package(
+        tmp_path,
+        "menu_duplicate_a",
+        {
+            "register.py": """
+                from eegprep.extensions import ExtensionMenu, ExtensionSpec
+
+                def register():
+                    return ExtensionSpec(
+                        name="menu_duplicate_a",
+                        menus=(ExtensionMenu(path=("tools",), action="pop_a", label="Shared menu"),),
+                    )
+            """,
+        },
+        monkeypatch,
+    )
+    _write_package(
+        tmp_path,
+        "menu_duplicate_b",
+        {
+            "register.py": """
+                from eegprep.extensions import ExtensionMenu, ExtensionSpec
+
+                def register():
+                    return ExtensionSpec(
+                        name="menu_duplicate_b",
+                        menus=(ExtensionMenu(path=("tools",), action="pop_b", label="Shared menu"),),
+                    )
+            """,
+        },
+        monkeypatch,
+    )
+    registry = ExtensionRegistry(
+        include_bundled=False,
+        entry_points_provider=_provider(
+            FakeEntryPoint("menu-a", "menu_duplicate_a.register:register"),
+            FakeEntryPoint("menu-b", "menu_duplicate_b.register:register"),
+        ),
+    )
+
+    records = registry.discover()
+
+    assert [record.status for record in records] == [ExtensionStatus.INSTALLED, ExtensionStatus.INVALID_SPEC]
+    assert "Duplicate menu 'Shared menu'" in records[1].errors[0]
+
+
+def test_malformed_extension_help_resource_invalidates_spec() -> None:
+    spec = ExtensionSpec(
+        name="malformed_help_extension",
+        help_resources=(ExtensionResource("malformed_help_extension", "help/pop_bad.txt"),),
+    )
+
+    result = validate_extension_spec(spec)
+
+    assert result.invalid_spec
+    assert "must be a Markdown file" in result.invalid_spec[0]
+
+
+def test_extension_action_result_shapes_update_session_history_and_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_action_shapes"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "actions.py": """
+                def pop_eeg_only(EEG, *, return_com=False):
+                    return dict(EEG, setname="eeg-only")
+
+                def pop_eeg_command(EEG, *, return_com=False):
+                    return dict(EEG, setname="eeg-command"), "EEG = pop_eeg_command(EEG);"
+
+                def command_only(*, session=None, return_com=False):
+                    return "LASTCOM = extension_command();"
+
+                def no_mutation(*, session=None, return_com=False):
+                    return None
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="action_shapes_extension",
+            actions=(
+                ExtensionAction("pop_eeg_only", LazyImport(f"{package}.actions", "pop_eeg_only")),
+                ExtensionAction("pop_eeg_command", LazyImport(f"{package}.actions", "pop_eeg_command")),
+                ExtensionAction("command_only", LazyImport(f"{package}.actions", "command_only")),
+                ExtensionAction("no_mutation", LazyImport(f"{package}.actions", "no_mutation")),
+            ),
+        )
+    )
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg(), new=True)
+    refresh = mock.Mock()
+    dispatcher = MenuActionDispatcher(session, refresh=refresh, extension_runtime=runtime)
+
+    dispatcher.dispatch("pop_eeg_only")
+    dispatcher.dispatch("pop_eeg_command")
+    dispatcher.dispatch("command_only")
+    history_after_command = list(session.ALLCOM)
+    dispatcher.dispatch("no_mutation")
+
+    assert session.EEG["setname"] == "eeg-command"
+    assert session.ALLCOM == [
+        "EEG = pop_eeg_command(EEG);",
+        "LASTCOM = extension_command();",
+    ]
+    assert session.ALLCOM == history_after_command
+    assert refresh.call_count == 3
+
+
+def test_registered_extension_pop_function_dispatches_as_gui_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_gui_pop"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "pop_functions.py": """
+                def pop_gui_ext(EEG, *, return_com=False):
+                    output = dict(EEG, setname="gui-extension")
+                    command = "EEG = pop_gui_ext(EEG);"
+                    return (output, command) if return_com else output
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="gui_pop_extension",
+            pop_functions=(
+                ExtensionPopFunction(
+                    "pop_gui_ext",
+                    LazyImport(f"{package}.pop_functions", "pop_gui_ext"),
+                ),
+            ),
+        )
+    )
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg(), new=True)
+    echoed = []
+    session.add_command_echo_listener(echoed.append)
+    dispatcher = MenuActionDispatcher(session, extension_runtime=runtime)
+
+    dispatcher.dispatch("pop_gui_ext")
+
+    assert session.EEG["setname"] == "gui-extension"
+    assert session.ALLCOM == ["EEG = pop_gui_ext(EEG);"]
+    assert echoed == ["EEG = pop_gui_ext(EEG);"]
+
+
+def test_extension_action_error_after_menu_click_is_reported_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_action_error"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "actions.py": """
+                def pop_raises(EEG, *, return_com=False):
+                    raise RuntimeError("extension boom")
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="raising_extension",
+            actions=(ExtensionAction("pop_raises", LazyImport(f"{package}.actions", "pop_raises")),),
+        )
+    )
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg(), new=True)
+    dispatcher = MenuActionDispatcher(session, extension_runtime=runtime)
+
+    with mock.patch.object(dispatcher, "_warn") as warn:
+        dispatcher.dispatch_gui("pop_raises", parent="window")
+
+    warn.assert_called_once_with("window", "extension boom")
+    assert session.ALLCOM == []
+    assert session.EEG["setname"] == "demo"
+
+
+def test_extension_pop_function_console_bare_and_assigned_calls_store_history_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_console_pop"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "pop_functions.py": """
+                def pop_console_ext(EEG, *, return_com=False):
+                    output = dict(EEG, setname="console-extension")
+                    command = "EEG = pop_console_ext(EEG);"
+                    return (output, command) if return_com else output
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="console_extension",
+            pop_functions=(
+                ExtensionPopFunction(
+                    "pop_console_ext",
+                    LazyImport(f"{package}.pop_functions", "pop_console_ext"),
+                ),
+            ),
+        )
+    )
+
+    bare_session = EEGPrepSession()
+    bare_session.store_current(_demo_eeg(), new=True)
+    bare_workspace = EEGPrepConsoleWorkspace(bare_session, exports={}, extension_runtime=runtime)
+    bare_result = bare_workspace.namespace["pop_console_ext"](bare_workspace.namespace["EEG"])
+    bare_workspace.after_execute("pop_console_ext(EEG)")
+
+    assert bare_result.command == "EEG = pop_console_ext(EEG);"
+    assert bare_session.EEG["setname"] == "console-extension"
+    assert bare_session.ALLCOM == ["EEG = pop_console_ext(EEG);"]
+
+    assigned_session = EEGPrepSession()
+    assigned_session.store_current(_demo_eeg(), new=True)
+    assigned_workspace = EEGPrepConsoleWorkspace(assigned_session, exports={}, extension_runtime=runtime)
+    exec("EEG, com = pop_console_ext(EEG)", assigned_workspace.namespace)
+    assigned_workspace.after_execute("EEG, com = pop_console_ext(EEG)")
+
+    assert assigned_workspace.namespace["EEG"] is assigned_session.EEG
+    assert assigned_workspace.namespace["com"] == "EEG = pop_console_ext(EEG);"
+    assert assigned_session.EEG["setname"] == "console-extension"
+    assert assigned_session.ALLCOM == ["EEG = pop_console_ext(EEG);"]
+
+
+def test_extension_help_resource_lookup_uses_packaged_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_help_resource"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "help/pop_help_ext.md": "POP_HELP_EXT - extension help text",
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="help_extension",
+            help_resources=(ExtensionResource(package, "help/pop_help_ext.md"),),
+        )
+    )
+
+    text, source_path = pophelp_text("pop_help_ext", extension_runtime=runtime)
+
+    assert "POP_HELP_EXT - extension help text" in text
+    assert source_path == f"{package}:help/pop_help_ext.md"
+
+
+def test_extension_action_kind_is_runtime_backed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = "extension_action_kind"
+    _write_package(
+        tmp_path,
+        package,
+        {
+            "actions.py": """
+                def run():
+                    return None
+            """,
+        },
+        monkeypatch,
+    )
+    runtime = _runtime(
+        ExtensionSpec(
+            name="kind_extension",
+            actions=(ExtensionAction("kind_action", LazyImport(f"{package}.actions", "run")),),
+        )
+    )
+
+    assert action_kind("kind_action") == "unknown"
+    assert action_kind("kind_action", extension_runtime=runtime) == "implemented"
+
+
+def _runtime(spec: ExtensionSpec) -> ExtensionRuntime:
+    return ExtensionRuntime.from_records(
+        (
+            ExtensionRecord(
+                name=spec.name,
+                status=ExtensionStatus.INSTALLED,
+                spec=spec,
+                source_type=ExtensionSourceType.INSTALLED,
+            ),
+        )
+    )
+
+
+def _child(items, label):
+    for item in items:
+        if item.label == label:
+            return item
+    raise AssertionError(f"missing menu item {label!r}")
+
+
+def _demo_eeg():
+    return {
+        "setname": "demo",
+        "data": np.array([[1.0, 2.0], [3.0, 4.0]]),
+        "nbchan": 2,
+        "pnts": 2,
+        "trials": 1,
+        "srate": 100.0,
+        "xmin": 0.0,
+        "xmax": 0.01,
+        "chanlocs": [{"labels": "Cz", "theta": 0.0}, {"labels": "Pz", "theta": 180.0}],
+        "event": [],
+        "urevent": [],
+        "epoch": [],
+    }
+
+
+def _provider(*entry_points: FakeEntryPoint):
+    def select(*, group: str) -> tuple[FakeEntryPoint, ...]:
+        return tuple(entry_point for entry_point in entry_points if entry_point.group == group)
+
+    return select
+
+
+def _write_package(
+    tmp_path: Path,
+    package: str,
+    files: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    for module_name in list(sys.modules):
+        if module_name == package or module_name.startswith(f"{package}."):
+            del sys.modules[module_name]
+    package_dir = tmp_path / package
+    package_dir.mkdir(exist_ok=True)
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    for relative_path, content in files.items():
+        path = package_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+    importlib.invalidate_caches()

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -464,7 +464,11 @@ class MenuActionDispatcherTests(unittest.TestCase):
         with mock.patch("eegprep.functions.guifunc.menu_actions.pophelp") as help_dialog:
             dispatcher.dispatch("help:eeg_helpadmin")
 
-        help_dialog.assert_called_once_with("eeg_helpadmin", parent=None)
+        help_dialog.assert_called_once_with(
+            "eeg_helpadmin",
+            parent=None,
+            extension_runtime=dispatcher.extension_runtime,
+        )
 
     def test_bare_help_action_defaults_to_eegprep_topic(self):
         dispatcher = MenuActionDispatcher(EEGPrepSession())
@@ -472,7 +476,11 @@ class MenuActionDispatcherTests(unittest.TestCase):
         with mock.patch("eegprep.functions.guifunc.menu_actions.pophelp") as help_dialog:
             dispatcher.dispatch("help")
 
-        help_dialog.assert_called_once_with("eegprep", parent=None)
+        help_dialog.assert_called_once_with(
+            "eegprep",
+            parent=None,
+            extension_runtime=dispatcher.extension_runtime,
+        )
 
     def test_help_and_admin_link_actions_do_not_mutate_session_history(self):
         session = EEGPrepSession()

--- a/tests/test_plugin_menu.py
+++ b/tests/test_plugin_menu.py
@@ -11,6 +11,7 @@ from eegprep.functions.adminfunc.plugin_menu import (
 )
 from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.extensions import ExtensionRegistry
 
 
 def test_bundled_plugins_describe_in_repo_extensions() -> None:
@@ -22,6 +23,16 @@ def test_bundled_plugins_describe_in_repo_extensions() -> None:
     assert all(plugin["status"] == "ok" for plugin in plugins)
     assert all(plugin["source"] == "bundled" for plugin in plugins)
     assert all(plugin["menu"] for plugin in plugins)
+
+
+def test_bundled_plugins_match_extension_registry_records() -> None:
+    plugins = bundled_plugins()
+    records = ExtensionRegistry(include_entry_points=False).discover()
+
+    assert [plugin["plugin"] for plugin in plugins] == [record.name for record in records]
+    assert [plugin["funcname"] for plugin in plugins] == [
+        record.spec.pop_functions[0].name for record in records if record.spec is not None
+    ]
 
 
 def test_bundled_plugins_returns_copies() -> None:


### PR DESCRIPTION
Wire active extension specs into EEGPrep menu construction, GUI dispatch, packaged help lookup, and eegprep-console pop_* wrappers. Bundled plugin menus now use the same declarative runtime path while --no-plugins still hides plugin contributions without hiding core menus. Closes #114