### PR TITLE
Fix EEGBrowser visual parity axes

### DIFF
--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -48,6 +48,7 @@ _MIN_SPACING = 0.001
 _TRACE_SCALE = 0.72
 _WINREJ_BRUSH_ALPHA = 210
 _WINREJ_EDGE_ALPHA = 230
+_EPOCHED_XTICK_LABEL_ROTATION = -45.0
 _AXES_POSITION = (0.0964286, 0.15, 0.842, 0.75)
 _NOUI_AXES_POSITION = (0.055, 0.075, 0.90, 0.87)
 _CONTROL_POSITIONS = {
@@ -618,6 +619,7 @@ class EEGBrowserCanvas(_QWidget):
         self._event_line_items: list[Any] = []
         self._event_label_items: list[Any] = []
         self._trial_boundary_items: list[Any] = []
+        self._bottom_tick_label_items: list[Any] = []
         self._drag_start_sample: int | None = None
         self._drag_start_pos: Any = None
         self._drag_channel_index: int | None = None
@@ -710,6 +712,7 @@ class EEGBrowserCanvas(_QWidget):
         self.plot.clear()
         self._items.clear()
         self._trial_boundary_items.clear()
+        self._bottom_tick_label_items.clear()
         self.plot.showGrid(x=False, y=False)
         self._configure_axes()
         self._draw_grid()
@@ -719,6 +722,7 @@ class EEGBrowserCanvas(_QWidget):
         self._draw_marked_channel_segments()
         self._draw_event_lines_and_labels()
         self._draw_plot_box()
+        self._draw_epoched_latency_tick_labels()
 
     def _clear_scene_items(self) -> None:
         scene = self.plot.scene()
@@ -727,6 +731,7 @@ class EEGBrowserCanvas(_QWidget):
         self._scene_items.clear()
         self._event_line_items.clear()
         self._event_label_items.clear()
+        self._bottom_tick_label_items.clear()
 
     def _configure_axes(self) -> None:
         start, stop = visible_sample_bounds(self.model.data, self.model.state)
@@ -741,8 +746,14 @@ class EEGBrowserCanvas(_QWidget):
                     label = self.model.data.channel_labels[channel_index]
                 labels.append((float(screen_index), label))
         self.plot.getAxis("left").setTicks([labels])
-        self.plot.getAxis("bottom").setLabel("")
-        self.plot.getAxis("bottom").setTicks([self._bottom_x_ticks(start, stop)])
+        bottom_axis = self.plot.getAxis("bottom")
+        bottom_axis.setLabel("")
+        if self.model.data.epoched:
+            bottom_axis.setHeight(44)
+            bottom_axis.setTicks([[(x_value, "") for x_value, _label in self._bottom_x_ticks(start, stop)]])
+        else:
+            bottom_axis.setHeight(28)
+            bottom_axis.setTicks([self._bottom_x_ticks(start, stop)])
         top_axis = self.plot.getAxis("top")
         if self.model.data.epoched:
             top_axis.setHeight(22)
@@ -865,6 +876,30 @@ class EEGBrowserCanvas(_QWidget):
         frame.setZValue(35)
         self.plot.scene().addItem(frame)
         self._scene_items.append(frame)
+
+    def _draw_epoched_latency_tick_labels(self) -> None:
+        if QtCore is None or QtGui is None or QtWidgets is None:
+            return
+        if not self.model.data.epoched:
+            return
+        start, stop = visible_sample_bounds(self.model.data, self.model.state)
+        view_box = self.plot.getPlotItem().vb
+        view_rect = view_box.sceneBoundingRect()
+        font = QtGui.QFont()
+        font.setPointSize(9)
+        for x_value, label_text in self._bottom_x_ticks(start, stop):
+            if not label_text:
+                continue
+            scene_pos = view_box.mapViewToScene(QtCore.QPointF(float(x_value), 0.0))
+            label = QtWidgets.QGraphicsSimpleTextItem(label_text)
+            label.setFont(font)
+            label.setBrush(QtGui.QBrush(QtGui.QColor("#000000")))
+            label.setRotation(_EPOCHED_XTICK_LABEL_ROTATION)
+            label.setZValue(45)
+            label.setPos(scene_pos.x() - 2.0, view_rect.bottom() + 18.0)
+            self.plot.scene().addItem(label)
+            self._scene_items.append(label)
+            self._bottom_tick_label_items.append(label)
 
     def _draw_traces(self) -> None:
         _qt_widgets, plot_graphics = _require_gui()

--- a/src/eegprep/functions/guifunc/eegbrowser.py
+++ b/src/eegprep/functions/guifunc/eegbrowser.py
@@ -7,9 +7,12 @@ from typing import Any
 
 import numpy as np
 
+from eegprep.functions.popfunc.eeg_point2lat import eeg_point2lat
 from eegprep.functions.sigprocfunc.eegplot import (
     BrowserModel,
     add_winrej_region,
+    browser_max_channel_offset,
+    browser_visible_channel_count,
     browser_window_duration,
     decimate_minmax,
     event_latency_to_sample,
@@ -486,10 +489,10 @@ class EEGBrowserWindow(_QMainWindow):
             return
         self.controls.show()
         self.menuBar().show()
-        maximum_offset = max(0, self.model.data.n_channels - self.model.state.dispchans)
+        maximum_offset = browser_max_channel_offset(self.model.data, self.model.state)
         self.channel_slider.blockSignals(True)
         self.channel_slider.setRange(0, maximum_offset)
-        self.channel_slider.setPageStep(max(1, self.model.state.dispchans))
+        self.channel_slider.setPageStep(browser_visible_channel_count(self.model.data, self.model.state))
         self.channel_slider.setSingleStep(1)
         self.channel_slider.setValue(self.model.state.channel_offset)
         self.channel_slider.setVisible(maximum_offset > 0)
@@ -614,6 +617,7 @@ class EEGBrowserCanvas(_QWidget):
         self._scene_items: list[Any] = []
         self._event_line_items: list[Any] = []
         self._event_label_items: list[Any] = []
+        self._trial_boundary_items: list[Any] = []
         self._drag_start_sample: int | None = None
         self._drag_start_pos: Any = None
         self._drag_channel_index: int | None = None
@@ -705,6 +709,7 @@ class EEGBrowserCanvas(_QWidget):
         self._clear_scene_items()
         self.plot.clear()
         self._items.clear()
+        self._trial_boundary_items.clear()
         self.plot.showGrid(x=False, y=False)
         self._configure_axes()
         self._draw_grid()
@@ -737,7 +742,16 @@ class EEGBrowserCanvas(_QWidget):
                 labels.append((float(screen_index), label))
         self.plot.getAxis("left").setTicks([labels])
         self.plot.getAxis("bottom").setLabel("")
-        self.plot.getAxis("bottom").setTicks([self._x_ticks(start, stop)])
+        self.plot.getAxis("bottom").setTicks([self._bottom_x_ticks(start, stop)])
+        top_axis = self.plot.getAxis("top")
+        if self.model.data.epoched:
+            top_axis.setHeight(22)
+            top_axis.setStyle(showValues=True, tickLength=0)
+            top_axis.setTicks([self._epoch_ticks(start, stop)])
+        else:
+            top_axis.setHeight(1)
+            top_axis.setStyle(showValues=False, tickLength=0)
+            top_axis.setTicks([[]])
         self.plot.setTitle(self.model.state.plottitle)
 
     def _draw_winrej(self) -> None:
@@ -945,9 +959,7 @@ class EEGBrowserCanvas(_QWidget):
         return range(state.channel_offset, state.channel_offset + self._plot_channel_count())
 
     def _plot_channel_count(self) -> int:
-        state = self.model.state
-        remaining = self.model.data.n_channels - state.channel_offset
-        return max(1, min(remaining, state.dispchans))
+        return browser_visible_channel_count(self.model.data, self.model.state)
 
     def _sample_range_to_x_values(self, start: int, stop: int) -> np.ndarray:
         if self.model.data.x_values is not None:
@@ -975,15 +987,9 @@ class EEGBrowserCanvas(_QWidget):
             return float(values[-1])
         return float(values[index])
 
-    def _x_ticks(self, start: int, stop: int) -> list[tuple[float, str]]:
+    def _bottom_x_ticks(self, start: int, stop: int) -> list[tuple[float, str]]:
         if self.model.data.epoched:
-            first_epoch = int(start // max(1, self.model.data.pnts)) + 1
-            last_epoch = int(np.ceil(stop / max(1, self.model.data.pnts)))
-            return [
-                (float((epoch - 1) * self.model.data.pnts), str(epoch))
-                for epoch in range(first_epoch, last_epoch + 1)
-                if start <= (epoch - 1) * self.model.data.pnts <= stop
-            ]
+            return self._latency_ticks(start, stop)
         start_x = self._sample_edge_to_x_value(start)
         stop_x = self._sample_edge_to_x_value(stop)
         step = 1.0
@@ -993,6 +999,42 @@ class EEGBrowserCanvas(_QWidget):
         while current <= stop_x:
             ticks.append((float(current), f"{current:g}"))
             current += step
+        return ticks
+
+    def _epoch_ticks(self, start: int, stop: int) -> list[tuple[float, str]]:
+        pnts = max(1, int(self.model.data.pnts))
+        first_epoch = max(0, int(start // pnts))
+        last_epoch = min(int(self.model.data.trials) - 1, int(np.ceil(stop / pnts)) - 1)
+        ticks = []
+        for epoch in range(first_epoch, last_epoch + 1):
+            epoch_start = epoch * pnts
+            epoch_stop = min((epoch + 1) * pnts, self.model.data.total_samples)
+            center = (max(start, epoch_start) + min(stop, epoch_stop)) / 2.0
+            ticks.append((float(center), str(epoch + 1)))
+        return ticks
+
+    def _trial_boundary_ticks(self, start: int, stop: int) -> list[float]:
+        pnts = max(1, int(self.model.data.pnts))
+        first_epoch = max(0, int(start // pnts))
+        last_epoch = min(int(self.model.data.trials) - 1, int(np.ceil(stop / pnts)) - 1)
+        return [float(epoch * pnts) for epoch in range(first_epoch, last_epoch + 1) if start <= epoch * pnts <= stop]
+
+    def _latency_ticks(self, start: int, stop: int) -> list[tuple[float, str]]:
+        pnts = max(1, int(self.model.data.pnts))
+        srate = float(self.model.state.srate)
+        limits = np.asarray(self.model.state.limits, dtype=float)
+        increment = _epoch_latency_increment_ms(float(self.model.state.winlength), float(limits[1] - limits[0]))
+        first_epoch = max(0, int(start // pnts))
+        last_epoch = min(int(self.model.data.trials) - 1, int(np.ceil(stop / pnts)) - 1)
+        ticks: list[tuple[float, str]] = []
+        for epoch in range(first_epoch, last_epoch + 1):
+            first_ms = np.ceil(limits[0] / increment) * increment
+            for latency_ms in np.arange(first_ms, limits[1] + increment * 0.001, increment):
+                point = (latency_ms * 0.001 - limits[0] * 0.001) * srate + 1.0 + epoch * pnts
+                x_value = float(point - 1.0)
+                if start <= x_value <= stop:
+                    label = eeg_point2lat(point, epoch + 1, srate, limits, 1e-3)[0]
+                    ticks.append((x_value, _format_tick_label(float(label))))
         return ticks
 
     def _event_scene_point(self, event: Any) -> Any:
@@ -1061,15 +1103,58 @@ class EEGBrowserCanvas(_QWidget):
         start, stop = visible_sample_bounds(self.model.data, self.model.state)
         pen = plot_graphics.mkPen((225, 225, 225), width=1)
         if self.model.state.xgrid:
-            for x_value, _label in self._x_ticks(start, stop):
+            for x_value, _label in self._bottom_x_ticks(start, stop):
                 line = plot_graphics.InfiniteLine(pos=x_value, angle=90, pen=pen, movable=False)
                 self.plot.addItem(line)
                 self._items.append(line)
+        if self.model.data.epoched:
+            boundary_pen = plot_graphics.mkPen((0, 0, 180), width=1, style=QtCore.Qt.PenStyle.DashLine)
+            for x_value in self._trial_boundary_ticks(start, stop):
+                line = plot_graphics.InfiniteLine(pos=x_value, angle=90, pen=boundary_pen, movable=False)
+                line.setZValue(-1)
+                self.plot.addItem(line)
+                self._items.append(line)
+                self._trial_boundary_items.append(line)
         if self.model.state.ygrid:
             for y_value in range(self._plot_channel_count()):
                 line = plot_graphics.InfiniteLine(pos=float(y_value), angle=0, pen=pen, movable=False)
                 self.plot.addItem(line)
                 self._items.append(line)
+
+
+def _epoch_latency_increment_ms(winlength: float, epoch_width_ms: float) -> float:
+    divisions = 20.0 / max(float(winlength), np.finfo(float).eps)
+    candidates = np.asarray(
+        [
+            100000 / 1,
+            100000 / 2,
+            100000 / 4,
+            100000 / 5,
+            10000 / 1,
+            10000 / 2,
+            10000 / 4,
+            10000 / 5,
+            1000 / 1,
+            1000 / 2,
+            1000 / 4,
+            1000 / 5,
+            100 / 1,
+            100 / 2,
+            100 / 4,
+            100 / 5,
+            100 / 10,
+            100 / 20,
+        ],
+        dtype=float,
+    )
+    index = int(np.argmin(np.abs(divisions * candidates - float(epoch_width_ms))))
+    return float(candidates[index])
+
+
+def _format_tick_label(value: float) -> str:
+    if np.isclose(value, round(value)):
+        return str(int(round(value)))
+    return f"{value:g}"
 
 
 class _ScaleIndicator(_QWidget):

--- a/src/eegprep/functions/guifunc/visual_capture.py
+++ b/src/eegprep/functions/guifunc/visual_capture.py
@@ -493,7 +493,7 @@ def capture_eegbrowser(output: pathlib.Path, *, variant: str = "continuous") -> 
         has_events = variant in {"events", "labels", "pop_eegplot_reject_data", "rejection_epochs"}
         winrej = _demo_eegbrowser_winrej(variant)
         eeg = _demo_eegbrowser_eeg(epoched=epoched, events=has_events)
-        data = eeg
+        data = np.asarray(eeg["data"], dtype=float)
         if variant == "rejcont_continuous":
             selected_rows = [0, 1, 2, 3]
             data = np.asarray(eeg["data"], dtype=float)[selected_rows, :]
@@ -514,6 +514,7 @@ def capture_eegbrowser(output: pathlib.Path, *, variant: str = "continuous") -> 
             xgrid="off" if variant == "grid_off" or variant == "rejcont_continuous" else "on",
             ygrid="off" if variant == "grid_off" else "on",
             winrej=winrej,
+            events=eeg["event"] if has_events else [],
             wincolor=(0.0, 0.9, 0.0) if variant == "rejcont_continuous" else None,
             command="TMPREJ=[];" if winrej is not None else None,
             butlabel="Reject",

--- a/src/eegprep/functions/sigprocfunc/eegplot.py
+++ b/src/eegprep/functions/sigprocfunc/eegplot.py
@@ -138,7 +138,7 @@ class BrowserState:
     def clamp_to_data(self, browser_data: BrowserData) -> None:
         """Clamp visible time and channel offsets to the available data."""
         self.dispchans = max(1, min(int(self.dispchans), browser_data.n_channels))
-        self.channel_offset = max(0, min(int(self.channel_offset), browser_data.n_channels - self.dispchans))
+        self.channel_offset = max(0, min(int(self.channel_offset), browser_max_channel_offset(browser_data, self)))
         max_time = max(0.0, browser_window_duration(browser_data, self) - float(self.winlength))
         self.time = max(0.0, min(float(self.time), max_time))
 
@@ -210,11 +210,14 @@ def build_eegplot_model(data: Any, **kwargs: Any) -> BrowserModel:
     """Build a browser model without opening a Qt window."""
     source_eeg = data if isinstance(data, dict) else None
     time_supplied = "time" in kwargs and kwargs["time"] is not None
+    limits_supplied = "limits" in kwargs and kwargs["limits"] is not None
     if source_eeg is not None and bool(kwargs.get("component", False)):
         kwargs = dict(kwargs)
         kwargs["_component_data"] = component_activations(source_eeg)
     options = _model_options(source_eeg, kwargs)
     browser_data = normalize_browser_data(data, options)
+    if not limits_supplied and source_eeg is None and browser_data.axis_limits is None:
+        options["limits"] = _default_limits(None, browser_data.pnts, float(options["srate"]))
     if options["dispchans"] is None:
         options["dispchans"] = browser_data.n_channels
     if browser_data.epoched:
@@ -311,6 +314,20 @@ def browser_window_duration(browser_data: BrowserData, state: BrowserState) -> f
     if browser_data.epoched:
         return float(browser_data.trials)
     return float(browser_data.total_samples) / float(state.srate)
+
+
+def browser_visible_channel_count(browser_data: BrowserData, state: BrowserState) -> int:
+    """Return EEGLAB-style trace rows visible for the current channel window."""
+    displayed = max(1, min(int(state.dispchans), browser_data.n_channels))
+    remaining = max(1, browser_data.n_channels - int(state.channel_offset))
+    if browser_data.n_channels > displayed:
+        return min(remaining, displayed + 2)
+    return displayed
+
+
+def browser_max_channel_offset(browser_data: BrowserData, state: BrowserState) -> int:
+    """Return the largest valid EEGLAB-style channel scroll offset."""
+    return max(0, browser_data.n_channels - max(1, min(int(state.dispchans), browser_data.n_channels)))
 
 
 def visible_sample_bounds(browser_data: BrowserData, state: BrowserState) -> tuple[int, int]:

--- a/tests/test_eegplot.py
+++ b/tests/test_eegplot.py
@@ -76,6 +76,7 @@ def test_epoched_data_flattens_in_eeglab_trial_order_and_clamps_window() -> None
 
     np.testing.assert_array_equal(model.data.flat_data[0], np.arange(1, 13))
     assert model.data.mode == "epoched"
+    assert model.state.limits == (0.0, 750.0)
     assert visible_sample_bounds(model.data, model.state) == (4, 8)
 
 

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -319,6 +319,13 @@ def test_gui_epoched_browser_uses_eeglab_epoch_and_latency_axes(qapp) -> None:
     window.close()
 
 
+def test_gui_epoched_latency_tick_increment_matches_eeglab_visual_divisor(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import _epoch_latency_increment_ms
+
+    assert _epoch_latency_increment_ms(3.0, 996.0) == pytest.approx(100.0)
+    assert _epoch_latency_increment_ms(1.0, 996.0) == pytest.approx(50.0)
+
+
 def test_gui_cancel_and_accept_buttons_set_close_state(qapp) -> None:
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -293,7 +293,7 @@ def test_gui_eegbrowser_uses_eeglab_extra_visible_channel_row(qapp) -> None:
 
 
 def test_gui_epoched_browser_uses_eeglab_epoch_and_latency_axes(qapp) -> None:
-    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow, _EPOCHED_XTICK_LABEL_ROTATION
 
     data = np.zeros((8, 250, 3))
     model = build_eegplot_model(
@@ -314,6 +314,9 @@ def test_gui_epoched_browser_uses_eeglab_epoch_and_latency_axes(qapp) -> None:
     assert (50.0, "0") in latency_ticks
     assert (300.0, "0") in latency_ticks
     assert (550.0, "0") in latency_ticks
+    assert len(window.canvas._bottom_tick_label_items) == len(latency_ticks)
+    assert {label.rotation() for label in window.canvas._bottom_tick_label_items} == {_EPOCHED_XTICK_LABEL_ROTATION}
+    assert window.canvas.plot.getAxis("bottom").height() == 44
     assert len(window.canvas._trial_boundary_items) == 3
     assert window.canvas.plot.getAxis("top").height() == 22
     window.close()

--- a/tests/test_eegplot_gui.py
+++ b/tests/test_eegplot_gui.py
@@ -260,12 +260,12 @@ def test_gui_displayed_channels_and_vertical_slider_update_visible_state(qapp) -
     window = EEGBrowserWindow(model)
 
     assert window.channel_slider.isHidden() is False
-    assert tuple(window.canvas._visible_channels()) == (0, 1)
+    assert tuple(window.canvas._visible_channels()) == (0, 1, 2, 3)
     window.channel_slider.setValue(2)
     qapp.processEvents()
 
     assert model.state.channel_offset == 2
-    assert tuple(window.canvas._visible_channels()) == (2, 3)
+    assert tuple(window.canvas._visible_channels()) == (2, 3, 4)
 
     window.set_displayed_channels(5)
     qapp.processEvents()
@@ -273,6 +273,49 @@ def test_gui_displayed_channels_and_vertical_slider_update_visible_state(qapp) -
     assert model.state.dispchans == 5
     assert tuple(window.canvas._visible_channels()) == (0, 1, 2, 3, 4)
     assert window.channel_slider.isVisible() is False
+    window.close()
+
+
+def test_gui_eegbrowser_uses_eeglab_extra_visible_channel_row(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    model = build_eegplot_model(np.zeros((8, 100)), srate=10, spacing=1, winlength=2, dispchans=6)
+    window = EEGBrowserWindow(model)
+
+    assert tuple(window.canvas._visible_channels()) == (0, 1, 2, 3, 4, 5, 6, 7)
+    assert window.channel_slider.maximum() == 2
+    window.channel_slider.setValue(2)
+    qapp.processEvents()
+
+    assert model.state.channel_offset == 2
+    assert tuple(window.canvas._visible_channels()) == (2, 3, 4, 5, 6, 7)
+    window.close()
+
+
+def test_gui_epoched_browser_uses_eeglab_epoch_and_latency_axes(qapp) -> None:
+    from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
+
+    data = np.zeros((8, 250, 3))
+    model = build_eegplot_model(
+        {"data": data, "nbchan": 8, "pnts": 250, "trials": 3, "srate": 250, "xmin": -0.2, "xmax": 0.796},
+        winlength=3,
+        dispchans=6,
+        spacing=1,
+        xgrid="on",
+    )
+    window = EEGBrowserWindow(model)
+    qapp.processEvents()
+
+    assert tuple(window.canvas._visible_channels()) == (0, 1, 2, 3, 4, 5, 6, 7)
+    assert window.canvas._epoch_ticks(0, 750) == [(125.0, "1"), (375.0, "2"), (625.0, "3")]
+    assert window.canvas._trial_boundary_ticks(0, 750) == [0.0, 250.0, 500.0]
+
+    latency_ticks = window.canvas._bottom_x_ticks(0, 750)
+    assert (50.0, "0") in latency_ticks
+    assert (300.0, "0") in latency_ticks
+    assert (550.0, "0") in latency_ticks
+    assert len(window.canvas._trial_boundary_items) == 3
+    assert window.canvas.plot.getAxis("top").height() == 22
     window.close()
 
 
@@ -304,7 +347,7 @@ def test_gui_keyboard_shortcuts_match_navigation_and_scale(qapp) -> None:
     qt_test = pytest.importorskip("PySide6.QtTest")
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 
-    model = build_eegplot_model(np.zeros((3, 100)), srate=10, winlength=2, dispchans=2, spacing=10)
+    model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=10)
     window = EEGBrowserWindow(model)
     window.show()
     window.activateWindow()
@@ -471,7 +514,7 @@ def test_gui_eegplot_children_option_links_opened_browser(qapp) -> None:
 def test_gui_noui_publication_view_hides_and_restores_browser_controls(qapp) -> None:
     from eegprep.functions.guifunc.eegbrowser import EEGBrowserWindow
 
-    model = build_eegplot_model(np.zeros((3, 100)), srate=10, winlength=2, dispchans=2, spacing=1, noui="on")
+    model = build_eegplot_model(np.zeros((4, 100)), srate=10, winlength=2, dispchans=2, spacing=1, noui="on")
     window = EEGBrowserWindow(model)
     window.show()
     qapp.processEvents()

--- a/tests/test_visual_parity.py
+++ b/tests/test_visual_parity.py
@@ -127,6 +127,16 @@ class VisualParityConfigTests(unittest.TestCase):
         self.assertEqual(cases["pop_interp_dataset_index_dialog"].targets["eeglab"].action, "inputdlg2:dataset_index")
         self.assertEqual(cases["pop_reref_help_dialog"].targets["eeglab"].action, "pophelp:pop_reref")
 
+    def test_eegbrowser_epoched_cases_compare_raw_matrix_captures(self):
+        cases = load_manifest()
+
+        for case_id in ("eegbrowser_epoched", "eegbrowser_epoched_marked", "eegbrowser_rejection_epochs"):
+            with self.subTest(case_id=case_id):
+                matlab_command = cases[case_id].targets["eeglab"].matlab_command
+                self.assertIn("data = zeros(8,250,3)", matlab_command)
+                self.assertIn("eegplot(data,", matlab_command)
+                self.assertNotIn("eegplot(EEG", matlab_command)
+
 
 class VisualParityCaptureTests(unittest.TestCase):
     def test_capture_command_receives_output_environment(self):


### PR DESCRIPTION
Align EEGBrowser channel visibility and epoched x-axis rendering with EEGLAB captures. This restores EEGLAB-style extra visible rows, separates epoched epoch labels from latency ticks, and keeps visual parity captures using comparable raw data.

Fixes #129