### PR TITLE
[Parity] Close Phase 8 core parity evidence

### DIFF
--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -6,6 +6,26 @@
 </head>
 <body>
   <h1>EEGPrep Core Parity Implementation Notes</h1>
+  <h1>EEGPrep Phase 8 Epic Closeout Notes</h1>
+  <p>Phase 8 reviews the integrated Phases 1-7 surface for closeout evidence
+  rather than adding another feature area. The branch remains scoped to matrix,
+  docs/help, QA evidence, and concrete integration defects.</p>
+  <h2>Phase 8 Closeout Findings</h2>
+  <ul>
+    <li>The committed parity matrix already classified every in-scope EEGLAB file once the EEGLAB reference submodule was initialized, but remaining <code>port</code> and <code>partial</code> rows only named generic follow-up work in <code>test_notes</code>. The closeout now requires actionable rows to cite a concrete issue, and rows point to <a href="https://github.com/sccn/eegprep/issues/146">#146</a>, <a href="https://github.com/sccn/eegprep/issues/147">#147</a>, <a href="https://github.com/sccn/eegprep/issues/148">#148</a>, or <a href="https://github.com/sccn/eegprep/issues/149">#149</a>.</li>
+    <li>Help Markdown coverage was complete for new Phase 2/4/5/7 <code>pop_*</code> wrappers, but Phase 6's public STUDY helpers <code>pop_addindepvar</code> and <code>pop_listfactors</code> were missing packaged help resources. Phase 8 adds those help topics and a focused packaged-help regression check.</li>
+    <li>The docs already explain supported long-tail imports, statistics, time-frequency helpers, STUDY workflows, and legacy wrapper surfaces through the API and user-guide pages added by earlier phases.</li>
+    <li>No Phase 8 runtime GUI implementation was added. Earlier phase notes show GUI changes were limited to existing dialog behavior or non-GUI API/console surfaces, so no new Phase 8 visual parity attachment is required.</li>
+  </ul>
+  <h2>Phase 8 Tradeoffs</h2>
+  <ul>
+    <li>Remaining <code>port</code>/<code>partial</code> rows were not force-ported during closeout. They represent follow-up issues whose own scopes require parity-first design, fixtures, or GUI evidence. Closing Phase 8 by naming those issues is safer than adding incomplete analysis math or one-for-one MATLAB GUI internals.</li>
+    <li>The parity matrix validator remains a development tool that may read the EEGLAB submodule. Runtime code under <code>src/eegprep</code> continues to avoid importing from, reading from, or shelling out to <code>src/eegprep/eeglab</code>.</li>
+  </ul>
+  <h2>Phase 8 Verification Notes</h2>
+  <ul>
+    <li>Final verification commands will be recorded in the Phase 8 PR body after the required matrix, lint, type, test, pre-commit, GUI/console, and review checks run.</li>
+  </ul>
   <h1>EEGPrep Phase 7 Long-Tail Core Helpers Notes</h1>
   <p>Phase 7 closes the remaining audit-approved helper and wrapper gaps that
   were still actionable after Phases 2-6, while classifying obsolete or

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -31,6 +31,7 @@
     <li>Focused regression coverage passed for parity-matrix validation, packaged help, STUDY metadata, STUDY measures, and STUDY clustering behavior. A sample-data console smoke verified shared <code>EEGPrepSession</code> state across load, bare <code>pop_select</code>, and bare <code>pop_reref</code> calls.</li>
     <li>MATLAB-marked parity tests were attempted locally. MATLAB CLI exists, but the Python MATLAB engine is unavailable and the marker run stalled after clean_rawdata failures, so the closeout preserves existing skip behavior through the non-slow lane.</li>
     <li>The OC autoreview helper initially flagged <code>pop_listfactors</code> display-only options as a non-GUI EEGLAB compatibility regression. Phase 8 fixed that by accepting <code>splitreg</code>, <code>contrast</code>, and <code>interaction</code> as non-GUI no-ops, then reran autoreview clean against <code>origin/feature/eeglab-core-parity-completion</code>.</li>
+    <li>Post-PR Claude review comments were addressed by accepting structured <code>follow_up_issue</code> URLs as canonical matrix follow-up evidence and by adding direct channel-cache coverage for the hardened subject-filter error.</li>
   </ul>
   <h1>EEGPrep Phase 7 Long-Tail Core Helpers Notes</h1>
   <p>Phase 7 closes the remaining audit-approved helper and wrapper gaps that

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -15,7 +15,7 @@
     <li>The committed parity matrix already classified every in-scope EEGLAB file once the EEGLAB reference submodule was initialized, but remaining <code>port</code> and <code>partial</code> rows only named generic follow-up work in <code>test_notes</code>. The closeout now requires actionable rows to cite a concrete issue, and rows point to <a href="https://github.com/sccn/eegprep/issues/146">#146</a>, <a href="https://github.com/sccn/eegprep/issues/147">#147</a>, <a href="https://github.com/sccn/eegprep/issues/148">#148</a>, or <a href="https://github.com/sccn/eegprep/issues/149">#149</a>.</li>
     <li>Help Markdown coverage was complete for new Phase 2/4/5/7 <code>pop_*</code> wrappers, but Phase 6's public STUDY helpers <code>pop_addindepvar</code> and <code>pop_listfactors</code> were missing packaged help resources. Phase 8 adds those help topics and a focused packaged-help regression check.</li>
     <li>The docs already explain supported long-tail imports, statistics, time-frequency helpers, STUDY workflows, and legacy wrapper surfaces through the API and user-guide pages added by earlier phases.</li>
-    <li>No Phase 8 runtime GUI implementation was added. Earlier phase notes show GUI changes were limited to existing dialog behavior or non-GUI API/console surfaces, so no new Phase 8 visual parity attachment is required.</li>
+    <li>No Phase 8 runtime GUI implementation was added. The final tree does not commit visual parity artifacts. Phase 4 GUI evidence for <code>pop_newtimef</code> and <code>pop_newcrossf</code> is present in PR review comments rather than committed files; Phase 8 keeps that as evidence documentation because closeout did not change those dialogs.</li>
   </ul>
   <h2>Phase 8 Tradeoffs</h2>
   <ul>
@@ -24,7 +24,13 @@
   </ul>
   <h2>Phase 8 Verification Notes</h2>
   <ul>
-    <li>Final verification commands will be recorded in the Phase 8 PR body after the required matrix, lint, type, test, pre-commit, GUI/console, and review checks run.</li>
+    <li><code>uv run --no-sync python -m tools.eeglab_parity_matrix</code>: parity matrix OK, 608 rows cover 608 in-scope EEGLAB functions.</li>
+    <li><code>uv run --no-sync ruff check .</code>, <code>uv run --no-sync ruff format --check .</code>, and <code>uv run --no-sync ty check</code>: passed after syncing optional GUI/torch extras needed by the type checker.</li>
+    <li><code>EEGPREP_SKIP_MATLAB=1 uv run --no-sync pytest -m "not slow"</code>: passed with 1746 tests passing, 233 skipped, and 11 deselected.</li>
+    <li><code>./pre-commit.py --changed-from origin/feature/eeglab-core-parity-completion</code>: passed for the Phase 8 changed-file set.</li>
+    <li>Focused regression coverage passed for parity-matrix validation, packaged help, STUDY metadata, STUDY measures, and STUDY clustering behavior. A sample-data console smoke verified shared <code>EEGPrepSession</code> state across load, bare <code>pop_select</code>, and bare <code>pop_reref</code> calls.</li>
+    <li>MATLAB-marked parity tests were attempted locally. MATLAB CLI exists, but the Python MATLAB engine is unavailable and the marker run stalled after clean_rawdata failures, so the closeout preserves existing skip behavior through the non-slow lane.</li>
+    <li>The OC autoreview helper initially flagged <code>pop_listfactors</code> display-only options as a non-GUI EEGLAB compatibility regression. Phase 8 fixed that by accepting <code>splitreg</code>, <code>contrast</code>, and <code>interaction</code> as non-GUI no-ops, then reran autoreview clean against <code>origin/feature/eeglab-core-parity-completion</code>.</li>
   </ul>
   <h1>EEGPrep Phase 7 Long-Tail Core Helpers Notes</h1>
   <p>Phase 7 closes the remaining audit-approved helper and wrapper gaps that

--- a/docs/parity/eeglab_core_parity_matrix.json
+++ b/docs/parity/eeglab_core_parity_matrix.json
@@ -4416,7 +4416,7 @@
         "console",
         "gui"
       ],
-      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -6842,7 +6842,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6857,7 +6857,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6872,7 +6872,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6887,7 +6887,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6982,7 +6982,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6999,7 +6999,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7016,7 +7016,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7033,7 +7033,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7174,7 +7174,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7191,7 +7191,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7326,7 +7326,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7341,7 +7341,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7370,7 +7370,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7385,7 +7385,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7400,7 +7400,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7415,7 +7415,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7444,7 +7444,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7487,7 +7487,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7502,7 +7502,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7517,7 +7517,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7546,7 +7546,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7561,7 +7561,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7576,7 +7576,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7591,7 +7591,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7620,7 +7620,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7635,7 +7635,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7650,7 +7650,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7679,7 +7679,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7708,7 +7708,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7723,7 +7723,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7738,7 +7738,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7781,7 +7781,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7796,7 +7796,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7811,7 +7811,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7826,7 +7826,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7841,7 +7841,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7856,7 +7856,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7941,7 +7941,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7956,7 +7956,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7971,7 +7971,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8000,7 +8000,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8029,7 +8029,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8072,7 +8072,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8087,7 +8087,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8102,7 +8102,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8117,7 +8117,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8132,7 +8132,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8147,7 +8147,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8162,7 +8162,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8205,7 +8205,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8220,7 +8220,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8235,7 +8235,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8250,7 +8250,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8265,7 +8265,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8294,7 +8294,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8323,7 +8323,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8352,7 +8352,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8395,7 +8395,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8424,7 +8424,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8453,7 +8453,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8510,7 +8510,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8525,7 +8525,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8540,7 +8540,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8555,7 +8555,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8598,7 +8598,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8613,7 +8613,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8642,7 +8642,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8657,7 +8657,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8672,7 +8672,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8687,7 +8687,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8716,7 +8716,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8731,7 +8731,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8746,7 +8746,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8761,7 +8761,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8804,7 +8804,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8819,7 +8819,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -8848,7 +8848,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -8863,7 +8863,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -8946,7 +8946,7 @@
       "user_facing_surface": [
         "helper"
       ],
-      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -9017,7 +9017,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -9032,7 +9032,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -9047,7 +9047,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9062,7 +9062,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9077,7 +9077,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9092,7 +9092,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9107,7 +9107,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9122,7 +9122,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -9165,7 +9165,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {

--- a/docs/parity/eeglab_core_parity_matrix.json
+++ b/docs/parity/eeglab_core_parity_matrix.json
@@ -4416,7 +4416,7 @@
         "console",
         "gui"
       ],
-      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -6842,7 +6842,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6857,7 +6857,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6872,7 +6872,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6887,7 +6887,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6982,7 +6982,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -6999,7 +6999,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7016,7 +7016,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7033,7 +7033,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7174,7 +7174,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7191,7 +7191,7 @@
         "gui",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7326,7 +7326,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7341,7 +7341,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7370,7 +7370,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7385,7 +7385,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7400,7 +7400,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7415,7 +7415,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7444,7 +7444,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7487,7 +7487,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7502,7 +7502,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7517,7 +7517,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7546,7 +7546,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7561,7 +7561,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7576,7 +7576,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7591,7 +7591,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7620,7 +7620,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7635,7 +7635,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7650,7 +7650,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7679,7 +7679,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7708,7 +7708,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7723,7 +7723,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7738,7 +7738,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7781,7 +7781,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7796,7 +7796,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7811,7 +7811,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7826,7 +7826,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7841,7 +7841,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7856,7 +7856,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7941,7 +7941,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7956,7 +7956,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -7971,7 +7971,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8000,7 +8000,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8029,7 +8029,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8072,7 +8072,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8087,7 +8087,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8102,7 +8102,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8117,7 +8117,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8132,7 +8132,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8147,7 +8147,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8162,7 +8162,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8205,7 +8205,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8220,7 +8220,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8235,7 +8235,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8250,7 +8250,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8265,7 +8265,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8294,7 +8294,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8323,7 +8323,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8352,7 +8352,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8395,7 +8395,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -8424,7 +8424,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8453,7 +8453,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8510,7 +8510,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8525,7 +8525,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8540,7 +8540,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8555,7 +8555,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8598,7 +8598,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8613,7 +8613,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8642,7 +8642,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8657,7 +8657,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8672,7 +8672,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8687,7 +8687,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8716,7 +8716,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8731,7 +8731,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8746,7 +8746,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8761,7 +8761,7 @@
         "api",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8804,7 +8804,7 @@
         "helper",
         "study"
       ],
-      "test_notes": "Follow-up issue #149 must either implement with multi-dataset tests or classify with row-level rationale.",
+      "test_notes": "Follow-up issue must either implement with multi-dataset tests or classify with row-level rationale.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/149"
     },
     {
@@ -8819,7 +8819,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -8848,7 +8848,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -8863,7 +8863,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -8946,7 +8946,7 @@
       "user_facing_surface": [
         "helper"
       ],
-      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -9017,7 +9017,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -9032,7 +9032,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #148 must add PAC numerical/cache tests before marking implemented.",
+      "test_notes": "Follow-up issue must add PAC numerical/cache tests before marking implemented.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/148"
     },
     {
@@ -9047,7 +9047,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9062,7 +9062,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9077,7 +9077,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9092,7 +9092,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9107,7 +9107,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #147 must add deterministic distribution-fitting parity tests before porting.",
+      "test_notes": "Follow-up issue must add deterministic distribution-fitting parity tests before porting.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/147"
     },
     {
@@ -9122,7 +9122,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {
@@ -9165,7 +9165,7 @@
         "helper",
         "time_frequency"
       ],
-      "test_notes": "Follow-up issue #146 must add timewarp/marker numerical tests and GUI parity where applicable.",
+      "test_notes": "Follow-up issue must add timewarp/marker numerical tests and GUI parity where applicable.",
       "follow_up_issue": "https://github.com/sccn/eegprep/issues/146"
     },
     {

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -242,8 +242,8 @@ When a later phase implements or intentionally skips a row:
 3. For ``partial`` rows, keep the row ``partial`` until unsupported behavior is
    implemented or explicitly reclassified with a defensible limitation.
    Any row left as ``port`` or ``partial`` after a phase closes must cite a
-   concrete follow-up issue, such as ``#146``, in ``rationale`` or
-   ``test_notes``.
+   concrete follow-up issue in ``follow_up_issue`` or, when needed for prose
+   context, in ``rationale`` or ``test_notes``.
 4. Run the validator:
 
    .. code-block:: bash

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -241,6 +241,9 @@ When a later phase implements or intentionally skips a row:
    with all fields set to ``false`` and explain the evidence in ``rationale``.
 3. For ``partial`` rows, keep the row ``partial`` until unsupported behavior is
    implemented or explicitly reclassified with a defensible limitation.
+   Any row left as ``port`` or ``partial`` after a phase closes must cite a
+   concrete follow-up issue, such as ``#146``, in ``rationale`` or
+   ``test_notes``.
 4. Run the validator:
 
    .. code-block:: bash

--- a/src/eegprep/functions/studyfunc/pop_addindepvar.py
+++ b/src/eegprep/functions/studyfunc/pop_addindepvar.py
@@ -62,8 +62,6 @@ def _factor_lists(varlist: dict[str, Any] | list[str]) -> tuple[list[str], list[
     factors = []
     values = []
     numerical = []
-    for label in study.get("subject", []):
-        _ = label
     for label in _study_factor_names(study):
         factor_values = variable_values(study, label)
         factors.append(label)

--- a/src/eegprep/functions/studyfunc/std_apcluster.py
+++ b/src/eegprep/functions/studyfunc/std_apcluster.py
@@ -84,8 +84,7 @@ def _distance_matrix(data: np.ndarray, metric: str) -> np.ndarray:
 def _assign_exemplars(similarity: np.ndarray, exemplars: list[int]) -> np.ndarray:
     selected = similarity[:, exemplars]
     raw = np.argmax(selected, axis=1)
-    remap = {position: index + 1 for index, position in enumerate(range(len(exemplars)))}
-    return np.asarray([remap[int(item)] for item in raw], dtype=int)
+    return raw.astype(int) + 1
 
 
 def _sum_distances(data: np.ndarray, labels: np.ndarray, centers: np.ndarray) -> np.ndarray:

--- a/src/eegprep/functions/studyfunc/std_readdata.py
+++ b/src/eegprep/functions/studyfunc/std_readdata.py
@@ -50,6 +50,8 @@ def std_readdata(
         cluster = clusters_list[cluster_index - 1]
         source = clusters_list[0] if cluster_index > 1 else cluster
         data = _data_array(source, measure)
+        if cluster_index > 1 and _subject_values(subject):
+            raise ValueError("subject filter requires a parent component cache with a dataset axis")
         if cluster_index > 1:
             data = _cluster_component_data(source, cluster, data, components)
         elif components is not None:
@@ -121,7 +123,9 @@ def std_readpac(
     **_kwargs: Any,
 ) -> tuple[dict[str, Any], list[np.ndarray], np.ndarray, np.ndarray]:
     """Read cached STUDY PAC data when a standalone cache is present."""
-    _ = ALLEEG, components
+    _ = ALLEEG
+    if components is not None:
+        raise ValueError("std_readpac does not yet support component selection for PAC caches")
     study = ensure_study(STUDY)
     if channels is not None:
         groups = _channel_groups(study, channels)
@@ -336,7 +340,7 @@ def _subject_filter(data: np.ndarray, study: dict[str, Any], subject: Any) -> np
         return data
     datasetinfo = study.get("datasetinfo") or []
     if data.ndim == 0 or data.shape[0] != len(datasetinfo):
-        return data
+        raise ValueError("subject filter requires a dataset-axis cache")
     keep = [index for index, info in enumerate(datasetinfo) if str(info.get("subject") or "") in subjects]
     if not keep:
         raise ValueError("subject filter did not match any STUDY datasets")

--- a/src/eegprep/resources/help/pop_addindepvar.md
+++ b/src/eegprep/resources/help/pop_addindepvar.md
@@ -1,0 +1,19 @@
+# POP_ADDINDEPVAR - Select a STUDY independent variable
+
+`pop_addindepvar` returns the variable name, selected values, and categorical
+flag used by STUDY design helpers.
+
+```python
+variable, values, categorical = pop_addindepvar(
+    STUDY,
+    var="condition",
+    values=["target", "standard"],
+    vartype="categorical",
+)
+```
+
+EEGPrep supports the command-line design-selection behavior used by
+`pop_studydesign` and `std_makedesign`. MATLAB GUI callback strings and direct
+figure mutation are not available in standalone EEGPrep.
+
+See also: POP_LISTFACTORS, POP_STUDYDESIGN, STD_MAKEDESIGN

--- a/src/eegprep/resources/help/pop_listfactors.md
+++ b/src/eegprep/resources/help/pop_listfactors.md
@@ -1,0 +1,17 @@
+# POP_LISTFACTORS - List STUDY design factors
+
+`pop_listfactors` returns EEGLAB-style factor descriptors for a STUDY or design
+structure.
+
+```python
+factors = pop_listfactors(STUDY, level="both", vartype="both", constant="off")
+```
+
+Each descriptor includes the factor label, variable type, level, and value when
+the factor is categorical. Use `constant="off"` to omit the intercept-like
+constant factor.
+
+The standalone EEGPrep helper does not open EEGLAB's MATLAB factor-list GUI.
+Requests with `gui="on"` raise a clear `NotImplementedError`.
+
+See also: POP_ADDINDEPVAR, POP_STUDYDESIGN, STD_ADDVARLEVEL

--- a/tests/test_eeglab_parity_matrix.py
+++ b/tests/test_eeglab_parity_matrix.py
@@ -87,6 +87,21 @@ def test_validator_rejects_incomplete_stale_skip_policy() -> None:
     assert "stale_policy.likely_user_alias: must be false" in _messages(report)
 
 
+def test_validator_requires_concrete_follow_up_issue_for_actionable_rows() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    actionable_row = next(row for row in changed["rows"] if row["status"] in {"port", "partial"})
+    actionable_row["rationale"] = "Deferred to a follow-up after the integrated closeout review."
+    actionable_row["test_notes"] = "Follow-up issue must add parity tests before marking implemented."
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert "must cite a concrete follow-up issue" in _messages(report)
+
+
 def test_cli_json_report_is_machine_readable(capsys) -> None:
     _require_eeglab_reference()
 

--- a/tests/test_eeglab_parity_matrix.py
+++ b/tests/test_eeglab_parity_matrix.py
@@ -95,11 +95,27 @@ def test_validator_requires_concrete_follow_up_issue_for_actionable_rows() -> No
     actionable_row = next(row for row in changed["rows"] if row["status"] in {"port", "partial"})
     actionable_row["rationale"] = "Deferred to a follow-up after the integrated closeout review."
     actionable_row["test_notes"] = "Follow-up issue must add parity tests before marking implemented."
+    actionable_row["follow_up_issue"] = ""
 
     report = validate_matrix_payload(changed, REPO_ROOT)
 
     assert not report.ok
     assert "must cite a concrete follow-up issue" in _messages(report)
+
+
+def test_validator_accepts_structured_follow_up_issue_for_actionable_rows() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    actionable_row = next(row for row in changed["rows"] if row["status"] in {"port", "partial"})
+    actionable_row["rationale"] = "Deferred to a follow-up after the integrated closeout review."
+    actionable_row["test_notes"] = "Follow-up issue must add parity tests before marking implemented."
+    actionable_row["follow_up_issue"] = "https://github.com/sccn/eegprep/issues/146"
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert report.ok, [error.as_text() for error in report.errors]
 
 
 def test_cli_json_report_is_machine_readable(capsys) -> None:

--- a/tests/test_guifunc_pophelp_chansel.py
+++ b/tests/test_guifunc_pophelp_chansel.py
@@ -52,6 +52,14 @@ class PopHelpAndChanSelTests(unittest.TestCase):
         self.assertIn("resources/help", Path(source_path).as_posix())
         self.assertTrue(source_path.endswith("reref.md"))
 
+    def test_phase_study_pop_help_resources_are_packaged(self):
+        for target in ("pop_addindepvar", "pop_listfactors"):
+            with self.subTest(target=target):
+                text, source_path = pophelp_text(target)
+                self.assertIn(target.upper(), text.upper())
+                self.assertIn("resources/help", Path(source_path).as_posix())
+                self.assertTrue(source_path.endswith(f"{target}.md"))
+
     def test_dialog_help_targets_have_packaged_resources(self):
         interp_eeg = {"data": [], "trials": 1, "chanlocs": [], "chaninfo": {}, "epoch": []}
         specs = (pop_reref_dialog_spec(), pop_interp_dialog_spec(interp_eeg))

--- a/tests/test_study_measures.py
+++ b/tests/test_study_measures.py
@@ -248,6 +248,16 @@ def test_std_precomp_component_measures_and_parent_cluster_plot():
     _study, topodata, channel_axis = std_readtopo(study, alleeg, clusters=1, components=[1])
     assert topodata[0].shape == (2, 1, first["nbchan"])
     assert channel_axis.tolist() == [1, 2, 3, 4, 5]
+    cluster["pacdata"] = np.ones((2, 3, 4))
+    cluster["pactimes"] = [0.0, 10.0, 20.0, 30.0]
+    cluster["pacfreqs"] = [4.0, 8.0, 12.0]
+    _study, pacdata, pactimes, pacfreqs = std_readpac(study, alleeg, clusters=1)
+    assert pacdata[0].shape == (2, 3, 4)
+    assert pactimes.tolist() == [0.0, 10.0, 20.0, 30.0]
+    assert pacfreqs.tolist() == [4.0, 8.0, 12.0]
+    with pytest.raises(ValueError, match="component selection"):
+        std_readpac(study, alleeg, clusters=1, components=[1])
+    del cluster["pacdata"]
     with pytest.raises(NotImplementedError, match="PAC"):
         std_readpac(study, alleeg, clusters=1)
     plt.close(figure)
@@ -317,6 +327,8 @@ def test_child_cluster_measure_reads_slice_parent_component_cache():
 
     assert erpdata[0].shape == (len(child["comps"]), first["pnts"])
     assert figure is None
+    with pytest.raises(ValueError, match="subject filter requires"):
+        std_readerp(study, alleeg, clusters=[2], subject="S01")
 
 
 def test_precomp_missing_ica_and_unknown_channel_paths_fail_clearly():

--- a/tests/test_study_measures.py
+++ b/tests/test_study_measures.py
@@ -85,6 +85,11 @@ def test_std_precomp_channel_measures_store_eeglab_named_fields():
     assert specdata[0].shape[0] == 2
     assert freqs.size == specdata[0].shape[1]
 
+    collapsed = deepcopy(study)
+    collapsed["changrp"][0]["erpdata"] = np.asarray(collapsed["changrp"][0]["erpdata"])[0]
+    with pytest.raises(ValueError, match="dataset-axis"):
+        std_readerp(collapsed, alleeg, channels=[1], subject="S01")
+
 
 def test_std_precomp_baseline_and_design_contract(caplog):
     study, alleeg = _study_pair()

--- a/tests/test_study_metadata.py
+++ b/tests/test_study_metadata.py
@@ -275,6 +275,8 @@ def test_design_variable_helpers_build_factors_and_matrices():
     assert variable == "condition"
     assert values == ["target"]
     assert categorical == 1
+    display_options = pop_listfactors(leveled, splitreg="on", interaction="on", gui="off")
+    assert display_options == pop_listfactors(leveled)
     assert labels == ["condition-target", "condition-standard", "rt", "constant"]
     np.testing.assert_allclose(matrix[:, -2:], [[300.0, 1.0], [400.0, 1.0]])
     np.testing.assert_array_equal(catflag, np.asarray([True, True, False, False]))

--- a/tools/eeglab_parity_matrix.py
+++ b/tools/eeglab_parity_matrix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +46,7 @@ VALID_STATUSES = (
 VALID_PHASES = ("none", "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6", "phase_7")
 ACTIONABLE_STATUSES = {"partial", "port"}
 EQUIVALENT_REQUIRED_STATUSES = {"implemented", "partial", "consolidated"}
+FOLLOW_UP_ISSUE_RE = re.compile(r"#[1-9][0-9]*")
 REQUIRED_ROW_FIELDS = (
     "eeglab_path",
     "eeglab_name",
@@ -237,6 +239,15 @@ def _validate_row(row: dict[str, Any], location: str, errors: list[MatrixValidat
         errors.append(MatrixValidationError(f"{location}.responsible_phase", "must be a valid phase id"))
     if status in ACTIONABLE_STATUSES and phase == "none":
         errors.append(MatrixValidationError(f"{location}.responsible_phase", f"is required for status {status!r}"))
+    if status in ACTIONABLE_STATUSES and not FOLLOW_UP_ISSUE_RE.search(
+        f"{row.get('rationale') or ''} {row.get('test_notes') or ''}"
+    ):
+        errors.append(
+            MatrixValidationError(
+                location,
+                f"status {status!r} must cite a concrete follow-up issue in rationale or test_notes",
+            )
+        )
 
     surfaces = row.get("user_facing_surface")
     if not isinstance(surfaces, list) or not all(isinstance(surface, str) and surface for surface in surfaces):

--- a/tools/eeglab_parity_matrix.py
+++ b/tools/eeglab_parity_matrix.py
@@ -46,7 +46,7 @@ VALID_STATUSES = (
 VALID_PHASES = ("none", "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6", "phase_7")
 ACTIONABLE_STATUSES = {"partial", "port"}
 EQUIVALENT_REQUIRED_STATUSES = {"implemented", "partial", "consolidated"}
-FOLLOW_UP_ISSUE_RE = re.compile(r"#[1-9][0-9]*")
+FOLLOW_UP_ISSUE_RE = re.compile(r"(?:#[1-9][0-9]*|/issues/[1-9][0-9]*)")
 REQUIRED_ROW_FIELDS = (
     "eeglab_path",
     "eeglab_name",
@@ -239,13 +239,12 @@ def _validate_row(row: dict[str, Any], location: str, errors: list[MatrixValidat
         errors.append(MatrixValidationError(f"{location}.responsible_phase", "must be a valid phase id"))
     if status in ACTIONABLE_STATUSES and phase == "none":
         errors.append(MatrixValidationError(f"{location}.responsible_phase", f"is required for status {status!r}"))
-    if status in ACTIONABLE_STATUSES and not FOLLOW_UP_ISSUE_RE.search(
-        f"{row.get('rationale') or ''} {row.get('test_notes') or ''}"
-    ):
+    follow_up_text = " ".join(str(row.get(field) or "") for field in ("rationale", "test_notes", "follow_up_issue"))
+    if status in ACTIONABLE_STATUSES and not FOLLOW_UP_ISSUE_RE.search(follow_up_text):
         errors.append(
             MatrixValidationError(
                 location,
-                f"status {status!r} must cite a concrete follow-up issue in rationale or test_notes",
+                f"status {status!r} must cite a concrete follow-up issue in rationale, test_notes, or follow_up_issue",
             )
         )
 


### PR DESCRIPTION
Close Phase 8 by hardening the parity matrix follow-up contract, adding missing STUDY pophelp resources, and fixing closeout defects in STUDY measure/filter behavior. Evidence: matrix, ruff, format, ty, non-slow pytest, changed-file pre-commit, sample-console smoke, visual parity tests, and clean autoreview passed; MATLAB marker run was attempted but local engine unavailable/stalled.

After merge, open the final epic PR from feature/eeglab-core-parity-completion to develop, summarize PRs #140-#145/#150 plus this PR, and carry follow-ups #146-#149.

Fixes #139
Part of #131
