### PR TITLE
Phase 5: close user-facing option gaps

### DIFF
--- a/.notes/eeglab-migration-gap-audit.md
+++ b/.notes/eeglab-migration-gap-audit.md
@@ -111,37 +111,39 @@ Known examples:
     `subitc`, `amplag`
   - bootstrap significance is not implemented
 - `pop_erpimage`
-  - event-field sorting, event-type sorting, event-window sorting, event
-    alignment, phase sorting, ITC/coherence overlays, spectrum inset, baseline
-    amplitude limits, amplitude image mode, and free-form ERP-image options are
-    not fully supported
+  - Phase 5 added event-field/type/window sorting and supported More-options
+    parsing for standalone plot controls
+  - event alignment, phase sorting, ITC/coherence overlays, spectrum inset,
+    baseline amplitude limits, and amplitude image mode remain explicit
+    standalone non-goals
 - `pop_comperp`
-  - significance highlighting, standard-deviation displays, all-ERP display
-    variants, and some average/difference display variants are not fully
-    supported
+  - Phase 5 added significance highlighting, standard-deviation displays,
+    all-ERP display variants, and average/difference display toggles
 - `pop_editset`
-  - file/workspace expressions for `data`, ICA matrices, and some channel
-    location paths are not fully supported
-  - history serialization for mapping values and channel-location structures is
-    incomplete
+  - Phase 5 added concrete file paths for `data`, channel locations, ICA
+    matrices, `icachansind`, and mapping/channel-location history replay
+  - MATLAB workspace expression evaluation remains an explicit standalone
+    non-goal
 - `pop_export`
-  - `expr` export filtering is not supported
+  - Phase 5 added restricted standalone numeric `expr` export transforms
 - `pop_epoch`
-  - loading EEG data from a filename in `EEG["data"]` is not implemented
+  - Phase 5 added filename-backed `EEG["data"]` loading through the standalone
+    import loader
 - `pop_eegfilt`
-  - legacy FFT filtering path is not implemented; users are directed to
-    `pop_eegfiltnew`
+  - legacy FFT filtering is an explicit non-goal for the legacy wrapper; users
+    are directed to `pop_eegfiltnew(..., usefftfilt=True)`
 - `pop_runica`
   - supports `runica`, `picard`, and AMICA-style routes; EEGLAB algorithms such
-    as JADER, SOBI, and FastICA are not ported
+    as JADER, SOBI, and FastICA are explicit unported backend non-goals
 - `headplot`
-  - `plotmeshonly` preview and setup with original unprojected locations are not
-    implemented
+  - Phase 5 added `plotmeshonly` preview and setup with original unprojected
+    locations
 - `coregister`
   - only standalone `traditional` and `globalrescale` alignment methods are
-    supported
+    supported; FieldTrip/nonlinear/manual MATLAB routes are explicit non-goals
 - `clean_asr`
-  - Riemannian ASR mode is not implemented
+  - Phase 5 clarified and tested calibration-time Riemannian ASR support;
+    full Riemannian ASR processing remains an explicit non-goal
 
 ### 4. STUDY And Group-Level Depth
 

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -2,9 +2,31 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>EEGPrep Phase 2 File Format And Channel-Location Notes</title>
+  <title>EEGPrep Phase 5 Unsupported User-Facing Options Notes</title>
 </head>
 <body>
+  <h1>EEGPrep Phase 5 Unsupported User-Facing Options Notes</h1>
+  <p>Phase 5 closes option-level gaps in existing user-facing functions while
+  keeping EEGPrep standalone and explicit about MATLAB-only or toolbox-dependent
+  behavior.</p>
+  <h2>Phase 5 Design Decisions</h2>
+  <ul>
+    <li>Implemented concrete standalone option paths for <code>pop_export</code> expressions, filename-backed <code>pop_epoch</code> data, <code>pop_editset</code> file assignments, <code>pop_comperp</code> display/significance toggles, <code>pop_erpimage</code> event sorting, and <code>headplot_setup</code> preview/original-location options.</li>
+    <li>Kept MATLAB workspace expression evaluation out of runtime code. Users must pass Python values directly or provide concrete file paths so GUI and console history remain replayable.</li>
+    <li>Classified legacy or external-toolbox behavior as explicit non-goals where a standalone path is not maintainable: legacy <code>pop_eegfilt</code> FFT filtering, MATLAB/text <code>pop_runscript</code>, unsupported <code>pop_runica</code> algorithms, FieldTrip-style <code>coregister</code> methods, and full Riemannian ASR processing.</li>
+    <li>Did not change GUI layout or dialog geometry. Existing GUI controls now reach more supported paths, so new visual parity captures were not required for this phase.</li>
+  </ul>
+  <h2>Phase 5 Tradeoffs</h2>
+  <ul>
+    <li><code>pop_export</code> accepts a restricted numeric expression language instead of arbitrary Python evaluation. This covers common scale/log/clip transforms without exposing broad runtime objects through command history.</li>
+    <li><code>clean_artifacts(Distance='Riemannian')</code> uses the supported calibration-time Riemannian ASR estimate. Full Riemannian ASR processing remains unported and raises a clear error when requested directly.</li>
+    <li><code>pop_envtopo</code> remains a one-dataset wrapper because multi-dataset component envelopes need a deliberate group workflow rather than a silent merge of dataset-specific ICA maps.</li>
+  </ul>
+  <h2>Phase 5 Verification Notes</h2>
+  <ul>
+    <li>Focused tests cover sample-data export, filename-backed epoching, editset history replay, invalid option paths, plot option behavior, clean ASR limitations, and legacy non-goals.</li>
+    <li>MATLAB parity tests remain available behind the existing skip behavior. Local MATLAB parity execution exposed unrelated EEGLAB save-wrapper failures, so Python-focused runs use <code>EEGPREP_SKIP_MATLAB=1</code> where needed.</li>
+  </ul>
   <h1>EEGPrep Phase 2 File Format And Channel-Location Notes</h1>
   <h2>Design Decisions</h2>
   <ul>

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -21,14 +21,15 @@
     <li><code>pop_export</code> accepts a restricted numeric expression language instead of arbitrary Python evaluation. This covers common scale/log/clip transforms without exposing broad runtime objects through command history.</li>
     <li><code>clean_artifacts(Distance='Riemannian')</code> uses the supported calibration-time Riemannian ASR estimate. Full Riemannian ASR processing remains unported and raises a clear error when requested directly.</li>
     <li><code>pop_envtopo</code> remains a one-dataset wrapper because multi-dataset component envelopes need a deliberate group workflow rather than a silent merge of dataset-specific ICA maps.</li>
+    <li>Post-review tightening keeps useful options permissive but explicit: selected safe <code>pop_export</code> keywords are accepted, missing <code>pop_editset</code> paths fail as missing files, <code>dataformat</code> applies to numeric ICA imports, <code>pop_comperp</code> standard-deviation traces use EEGLAB's dataset-axis spread, and unknown ASR distance names are rejected.</li>
   </ul>
   <h2>Phase 5 Verification Notes</h2>
   <ul>
     <li>Focused tests cover sample-data export, filename-backed epoching, editset history replay, invalid option paths, plot option behavior, clean ASR limitations, and legacy non-goals.</li>
     <li>MATLAB parity tests remain available behind the existing skip behavior. Local MATLAB parity execution exposed unrelated EEGLAB save-wrapper failures, so Python-focused runs use <code>EEGPREP_SKIP_MATLAB=1</code> where needed.</li>
   </ul>
-  <h1>EEGPrep Phase 2 File Format And Channel-Location Notes</h1>
-  <h2>Design Decisions</h2>
+  <h2>EEGPrep Phase 2 File Format And Channel-Location Notes</h2>
+  <h3>Design Decisions</h3>
   <ul>
     <li>Implemented the useful channel-location core as standalone Python modules under <code>src/eegprep/functions/sigprocfunc</code>: <code>readlocs</code>, <code>writelocs</code>, <code>convertlocs</code>, <code>chancenter</code>, <code>floatread</code>, <code>floatwrite</code>, <code>snapread</code>, and EGI location lookup.</li>
     <li>Added EEGLAB-style public wrappers under <code>src/eegprep/functions/popfunc</code> for <code>pop_readlocs</code>, <code>pop_writelocs</code>, <code>pop_chancenter</code>, <code>pop_chancoresp</code>, <code>pop_loadbci</code>, and <code>pop_snapread</code>.</li>
@@ -36,20 +37,20 @@
     <li>Reused the new channel-location parser/writer inside <code>pop_chanedit</code> so GUI and command workflows share one implementation.</li>
     <li>Preserved EEGLAB-facing 1-based channel indices in <code>readchans</code>, <code>elecind</code>, <code>omitchans</code>, and channel-correspondence return values.</li>
   </ul>
-  <h2>Deviations</h2>
+  <h3>Deviations</h3>
   <ul>
     <li>No new channel-location GUI dialogs were added in this phase. The command paths are tested and history-capable; GUI visual parity artifacts were therefore not applicable.</li>
     <li><code>pop_chancoresp</code> implements the workflow-supporting label and fiducial pairing behavior without recreating EEGLAB's full interactive listbox editor.</li>
     <li>BCI2000 and SnapMaster support is limited to documented, fixture-testable import surfaces. Obsolete or toolbox-dependent readers are classified in the matrix instead of being ported blindly.</li>
     <li>Coordinate conversion keeps original Cartesian coordinates stable during <code>cart2all</code> and fills derived fields without avoidable spherical round-trip drift.</li>
   </ul>
-  <h2>Tradeoffs</h2>
+  <h3>Tradeoffs</h3>
   <ul>
     <li>Text location parsing accepts common EEGLAB formats and explicit custom column formats, but it rejects malformed rows early instead of silently padding incompatible files.</li>
     <li>EGI sensor-location lookup maps 128/129 and 256/257-channel workflows to packaged HydroCel montage resources. Legacy binary EGI RAW import remains consolidated under modern file import routes.</li>
     <li>Low-level <code>floatread</code> and <code>floatwrite</code> are implemented for EEGLAB-style binary helper coverage, while high-level EEG file export remains owned by existing <code>pop_writeeeg</code> paths.</li>
   </ul>
-  <h2>Open Questions</h2>
+  <h3>Open Questions</h3>
   <ul>
     <li>Future GUI parity work may add EEGLAB-style modal dialogs for <code>pop_readlocs</code>, <code>pop_writelocs</code>, <code>pop_chancenter</code>, and <code>pop_chancoresp</code>; this phase intentionally shipped API and console behavior first.</li>
     <li>Rare historical readers such as Neurodata, old EGI segmented RAW, and BIOSIG conversion shims should stay skipped or consolidated until a documented user workflow and deterministic fixture justify them.</li>

--- a/docs/parity/eeglab_core_parity_matrix.json
+++ b/docs/parity/eeglab_core_parity_matrix.json
@@ -3340,15 +3340,15 @@
       "eeglab_name": "pop_comperp",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_comperp.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_comperp lacks several EEGLAB significance, standard-deviation, and display variants.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 implemented the previously unsupported significance, standard-deviation, all-ERP, average, and difference display option paths for the standalone pop_comperp workflow.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add tests for average, difference, significance, and display variants before marking implemented."
+      "test_notes": "Covered by tests/test_phase4_plot_wrappers.py display/significance, RMS, grid-validation, GUI/spec, history, and sample epoched dataset-list tests."
     },
     {
       "eeglab_path": "functions/popfunc/pop_copyset.m",
@@ -3416,30 +3416,30 @@
       "eeglab_name": "pop_editset",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_editset.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_editset does not fully support EEGLAB file/workspace expressions or all history serialization paths.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 added concrete file-backed data, channel-location, ICA matrix, icachansind, dataformat, and channel-structure history serialization support. MATLAB base-workspace expression evaluation remains an explicit standalone non-goal.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add expression, channel-location, mapping, and history-replay tests before marking implemented."
+      "test_notes": "Covered by tests/test_pop_editset.py file-backed assignments, mapping history replay, explicit workspace-expression errors, GUI cancel/no-change paths, sample-data metadata, and MATLAB parity metadata tests when available."
     },
     {
       "eeglab_path": "functions/popfunc/pop_eegfilt.m",
       "eeglab_name": "pop_eegfilt",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_eegfilt.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_eegfilt intentionally rejects the legacy EEGLAB FFT filtering path pending a scoped decision.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 classified the legacy EEGLAB usefft route as an explicit non-goal for pop_eegfilt because EEGPrep provides the maintained frequency-domain FIR path through pop_eegfiltnew(usefftfilt=True).",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Phase 5 should either implement a maintainable legacy route or document and preserve the limitation with tests."
+      "test_notes": "Covered by tests/test_pop_firfilt.py legacy FIR behavior, history replay, and the explicit usefft limitation test."
     },
     {
       "eeglab_path": "functions/popfunc/pop_eegplot.m",
@@ -3476,45 +3476,45 @@
       "eeglab_name": "pop_envtopo",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_envtopo.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_envtopo supports single-dataset ERP envelopes but rejects EEGLAB-style multi-dataset envelopes.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 documented the single-dataset standalone contract and classified EEGLAB-style multi-dataset envelopes as a non-goal for this wrapper rather than silently merging dataset-specific ICA envelopes.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add single- and multi-dataset envelope tests, valid history assertions, and visual/headless plot coverage before marking implemented."
+      "test_notes": "Covered by tests/test_phase4_plot_wrappers.py single-dataset envtopo, icachansind subset handling, history syntax, and explicit multi-dataset limitation test."
     },
     {
       "eeglab_path": "functions/popfunc/pop_epoch.m",
       "eeglab_name": "pop_epoch",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_epoch.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_epoch does not load data from filename-backed EEG['data'] like EEGLAB can.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 added filename-backed EEG.data loading through the standalone import loader, including relative EEG.filepath resolution and dataformat inference.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add filename-backed data, boundary, first/last sample, and MATLAB parity tests before marking implemented."
+      "test_notes": "Covered by tests/test_pop_epoch.py filename-backed data loading, invalid options, GUI/history/cancel behavior, first/last sample edge cases, boundary behavior, and MATLAB parity tests when available."
     },
     {
       "eeglab_path": "functions/popfunc/pop_erpimage.m",
       "eeglab_name": "pop_erpimage",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_erpimage.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_erpimage rejects several EEGLAB sorting, alignment, overlay, inset, and image-mode options.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 added event-field/type/window sorting, nosort/noplot handling, More-options parsing for supported standalone plot controls, and documented phase/coherence/spectrum/amplitude/alignment workflows as explicit non-goals.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Cover supported and newly implemented sort/alignment/overlay paths with sample-data and MATLAB parity tests."
+      "test_notes": "Covered by tests/test_phase4_plot_wrappers.py sample channel/component ERP images, projected components, time limits, decimation, event sorting, nosort, unsupported alignment, GUI/spec, and history syntax."
     },
     {
       "eeglab_path": "functions/popfunc/pop_eventstat.m",
@@ -3566,15 +3566,15 @@
       "eeglab_name": "pop_export",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_export.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_export does not implement EEGLAB expr filtering.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 implemented standalone expr transforms for exported arrays using a restricted numeric expression evaluator before time-row insertion.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add export filtering tests and history replay tests before marking implemented."
+      "test_notes": "Covered by tests/test_sample_data_pop_functions.py sample-data text export, expr transform export, ICA fallback export, and command-history assertions."
     },
     {
       "eeglab_path": "functions/popfunc/pop_fileio.m",
@@ -4131,30 +4131,30 @@
       "eeglab_name": "pop_runica",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_runica.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_runica supports runica, Picard, and AMICA-style routes but not all EEGLAB algorithm choices.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 kept runica, Picard, and AMICA as the supported standalone algorithms and documented unported EEGLAB algorithms such as JADER, SOBI, and FastICA as explicit backend non-goals.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Add algorithm-selection, history, and deterministic parity tests for any newly supported algorithms."
+      "test_notes": "Covered by tests/test_gui_pop_runica.py backend routing, options/history, multi-dataset selection/concatenation, sample-data smoke, and unsupported-algorithm limitation tests."
     },
     {
       "eeglab_path": "functions/popfunc/pop_runscript.m",
       "eeglab_name": "pop_runscript",
       "eegprep_equivalent": "src/eegprep/functions/popfunc/pop_runscript.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing pop_runscript runs Python history scripts but intentionally rejects MATLAB/text scripts; Phase 5 should document or reclassify the standalone limitation.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 documented Python history scripts as the standalone replay contract and classified MATLAB/text history replay as a runtime non-goal.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "api",
         "console",
         "gui"
       ],
-      "test_notes": "Keep Python script execution tests and add explicit limitation/history tests for unsupported MATLAB/text script inputs."
+      "test_notes": "Covered by tests/test_file_menu_pop_functions.py Python script execution, command history, and explicit MATLAB/text script limitation tests."
     },
     {
       "eeglab_path": "functions/popfunc/pop_saveh.m",
@@ -4588,13 +4588,13 @@
       "eeglab_name": "coregister",
       "eegprep_equivalent": "src/eegprep/functions/sigprocfunc/coregister.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing coregister supports standalone traditional/globalrescale alignment but not every EEGLAB alignment route.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 preserved standalone traditional/globalrescale fitting and documented FieldTrip/nonlinear/manual MATLAB alignment routes as external-toolbox non-goals.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "helper"
       ],
-      "test_notes": "Add transform parity tests and explicit limitation tests for unsupported external-toolbox alignment routes."
+      "test_notes": "Covered by tests/test_phase4_plot_wrappers.py packaged reference matching, traditional and shared-scale fitting, noninteractive coregister, manual coregistration callback, and unsupported-method limitation tests."
     },
     {
       "eeglab_path": "functions/sigprocfunc/dipoledensity.m",
@@ -4908,13 +4908,13 @@
       "eeglab_name": "headplot",
       "eegprep_equivalent": "src/eegprep/functions/sigprocfunc/headplot.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing headplot lacks EEGLAB plotmeshonly setup preview and original-location setup behavior.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 implemented plotmeshonly head/sphere preview and orilocs setup behavior for standalone headplot spline setup.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "helper"
       ],
-      "test_notes": "Add headless setup tests and visual parity evidence for any GUI/plot preview paths."
+      "test_notes": "Covered by tests/test_phase4_plot_wrappers.py spline reuse, plotmeshonly preview, orilocs metadata, sample headplot rendering, GUI setup replay, and MATLAB parity tests when available."
     },
     {
       "eeglab_path": "functions/sigprocfunc/icaact.m",
@@ -8384,13 +8384,13 @@
       "eeglab_name": "clean_asr",
       "eegprep_equivalent": "src/eegprep/plugins/clean_rawdata/clean_asr.py",
       "gap_category": "3_unsupported_options",
-      "status": "partial",
-      "rationale": "Existing clean_asr does not implement the EEGLAB clean_rawdata Riemannian ASR mode.",
-      "responsible_phase": "phase_5",
+      "status": "implemented",
+      "rationale": "Phase 5 clarified that EEGPrep supports Riemannian ASR calibration via useriemannian=calib and Distance=Riemannian, while full Riemannian ASR processing remains an explicit non-goal.",
+      "responsible_phase": "none",
       "user_facing_surface": [
         "helper"
       ],
-      "test_notes": "Add numerical parity or explicit limitation tests for Riemannian ASR before marking implemented."
+      "test_notes": "Covered by tests/test_clean_asr.py calibration-mode acceptance and full-process limitation tests, tests/test_clean_rawdata.py Riemannian calibration smoke, and sample pop_clean_rawdata Riemannian command coverage."
     }
   ]
 }

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -86,6 +86,10 @@ Text And External Export
 
 .. autofunction:: eegprep.pop_export
 
+``pop_export`` supports EEGLAB-style text export options including ICA export,
+time/electrode rows, transpose, ERP averaging, precision, separator, and a
+standalone numeric ``expr`` transform applied to the exported array ``x``.
+
 .. autofunction:: eegprep.pop_expica
 
 .. autofunction:: eegprep.pop_expevents

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -89,6 +89,9 @@ Text And External Export
 ``pop_export`` supports EEGLAB-style text export options including ICA export,
 time/electrode rows, transpose, ERP averaging, precision, separator, and a
 standalone numeric ``expr`` transform applied to the exported array ``x``.
+Most expression function calls are positional; ``clip`` and ``nan_to_num`` also
+accept documented safe numeric keywords. Power operators require small constant
+exponents.
 
 .. autofunction:: eegprep.pop_expica
 

--- a/docs/source/user_guide/preprocessing_pipeline.rst
+++ b/docs/source/user_guide/preprocessing_pipeline.rst
@@ -101,6 +101,12 @@ Remove bursts of high-amplitude artifacts:
         asr_wlen=0.5           # Window length in seconds
     )
 
+EEGPrep supports the Riemannian ASR calibration variant through
+``clean_asr(eeg, useriemannian="calib")`` and
+``clean_artifacts(eeg, Distance="Riemannian")``. Full Riemannian ASR
+processing is not ported, so direct full-process requests fail clearly instead
+of silently substituting MATLAB-only behavior.
+
 Comprehensive Artifact Removal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/eegprep/functions/popfunc/pop_comperp.py
+++ b/src/eegprep/functions/popfunc/pop_comperp.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy.stats import ttest_1samp, ttest_rel
 from scipy.signal import butter, sosfiltfilt
 
 from eegprep.functions.guifunc.inputgui import inputgui
@@ -44,29 +45,54 @@ def pop_comperp(
         kwargs.update(result["options"])
     add_indices = _dataset_indices(datadd, len(datasets))
     sub_indices = _dataset_indices(datsub, len(datasets), allow_empty=True)
-    _raise_for_unsupported_options(kwargs)
     if sub_indices.size and sub_indices.size != add_indices.size:
         raise ValueError("datadd and datsub must contain the same number of datasets")
+    options = _normalise_options(kwargs, has_sub=bool(sub_indices.size))
     selected_datasets = [datasets[index] for index in np.union1d(add_indices, sub_indices)]
     _validate_time_grid(selected_datasets)
-    mode = str(kwargs.get("mode") or "ave").lower()
-    erp1 = _grand_erp([datasets[index] for index in add_indices], int(flag), kwargs.get("chans"), mode)
-    erp2 = (
-        _grand_erp([datasets[index] for index in sub_indices], int(flag), kwargs.get("chans"), mode)
+    mode = str(options["mode"]).lower()
+    add_stack = _dataset_erps([datasets[index] for index in add_indices], int(flag), options.get("chans"))
+    sub_stack = (
+        _dataset_erps([datasets[index] for index in sub_indices], int(flag), options.get("chans"))
         if sub_indices.size
         else None
     )
+    diff_stack = add_stack - sub_stack if sub_stack is not None else None
+    erp1 = _collapse_erps(add_stack, mode)
+    erp2 = _collapse_erps(sub_stack, mode) if sub_stack is not None else None
     erpsub = erp1 - erp2 if erp2 is not None else None
-    lowpass = numeric_vector(kwargs.get("lowpass", []))
+    pvalues = _significance(add_stack, sub_stack, options.get("alpha"))
+    lowpass = numeric_vector(options.get("lowpass", []))
     if lowpass.size:
         erp1 = _lowpass_erp(erp1, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1))
         if erp2 is not None:
             erp2 = _lowpass_erp(erp2, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1))
         if erpsub is not None:
             erpsub = _lowpass_erp(erpsub, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1))
+        add_stack = _lowpass_stack(
+            add_stack, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1)
+        )
+        if sub_stack is not None:
+            sub_stack = _lowpass_stack(
+                sub_stack, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1)
+            )
+        if diff_stack is not None:
+            diff_stack = _lowpass_stack(
+                diff_stack, float(lowpass[0]), float(datasets[int(add_indices[0])].get("srate", 1) or 1)
+            )
     times = eeg_times_ms(datasets[int(add_indices[0])])
-    figure = _plot_comperp(erp1, erp2, erpsub, times, title=str(kwargs.get("title") or "ERP grand average"))
-    result = {"erp1": erp1, "erp2": erp2, "erpsub": erpsub, "times": times, "figure": figure}
+    figure = _plot_comperp(
+        erp1,
+        erp2,
+        erpsub,
+        add_stack,
+        sub_stack,
+        diff_stack,
+        times,
+        pvalues=pvalues,
+        options=options,
+    )
+    result = {"erp1": erp1, "erp2": erp2, "erpsub": erpsub, "times": times, "pvalues": pvalues, "figure": figure}
     command = history_command(
         "pop_comperp", int(flag), (add_indices + 1).tolist(), (sub_indices + 1).tolist(), eeg_name="ALLEEG", **kwargs
     )
@@ -144,7 +170,7 @@ def _run_gui(datasets: list[dict[str, Any]], *, flag: int, renderer: Any | None 
     result = inputgui(pop_comperp_dialog_spec(datasets, flag=flag), renderer=renderer)
     if result is None:
         return None
-    _raise_for_unsupported_gui_options(result)
+    alpha = numeric_vector(result.get("alpha", []))
     return {
         "datadd": numeric_vector(result.get("datadd", []), dtype=int).tolist(),
         "datsub": numeric_vector(result.get("datsub", []), dtype=int).tolist(),
@@ -152,6 +178,16 @@ def _run_gui(datasets: list[dict[str, Any]], *, flag: int, renderer: Any | None 
             "chans": numeric_vector(result.get("chans", []), dtype=int).tolist(),
             "mode": "rms" if bool(result.get("mode_rms", False)) else "ave",
             "lowpass": numeric_vector(result.get("lowpass", [])).tolist(),
+            "alpha": float(alpha[0]) if alpha.size else [],
+            "addavg": "on" if bool(result.get("addavg", True)) else "off",
+            "addstd": "on" if bool(result.get("addstd", False)) else "off",
+            "addall": "on" if bool(result.get("addall", False)) else "off",
+            "subavg": "on" if bool(result.get("subavg", True)) else "off",
+            "substd": "on" if bool(result.get("substd", False)) else "off",
+            "suball": "on" if bool(result.get("suball", False)) else "off",
+            "diffavg": "on" if bool(result.get("diffavg", True)) else "off",
+            "diffstd": "on" if bool(result.get("diffstd", False)) else "off",
+            "diffall": "on" if bool(result.get("diffall", False)) else "off",
         },
     }
 
@@ -167,7 +203,7 @@ def _dataset_indices(values: Any, count: int, *, allow_empty: bool = False) -> n
     return vector - 1
 
 
-def _grand_erp(datasets: list[dict[str, Any]], flag: int, chans: Any, mode: str) -> np.ndarray:
+def _dataset_erps(datasets: list[dict[str, Any]], flag: int, chans: Any) -> np.ndarray:
     erps = []
     for eeg in datasets:
         values = eeg_epoch_data(eeg) if flag else component_activations(eeg)
@@ -175,7 +211,10 @@ def _grand_erp(datasets: list[dict[str, Any]], flag: int, chans: Any, mode: str)
             raise ValueError("pop_comperp requires epoched datasets")
         selected = _selected_rows(chans, values.shape[0])
         erps.append(np.nanmean(values[selected, :, :], axis=2))
-    stacked = np.stack(erps, axis=0)
+    return np.stack(erps, axis=0)
+
+
+def _collapse_erps(stacked: np.ndarray, mode: str) -> np.ndarray:
     if mode == "rms":
         return np.sqrt(np.nanmean(stacked * stacked, axis=0))
     if mode != "ave":
@@ -193,19 +232,49 @@ def _selected_rows(values: Any, count: int) -> np.ndarray:
 
 
 def _plot_comperp(
-    erp1: np.ndarray, erp2: np.ndarray | None, erpsub: np.ndarray | None, times: np.ndarray, *, title: str
+    erp1: np.ndarray,
+    erp2: np.ndarray | None,
+    erpsub: np.ndarray | None,
+    add_stack: np.ndarray,
+    sub_stack: np.ndarray | None,
+    diff_stack: np.ndarray | None,
+    times: np.ndarray,
+    *,
+    pvalues: np.ndarray | None,
+    options: dict[str, Any],
 ):
     fig, ax = plt.subplots(figsize=(8, 4.5))
-    ax.plot(times, np.nanmean(erp1, axis=0), color="blue", label="add")
-    if erp2 is not None:
-        ax.plot(times, np.nanmean(erp2, axis=0), color="red", label="subtract")
-    if erpsub is not None:
-        ax.plot(times, np.nanmean(erpsub, axis=0), color="black", label="difference")
+    plot_times, mask = _plot_time_mask(times, options.get("tlim"))
+    if _is_on(options.get("addall")):
+        _plot_all(ax, add_stack, plot_times, mask, color="0.45", label_prefix="add")
+    if _is_on(options.get("suball")) and sub_stack is not None:
+        _plot_all(ax, sub_stack, plot_times, mask, color="0.65", label_prefix="sub")
+    if _is_on(options.get("diffall")) and diff_stack is not None:
+        _plot_all(ax, diff_stack, plot_times, mask, color="0.35", label_prefix="diff")
+    if _is_on(options.get("addavg")):
+        ax.plot(plot_times, np.nanmean(erp1, axis=0)[mask], color="blue", label="add")
+    if erp2 is not None and _is_on(options.get("subavg")):
+        ax.plot(plot_times, np.nanmean(erp2, axis=0)[mask], color="red", label="subtract")
+    if erpsub is not None and _is_on(options.get("diffavg")):
+        ax.plot(plot_times, np.nanmean(erpsub, axis=0)[mask], color="black", label="difference")
+    if _is_on(options.get("addstd")):
+        _plot_std(ax, add_stack, plot_times, mask, color="blue", label="add std")
+    if _is_on(options.get("substd")) and sub_stack is not None:
+        _plot_std(ax, sub_stack, plot_times, mask, color="red", label="sub std")
+    if _is_on(options.get("diffstd")) and diff_stack is not None:
+        _plot_std(ax, diff_stack, plot_times, mask, color="black", label="diff std")
+    alpha = options.get("alpha")
+    if pvalues is not None and alpha is not None:
+        _shade_significance(ax, times, mask, pvalues, float(alpha))
     ax.axhline(0, color="0.7", linewidth=0.6)
     ax.set_xlabel("Time (ms)")
     ax.set_ylabel("uV")
-    ax.set_title(title)
-    ax.legend()
+    ax.set_title(str(options.get("title") or "ERP grand average"))
+    ylim = numeric_vector(options.get("ylim", []))
+    if ylim.size == 2:
+        ax.set_ylim(float(ylim[0]), float(ylim[1]))
+    if ax.get_legend_handles_labels()[0]:
+        ax.legend()
     ax.grid(True, alpha=0.25)
     fig.tight_layout()
     return fig
@@ -238,33 +307,11 @@ def _lowpass_erp(values: np.ndarray, cutoff: float, srate: float) -> np.ndarray:
     return sosfiltfilt(sos, values, axis=1)
 
 
-def _raise_for_unsupported_gui_options(result: dict[str, Any]) -> None:
-    if numeric_vector(result.get("alpha", [])).size:
-        raise NotImplementedError("pop_comperp does not yet support significance highlighting")
-    unsupported_on = {
-        "addstd": "add standard deviation",
-        "addall": "plot all added ERPs",
-        "substd": "subtract standard deviation",
-        "suball": "plot all subtracted ERPs",
-        "diffstd": "difference standard deviation",
-        "diffall": "plot all differences",
-    }
-    for field, label in unsupported_on.items():
-        if bool(result.get(field, False)):
-            raise NotImplementedError(f"pop_comperp does not yet support {label}")
-    if not bool(result.get("addavg", True)):
-        raise NotImplementedError("pop_comperp currently requires plotting the added average")
-    if not bool(result.get("subavg", True)):
-        raise NotImplementedError("pop_comperp currently requires plotting the subtracted average")
-    if not bool(result.get("diffavg", True)):
-        raise NotImplementedError("pop_comperp currently requires plotting the difference average")
-
-
-def _raise_for_unsupported_options(options: dict[str, Any]) -> None:
-    supported = {"chans", "mode", "lowpass", "title"}
-    unsupported = sorted(key for key in set(options) - supported if not _is_default_off(options[key]))
-    if unsupported:
-        raise NotImplementedError(f"pop_comperp does not yet support option(s): {', '.join(unsupported)}")
+def _lowpass_stack(values: np.ndarray, cutoff: float, srate: float) -> np.ndarray:
+    if cutoff <= 0 or cutoff >= srate / 2:
+        raise ValueError("lowpass must be greater than 0 and below Nyquist")
+    sos = butter(4, cutoff, btype="lowpass", fs=srate, output="sos")
+    return sosfiltfilt(sos, values, axis=2)
 
 
 def _is_default_off(value: Any) -> bool:
@@ -275,6 +322,150 @@ def _is_default_off(value: Any) -> bool:
     if isinstance(value, (list, tuple, np.ndarray)):
         return len(np.asarray(value).ravel()) == 0
     return value is False
+
+
+def _normalise_options(options: dict[str, Any], *, has_sub: bool) -> dict[str, Any]:
+    supported = {
+        "chans",
+        "mode",
+        "lowpass",
+        "title",
+        "alpha",
+        "geom",
+        "tlim",
+        "ylim",
+        "tplotopt",
+        "addstd",
+        "substd",
+        "diffstd",
+        "addavg",
+        "subavg",
+        "diffavg",
+        "addall",
+        "suball",
+        "diffall",
+        "std",
+        "diffonly",
+        "allerps",
+        "multcmp",
+    }
+    unknown = sorted(key for key in set(options) - supported if not _is_default_off(options[key]))
+    if unknown:
+        raise ValueError(f"pop_comperp unsupported option(s): {', '.join(unknown)}")
+    normalised = {
+        "chans": options.get("chans"),
+        "mode": str(options.get("mode") or "ave").lower(),
+        "lowpass": options.get("lowpass", []),
+        "title": options.get("title") or "ERP grand average",
+        "alpha": _optional_alpha(options.get("alpha")),
+        "tlim": options.get("tlim", []),
+        "ylim": options.get("ylim", []),
+        "addavg": _onoff_option(options.get("addavg"), True),
+        "subavg": _onoff_option(options.get("subavg"), has_sub),
+        "diffavg": _onoff_option(options.get("diffavg"), has_sub),
+        "addstd": _onoff_option(options.get("addstd"), False),
+        "substd": _onoff_option(options.get("substd"), False),
+        "diffstd": _onoff_option(options.get("diffstd"), False),
+        "addall": _onoff_option(options.get("addall"), False),
+        "suball": _onoff_option(options.get("suball"), False),
+        "diffall": _onoff_option(options.get("diffall"), False),
+    }
+    std = str(options.get("std", "none")).lower()
+    if std != "none":
+        if has_sub:
+            normalised["diffstd"] = std
+        else:
+            normalised["addstd"] = std
+    allerps = str(options.get("allerps", "none")).lower()
+    if allerps != "none":
+        normalised["diffall" if has_sub else "addall"] = allerps
+    diffonly = str(options.get("diffonly", "none")).lower()
+    if diffonly == "on" and has_sub:
+        normalised.update({"addavg": "off", "subavg": "off", "addall": "off", "suball": "off", "diffavg": "on"})
+    elif diffonly == "off" and has_sub:
+        normalised.update({"addavg": "on", "subavg": "on"})
+    return normalised
+
+
+def _optional_alpha(value: Any) -> float | None:
+    values = numeric_vector(value if value is not None else [])
+    if values.size == 0:
+        return None
+    alpha = float(values[0])
+    if not 0 < alpha < 1:
+        raise ValueError("alpha must be between 0 and 1")
+    return alpha
+
+
+def _onoff_option(value: Any, default: bool) -> str:
+    if value is None or _is_default_off(value) and default is False:
+        return "on" if default else "off"
+    return "on" if _is_on(value) else "off"
+
+
+def _is_on(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "yes", "true", "1"}
+    if isinstance(value, np.ndarray):
+        return bool(value.size and np.asarray(value).ravel()[0])
+    return bool(value)
+
+
+def _significance(add_stack: np.ndarray, sub_stack: np.ndarray | None, alpha: float | None) -> np.ndarray | None:
+    if alpha is None:
+        return None
+    if add_stack.shape[0] <= 1:
+        raise ValueError("T-tests require more than one datadd dataset")
+    if sub_stack is not None:
+        if sub_stack.shape[0] <= 1:
+            raise ValueError("Paired T-tests require more than one datsub dataset")
+        return np.asarray(ttest_rel(add_stack, sub_stack, axis=0, nan_policy="omit").pvalue)
+    return np.asarray(ttest_1samp(add_stack, popmean=0.0, axis=0, nan_policy="omit").pvalue)
+
+
+def _plot_time_mask(times: np.ndarray, tlim: Any) -> tuple[np.ndarray, np.ndarray]:
+    values = numeric_vector(tlim if tlim is not None else [])
+    if values.size != 2:
+        return times, np.ones(times.shape, dtype=bool)
+    mask = (times >= values[0]) & (times <= values[1])
+    if not np.any(mask):
+        raise ValueError("tlim does not include any samples")
+    return times[mask], mask
+
+
+def _plot_all(
+    ax: Any, stack: np.ndarray, times: np.ndarray, mask: np.ndarray, *, color: str, label_prefix: str
+) -> None:
+    for index, erp in enumerate(stack, start=1):
+        label = f"{label_prefix} #{index}" if index == 1 else None
+        ax.plot(times, np.nanmean(erp, axis=0)[mask], color=color, linewidth=0.8, alpha=0.65, label=label)
+
+
+def _plot_std(ax: Any, stack: np.ndarray, times: np.ndarray, mask: np.ndarray, *, color: str, label: str) -> None:
+    row_means = np.nanmean(stack, axis=1)
+    center = np.nanmean(row_means, axis=0)
+    spread = np.nanstd(row_means, axis=0, ddof=1 if stack.shape[0] > 1 else 0)
+    ax.plot(times, (center + spread)[mask], color=color, linestyle=":", linewidth=1.0, label=label)
+    ax.plot(times, (center - spread)[mask], color=color, linestyle=":", linewidth=1.0)
+
+
+def _shade_significance(ax: Any, times: np.ndarray, mask: np.ndarray, pvalues: np.ndarray, alpha: float) -> None:
+    significant = np.nanmin(pvalues, axis=0) < alpha
+    significant = significant & mask
+    starts: list[int] = []
+    stops: list[int] = []
+    in_region = False
+    for index, value in enumerate(significant.tolist()):
+        if value and not in_region:
+            starts.append(index)
+            in_region = True
+        elif not value and in_region:
+            stops.append(index - 1)
+            in_region = False
+    if in_region:
+        stops.append(len(significant) - 1)
+    for start, stop in zip(starts, stops):
+        ax.axvspan(float(times[start]), float(times[stop]), color="gold", alpha=0.18, linewidth=0)
 
 
 __all__ = ["pop_comperp", "pop_comperp_dialog_spec"]

--- a/src/eegprep/functions/popfunc/pop_comperp.py
+++ b/src/eegprep/functions/popfunc/pop_comperp.py
@@ -245,6 +245,7 @@ def _plot_comperp(
 ):
     fig, ax = plt.subplots(figsize=(8, 4.5))
     plot_times, mask = _plot_time_mask(times, options.get("tlim"))
+    mode = str(options.get("mode") or "ave").lower()
     if _is_on(options.get("addall")):
         _plot_all(ax, add_stack, plot_times, mask, color="0.45", label_prefix="add")
     if _is_on(options.get("suball")) and sub_stack is not None:
@@ -258,11 +259,11 @@ def _plot_comperp(
     if erpsub is not None and _is_on(options.get("diffavg")):
         ax.plot(plot_times, np.nanmean(erpsub, axis=0)[mask], color="black", label="difference")
     if _is_on(options.get("addstd")):
-        _plot_std(ax, add_stack, plot_times, mask, color="blue", label="add std")
+        _plot_std(ax, add_stack, plot_times, mask, color="blue", label="add std", mode=mode)
     if _is_on(options.get("substd")) and sub_stack is not None:
-        _plot_std(ax, sub_stack, plot_times, mask, color="red", label="sub std")
+        _plot_std(ax, sub_stack, plot_times, mask, color="red", label="sub std", mode=mode)
     if _is_on(options.get("diffstd")) and diff_stack is not None:
-        _plot_std(ax, diff_stack, plot_times, mask, color="black", label="diff std")
+        _plot_std(ax, diff_stack, plot_times, mask, color="black", label="diff std", mode=mode)
     alpha = options.get("alpha")
     if pvalues is not None and alpha is not None:
         _shade_significance(ax, times, mask, pvalues, float(alpha))
@@ -318,10 +319,11 @@ def _is_default_off(value: Any) -> bool:
     if value is None:
         return True
     if isinstance(value, str):
-        return value.lower() == "off" or value == ""
+        return value.strip().lower() in {"", "off", "no", "false", "0"}
     if isinstance(value, (list, tuple, np.ndarray)):
-        return len(np.asarray(value).ravel()) == 0
-    return value is False
+        array = np.asarray(value).ravel()
+        return len(array) == 0 or (len(array) == 1 and not bool(array[0]))
+    return not bool(value)
 
 
 def _normalise_options(options: dict[str, Any], *, has_sub: bool) -> dict[str, Any]:
@@ -398,7 +400,7 @@ def _optional_alpha(value: Any) -> float | None:
 
 
 def _onoff_option(value: Any, default: bool) -> str:
-    if value is None or _is_default_off(value) and default is False:
+    if value is None or (_is_default_off(value) and default is False):
         return "on" if default else "off"
     return "on" if _is_on(value) else "off"
 
@@ -441,10 +443,12 @@ def _plot_all(
         ax.plot(times, np.nanmean(erp, axis=0)[mask], color=color, linewidth=0.8, alpha=0.65, label=label)
 
 
-def _plot_std(ax: Any, stack: np.ndarray, times: np.ndarray, mask: np.ndarray, *, color: str, label: str) -> None:
-    row_means = np.nanmean(stack, axis=1)
-    center = np.nanmean(row_means, axis=0)
-    spread = np.nanstd(row_means, axis=0, ddof=1 if stack.shape[0] > 1 else 0)
+def _plot_std(
+    ax: Any, stack: np.ndarray, times: np.ndarray, mask: np.ndarray, *, color: str, label: str, mode: str
+) -> None:
+    center = np.nanmean(_collapse_erps(stack, mode), axis=0)
+    channel_spread = np.nanstd(stack, axis=0, ddof=1 if stack.shape[0] > 1 else 0)
+    spread = np.nanmean(channel_spread, axis=0)
     ax.plot(times, (center + spread)[mask], color=color, linestyle=":", linewidth=1.0, label=label)
     ax.plot(times, (center - spread)[mask], color=color, linestyle=":", linewidth=1.0)
 

--- a/src/eegprep/functions/popfunc/pop_editset.py
+++ b/src/eegprep/functions/popfunc/pop_editset.py
@@ -28,6 +28,20 @@ _TEXT_FIELDS = ("setname", "subject", "condition", "group", "comments")
 _NUMERIC_FIELDS = ("srate", "pnts", "xmin", "nbchan")
 _OPTIONAL_NUMERIC_FIELDS = ("run", "session")
 _DIRECT_ASSIGNMENT_FIELDS = ("chanlocs", "icaweights", "icasphere", "icachansind", "data")
+_PATH_EXTENSIONS = {
+    ".asc",
+    ".bdf",
+    ".csv",
+    ".dat",
+    ".elp",
+    ".fdt",
+    ".mat",
+    ".npy",
+    ".npz",
+    ".sfp",
+    ".tsv",
+    ".txt",
+}
 _SUPPORTED_FIELDS = {
     "ref",
     "dataformat",
@@ -226,15 +240,21 @@ def _assign_option(output: dict[str, Any], key: str, value: Any, *, dataformat: 
         _assign_chanlocs(output, value)
         return
     if key in {"icaweights", "icasphere"}:
-        _assign_ica_matrix(output, key, value)
+        _assign_ica_matrix(output, key, value, dataformat=dataformat)
         return
     if key == "icachansind":
-        if isinstance(value, str) and value.strip() != "[]" and not _is_existing_path(value):
+        if isinstance(value, (str, Path)) and str(value).strip() != "[]":
+            path = _existing_path(value)
+            if path is not None:
+                output[key] = _as_int_array(_load_array_path(path, dataformat=dataformat))
+                return
+            if _looks_like_path(value):
+                raise FileNotFoundError(f"pop_editset icachansind file not found: {value}")
             raise ValueError(
                 "pop_editset cannot evaluate MATLAB workspace expressions for icachansind; "
                 "pass Python indices directly or provide a numeric file path."
             )
-        output[key] = _as_int_array(_load_array_path(value) if _is_existing_path(value) else value)
+        output[key] = _as_int_array(value)
         return
     if key == "data":
         _assign_data(output, value, dataformat=dataformat)
@@ -244,12 +264,14 @@ def _assign_chanlocs(output: dict[str, Any], value: Any) -> None:
     if _is_empty_value(value):
         output["chanlocs"] = []
         return
-    if isinstance(value, str):
-        if value.strip() == "[]":
+    if isinstance(value, (str, Path)):
+        if str(value).strip() == "[]":
             output["chanlocs"] = []
             return
         path = _existing_path(value)
         if path is None:
+            if _looks_like_path(value):
+                raise FileNotFoundError(f"pop_editset channel-location file not found: {value}")
             raise ValueError(
                 "pop_editset cannot evaluate MATLAB workspace expressions for chanlocs; "
                 "pass channel-location structures directly or provide a file path."
@@ -267,20 +289,22 @@ def _assign_chanlocs(output: dict[str, Any], value: Any) -> None:
     output["chanlocs"] = copy.deepcopy(value)
 
 
-def _assign_ica_matrix(output: dict[str, Any], key: str, value: Any) -> None:
+def _assign_ica_matrix(output: dict[str, Any], key: str, value: Any, *, dataformat: str = "auto") -> None:
     if _is_empty_value(value):
         output[key] = np.array([])
-    elif isinstance(value, str):
-        if value.strip() == "[]":
+    elif isinstance(value, (str, Path)):
+        if str(value).strip() == "[]":
             output[key] = np.array([])
         else:
             path = _existing_path(value)
             if path is None:
+                if _looks_like_path(value):
+                    raise FileNotFoundError(f"pop_editset {key} file not found: {value}")
                 raise ValueError(
                     f"pop_editset cannot evaluate MATLAB workspace expressions for {key}; "
                     "pass a Python array directly or provide a matrix file path."
                 )
-            output[key] = _load_matrix_file(path, output)
+            output[key] = _load_matrix_file(path, output, dataformat=dataformat)
     else:
         output[key] = np.asarray(value)
     output["icawinv"] = np.array([])
@@ -294,9 +318,11 @@ def _assign_ica_matrix(output: dict[str, Any], key: str, value: Any) -> None:
 
 
 def _assign_data(output: dict[str, Any], value: Any, *, dataformat: str = "auto") -> None:
-    if isinstance(value, str):
+    if isinstance(value, (str, Path)):
         path = _existing_path(value)
         if path is None:
+            if _looks_like_path(value):
+                raise FileNotFoundError(f"pop_editset data file not found: {value}")
             raise ValueError(
                 "pop_editset cannot evaluate MATLAB workspace expressions for data; "
                 "pass a Python array directly or provide a data file path."
@@ -456,20 +482,24 @@ def _existing_path(value: Any) -> Path | None:
     return path if path.exists() else None
 
 
-def _is_existing_path(value: Any) -> bool:
-    return _existing_path(value) is not None
+def _looks_like_path(value: Any) -> bool:
+    if isinstance(value, Path):
+        return True
+    if not isinstance(value, str):
+        return False
+    text = str(value).strip()
+    if not text or text == "[]":
+        return False
+    return any(separator in text for separator in ("/", "\\")) or Path(text).suffix.lower() in _PATH_EXTENSIONS
 
 
-def _load_array_path(value: Any) -> np.ndarray:
-    path = _existing_path(value)
-    if path is None:
-        raise ValueError(f"pop_editset file not found: {value}")
-    return load_data_array(path, dataformat=infer_dataformat(path)).ravel()
+def _load_array_path(path: Path, *, dataformat: str = "auto") -> np.ndarray:
+    return load_data_array(path, dataformat=_resolved_dataformat(path, dataformat)).ravel()
 
 
-def _load_matrix_file(path: Path, output: dict[str, Any]) -> np.ndarray:
+def _load_matrix_file(path: Path, output: dict[str, Any], *, dataformat: str = "auto") -> np.ndarray:
     nbchan = int(output.get("nbchan", 0) or 0) or None
-    matrix = np.asarray(load_data_array(path, dataformat=infer_dataformat(path), nbchan=nbchan))
+    matrix = np.asarray(load_data_array(path, dataformat=_resolved_dataformat(path, dataformat), nbchan=nbchan))
     if matrix.ndim == 1:
         nbcol = int(np.asarray(output.get("icachansind", [])).size or output.get("nbchan", 0) or 0)
         if nbcol <= 0 or matrix.size % nbcol:
@@ -478,6 +508,10 @@ def _load_matrix_file(path: Path, output: dict[str, Any]) -> np.ndarray:
     if matrix.ndim != 2:
         raise ValueError("ICA matrix files must contain a 2-D array")
     return matrix
+
+
+def _resolved_dataformat(path: Path, dataformat: str) -> str:
+    return infer_dataformat(path, None if dataformat == "auto" else dataformat)
 
 
 def _parse_required_number(value: Any, key: str) -> float | int:

--- a/src/eegprep/functions/popfunc/pop_editset.py
+++ b/src/eegprep/functions/popfunc/pop_editset.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import logging
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -12,11 +13,13 @@ import numpy as np
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
+from eegprep.functions.popfunc._file_io import infer_dataformat, load_data_array
 from eegprep.functions.popfunc._pop_utils import (
     format_history_value,
     is_empty_value as _is_empty_value,
     parse_key_value_args,
 )
+from eegprep.functions.sigprocfunc.readlocs import readlocs
 
 
 logger = logging.getLogger(__name__)
@@ -27,6 +30,7 @@ _OPTIONAL_NUMERIC_FIELDS = ("run", "session")
 _DIRECT_ASSIGNMENT_FIELDS = ("chanlocs", "icaweights", "icasphere", "icachansind", "data")
 _SUPPORTED_FIELDS = {
     "ref",
+    "dataformat",
     *_TEXT_FIELDS,
     *_NUMERIC_FIELDS,
     *_OPTIONAL_NUMERIC_FIELDS,
@@ -72,8 +76,11 @@ def pop_editset(
     old_xmin = float(output.get("xmin", 0.0) or 0.0)
     old_srate = float(output.get("srate", 1.0) or 1.0)
 
+    dataformat = str(options.get("dataformat") or "auto")
     for key, value in options.items():
-        _assign_option(output, key, value)
+        if key == "dataformat":
+            continue
+        _assign_option(output, key, value, dataformat=dataformat)
 
     _normalize_data_dimensions(output, strict_pnts="pnts" in options)
     if "xmin" in options:
@@ -190,7 +197,7 @@ def _changed_options_from_gui(EEG: dict[str, Any], result: Mapping[str, Any]) ->
     return options
 
 
-def _assign_option(output: dict[str, Any], key: str, value: Any) -> None:
+def _assign_option(output: dict[str, Any], key: str, value: Any, *, dataformat: str = "auto") -> None:
     if key in _TEXT_FIELDS:
         output[key] = "" if value is None else str(value)
         return
@@ -222,10 +229,15 @@ def _assign_option(output: dict[str, Any], key: str, value: Any) -> None:
         _assign_ica_matrix(output, key, value)
         return
     if key == "icachansind":
-        output[key] = _as_int_array(value)
+        if isinstance(value, str) and value.strip() != "[]" and not _is_existing_path(value):
+            raise ValueError(
+                "pop_editset cannot evaluate MATLAB workspace expressions for icachansind; "
+                "pass Python indices directly or provide a numeric file path."
+            )
+        output[key] = _as_int_array(_load_array_path(value) if _is_existing_path(value) else value)
         return
     if key == "data":
-        _assign_data(output, value)
+        _assign_data(output, value, dataformat=dataformat)
 
 
 def _assign_chanlocs(output: dict[str, Any], value: Any) -> None:
@@ -236,7 +248,14 @@ def _assign_chanlocs(output: dict[str, Any], value: Any) -> None:
         if value.strip() == "[]":
             output["chanlocs"] = []
             return
-        raise NotImplementedError("pop_editset chanlocs file/workspace expressions are handled by pop_chanedit.")
+        path = _existing_path(value)
+        if path is None:
+            raise ValueError(
+                "pop_editset cannot evaluate MATLAB workspace expressions for chanlocs; "
+                "pass channel-location structures directly or provide a file path."
+            )
+        output["chanlocs"] = readlocs(path)
+        return
     if _looks_like_chanloc_package(value):
         package = list(value)
         output["chanlocs"] = copy.deepcopy(package[0])
@@ -255,7 +274,13 @@ def _assign_ica_matrix(output: dict[str, Any], key: str, value: Any) -> None:
         if value.strip() == "[]":
             output[key] = np.array([])
         else:
-            raise NotImplementedError(f"pop_editset {key} file/workspace expressions are not yet supported.")
+            path = _existing_path(value)
+            if path is None:
+                raise ValueError(
+                    f"pop_editset cannot evaluate MATLAB workspace expressions for {key}; "
+                    "pass a Python array directly or provide a matrix file path."
+                )
+            output[key] = _load_matrix_file(path, output)
     else:
         output[key] = np.asarray(value)
     output["icawinv"] = np.array([])
@@ -268,12 +293,22 @@ def _assign_ica_matrix(output: dict[str, Any], key: str, value: Any) -> None:
         output["icasphere"] = np.eye(np.asarray(output["icaweights"]).shape[1])
 
 
-def _assign_data(output: dict[str, Any], value: Any) -> None:
+def _assign_data(output: dict[str, Any], value: Any, *, dataformat: str = "auto") -> None:
     if isinstance(value, str):
-        raise NotImplementedError(
-            "pop_editset data file/workspace expressions are not supported; use pop_importdata instead."
+        path = _existing_path(value)
+        if path is None:
+            raise ValueError(
+                "pop_editset cannot evaluate MATLAB workspace expressions for data; "
+                "pass a Python array directly or provide a data file path."
+            )
+        data = load_data_array(
+            path,
+            dataformat=infer_dataformat(path, None if dataformat == "auto" else dataformat),
+            nbchan=int(output.get("nbchan", 0) or 0) or None,
         )
-    data = np.asarray(value)
+    else:
+        data = value
+    data = np.asarray(data)
     if data.ndim == 1:
         data = data.reshape(1, -1)
     if data.ndim not in {2, 3}:
@@ -398,10 +433,51 @@ def _history_value(value: Any) -> str:
     if isinstance(value, np.ndarray) and value.dtype == object:
         value = value.tolist()
     if isinstance(value, Mapping):
-        raise NotImplementedError("pop_editset history cannot serialize mapping values yet")
+        return _history_mapping(value)
     if isinstance(value, (list, tuple)) and any(isinstance(item, Mapping) for item in value):
-        raise NotImplementedError("pop_editset history cannot serialize channel-location structures yet")
+        return "[" + ", ".join(_history_value(item) for item in value) + "]"
     return format_history_value(value)
+
+
+def _history_mapping(value: Mapping[str, Any]) -> str:
+    pieces = []
+    for key, item in value.items():
+        pieces.append(f"{format_history_value(str(key))}: {_history_value(item)}")
+    return "{" + ", ".join(pieces) + "}"
+
+
+def _existing_path(value: Any) -> Path | None:
+    if not isinstance(value, (str, Path)):
+        return None
+    text = str(value).strip()
+    if not text or text == "[]":
+        return None
+    path = Path(text).expanduser()
+    return path if path.exists() else None
+
+
+def _is_existing_path(value: Any) -> bool:
+    return _existing_path(value) is not None
+
+
+def _load_array_path(value: Any) -> np.ndarray:
+    path = _existing_path(value)
+    if path is None:
+        raise ValueError(f"pop_editset file not found: {value}")
+    return load_data_array(path, dataformat=infer_dataformat(path)).ravel()
+
+
+def _load_matrix_file(path: Path, output: dict[str, Any]) -> np.ndarray:
+    nbchan = int(output.get("nbchan", 0) or 0) or None
+    matrix = np.asarray(load_data_array(path, dataformat=infer_dataformat(path), nbchan=nbchan))
+    if matrix.ndim == 1:
+        nbcol = int(np.asarray(output.get("icachansind", [])).size or output.get("nbchan", 0) or 0)
+        if nbcol <= 0 or matrix.size % nbcol:
+            raise ValueError(f"pop_editset cannot infer matrix shape for {path}")
+        matrix = matrix.reshape(matrix.size // nbcol, nbcol)
+    if matrix.ndim != 2:
+        raise ValueError("ICA matrix files must contain a 2-D array")
+    return matrix
 
 
 def _parse_required_number(value: Any, key: str) -> float | int:

--- a/src/eegprep/functions/popfunc/pop_eegfilt.py
+++ b/src/eegprep/functions/popfunc/pop_eegfilt.py
@@ -56,8 +56,8 @@ def pop_eegfilt(
     if locutoff == 0 and hicutoff == 0:
         return (EEG, "") if return_com else EEG
     if usefft:
-        raise NotImplementedError(
-            "Legacy pop_eegfilt FFT filtering is not implemented. "
+        raise ValueError(
+            "Legacy pop_eegfilt FFT filtering is not a standalone EEGPrep path. "
             "Use pop_eegfiltnew(..., usefftfilt=True) for frequency-domain FIR filtering."
         )
 

--- a/src/eegprep/functions/popfunc/pop_envtopo.py
+++ b/src/eegprep/functions/popfunc/pop_envtopo.py
@@ -35,8 +35,9 @@ def pop_envtopo(
         return (None, "") if return_com else None
     if isinstance(EEG, list):
         if len(EEG) != 1:
-            raise NotImplementedError(
-                "pop_envtopo currently accepts one dataset; multi-dataset envelopes are Phase 5 work"
+            raise ValueError(
+                "pop_envtopo accepts one dataset in EEGPrep; multi-dataset envelope comparison is not a "
+                "standalone runtime workflow."
             )
         dataset = EEG[0]
     else:

--- a/src/eegprep/functions/popfunc/pop_epoch.py
+++ b/src/eegprep/functions/popfunc/pop_epoch.py
@@ -6,6 +6,7 @@ import copy
 import logging
 import re
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -13,6 +14,7 @@ import numpy as np
 from eegprep.functions.adminfunc.eeg_checkset import eeg_checkset
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import CallbackSpec, ControlSpec, DialogSpec
+from eegprep.functions.popfunc._file_io import infer_dataformat, load_data_array
 from eegprep.functions.popfunc._pop_utils import (
     format_history_value,
     parse_key_value_args,
@@ -181,7 +183,8 @@ def _pop_epoch_one(
     if not any("latency" in event for event in events):
         raise ValueError("Absent latency field in event array/structure: must name one of the fields 'latency'")
     if isinstance(EEG.get("data"), str):
-        raise NotImplementedError("Data loading from file not implemented")
+        EEG = copy.deepcopy(EEG)
+        EEG["data"] = _load_filename_backed_data(EEG)
 
     data = np.asarray(EEG.get("data"))
     if data.ndim not in {2, 3}:
@@ -622,3 +625,24 @@ def _is_boundary_event(event: dict[str, Any]) -> bool:
 
 def _is_multiple(EEG: Any) -> bool:
     return isinstance(EEG, list) and len(EEG) > 1
+
+
+def _load_filename_backed_data(EEG: dict[str, Any]) -> np.ndarray:
+    filename = str(EEG.get("data") or "").strip()
+    if not filename:
+        raise ValueError("pop_epoch: filename-backed EEG.data is empty")
+    path = Path(filename).expanduser()
+    if not path.is_absolute():
+        filepath = str(EEG.get("filepath") or "").strip()
+        if filepath:
+            path = Path(filepath).expanduser() / path
+    if not path.exists():
+        raise FileNotFoundError(f"pop_epoch: filename-backed EEG.data file not found: {path}")
+    dataformat = infer_dataformat(path, str(EEG.get("dataformat") or "") or None)
+    data = load_data_array(path, dataformat=dataformat, nbchan=int(EEG.get("nbchan", 0) or 0) or None)
+    array = np.asarray(data)
+    pnts = int(EEG.get("pnts", 0) or 0)
+    trials = int(EEG.get("trials", 1) or 1)
+    if array.ndim == 2 and pnts > 0 and trials > 1 and array.shape[1] == pnts * trials:
+        array = array.reshape(array.shape[0], trials, pnts).transpose(0, 2, 1)
+    return array

--- a/src/eegprep/functions/popfunc/pop_erpimage.py
+++ b/src/eegprep/functions/popfunc/pop_erpimage.py
@@ -16,6 +16,7 @@ from eegprep.functions.popfunc._plot_utils import (
     eeg_times_ms,
     history_command,
     numeric_vector,
+    parse_plot_options_text,
 )
 from eegprep.functions.sigprocfunc.erpimage import erpimage
 
@@ -49,6 +50,19 @@ def pop_erpimage(
     projchan = kwargs.pop("projchan", None)
     values = _erpimage_values(EEG, typeplot, int(index), projchan=projchan)
     times = eeg_times_ms(EEG)
+    sort_values = kwargs.pop("sort_values", None)
+    sorting_field = kwargs.pop("sortingeventfield", kwargs.pop("field", ""))
+    sorting_type = kwargs.pop("sortingtype", kwargs.pop("type", []))
+    sorting_window = kwargs.pop("sortingwin", kwargs.pop("eventrange", []))
+    renorm = kwargs.pop("renorm", "no")
+    if sorting_field:
+        sort_values = _event_sort_values(EEG, sorting_field, sorting_type, sorting_window, renorm)
+    if _is_on(kwargs.pop("nosort", False)):
+        sort_values = None
+    kwargs.pop("noplot", None)
+    align = numeric_vector(kwargs.pop("align", []))
+    if align.size:
+        raise ValueError("pop_erpimage event alignment is not available in EEGPrep's standalone ERP image plot")
     limits = numeric_vector(kwargs.pop("limits", []))
     if limits.size == 2:
         mask = (times >= limits[0]) & (times <= limits[1])
@@ -60,7 +74,7 @@ def pop_erpimage(
         values,
         times=times,
         title=str(kwargs.pop("title", _default_title(typeplot, int(index), projchan=projchan))),
-        sort_values=kwargs.pop("sort_values", None),
+        sort_values=sort_values,
         smooth=kwargs.pop("smooth", None),
         decimate=_first_int(kwargs.pop("decimate", None), default=1),
         caxis=kwargs.pop("caxis", None),
@@ -252,6 +266,7 @@ def _run_gui(EEG: dict[str, Any], *, typeplot: int, renderer: Any | None = None)
     if result is None:
         return None
     _raise_for_unsupported_gui_options(result)
+    other_options = _normalise_other_options(result.get("others", ""))
     values = numeric_vector(result.get("index", 1), dtype=int)
     options = {
         "title": str(result.get("title", "") or ""),
@@ -263,6 +278,23 @@ def _run_gui(EEG: dict[str, Any], *, typeplot: int, renderer: Any | None = None)
         "caxis": numeric_vector(result.get("caxis", [])).tolist(),
         "vert": numeric_vector(result.get("vert", [])).tolist(),
     }
+    field = str(result.get("field", "") or "").strip()
+    if field:
+        options["sortingeventfield"] = field
+        event_type = str(result.get("type", "") or "").strip()
+        if event_type:
+            options["sortingtype"] = _parse_event_type_text(event_type)
+        eventrange = numeric_vector(result.get("eventrange", [])).tolist()
+        if eventrange:
+            options["sortingwin"] = eventrange
+        renorm = str(result.get("renorm", "") or "no").strip()
+        if renorm and renorm.lower() != "no":
+            options["renorm"] = renorm
+    if bool(result.get("nosort", False)):
+        options["nosort"] = True
+    if bool(result.get("noplot", False)):
+        options["noplot"] = True
+    options.update(other_options)
     projchan = numeric_vector(result.get("projchan", []), dtype=int)
     if projchan.size:
         options["projchan"] = projchan.tolist()
@@ -313,9 +345,6 @@ def _first_int(value: Any, *, default: int) -> int:
 
 def _raise_for_unsupported_gui_options(result: dict[str, Any]) -> None:
     unsupported_text_fields = {
-        "field": "event-field sorting",
-        "type": "event-type sorting",
-        "eventrange": "event-window sorting",
         "align": "event alignment",
         "phase": "phase sorting",
         "phase2": "phase sorting",
@@ -326,26 +355,150 @@ def _raise_for_unsupported_gui_options(result: dict[str, Any]) -> None:
         "limcoher": "inter-trial coherence limits",
         "spec": "spectrum inset",
         "limbaseamp": "baseline amplitude limits",
-        "others": "free-form erpimage options",
     }
     for field, label in unsupported_text_fields.items():
         if str(result.get(field, "") or "").strip():
-            raise NotImplementedError(f"pop_erpimage does not yet support {label}")
+            raise ValueError(f"pop_erpimage {label} is not available in EEGPrep's standalone ERP image plot")
     unsupported_checks = {
-        "nosort": "value-sort disabling",
-        "noplot": "value-plot disabling",
         "plotamps": "amplitude image mode",
     }
     for field, label in unsupported_checks.items():
         if bool(result.get(field, False)):
-            raise NotImplementedError(f"pop_erpimage does not yet support {label}")
+            raise ValueError(f"pop_erpimage {label} is not available in EEGPrep's standalone ERP image plot")
 
 
 def _raise_for_unsupported_kwargs(kwargs: dict[str, Any]) -> None:
-    supported = {"title", "sort_values", "smooth", "decimate", "limits", "caxis", "cbar", "erp", "vert", "projchan"}
+    supported = {
+        "title",
+        "sort_values",
+        "smooth",
+        "decimate",
+        "limits",
+        "caxis",
+        "cbar",
+        "erp",
+        "vert",
+        "projchan",
+        "sortingeventfield",
+        "sortingtype",
+        "sortingwin",
+        "field",
+        "type",
+        "eventrange",
+        "renorm",
+        "nosort",
+        "noplot",
+        "align",
+    }
     unsupported = sorted(set(kwargs) - supported)
     if unsupported:
-        raise NotImplementedError(f"pop_erpimage does not yet support option(s): {', '.join(unsupported)}")
+        raise ValueError(
+            "pop_erpimage option(s) are not available in EEGPrep's standalone ERP image plot: " + ", ".join(unsupported)
+        )
+
+
+def _event_sort_values(EEG: dict[str, Any], field: Any, event_types: Any, eventrange: Any, renorm: Any) -> np.ndarray:
+    field_name = str(field).strip()
+    if not field_name:
+        return np.asarray([])
+    if str(renorm).strip().lower() not in {"", "no", "yes"}:
+        raise ValueError("pop_erpimage renorm formulas are not available in EEGPrep; use 'yes' or 'no'")
+    trials = int(EEG.get("trials", 1) or 1)
+    pnts = int(EEG.get("pnts", 0) or 0)
+    srate = float(EEG.get("srate", 1) or 1)
+    xmin = float(EEG.get("xmin", 0) or 0)
+    types = _event_type_set(event_types)
+    window = numeric_vector(eventrange)
+    if window.size not in {0, 2}:
+        raise ValueError("sortingwin/eventrange must contain [start end] in milliseconds")
+    values = np.full(trials, np.nan)
+    for event in _event_records(EEG.get("event")):
+        epoch = _event_epoch(event, pnts)
+        if epoch < 1 or epoch > trials:
+            continue
+        if types and str(event.get("type", "")) not in types:
+            continue
+        latency_ms = _event_latency_ms(event, epoch, pnts, srate, xmin)
+        if window.size == 2 and not (window[0] <= latency_ms <= window[1]):
+            continue
+        if not np.isnan(values[epoch - 1]):
+            continue
+        raw_value = latency_ms if field_name == "latency" else event.get(field_name, np.nan)
+        try:
+            values[epoch - 1] = float(raw_value)
+        except (TypeError, ValueError):
+            values[epoch - 1] = np.nan
+    if np.all(np.isnan(values)):
+        raise ValueError("pop_erpimage event sorting found no matching event values")
+    if str(renorm).strip().lower() == "yes":
+        finite = np.isfinite(values)
+        if np.any(finite):
+            minimum = float(np.nanmin(values))
+            maximum = float(np.nanmax(values))
+            if maximum > minimum:
+                values[finite] = (values[finite] - minimum) / (maximum - minimum)
+    return values
+
+
+def _event_records(events: Any) -> list[dict[str, Any]]:
+    if events is None:
+        return []
+    if isinstance(events, np.ndarray):
+        events = events.tolist()
+    if isinstance(events, dict):
+        return [dict(events)]
+    return [dict(event) for event in events]
+
+
+def _event_epoch(event: dict[str, Any], pnts: int) -> int:
+    if event.get("epoch") not in (None, ""):
+        return int(float(event["epoch"]))
+    if pnts <= 0:
+        return 1
+    return int(np.floor((float(event.get("latency", 1)) - 1) / pnts)) + 1
+
+
+def _event_latency_ms(event: dict[str, Any], epoch: int, pnts: int, srate: float, xmin: float) -> float:
+    latency = float(event.get("latency", 1))
+    sample_in_epoch = latency - (epoch - 1) * pnts
+    return ((sample_in_epoch - 1) / srate + xmin) * 1000.0
+
+
+def _event_type_set(value: Any) -> set[str]:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return set()
+    if isinstance(value, np.ndarray):
+        value = value.ravel().tolist()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value}
+    return {str(value)}
+
+
+def _parse_event_type_text(text: str) -> list[str]:
+    return [token.strip("'\"") for token in text.replace(",", " ").split() if token.strip("'\"")]
+
+
+def _normalise_other_options(text: Any) -> dict[str, Any]:
+    parsed = parse_plot_options_text(text)
+    options: dict[str, Any] = {}
+    aliases = {"avewidth": "smooth", "limit": "limits"}
+    for key, value in parsed.items():
+        normalised = aliases.get(key, key)
+        if normalised in {"erp", "cbar", "nosort", "noplot"}:
+            options[normalised] = _is_on(value)
+        elif normalised in {"title", "smooth", "decimate", "limits", "caxis", "vert"}:
+            options[normalised] = value
+        else:
+            raise ValueError(f"pop_erpimage More options does not support '{key}' in EEGPrep")
+    return options
+
+
+def _is_on(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "yes", "true", "1"}
+    if isinstance(value, np.ndarray):
+        return bool(value.size and np.asarray(value).ravel()[0])
+    return bool(value)
 
 
 __all__ = ["pop_erpimage", "pop_erpimage_dialog_spec"]

--- a/src/eegprep/functions/popfunc/pop_erpimage.py
+++ b/src/eegprep/functions/popfunc/pop_erpimage.py
@@ -412,13 +412,14 @@ def _event_sort_values(EEG: dict[str, Any], field: Any, event_types: Any, eventr
     if window.size not in {0, 2}:
         raise ValueError("sortingwin/eventrange must contain [start end] in milliseconds")
     values = np.full(trials, np.nan)
+    needs_latency = window.size == 2 or field_name == "latency"
     for event in _event_records(EEG.get("event")):
         epoch = _event_epoch(event, pnts)
         if epoch < 1 or epoch > trials:
             continue
         if types and str(event.get("type", "")) not in types:
             continue
-        latency_ms = _event_latency_ms(event, epoch, pnts, srate, xmin)
+        latency_ms = _event_latency_ms(event, epoch, pnts, srate, xmin) if needs_latency else np.nan
         if window.size == 2 and not (window[0] <= latency_ms <= window[1]):
             continue
         if not np.isnan(values[epoch - 1]):

--- a/src/eegprep/functions/popfunc/pop_export.py
+++ b/src/eegprep/functions/popfunc/pop_export.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 import csv
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -11,6 +13,17 @@ import numpy as np
 from eegprep.functions.miscfunc.misc import finite_matmul
 from eegprep.functions.popfunc._file_io import channel_labels
 from eegprep.functions.popfunc._pop_utils import format_history_value, parse_key_value_args
+
+
+_EXPORT_EXPR_FUNCTIONS = {
+    "abs": np.abs,
+    "clip": np.clip,
+    "exp": np.exp,
+    "log": np.log,
+    "log10": np.log10,
+    "nan_to_num": np.nan_to_num,
+    "sqrt": np.sqrt,
+}
 
 
 def pop_export(EEG: dict[str, Any], filename: str | Path, *args: Any, **kwargs: Any) -> str:
@@ -22,7 +35,9 @@ def pop_export(EEG: dict[str, Any], filename: str | Path, *args: Any, **kwargs: 
     elif data.ndim == 3:
         data = data.reshape((data.shape[0], data.shape[1] * data.shape[2]))
     if options.get("expr"):
-        raise NotImplementedError("pop_export expr is not supported in EEGPrep yet")
+        data = _apply_expression(data, str(options["expr"]))
+        if data.ndim == 3:
+            data = data.reshape((data.shape[0], data.shape[1] * data.shape[2]))
     if _is_on(options.get("time", "on")):
         time = np.tile(
             np.linspace(float(EEG.get("xmin", 0)), float(EEG.get("xmax", 0)), int(EEG["pnts"]))
@@ -72,13 +87,117 @@ def _format_row(row: np.ndarray, precision: int) -> list[str]:
     return [f"{float(value):.{precision}g}" for value in row]
 
 
+def _apply_expression(data: np.ndarray, expression: str) -> np.ndarray:
+    text = expression.strip().rstrip(";")
+    if not text:
+        return data
+    expression_node = _parse_expression(text)
+    _validate_expression(expression_node)
+    functions = SimpleNamespace(**_EXPORT_EXPR_FUNCTIONS)
+    namespace = {"x": data, "np": functions, "numpy": functions, **_EXPORT_EXPR_FUNCTIONS}
+    try:
+        compiled = compile(ast.fix_missing_locations(ast.Expression(expression_node)), "<pop_export expr>", "eval")
+        evaluated = eval(compiled, {"__builtins__": {}}, namespace)
+    except Exception as exc:
+        raise ValueError(f"pop_export expr could not be evaluated: {exc}") from exc
+    output = np.asarray(evaluated)
+    if output.ndim not in {2, 3}:
+        raise ValueError("pop_export expr must leave x as a 2-D or 3-D array")
+    return output
+
+
+def _parse_expression(source: str) -> ast.expr:
+    try:
+        tree = ast.parse(source, mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(f"pop_export expr is not a valid Python expression: {exc.msg}") from exc
+    if len(tree.body) != 1:
+        raise ValueError("pop_export expr must contain one expression or x assignment")
+    statement = tree.body[0]
+    if isinstance(statement, ast.Expr):
+        return statement.value
+    if isinstance(statement, ast.Assign):
+        if len(statement.targets) != 1 or not isinstance(statement.targets[0], ast.Name):
+            raise ValueError("pop_export expr may only assign to x")
+        if statement.targets[0].id != "x":
+            raise ValueError("pop_export expr may only assign to x")
+        return statement.value
+    raise ValueError("pop_export expr must contain one expression or x assignment")
+
+
+def _validate_expression(tree: ast.expr) -> None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            _validate_expression_call(node)
+            continue
+        if isinstance(node, ast.Attribute):
+            if _allowed_numpy_attribute(node):
+                continue
+            raise ValueError(f"pop_export expr contains unsupported syntax: {type(node).__name__}")
+        if isinstance(node, ast.Name):
+            if node.id not in {"x", "np", "numpy", *_EXPORT_EXPR_FUNCTIONS}:
+                raise ValueError(f"pop_export expr references unknown name: {node.id}")
+            continue
+        if isinstance(
+            node,
+            (
+                ast.Load,
+                ast.Constant,
+                ast.UnaryOp,
+                ast.BinOp,
+                ast.BoolOp,
+                ast.Compare,
+                ast.IfExp,
+                ast.Subscript,
+                ast.Slice,
+                ast.Tuple,
+                ast.List,
+                ast.Add,
+                ast.Sub,
+                ast.Mult,
+                ast.Div,
+                ast.FloorDiv,
+                ast.Mod,
+                ast.Pow,
+                ast.MatMult,
+                ast.UAdd,
+                ast.USub,
+                ast.Not,
+                ast.And,
+                ast.Or,
+                ast.Eq,
+                ast.NotEq,
+                ast.Lt,
+                ast.LtE,
+                ast.Gt,
+                ast.GtE,
+            ),
+        ):
+            continue
+        raise ValueError(f"pop_export expr contains unsupported syntax: {type(node).__name__}")
+
+
+def _validate_expression_call(node: ast.Call) -> None:
+    if node.keywords:
+        raise ValueError("pop_export expr function calls do not support keyword arguments")
+    if isinstance(node.func, ast.Name) and node.func.id in _EXPORT_EXPR_FUNCTIONS:
+        return
+    if isinstance(node.func, ast.Attribute) and _allowed_numpy_attribute(node.func):
+        return
+    raise ValueError("pop_export expr only supports arithmetic and selected NumPy numeric functions")
+
+
+def _allowed_numpy_attribute(node: ast.Attribute) -> bool:
+    return isinstance(node.value, ast.Name) and node.value.id in {"np", "numpy"} and node.attr in _EXPORT_EXPR_FUNCTIONS
+
+
 def _is_on(value: Any) -> bool:
     return str(value).lower() in {"on", "yes", "true", "1"}
 
 
 def _history_command(filename: str | Path, options: dict[str, Any]) -> str:
     pieces = [format_history_value(str(filename))]
-    for key in ["ica", "time", "timeunit", "elec", "transpose", "erp", "precision", "separator"]:
+    for key in ["ica", "time", "timeunit", "elec", "transpose", "erp", "expr", "precision", "separator"]:
         if key in options:
             pieces.extend([format_history_value(key), format_history_value(options[key])])
     return f"LASTCOM = pop_export(EEG, {', '.join(pieces)});"

--- a/src/eegprep/functions/popfunc/pop_export.py
+++ b/src/eegprep/functions/popfunc/pop_export.py
@@ -24,6 +24,11 @@ _EXPORT_EXPR_FUNCTIONS = {
     "nan_to_num": np.nan_to_num,
     "sqrt": np.sqrt,
 }
+_EXPORT_EXPR_KEYWORDS = {
+    "clip": {"a_min", "a_max", "max", "min"},
+    "nan_to_num": {"nan", "neginf", "posinf"},
+}
+_MAX_POWER_EXPONENT = 12
 
 
 def pop_export(EEG: dict[str, Any], filename: str | Path, *args: Any, **kwargs: Any) -> str:
@@ -130,6 +135,9 @@ def _validate_expression(tree: ast.expr) -> None:
         if isinstance(node, ast.Call):
             _validate_expression_call(node)
             continue
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow):
+            _validate_power_exponent(node.right)
+            continue
         if isinstance(node, ast.Attribute):
             if _allowed_numpy_attribute(node):
                 continue
@@ -152,6 +160,7 @@ def _validate_expression(tree: ast.expr) -> None:
                 ast.Slice,
                 ast.Tuple,
                 ast.List,
+                ast.keyword,
                 ast.Add,
                 ast.Sub,
                 ast.Mult,
@@ -178,13 +187,53 @@ def _validate_expression(tree: ast.expr) -> None:
 
 
 def _validate_expression_call(node: ast.Call) -> None:
-    if node.keywords:
-        raise ValueError("pop_export expr function calls do not support keyword arguments")
-    if isinstance(node.func, ast.Name) and node.func.id in _EXPORT_EXPR_FUNCTIONS:
-        return
-    if isinstance(node.func, ast.Attribute) and _allowed_numpy_attribute(node.func):
+    name = _expression_call_name(node.func)
+    if name in _EXPORT_EXPR_FUNCTIONS:
+        _validate_expression_keywords(name, node.keywords)
         return
     raise ValueError("pop_export expr only supports arithmetic and selected NumPy numeric functions")
+
+
+def _expression_call_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute) and _allowed_numpy_attribute(node):
+        return node.attr
+    return None
+
+
+def _validate_expression_keywords(function_name: str, keywords: list[ast.keyword]) -> None:
+    allowed = _EXPORT_EXPR_KEYWORDS.get(function_name, set())
+    for keyword in keywords:
+        if keyword.arg is None:
+            raise ValueError("pop_export expr does not support ** keyword expansion")
+        if keyword.arg not in allowed:
+            allowed_text = ", ".join(sorted(allowed)) or "none"
+            raise ValueError(
+                f"pop_export expr does not support keyword argument {keyword.arg!r} "
+                f"for {function_name}; allowed keywords: {allowed_text}"
+            )
+
+
+def _validate_power_exponent(node: ast.expr) -> None:
+    exponent = _literal_number(node)
+    if exponent is None:
+        raise ValueError("pop_export expr power exponents must be numeric constants")
+    if abs(exponent) > _MAX_POWER_EXPONENT:
+        raise ValueError(
+            f"pop_export expr power exponents must be between -{_MAX_POWER_EXPONENT} and {_MAX_POWER_EXPONENT}"
+        )
+
+
+def _literal_number(node: ast.expr) -> float | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int | float):
+        return float(node.value)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        value = _literal_number(node.operand)
+        if value is None:
+            return None
+        return value if isinstance(node.op, ast.UAdd) else -value
+    return None
 
 
 def _allowed_numpy_attribute(node: ast.Attribute) -> bool:

--- a/src/eegprep/functions/popfunc/pop_runica.py
+++ b/src/eegprep/functions/popfunc/pop_runica.py
@@ -47,6 +47,7 @@ def pop_runica(
     parsed = _parse_runica_args(args, kwargs)
     has_programmatic_options = bool(parsed)
     icatype = _normalise_icatype(parsed.pop("icatype", icatype))
+    has_programmatic_options = has_programmatic_options or icatype != "runica"
     options = parsed.pop("options", options)
     reorder = parsed.pop("reorder", reorder)
     chanind = parsed.pop("chanind", chanind)

--- a/src/eegprep/functions/popfunc/pop_runscript.py
+++ b/src/eegprep/functions/popfunc/pop_runscript.py
@@ -19,7 +19,9 @@ def pop_runscript(filename: str | Path, namespace: dict[str, Any] | None = None)
         exec_globals = {} if namespace is None else namespace
         exec(path.read_text(encoding="utf-8"), exec_globals)
     elif path.suffix.lower() in {".m", ".txt"}:
-        raise NotImplementedError("EEGPrep can only run Python history scripts; MATLAB/text scripts are not supported")
+        raise ValueError(
+            "EEGPrep can only run Python history scripts; MATLAB/text history replay is not a standalone runtime feature"
+        )
     else:
         raise ValueError("History scripts must be .py, .m, or .txt files")
     return f"LASTCOM = pop_runscript({format_history_value(path)});"

--- a/src/eegprep/functions/sigprocfunc/coregister.py
+++ b/src/eegprep/functions/sigprocfunc/coregister.py
@@ -322,9 +322,7 @@ def estimate_coregistration_transform(
     target_points = target.points[target_indices]
     method = method.lower()
     if method not in {"traditional", "globalrescale"}:
-        raise NotImplementedError(
-            "EEGPrep coregistration supports standalone 'traditional' and 'globalrescale' alignment"
-        )
+        raise ValueError("EEGPrep coregistration supports standalone 'traditional' and 'globalrescale' alignment")
     initial_transform = _initial_transform(source_points, target_points)
     if initial is not None:
         user_initial = _canonicalise_fit_transform(

--- a/src/eegprep/functions/sigprocfunc/headplot.py
+++ b/src/eegprep/functions/sigprocfunc/headplot.py
@@ -10,6 +10,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm, colors
+from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from scipy.io import loadmat, savemat
 from scipy.special import eval_legendre
@@ -127,20 +128,14 @@ def headplot_setup(
     comment: str = "",
     orilocs: str = "off",
     plotmeshonly: str = "off",
-) -> Path:
+) -> Path | Figure:
     """Create an EEGLAB-compatible ``.spl`` spline setup file.
 
     The generated file is a MATLAB ``.mat`` file with the conventional
     ``.spl`` extension. It contains the spline matrices and transformed
     electrode positions needed for later :func:`headplot` calls.
     """
-    if str(plotmeshonly).lower() != "off":
-        raise NotImplementedError("headplot plotmeshonly preview is not yet available in EEGPrep")
-    if str(orilocs).lower() != "off":
-        raise NotImplementedError("headplot setup with original unprojected locations is not yet available in EEGPrep")
-
-    output = _normalise_spline_path(splinefile)
-    output.parent.mkdir(parents=True, exist_ok=True)
+    preview_mode = _normalise_plotmeshonly(plotmeshonly)
     locs = chanlocs_as_list(chanlocs)
     if not locs:
         raise ValueError("headplot setup requires channel locations")
@@ -157,10 +152,18 @@ def headplot_setup(
     sphere_vertices = _mesh_unit_sphere(mesh)
     g_matrix = _spherical_spline_matrix(unit_electrodes)
     gx = _spherical_spline_between(sphere_vertices[mesh.scalp_indices], unit_electrodes)
-    new_electrodes = _project_electrodes_to_mesh(
-        unit_electrodes, mesh.vertices[mesh.scalp_indices], sphere_vertices[mesh.scalp_indices]
-    )
+    if _is_on(orilocs):
+        new_electrodes = unit_electrodes
+    else:
+        new_electrodes = _project_electrodes_to_mesh(
+            unit_electrodes, mesh.vertices[mesh.scalp_indices], sphere_vertices[mesh.scalp_indices]
+        )
 
+    if preview_mode is not None:
+        return _plot_mesh_preview(mesh, sphere_vertices, unit_electrodes, new_electrodes, labels, preview_mode)
+
+    output = _normalise_spline_path(splinefile)
+    output.parent.mkdir(parents=True, exist_ok=True)
     savemat(
         output,
         {
@@ -487,6 +490,45 @@ def _project_electrodes_to_mesh(
         delta = np.mean(mesh_vertices[nearest] - sphere_vertices[nearest], axis=0)
         projected.append(electrode + delta * ELECTRODE_DISPLAY_FACTOR)
     return np.asarray(projected, dtype=float)
+
+
+def _normalise_plotmeshonly(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if text in {"", "0", "off", "false", "no"}:
+        return None
+    if text in {"1", "on", "true", "yes", "head", "mesh"}:
+        return "head"
+    if text == "sphere":
+        return "sphere"
+    raise ValueError("headplot plotmeshonly must be 'off', 'head', or 'sphere'")
+
+
+def _plot_mesh_preview(
+    mesh: HeadplotMesh,
+    sphere_vertices: np.ndarray,
+    unit_electrodes: np.ndarray,
+    new_electrodes: np.ndarray,
+    labels: list[str],
+    mode: str,
+) -> Figure:
+    fig = plt.figure(figsize=(5.6, 5.2))
+    ax = fig.add_subplot(111, projection="3d")
+    vertices = sphere_vertices if mode == "sphere" else mesh.vertices
+    electrodes = unit_electrodes if mode == "sphere" else new_electrodes
+    collection = Poly3DCollection(vertices[mesh.faces], facecolors=HEADPLOT_FACE_COLOR, linewidths=0.15)
+    collection.set_edgecolor("0.45")
+    ax.add_collection3d(collection)
+    ax.scatter(electrodes[:, 0], electrodes[:, 1], electrodes[:, 2], color="black", s=14, depthshade=False)
+    for label, point in zip(labels, electrodes):
+        ax.text(point[0] * 1.04, point[1] * 1.04, point[2] * 1.04, label, fontsize=8)
+    _autoscale_3d(ax, vertices)
+    _set_view(ax, [143, 18])
+    ax.set_axis_off()
+    ax.set_box_aspect((1, 1, 1))
+    fig.tight_layout()
+    return fig
 
 
 def _values_for_spline(values: Any, spline: HeadplotSpline) -> np.ndarray:

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -18,6 +18,11 @@ from ...functions.popfunc.eeg_eegrej import eeg_eegrej
 
 
 logger = logging.getLogger(__name__)
+_DISTANCE_MODES = {
+    'euclidian': None,
+    'euclidean': None,
+    'riemannian': 'calib',
+}
 
 # -----------------------------------------------------------------------------
 #                               Public API
@@ -137,6 +142,10 @@ def clean_artifacts(
     if Channels is not None and Channels_ignore is not None and len(Channels) and len(Channels_ignore):
         raise ValueError('"Channels" and "Channels_ignore" are mutually exclusive – supply at most one.')
 
+    distance = str(Distance).strip().lower()
+    if distance not in _DISTANCE_MODES:
+        raise ValueError("Distance must be 'euclidian', 'euclidean', or 'riemannian'")
+
     # Ensure some obligatory fields exist in the structure (MATLAB code assumes)
     if 'etc' not in EEG:
         EEG['etc'] = {}
@@ -233,8 +242,7 @@ def clean_artifacts(
         # MATLAB passes structs by value so the caller's EEG retains the
         # original data, but Python dicts are passed by reference.
         original_data = EEG['data'].copy() if BurstRejection else None
-        distance = str(Distance).strip().lower()
-        useriemannian = 'calib' if distance not in {'euclidian', 'euclidean'} else None
+        useriemannian = _DISTANCE_MODES[distance]
         BUR = clean_asr(
             EEG,
             cutoff=float(BurstCriterion),

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -107,7 +107,9 @@ def clean_artifacts(
     MaxMem : int
         Maximum memory in MB for ASR processing. Default 64.
     Distance : str
-        Distance metric for ASR processing ('euclidian'). Default 'euclidian'.
+        Distance metric for ASR calibration ('euclidian' or 'riemannian'). The
+        Riemannian path uses EEGPrep's calibration-time estimate; full
+        Riemannian ASR processing is not ported.
     Channels : sequence of str or None
         List of channel labels to include before cleaning (pop_select). Default None.
     Channels_ignore : sequence of str or None
@@ -231,27 +233,17 @@ def clean_artifacts(
         # MATLAB passes structs by value so the caller's EEG retains the
         # original data, but Python dicts are passed by reference.
         original_data = EEG['data'].copy() if BurstRejection else None
-        try:
-            BUR = clean_asr(
-                EEG,
-                cutoff=float(BurstCriterion),
-                ref_maxbadchannels=BurstCriterionRefMaxBadChns,
-                ref_tolerances=BurstCriterionRefTolerances,
-                use_gpu=False,
-                useriemannian=(Distance.lower() != 'euclidian'),
-                maxmem=int(MaxMem),
-            )
-        except NotImplementedError as e:
-            logger.warning(str(e))
-            BUR = clean_asr(
-                EEG,
-                cutoff=float(BurstCriterion),
-                ref_maxbadchannels=BurstCriterionRefMaxBadChns,
-                ref_tolerances=BurstCriterionRefTolerances,
-                use_gpu=False,
-                useriemannian=False,
-                maxmem=int(MaxMem),
-            )
+        distance = str(Distance).strip().lower()
+        useriemannian = 'calib' if distance not in {'euclidian', 'euclidean'} else None
+        BUR = clean_asr(
+            EEG,
+            cutoff=float(BurstCriterion),
+            ref_maxbadchannels=BurstCriterionRefMaxBadChns,
+            ref_tolerances=BurstCriterionRefTolerances,
+            use_gpu=False,
+            useriemannian=useriemannian,
+            maxmem=int(MaxMem),
+        )
 
         if BurstRejection:
             # Determine unchanged samples: compare original (pre-ASR) with repaired.

--- a/src/eegprep/plugins/clean_rawdata/clean_asr.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_asr.py
@@ -63,9 +63,8 @@ def clean_asr(
                                     for a channel to be considered 'bad' during calibration data selection. Default: (-3.5, 5.5). Use 'off' to disable.
         ref_wndlen (Union[float, str], optional): Window length in seconds for calibration data selection granularity. Default: 1.0. Use 'off' to disable.
         use_gpu (bool, optional): Whether to try using GPU (requires compatible hardware and libraries, currently ignored). Default: False.
-        useriemannian (str, optional): Option to use a Riemannian ASR variant. Can be set to 'calib' to use a Riemannian estimate
-            at calibration time; this make somewhat different statistical tradeoffs than the default, resulting in a somewhat different
-            baseline rejection threshold; as a result it is suggested to visually check results and adjust the cutoff as needed. Default: None (disabled).
+        useriemannian (str, optional): Option to use a Riemannian ASR variant. Set to 'calib' to use a Riemannian estimate
+            at calibration time. Full Riemannian ASR processing is not ported in EEGPrep. Default: None (disabled).
         maxmem (Optional[int], optional): Maximum memory in MB (passed to asr_calibrate/process, but chunking based on it is not implemented in Python port). Default: 64.
 
     Returns
@@ -74,12 +73,12 @@ def clean_asr(
 
     Raises
     ------
-    NotImplementedError : If useriemannian is True.
     ImportError : If automatic calibration data selection is needed (`ref_maxbadchannels` is float) but `clean_windows` cannot be imported.
-    ValueError : If input arguments are invalid or calibration fails critically.
+    ValueError : If input arguments are invalid, full Riemannian ASR processing is requested, or calibration fails critically.
     """
     if 'data' not in EEG or 'srate' not in EEG or 'nbchan' not in EEG:
         raise ValueError("EEG dictionary must contain 'data', 'srate', and 'nbchan'.")
+    useriemannian = _normalise_useriemannian(useriemannian)
 
     data = np.asarray(EEG['data'], dtype=np.float64)
     srate = float(EEG['srate'])
@@ -205,3 +204,23 @@ def clean_asr(
     logger.info('ASR cleaning finished.')
 
     return EEG
+
+
+def _normalise_useriemannian(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        if not value:
+            return None
+        raise ValueError("clean_asr supports useriemannian='calib' only; full Riemannian ASR processing is not ported.")
+    if isinstance(value, str):
+        lower = value.strip().lower()
+        if lower in {"", "0", "false", "no", "none", "off"}:
+            return None
+        if lower in {"calib", "calibration"}:
+            return "calib"
+        if lower in {"1", "true", "yes", "on", "all", "process", "riemannian"}:
+            raise ValueError(
+                "clean_asr supports useriemannian='calib' only; full Riemannian ASR processing is not ported."
+            )
+    raise ValueError("clean_asr useriemannian must be None, 'off', or 'calib'.")

--- a/src/eegprep/resources/help/clean_artifacts.md
+++ b/src/eegprep/resources/help/clean_artifacts.md
@@ -7,3 +7,7 @@ Usage:
 The clean_rawdata workflow can remove flatline channels, high-pass drift,
 noisy channels, ASR bursts, and bad windows. The pop_clean_rawdata GUI exposes
 the same major options as the EEGLAB clean_rawdata plugin.
+
+`Distance='Riemannian'` is supported as a calibration-time ASR option. EEGPrep
+does not implement full Riemannian ASR processing; use `clean_asr(...,
+useriemannian='calib')` for the supported standalone variant.

--- a/src/eegprep/resources/help/clean_artifacts.md
+++ b/src/eegprep/resources/help/clean_artifacts.md
@@ -8,6 +8,8 @@ The clean_rawdata workflow can remove flatline channels, high-pass drift,
 noisy channels, ASR bursts, and bad windows. The pop_clean_rawdata GUI exposes
 the same major options as the EEGLAB clean_rawdata plugin.
 
-`Distance='Riemannian'` is supported as a calibration-time ASR option. EEGPrep
-does not implement full Riemannian ASR processing; use `clean_asr(...,
-useriemannian='calib')` for the supported standalone variant.
+`Distance` accepts `Euclidian`, `Euclidean`, or `Riemannian`. `Riemannian` is
+supported as a calibration-time ASR option. EEGPrep does not implement full
+Riemannian ASR processing; use `clean_asr(..., useriemannian='calib')` for the
+supported standalone variant. Other distance names raise `ValueError` so typos
+do not silently change the ASR path.

--- a/src/eegprep/resources/help/coregister.md
+++ b/src/eegprep/resources/help/coregister.md
@@ -15,3 +15,9 @@ The manual editor follows the EEGLAB workflow:
 
 Press `Ok` to return the transform to the calling dialog, or `Cancel` to leave
 the original transform unchanged.
+
+Programmatic `coregister` supports standalone `traditional` and
+`globalrescale` fitting against common electrode labels. FieldTrip nonlinear,
+rigid-body-only, and MATLAB manual-editor routes are not runtime dependencies
+in EEGPrep; requests for unsupported methods fail clearly instead of invoking
+external MATLAB toolboxes.

--- a/src/eegprep/resources/help/pop_clean_rawdata.md
+++ b/src/eegprep/resources/help/pop_clean_rawdata.md
@@ -32,6 +32,10 @@ Behavior:
 
 - The function calls EEGPrep's `clean_artifacts` backend and returns a cleaned EEG dataset.
 - GUI choices are converted to the same named options used by the command-line API.
+- `Distance='Riemannian'` uses EEGPrep's calibration-time Riemannian ASR
+  estimate (`clean_asr(..., useriemannian='calib')`). Full Riemannian ASR
+  processing is not ported, and direct `clean_asr(useriemannian=True)` requests
+  raise a clear `ValueError`.
 - The "Pop up scrolling data window with rejected data highlighted" option is present for parity, but the viewer is not yet ported. When selected, EEGPrep shows a user-facing notification instead of silently doing nothing.
 
 Example:

--- a/src/eegprep/resources/help/pop_clean_rawdata.md
+++ b/src/eegprep/resources/help/pop_clean_rawdata.md
@@ -19,7 +19,7 @@ Inputs:
 - `WindowCriterionTolerances`: accepted channel RMS range for bad-window detection.
 - `Channels`: optional channel labels or indices to include.
 - `Channels_ignore`: optional channel labels or indices to ignore.
-- `Distance`: `'Euclidian'` or `'Riemannian'`.
+- `Distance`: `'Euclidian'`, `'Euclidean'`, or `'Riemannian'`.
 
 Graphical interface:
 
@@ -36,6 +36,8 @@ Behavior:
   estimate (`clean_asr(..., useriemannian='calib')`). Full Riemannian ASR
   processing is not ported, and direct `clean_asr(useriemannian=True)` requests
   raise a clear `ValueError`.
+- Other distance names are rejected so misspellings do not silently switch the
+  ASR calibration mode.
 - The "Pop up scrolling data window with rejected data highlighted" option is present for parity, but the viewer is not yet ported. When selected, EEGPrep shows a user-facing notification instead of silently doing nothing.
 
 Example:

--- a/src/eegprep/resources/help/pop_comperp.md
+++ b/src/eegprep/resources/help/pop_comperp.md
@@ -14,6 +14,10 @@ Supported options include dataset selection, channel/component subset, `mode`
 display toggles for added, subtracted, and difference averages, standard
 deviation traces, and per-dataset ERP traces.
 
+Standard-deviation traces follow EEGLAB `pop_comperp` semantics: the spread is
+computed across the selected datasets at each channel/time point, then displayed
+as a compact channel-averaged upper/lower trace in EEGPrep's Python plot.
+
 When `alpha` is supplied, EEGPrep runs deterministic t-tests across datasets
 and highlights significant time regions in the plot. A paired t-test is used
 when both `datadd` and `datsub` are supplied; otherwise added datasets are

--- a/src/eegprep/resources/help/pop_comperp.md
+++ b/src/eegprep/resources/help/pop_comperp.md
@@ -9,8 +9,17 @@ result, com = pop_comperp(ALLEEG, flag=1, datadd=[1, 2], return_com=True)
 `flag=1` uses channels. `flag=0` uses ICA components. Dataset indices are
 EEGLAB-facing and 1-based.
 
-The Phase 4 implementation wires dataset selection, channel/component subset,
-RMS mode, low-pass display filtering, and plottopo options. Statistical
-highlighting and the full EEGLAB checkbox matrix for all ERP/std display
-variants are intentionally deferred; selecting those unsupported options from
-the GUI raises a clear `NotImplementedError`.
+Supported options include dataset selection, channel/component subset, `mode`
+(`ave` or `rms`), `lowpass`, `title`, `tlim`, `ylim`, `alpha`, and the EEGLAB
+display toggles for added, subtracted, and difference averages, standard
+deviation traces, and per-dataset ERP traces.
+
+When `alpha` is supplied, EEGPrep runs deterministic t-tests across datasets
+and highlights significant time regions in the plot. A paired t-test is used
+when both `datadd` and `datsub` are supplied; otherwise added datasets are
+tested against zero. At least two datasets are required for significance
+testing.
+
+Unsupported option names now raise `ValueError` with the unsupported keys
+listed. STUDY-level ERP statistics and EEGLAB plot callbacks that depend on
+MATLAB workspace state remain outside this standalone wrapper.

--- a/src/eegprep/resources/help/pop_editset.md
+++ b/src/eegprep/resources/help/pop_editset.md
@@ -24,8 +24,15 @@ Common fields:
 Notes:
 
 - Changing `EEG.ref` only edits metadata; use `pop_reref` to re-reference data.
-- Channel-location and ICA file-picking workflows are handled by the channel
-  metadata phase. Programmatic direct assignments for `chanlocs`, `icaweights`,
-  `icasphere`, and `icachansind` are supported.
+- `data` may be assigned directly as a Python array or loaded from an existing
+  file path. Use `dataformat` to force the import format, or omit it to infer
+  from the extension.
+- `chanlocs` may be assigned directly as channel-location structures or loaded
+  from an existing channel-location file path supported by `readlocs`.
+- `icaweights`, `icasphere`, and `icachansind` may be assigned directly or
+  loaded from numeric file paths.
+- MATLAB workspace expressions such as `rawdata`, `locs`, or `icaweights`
+  are not evaluated by EEGPrep. Pass Python values directly or provide concrete
+  file paths so the command history is replayable in `eegprep-console`.
 
 See also: POP_COMMENTS, POP_REREF, POP_CHANEDIT

--- a/src/eegprep/resources/help/pop_editset.md
+++ b/src/eegprep/resources/help/pop_editset.md
@@ -30,7 +30,12 @@ Notes:
 - `chanlocs` may be assigned directly as channel-location structures or loaded
   from an existing channel-location file path supported by `readlocs`.
 - `icaweights`, `icasphere`, and `icachansind` may be assigned directly or
-  loaded from numeric file paths.
+  loaded from numeric file paths. The `dataformat` option also applies to these
+  numeric ICA file imports, which is useful when a file extension would
+  otherwise infer the wrong format.
+- Missing values that look like file paths raise a file-not-found error. Plain
+  names such as `rawdata` or `icaweights` are treated as unsupported MATLAB
+  workspace expressions.
 - MATLAB workspace expressions such as `rawdata`, `locs`, or `icaweights`
   are not evaluated by EEGPrep. Pass Python values directly or provide concrete
   file paths so the command history is replayable in `eegprep-console`.

--- a/src/eegprep/resources/help/pop_eegfilt.md
+++ b/src/eegprep/resources/help/pop_eegfilt.md
@@ -5,8 +5,9 @@ Legacy EEGLAB-style FIR filtering interface.
 `pop_eegfilt` is kept for menu and command-history compatibility. New EEGPrep
 workflows should prefer `pop_eegfiltnew` or the firfilt plugin wrappers.
 The legacy `firls` and `fir1` FIR design modes are supported. The old EEGLAB
-`usefft` fallback is not implemented; use `pop_eegfiltnew(..., usefftfilt=True)`
-for frequency-domain FIR filtering.
+`usefft` fallback is intentionally not ported in this legacy wrapper because
+EEGPrep already exposes the maintained frequency-domain path through
+`pop_eegfiltnew(..., usefftfilt=True)`.
 
 ```python
 EEG = pop_eegfilt(EEG, 1, 40)

--- a/src/eegprep/resources/help/pop_envtopo.md
+++ b/src/eegprep/resources/help/pop_envtopo.md
@@ -7,3 +7,8 @@ fig, com = pop_envtopo(EEG, timerange=[-100, 300], return_com=True)
 ```
 
 This requires epoched data, channel locations, and ICA weights/maps.
+
+EEGPrep's standalone wrapper accepts one dataset. Multi-dataset envelope
+comparison is not implemented because component maps, ICA channel subsets, and
+dataset-level envelopes need a dedicated group workflow rather than a silent
+merge.

--- a/src/eegprep/resources/help/pop_epoch.md
+++ b/src/eegprep/resources/help/pop_epoch.md
@@ -30,7 +30,9 @@ dialog and command-line calls update the shared GUI workspace history.
 If `EEG.data` is a filename string, EEGPrep loads the file at epoch time using
 `EEG.filepath` for relative paths and `EEG.dataformat` when supplied. ASCII,
 MATLAB `.mat`, NumPy, and EEGLAB `.fdt` float32 files use the same standalone
-loader as `pop_importdata`; no EEGLAB checkout is required at runtime.
+loader as `pop_importdata`; no EEGLAB checkout is required at runtime. When a
+2-D file has shape `(nbchan, pnts * trials)`, EEGPrep interprets it as
+channel-major data with trials flattened in EEGLAB `.fdt` order.
 
 EEGPrep keeps returned `indices` 0-based for Python callers. The command
 history string remains EEGLAB-style so it is readable from the GUI history and

--- a/src/eegprep/resources/help/pop_epoch.md
+++ b/src/eegprep/resources/help/pop_epoch.md
@@ -27,6 +27,11 @@ dialog and command-line calls update the shared GUI workspace history.
 
 ## Notes
 
+If `EEG.data` is a filename string, EEGPrep loads the file at epoch time using
+`EEG.filepath` for relative paths and `EEG.dataformat` when supplied. ASCII,
+MATLAB `.mat`, NumPy, and EEGLAB `.fdt` float32 files use the same standalone
+loader as `pop_importdata`; no EEGLAB checkout is required at runtime.
+
 EEGPrep keeps returned `indices` 0-based for Python callers. The command
 history string remains EEGLAB-style so it is readable from the GUI history and
 shared console workspace.

--- a/src/eegprep/resources/help/pop_erpimage.md
+++ b/src/eegprep/resources/help/pop_erpimage.md
@@ -8,3 +8,30 @@ result, com = pop_erpimage(EEG, typeplot=1, index=1, return_com=True)
 
 `typeplot=1` selects channel data. `typeplot=0` selects ICA component data. The
 dataset must be epoched.
+
+Supported plot options include `title`, `limits`, `caxis`, `cbar`, `erp`,
+`vert`, `smooth`, `decimate`, `sort_values`, and component projection through
+`projchan`.
+
+Event-field sorting is available with EEGLAB-style names:
+
+```python
+result, com = pop_erpimage(
+    EEG,
+    typeplot=1,
+    index=1,
+    sortingeventfield="rt",
+    sortingtype=["target"],
+    sortingwin=[0, 800],
+    return_com=True,
+)
+```
+
+Use `nosort=True` to disable value sorting and `noplot=True` to suppress the
+event-value curve option from history replay. `renorm="yes"` rescales finite
+event values to 0..1; custom renormalization formulas are not evaluated.
+
+EEGPrep does not implement EEGLAB's phase-sorting, coherence, spectrum inset,
+amplitude-image, or event-alignment workflows in this standalone ERP-image
+wrapper. Those options raise clear `ValueError` messages instead of falling
+through to MATLAB-only behavior.

--- a/src/eegprep/resources/help/pop_export.md
+++ b/src/eegprep/resources/help/pop_export.md
@@ -6,7 +6,18 @@ Usage:
 
 ```python
 com = pop_export(EEG, "data.tsv", "transpose", "on")
+com = pop_export(EEG, "data.tsv", "expr", "x = x * 1e6")
 ```
+
+Supported options include `ica`, `time`, `timeunit`, `elec`, `transpose`,
+`erp`, `precision`, `separator`, and `expr`.
+
+`expr` applies a numeric Python expression to the exported array `x` before the
+optional time row is added. EEGPrep supports arithmetic, indexing, comparisons,
+and selected NumPy numeric functions (`abs`, `clip`, `exp`, `log`, `log10`,
+`nan_to_num`, `sqrt`, with or without the `np.` prefix). Expressions may either
+return the transformed array or assign it to `x`, for example `x * 1e6` or
+`x = np.log10(abs(x) + 1)`. The expression must leave a 2-D or 3-D array.
 
 The main-window export action prompts for an output file and records the
 resulting command in session history. Use BIDS export for dataset sidecars and

--- a/src/eegprep/resources/help/pop_export.md
+++ b/src/eegprep/resources/help/pop_export.md
@@ -17,7 +17,13 @@ optional time row is added. EEGPrep supports arithmetic, indexing, comparisons,
 and selected NumPy numeric functions (`abs`, `clip`, `exp`, `log`, `log10`,
 `nan_to_num`, `sqrt`, with or without the `np.` prefix). Expressions may either
 return the transformed array or assign it to `x`, for example `x * 1e6` or
-`x = np.log10(abs(x) + 1)`. The expression must leave a 2-D or 3-D array.
+`x = np.log10(abs(x) + 1)`. Function calls are sandboxed: `clip` accepts
+`a_min`/`a_max` and `min`/`max` keyword arguments, and `nan_to_num` accepts
+`nan`/`posinf`/`neginf`. Side-effect keywords such as `out` are not available.
+For example, `x = np.clip(x, a_min=0, a_max=100)` is supported. Power operators
+require small numeric-constant exponents such as `x ** 2`; dynamic or very
+large exponents are rejected before evaluation. The expression must leave a 2-D
+or 3-D array.
 
 The main-window export action prompts for an output file and records the
 resulting command in session history. Use BIDS export for dataset sidecars and

--- a/src/eegprep/resources/help/pop_headplot.md
+++ b/src/eegprep/resources/help/pop_headplot.md
@@ -25,6 +25,10 @@ in EEGLAB:
   mesh, and a Talairach transformation matrix.
 - Replaying a history command with `setup={...}` reuses an existing `.spl` file;
   pass `recompute=True` inside `setup` to force regeneration.
+- `headplot_setup(..., plotmeshonly="head")` or `"sphere"` opens a mesh preview
+  figure without writing a spline file.
+- `headplot_setup(..., orilocs="on")` stores the unprojected normalized
+  electrode locations instead of mesh-projected display locations.
 - The GUI exposes the same load-or-recompute workflow used by EEGLAB, including
   Manual coregistration for editing the Talairach transform against the selected
   head mesh and reference electrode file.

--- a/src/eegprep/resources/help/pop_runica.md
+++ b/src/eegprep/resources/help/pop_runica.md
@@ -49,4 +49,7 @@ Notes:
 
 - Programmatic channel indices follow EEGLAB user-facing convention and are one-based. Internally, EEGPrep stores `icachansind` as zero-based Python indices.
 - AMICA is available only when the AMICA executable can be found through the `amica_binary` argument, `AMICA_BINARY`, a development checkout, or `PATH`.
-- EEGLAB algorithms that do not yet have EEGPrep backends, such as JADER, SOBI, and FastICA, raise a clear `NotImplementedError`.
+- EEGLAB algorithms that do not yet have EEGPrep standalone backends, such as
+  JADER, SOBI, and FastICA, raise a clear `NotImplementedError`. EEGPrep does
+  not shell out to MATLAB toolboxes or silently substitute a different ICA
+  algorithm.

--- a/src/eegprep/resources/help/pop_runica.md
+++ b/src/eegprep/resources/help/pop_runica.md
@@ -32,6 +32,10 @@ Calling `pop_runica(EEG)` opens an EEGLAB-style dialog with:
 
 Behavior:
 
+- Supplying a non-default `icatype` programmatically, for example
+  `pop_runica(EEG, icatype='picard')`, runs the selected backend directly
+  instead of opening the GUI. Unsupported standalone backends therefore fail
+  clearly from the command path instead of opening a dialog first.
 - Existing ICA decompositions are saved in `EEG.etc.oldicaweights`,
   `EEG.etc.oldicasphere`, and `EEG.etc.oldicachansind` before being replaced.
 - Existing ICLabel classifications are removed when ICA is recomputed because they no longer describe the active components.

--- a/src/eegprep/resources/help/pop_runscript.md
+++ b/src/eegprep/resources/help/pop_runscript.md
@@ -12,6 +12,8 @@ The GUI provides the shared session namespace containing `EEG`, `ALLEEG`,
 `CURRENTSET`, and `STUDY`. After the script runs, EEGPrep copies those names
 back into the session and refreshes the GUI.
 
-MATLAB `.m` and text scripts are recognized but not executed by EEGPrep.
+MATLAB `.m` and text scripts are recognized but not executed by EEGPrep. Use
+Python history scripts for replayable EEGPrep sessions; MATLAB/text history
+replay is a documented non-goal for the standalone runtime.
 
 See also: POP_SAVEH

--- a/tests/test_clean_artifacts.py
+++ b/tests/test_clean_artifacts.py
@@ -752,9 +752,8 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
         except Exception as e:
             self.skipTest(f"clean_artifacts burst rejection validation not available: {e}")
 
-    def test_clean_artifacts_invalid_distance_metric(self):
-        """Test clean_artifacts with invalid Distance parameter."""
-        # Should accept 'euclidian' and other distance metrics
+    def test_clean_artifacts_documented_distance_metrics_with_asr_disabled(self):
+        """Test clean_artifacts accepts documented Distance spellings when ASR is disabled."""
         try:
             # Valid cases
             clean_artifacts(
@@ -775,10 +774,24 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
                 WindowCriterion='off',
                 Highpass='off',
                 FlatlineCriterion='off',
-                Distance='riemann',
-            )  # Should trigger riemannian mode
+                Distance='riemannian',
+            )
         except Exception as e:
             self.skipTest(f"clean_artifacts distance metric validation not available: {e}")
+
+    def test_clean_artifacts_rejects_unknown_distance_metric(self):
+        """Test clean_artifacts rejects unknown Distance spellings before cleaning."""
+        with self.assertRaisesRegex(ValueError, "Distance must be"):
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                Distance='riemann',
+            )
 
     def test_clean_artifacts_negative_values(self):
         """Test clean_artifacts with negative parameter values."""

--- a/tests/test_clean_asr.py
+++ b/tests/test_clean_asr.py
@@ -122,6 +122,11 @@ class TestCleanASRParameters(unittest.TestCase):
             except Exception as e:
                 self.skipTest(f"clean_asr parameter test {params} not available: {e}")
 
+    def test_clean_asr_rejects_full_riemannian_processing_request(self):
+        """Test that unsupported full Riemannian ASR processing fails clearly."""
+        with self.assertRaisesRegex(ValueError, "full Riemannian ASR processing is not ported"):
+            clean_asr(self.test_eeg, useriemannian=True)
+
 
 class TestCleanASRCalibrationData(unittest.TestCase):
     """Test clean_asr calibration data selection options."""

--- a/tests/test_clean_asr.py
+++ b/tests/test_clean_asr.py
@@ -9,6 +9,7 @@ import unittest
 import numpy as np
 
 from eegprep.plugins.clean_rawdata.clean_asr import clean_asr
+from eegprep.plugins.clean_rawdata.clean_artifacts import clean_artifacts
 
 
 class TestCleanASRBasic(unittest.TestCase):
@@ -126,6 +127,20 @@ class TestCleanASRParameters(unittest.TestCase):
         """Test that unsupported full Riemannian ASR processing fails clearly."""
         with self.assertRaisesRegex(ValueError, "full Riemannian ASR processing is not ported"):
             clean_asr(self.test_eeg, useriemannian=True)
+
+    def test_clean_artifacts_rejects_unknown_distance(self):
+        """Test that clean_artifacts catches Distance typos before ASR dispatch."""
+        with self.assertRaisesRegex(ValueError, "Distance must be"):
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion='off',
+                LineNoiseCriterion='off',
+                BurstCriterion=20,
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+                Distance='euclidiann',
+            )
 
 
 class TestCleanASRCalibrationData(unittest.TestCase):

--- a/tests/test_file_menu_pop_functions.py
+++ b/tests/test_file_menu_pop_functions.py
@@ -206,9 +206,9 @@ def test_pop_runscript_rejects_matlab_and_text_scripts(tmp_path):
     matlab_script.write_text("EEG = EEG;\n", encoding="utf-8")
     text_script.write_text("EEG = EEG;\n", encoding="utf-8")
 
-    with pytest.raises(NotImplementedError, match="only run Python"):
+    with pytest.raises(ValueError, match="only run Python"):
         pop_runscript(matlab_script)
-    with pytest.raises(NotImplementedError, match="only run Python"):
+    with pytest.raises(ValueError, match="only run Python"):
         pop_runscript(text_script)
 
 

--- a/tests/test_gui_pop_runica.py
+++ b/tests/test_gui_pop_runica.py
@@ -303,6 +303,10 @@ class PopRunicaGuiTests(unittest.TestCase):
         self.assertEqual(out["icaweights"].shape, (4, 4))
         self.assertEqual(com, "EEG = pop_runica(EEG, 'icatype', 'picard', 'maxiter', 7, 'mode', 'standard');")
 
+    def test_unported_ica_algorithm_fails_clearly(self):
+        with self.assertRaisesRegex(NotImplementedError, "not ported"):
+            pop_runica(_eeg(), icatype="fastica")
+
     def test_key_value_options_override_backend_defaults(self):
         eeg = _eeg()
         updated = dict(eeg, icaweights=np.eye(4), icasphere=np.eye(4), icawinv=np.eye(4), icaact=np.zeros((4, 20, 1)))

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -1062,6 +1062,26 @@ def test_pop_comperp_supports_display_options_and_significance(sample_epoch):
         pop_comperp(datasets, flag=1, datadd=[1, 2], unsupported="on")
 
 
+def test_pop_comperp_significance_shading_marks_known_effect(sample_epoch):
+    datasets = []
+    for amplitude in (1.0, 1.1, 0.9):
+        dataset = deepcopy(sample_epoch)
+        dataset["data"] = np.zeros_like(np.asarray(dataset["data"], dtype=float)) + amplitude
+        datasets.append(dataset)
+    for _index in range(3):
+        dataset = deepcopy(sample_epoch)
+        dataset["data"] = np.zeros_like(np.asarray(dataset["data"], dtype=float))
+        datasets.append(dataset)
+
+    result = pop_comperp(datasets, flag=1, datadd=[1, 2, 3], datsub=[4, 5, 6], chans=[1, 2], alpha=0.01)
+
+    significant_patches = [
+        patch for patch in result["figure"].axes[0].patches if patch.get_alpha() == pytest.approx(0.18)
+    ]
+    assert significant_patches
+    plt.close(result["figure"])
+
+
 def test_pop_chanplot_validates_time_grid(sample_epoch):
     second = deepcopy(sample_epoch)
     second["xmax"] = float(second["xmax"]) + 0.1

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -152,6 +152,33 @@ def test_headplot_setup_file_can_be_reused_for_sample_data(sample_eeg, tmp_path)
     plt.close(figure)
 
 
+def test_headplot_setup_plotmeshonly_and_orilocs_options(sample_eeg, tmp_path):
+    transform = [0, -10, 0, -0.1, 0, -1.6, 1100, 1100, 1100]
+    preview_file = tmp_path / "preview.spl"
+
+    preview = headplot_setup(
+        sample_eeg["chanlocs"],
+        preview_file,
+        chaninfo=sample_eeg["chaninfo"],
+        transform=transform,
+        plotmeshonly="sphere",
+    )
+
+    assert preview.axes[0].name == "3d"
+    assert not preview_file.exists()
+    plt.close(preview)
+
+    created = headplot_setup(
+        sample_eeg["chanlocs"],
+        tmp_path / "orilocs.spl",
+        chaninfo=sample_eeg["chaninfo"],
+        transform=transform,
+        orilocs="on",
+    )
+    spline = load_headplot_spline(created)
+    np.testing.assert_allclose(spline.new_electrodes, np.column_stack([spline.xe, spline.ye, spline.ze]))
+
+
 def test_pop_headplot_setup_reuses_existing_spline_file(sample_eeg, tmp_path):
     eeg = deepcopy(sample_eeg)
     splinefile = tmp_path / "existing.spl"
@@ -241,6 +268,9 @@ def test_coregister_fits_traditional_and_shared_scale_transforms():
     np.testing.assert_allclose(apply_coregistration_transform(source.points, fitted), target.points, atol=1e-6)
     np.testing.assert_allclose(shared[6], shared[7])
     np.testing.assert_allclose(shared[7], shared[8])
+
+    with pytest.raises(ValueError, match="traditional.*globalrescale"):
+        estimate_coregistration_transform(source, target, method="nonlin")
 
 
 def test_coregister_noninteractive_path_returns_transformed_electrodes(sample_eeg):
@@ -931,7 +961,7 @@ def test_pop_envtopo_uses_icachansind_subset_and_rejects_multiple(ica_epoch):
     assert len(figure.axes) >= 2
     _assert_python_command(command)
     plt.close(figure)
-    with pytest.raises(NotImplementedError, match="one dataset"):
+    with pytest.raises(ValueError, match="one dataset"):
         pop_envtopo([ica_epoch, deepcopy(ica_epoch)], components=[1])
 
 
@@ -993,6 +1023,45 @@ def test_pop_comperp_rms_mode_and_grid_validation(sample_epoch):
         pop_comperp([first, second], flag=1, datadd=[1, 2])
 
 
+def test_pop_comperp_supports_display_options_and_significance(sample_epoch):
+    datasets = [deepcopy(sample_epoch) for _ in range(4)]
+    scales = [1.0, 1.12, 0.78, 1.31]
+    for offset, dataset in enumerate(datasets):
+        dataset["data"] = np.asarray(dataset["data"], dtype=float) * scales[offset] + offset * 0.05
+        dataset["setname"] = f"dataset {offset + 1}"
+
+    result, command = pop_comperp(
+        datasets,
+        flag=1,
+        datadd=[3, 4],
+        datsub=[1, 2],
+        chans=[1, 2],
+        alpha=0.05,
+        addstd="on",
+        substd="on",
+        diffstd="on",
+        addall="on",
+        suball="on",
+        diffall="on",
+        tlim=[-50, 100],
+        ylim=[-20, 20],
+        title="Compared ERPs",
+        return_com=True,
+    )
+
+    assert result["erp1"].shape == (2, sample_epoch["pnts"])
+    assert result["erp2"].shape == (2, sample_epoch["pnts"])
+    assert result["erpsub"].shape == (2, sample_epoch["pnts"])
+    assert result["pvalues"].shape == (2, sample_epoch["pnts"])
+    assert np.isfinite(result["pvalues"]).any()
+    assert "addstd='on'" in command
+    _assert_python_command(command)
+    plt.close(result["figure"])
+
+    with pytest.raises(ValueError, match="unsupported option"):
+        pop_comperp(datasets, flag=1, datadd=[1, 2], unsupported="on")
+
+
 def test_pop_chanplot_validates_time_grid(sample_epoch):
     second = deepcopy(sample_epoch)
     second["xmax"] = float(second["xmax"]) + 0.1
@@ -1019,6 +1088,53 @@ def test_pop_erpimage_applies_time_limits_and_decimation(sample_epoch):
     assert "limits=[-50, 100]" in command
     _assert_python_command(command)
     plt.close(result["figure"])
+
+
+def test_pop_erpimage_sorts_by_epoch_event_field_and_limits(sample_epoch):
+    eeg = deepcopy(sample_epoch)
+    eeg["data"] = np.asarray(
+        [
+            [
+                [1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0],
+            ]
+        ]
+    )
+    eeg["nbchan"] = 1
+    eeg["pnts"] = 4
+    eeg["trials"] = 3
+    eeg["srate"] = 100.0
+    eeg["xmin"] = 0.0
+    eeg["xmax"] = 0.03
+    eeg["times"] = np.asarray([0.0, 10.0, 20.0, 30.0])
+    eeg["event"] = [
+        {"type": "rt", "latency": 2, "epoch": 1, "rt": 30},
+        {"type": "rt", "latency": 6, "epoch": 2, "rt": 10},
+        {"type": "rt", "latency": 10, "epoch": 3, "rt": 20},
+    ]
+
+    result, command = pop_erpimage(
+        eeg,
+        typeplot=1,
+        index=1,
+        sortingeventfield="rt",
+        sortingtype=["rt"],
+        sortingwin=[0, 20],
+        return_com=True,
+    )
+    unsorted, _command = pop_erpimage(eeg, typeplot=1, index=1, sort_values=[30, 10, 20], nosort=True, return_com=True)
+
+    np.testing.assert_allclose(result["image"][:, 0], [2, 3, 1])
+    np.testing.assert_allclose(unsorted["image"][:, 0], [1, 2, 3])
+    assert "sortingeventfield='rt'" in command
+    _assert_python_command(command)
+    plt.close(result["figure"])
+    plt.close(unsorted["figure"])
+
+    with pytest.raises(ValueError, match="standalone ERP image"):
+        pop_erpimage(eeg, typeplot=1, index=1, align=[0])
 
 
 def test_plot_history_preserves_effective_options(sample_epoch, ica_epoch):

--- a/tests/test_pop_editset.py
+++ b/tests/test_pop_editset.py
@@ -231,25 +231,68 @@ def test_pop_editset_pnts_metadata_keeps_data_dimensions_consistent():
         pop_editset(eeg, "pnts", 7)
 
 
-def test_pop_editset_history_rejects_unserializable_channel_structures():
+def test_pop_editset_history_serializes_channel_structures_for_replay():
     eeg = _eeg()
 
-    out = pop_editset(eeg, "chanlocs", [{"labels": "Fz"}])
+    chanlocs = [{"labels": "Fz"}, {"labels": "Cz"}]
+    out, com = pop_editset(eeg, "chanlocs", chanlocs, return_com=True)
+    namespace = {"EEG": _eeg(), "pop_editset": pop_editset}
 
+    exec(com, namespace)
     assert list(out["chanlocs"])[0]["labels"] == "Fz"
-    with pytest.raises(NotImplementedError, match="channel-location"):
-        pop_editset(eeg, "chanlocs", [{"labels": "Fz"}], return_com=True)
-    with pytest.raises(NotImplementedError, match="channel-location"):
-        pop_editset(eeg, "chanlocs", np.array([{"labels": "Fz"}], dtype=object), return_com=True)
+    assert namespace["EEG"]["chanlocs"][1]["labels"] == "Cz"
+
+    out, com = pop_editset(eeg, "chanlocs", np.array(chanlocs, dtype=object), return_com=True)
+    namespace = {"EEG": _eeg(), "pop_editset": pop_editset}
+    exec(com, namespace)
+    assert list(out["chanlocs"])[0]["labels"] == "Fz"
+    assert namespace["EEG"]["chanlocs"][1]["labels"] == "Cz"
 
 
-def test_pop_editset_rejects_unsupported_file_workspace_expressions():
-    with pytest.raises(NotImplementedError, match="pop_importdata"):
+def test_pop_editset_loads_data_chanlocs_and_ica_from_files(tmp_path):
+    data_file = tmp_path / "raw.txt"
+    locs_file = tmp_path / "locs.sfp"
+    weights_file = tmp_path / "weights.txt"
+    sphere_file = tmp_path / "sphere.txt"
+    index_file = tmp_path / "icachansind.txt"
+    np.savetxt(data_file, np.arange(15, dtype=float).reshape(3, 5))
+    locs_file.write_text("Fz 0 0 1\nCz 0 1 0\nPz 1 0 0\n", encoding="utf-8")
+    np.savetxt(weights_file, np.eye(3))
+    np.savetxt(sphere_file, np.eye(3) * 2)
+    np.savetxt(index_file, [0, 1, 2], fmt="%d")
+
+    out, com = pop_editset(
+        _eeg(),
+        "data",
+        str(data_file),
+        "chanlocs",
+        str(locs_file),
+        "icaweights",
+        str(weights_file),
+        "icasphere",
+        str(sphere_file),
+        "icachansind",
+        str(index_file),
+        "dataformat",
+        "ascii",
+        return_com=True,
+    )
+
+    assert out["data"].shape == (3, 5)
+    assert out["chanlocs"][0]["labels"] == "Fz"
+    np.testing.assert_allclose(out["icaweights"], np.eye(3))
+    np.testing.assert_allclose(out["icasphere"], np.eye(3) * 2)
+    np.testing.assert_array_equal(out["icachansind"], [0, 1, 2])
+    assert "'dataformat', 'ascii'" in com
+
+
+def test_pop_editset_rejects_matlab_workspace_expressions():
+    with pytest.raises(ValueError, match="workspace expressions for data"):
         pop_editset(_eeg(), "data", "raw.mat")
-    with pytest.raises(NotImplementedError, match="pop_chanedit"):
+    with pytest.raises(ValueError, match="workspace expressions for chanlocs"):
         pop_editset(_eeg(), "chanlocs", "locs.elp")
-    with pytest.raises(ValueError, match="dataformat"):
-        pop_editset(_eeg(), "dataformat", "ascii")
+    with pytest.raises(ValueError, match="workspace expressions for icachansind"):
+        pop_editset(_eeg(), "icachansind", "icachansind")
 
 
 def test_pop_editset_accepts_sample_data_metadata_edit():

--- a/tests/test_pop_editset.py
+++ b/tests/test_pop_editset.py
@@ -252,9 +252,9 @@ def test_pop_editset_history_serializes_channel_structures_for_replay():
 def test_pop_editset_loads_data_chanlocs_and_ica_from_files(tmp_path):
     data_file = tmp_path / "raw.txt"
     locs_file = tmp_path / "locs.sfp"
-    weights_file = tmp_path / "weights.txt"
-    sphere_file = tmp_path / "sphere.txt"
-    index_file = tmp_path / "icachansind.txt"
+    weights_file = tmp_path / "weights.fdt"
+    sphere_file = tmp_path / "sphere.fdt"
+    index_file = tmp_path / "icachansind.fdt"
     np.savetxt(data_file, np.arange(15, dtype=float).reshape(3, 5))
     locs_file.write_text("Fz 0 0 1\nCz 0 1 0\nPz 1 0 0\n", encoding="utf-8")
     np.savetxt(weights_file, np.eye(3))
@@ -264,15 +264,15 @@ def test_pop_editset_loads_data_chanlocs_and_ica_from_files(tmp_path):
     out, com = pop_editset(
         _eeg(),
         "data",
-        str(data_file),
+        data_file,
         "chanlocs",
-        str(locs_file),
+        locs_file,
         "icaweights",
-        str(weights_file),
+        weights_file,
         "icasphere",
-        str(sphere_file),
+        sphere_file,
         "icachansind",
-        str(index_file),
+        index_file,
         "dataformat",
         "ascii",
         return_com=True,
@@ -287,10 +287,18 @@ def test_pop_editset_loads_data_chanlocs_and_ica_from_files(tmp_path):
 
 
 def test_pop_editset_rejects_matlab_workspace_expressions():
-    with pytest.raises(ValueError, match="workspace expressions for data"):
+    with pytest.raises(FileNotFoundError, match="data file not found"):
         pop_editset(_eeg(), "data", "raw.mat")
-    with pytest.raises(ValueError, match="workspace expressions for chanlocs"):
+    with pytest.raises(FileNotFoundError, match="channel-location file not found"):
         pop_editset(_eeg(), "chanlocs", "locs.elp")
+    with pytest.raises(FileNotFoundError, match="icaweights file not found"):
+        pop_editset(_eeg(), "icaweights", "weights.txt")
+    with pytest.raises(FileNotFoundError, match="icachansind file not found"):
+        pop_editset(_eeg(), "icachansind", "icachansind.txt")
+    with pytest.raises(ValueError, match="workspace expressions for data"):
+        pop_editset(_eeg(), "data", "rawdata")
+    with pytest.raises(ValueError, match="workspace expressions for chanlocs"):
+        pop_editset(_eeg(), "chanlocs", "locs")
     with pytest.raises(ValueError, match="workspace expressions for icachansind"):
         pop_editset(_eeg(), "icachansind", "icachansind")
 

--- a/tests/test_pop_epoch.py
+++ b/tests/test_pop_epoch.py
@@ -9,6 +9,7 @@ MATLAB EEGLAB's pop_epoch function across all tested scenarios.
 import os
 import numpy as np
 import unittest
+import tempfile
 
 import copy
 import eegprep.functions.popfunc.pop_epoch as pop_epoch_module
@@ -703,17 +704,31 @@ class TestPopEpochEdgeCases(unittest.TestCase):
         # since pop_select would need proper implementation)
         self.assertGreater(len(eeg_out['event']), 3)  # Should have boundary event added
 
-    def test_data_loading_not_implemented(self):
-        """Test that data loading from file raises NotImplementedError"""
-        EEG = {
-            'data': 'filename.dat',  # String instead of array
-            'srate': 100.0,
-            'event': [{'type': 'test', 'latency': 100}],
-            'saved': 'no',
-        }
+    def test_filename_backed_data_is_loaded_for_epoching(self):
+        """Test that pop_epoch loads filename-backed EEG.data arrays."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data = np.arange(600, dtype=np.float32).reshape(3, 200)
+            data_file = os.path.join(tmpdir, "filename.txt")
+            np.savetxt(data_file, data)
+            EEG = {
+                'data': 'filename.txt',
+                'filepath': tmpdir,
+                'dataformat': 'ascii',
+                'srate': 100.0,
+                'nbchan': 3,
+                'pnts': 200,
+                'trials': 1,
+                'xmin': 0.0,
+                'xmax': 1.99,
+                'event': [{'type': 'test', 'latency': 100}],
+                'saved': 'no',
+            }
 
-        with self.assertRaises(NotImplementedError):
-            pop_epoch(EEG, 'test', [-0.1, 0.1])
+            eeg_out, indices = pop_epoch(EEG, 'test', [-0.1, 0.1])
+
+        self.assertEqual(indices, [0])
+        self.assertEqual(eeg_out['data'].shape, (3, 20))
+        np.testing.assert_allclose(eeg_out['data'][:, 0], data[:, 89])
 
 
 class TestPopEpochGuiAndHistory(unittest.TestCase):

--- a/tests/test_pop_firfilt.py
+++ b/tests/test_pop_firfilt.py
@@ -180,7 +180,7 @@ def test_pop_eegfilt_legacy_firtype_changes_filter_coefficients():
 
 
 def test_pop_eegfilt_legacy_usefft_fails_clearly():
-    with pytest.raises(NotImplementedError, match="Legacy pop_eegfilt FFT filtering is not implemented"):
+    with pytest.raises(ValueError, match="Legacy pop_eegfilt FFT filtering is not a standalone EEGPrep path"):
         pop_eegfilt(_continuous_eeg(), 1, 40, 100, 0, 1, 0, "firls", 0)
 
 

--- a/tests/test_sample_data_pop_functions.py
+++ b/tests/test_sample_data_pop_functions.py
@@ -419,6 +419,16 @@ def test_pop_export_writes_sample_data_table(tmp_path, sample_eeg):
     assert "pop_export" in command
 
 
+def test_pop_export_applies_expression_to_sample_data(tmp_path, sample_eeg):
+    output_file = tmp_path / "sample_export_expr.tsv"
+
+    command = pop_export(sample_eeg, output_file, "transpose", "on", "expr", "x = x * 2")
+
+    table = np.loadtxt(output_file, delimiter="\t", skiprows=1)
+    assert table[0, 1] == pytest.approx(float(sample_eeg["data"][0, 0]) * 2)
+    assert "'expr', 'x = x * 2'" in command
+
+
 def test_pop_export_writes_sample_ica_activity_when_icaact_is_missing(sample_eeg_with_ica, tmp_path):
     output_file = tmp_path / "sample_ica.tsv"
     eeg = copy.deepcopy(sample_eeg_with_ica)

--- a/tests/test_sample_data_pop_functions.py
+++ b/tests/test_sample_data_pop_functions.py
@@ -334,6 +334,21 @@ def test_pop_clean_rawdata_riemannian_asr_runs_on_sample_data_without_warning_no
     assert not [record for record in caplog.records if record.levelname in {"WARNING", "ERROR"}]
 
 
+def test_pop_clean_rawdata_rejects_unknown_distance_before_asr(sample_eeg):
+    with pytest.raises(ValueError, match="Distance"):
+        pop_clean_rawdata(
+            sample_eeg,
+            Distance="euclidiann",
+            BurstCriterion=20,
+            BurstRejection="off",
+            WindowCriterion="off",
+            Highpass="off",
+            ChannelCriterion="off",
+            LineNoiseCriterion="off",
+            FlatlineCriterion="off",
+        )
+
+
 def test_pop_rmbase_zeroes_selected_sample_baseline_channels(sample_eeg):
     baseline = pop_rmbase(sample_eeg, pointrange=range(1, 21), chanlist=[1, 2])
 
@@ -422,11 +437,20 @@ def test_pop_export_writes_sample_data_table(tmp_path, sample_eeg):
 def test_pop_export_applies_expression_to_sample_data(tmp_path, sample_eeg):
     output_file = tmp_path / "sample_export_expr.tsv"
 
-    command = pop_export(sample_eeg, output_file, "transpose", "on", "expr", "x = x * 2")
+    command = pop_export(
+        sample_eeg, output_file, "transpose", "on", "expr", "x = np.clip(x * 2, a_min=-100, a_max=100)"
+    )
 
     table = np.loadtxt(output_file, delimiter="\t", skiprows=1)
-    assert table[0, 1] == pytest.approx(float(sample_eeg["data"][0, 0]) * 2)
-    assert "'expr', 'x = x * 2'" in command
+    assert table[0, 1] == pytest.approx(float(np.clip(sample_eeg["data"][0, 0] * 2, -100, 100)))
+    assert "'expr', 'x = np.clip(x * 2, a_min=-100, a_max=100)'" in command
+
+
+def test_pop_export_rejects_unsafe_expression_calls(tmp_path, sample_eeg):
+    with pytest.raises(ValueError, match="keyword argument"):
+        pop_export(sample_eeg, tmp_path / "keyword.tsv", "expr", "np.clip(x, a_min=0, a_max=1, out=x)")
+    with pytest.raises(ValueError, match="power exponents"):
+        pop_export(sample_eeg, tmp_path / "power.tsv", "expr", "x ** 999")
 
 
 def test_pop_export_writes_sample_ica_activity_when_icaact_is_missing(sample_eeg_with_ica, tmp_path):


### PR DESCRIPTION
Close option-level gaps in existing user-facing EEGLAB-style functions, including export expressions, filename-backed epoching, editset file paths, comperp and erpimage controls, headplot setup previews, runica selection, and ASR calibration options. Tightens review feedback around path errors, expression sandboxing, std display, and distance validation.

Fixes #136
Part of #131