### PR TITLE
[Parity] Add final standalone audit matrix

### DIFF
--- a/.notes/eeglab-final-parity-audit.md
+++ b/.notes/eeglab-final-parity-audit.md
@@ -1,0 +1,153 @@
+# EEGPrep Final Standalone Parity Audit
+
+Audit date: 2026-06-07
+Epic: #157
+Phase issue: #158
+Machine-readable contract: `docs/parity/eeglab_final_parity_matrix.json`
+Validator: `uv run --no-sync python -m tools.eeglab_final_parity_matrix --json`
+
+## Purpose
+
+This audit expands the completed core parity matrix into the final standalone
+product-completion surface for EEGPrep. It covers the remaining non-stale
+workflows that are not fully represented by
+`docs/parity/eeglab_core_parity_matrix.json`:
+
+- bundled plugin depth for `clean_rawdata`, `firfilt`, `ICLabel`/viewprops, and
+  `dipfit`;
+- MATLAB object/storage folders `@eegobj`, `@memmapdata`, and `@mmo`;
+- optional-toolbox workflows such as LIMO, PAC, FieldTrip-style STUDY helpers,
+  Riemannian ASR, and DIPFIT fitting;
+- EEGLAB tutorial/doc surfaces that should become EEGPrep-owned Sphinx docs.
+
+This phase does not port feature behavior. It defines the rows, status values,
+phase ownership, optional-dependency rules, documentation architecture, and
+validator behavior that later phase agents must use.
+
+## Status Taxonomy
+
+Rows in the final matrix use these statuses:
+
+- `implemented`: EEGPrep has the standalone behavior; the responsible phase
+  owns verification, docs, and final evidence.
+- `partial`: EEGPrep has part of the behavior, but important options, GUI
+  paths, diagnostics, numerical parity, or docs still need phase work.
+- `port`: a useful workflow is not implemented yet and should be ported or
+  redesigned as native Python/Qt behavior.
+- `consolidated`: EEGPrep intentionally covers the behavior through a different
+  Python helper or public contract instead of a same-name file.
+- `stale_skip`: a MATLAB demo, test, packaging helper, or obsolete alias is not
+  a user workflow. These rows require the full stale-policy object with every
+  field set to `false`.
+- `matlab_runtime_skip`: MATLAB path, command-window, GUI shim, or toolbox
+  activation behavior that must not exist in installed EEGPrep runtime code.
+- `optional_dependency`: a real scientific workflow needs a substantial backend
+  decision. The row must name the dependency, fallback behavior, user-facing
+  message, and phase contract.
+- `external_plugin`: behavior belongs to an external plugin ecosystem and
+  should use EEGPrep extension contracts rather than core package code.
+- `docs_gap`: a documentation/tutorial surface that Phase 7 must write after
+  feature phases define final behavior.
+
+All non-skip rows must name a responsible phase and the matching phase issue.
+Skip rows must have `responsible_phase: "none"` and `phase_issue: null`.
+
+## Phase Ownership
+
+- Phase 2 / #159 owns `clean_rawdata` and FIRFilt rows, including standard ASR,
+  Riemannian ASR optional-backend decisions, `vis_artifacts`, FIR order
+  calculators, boundary helpers, reports, and frequency-response plotting.
+- Phase 3 / #160 owns DIPFIT settings, fitting, FieldTrip/source-localization
+  boundaries, atlas and coordinate transforms, leadfield/LORETA workflows, and
+  dipole plotting evidence.
+- Phase 4 / #161 owns optional LIMO/PAC/STUDY statistics behavior and
+  FieldTrip-style STUDY neighbor/interpolation/source workflows. It must
+  coordinate with Phase 3 for source-localization assumptions.
+- Phase 5 / #162 owns Python-native large-dataset storage, `storedisk`,
+  `option_memmapdata`, and the product decision for `@memmapdata`/`@mmo`
+  semantics. It should not port MATLAB overloads one-for-one.
+- Phase 6 / #163 owns ICLabel, label statistics, viewprops, component-property
+  diagnostics, alternate runtime/network decisions, and visual evidence.
+- Phase 7 / #164 owns the EEGLAB-style Sphinx docs architecture and all
+  `docs_gap` tutorial rows. It should merge after feature phases describe
+  actual completed behavior rather than intentions.
+- Phase 8 / #165 owns final integration, release hardening, docs build,
+  non-slow tests, MATLAB parity where available, visual parity suite, GUI Agent
+  mixed-flow QA, and evidence rollup.
+
+## Optional-Dependency Rules
+
+EEGPrep should prefer standalone Python behavior for core preprocessing, data
+structures, GUI/console state, saved-file behavior, and bundled plugin workflows
+that can be tested without external scientific toolboxes.
+
+Use `optional_dependency` only when the workflow requires a substantial backend
+that can be installed, versioned, tested, and documented. These rows must not
+produce fake outputs. Until a backend is selected, user-facing functions should
+raise clear limitations that name the missing backend and point to EEGPrep docs.
+
+Use `external_plugin` for broad third-party ecosystems that do not belong in
+core EEGPrep. Those workflows should be built through the extension API,
+catalog/trust model, packaged help, tests, and docs.
+
+## Documentation Architecture
+
+Phase 7 should reorganize and expand Sphinx docs into an EEGLAB-style manual
+with EEGPrep-specific behavior:
+
+1. Installation and optional dependencies.
+2. Concepts guide: EEG structures, events, epochs, channel locations, ICA,
+   STUDY, history, `EEG`, `ALLEEG`, `CURRENTSET`, and indexing boundaries.
+3. GUI tutorials and menu workflows.
+4. Command line, `eegprep-console`, `LASTCOM`, `ALLCOM`, and script replay.
+5. Preprocessing, filtering, cleaning, and artifact diagnostics.
+6. ICA, ICLabel, rejection, and visual diagnostics.
+7. STUDY, statistics, PAC, source localization, and optional backend limits.
+8. Bundled plugins and external extensions.
+9. API reference.
+10. EEGLAB migration notes mapping familiar MATLAB workflows to EEGPrep GUI,
+    Python, and console workflows.
+11. Developer parity contracts, matrix maintenance, visual evidence, and the
+    standalone runtime boundary.
+
+The current docs already have useful pages under `docs/source/user_guide/`,
+`docs/source/api/`, and `docs/source/examples/`. Phase 7 should reorganize and
+extend those pages rather than generating API dumps or copying EEGLAB prose.
+
+## Runtime Contract
+
+The installed `eegprep` package must not read, import from, or shell out to
+`src/eegprep/eeglab`. That checkout is a development oracle for audits, parity
+tests, and tooling only. Runtime help text, options, sample resources, and docs
+must be EEGPrep-owned packaged resources.
+
+This phase adds `tests/test_runtime_eeglab_independence.py` to scan package
+Python files for vendored-reference dependency patterns. Tooling under `tools/`
+may read the vendored EEGLAB tree because validation is a development task.
+
+## Validator Contract
+
+`tools.eeglab_final_parity_matrix` discovers 180 final-epic EEGLAB reference
+paths from the vendored checkout:
+
+- plugin paths from the four bundled plugin roots, excluding MatConvNet and
+  Manopt third-party library internals/examples/tests;
+- object/storage MATLAB class folder files;
+- EEGLAB tutorial scripts and Live Scripts.
+
+Rows may group several source paths into one workflow, but each discovered
+reference path must appear exactly once. Missing paths, duplicated paths,
+missing optional-dependency contracts, stale-skip policy mistakes, missing docs
+architecture sections, and inconsistent phase ownership fail validation.
+
+The existing core command remains separate and must still pass:
+
+```bash
+uv run --no-sync python -m tools.eeglab_parity_matrix --json
+```
+
+The final epic command is:
+
+```bash
+uv run --no-sync python -m tools.eeglab_final_parity_matrix --json
+```

--- a/.notes/eeglab-migration-gap-audit.md
+++ b/.notes/eeglab-migration-gap-audit.md
@@ -205,18 +205,35 @@ Avoid these patterns in future migration work:
 
 ## Next Planning Step
 
-The next major migration epic should pick one of the remaining product areas
-above and turn it into a scoped issue tree. The strongest candidates are:
+Epic #157 now turns the remaining product areas above into a scoped issue tree.
+Its Phase 1 contract lives in:
+
+- `.notes/eeglab-final-parity-audit.md`
+- `docs/parity/eeglab_final_parity_matrix.json`
+- `tools/eeglab_final_parity_matrix.py`
+
+The final matrix assigns concrete phase ownership for bundled plugin depth,
+object/storage semantics, optional-toolbox workflows, and docs/tutorial gaps.
+Future phase agents should update that matrix instead of reclassifying product
+scope from this prose audit.
+
+Before the final epic started, the strongest candidates were:
 
 1. Bundled plugin depth, split by plugin family.
 2. Large-dataset storage and memory mapping semantics.
 3. External dependency workflows such as LIMO or advanced DIPFIT.
 4. User documentation/tutorial parity for completed core workflows.
 
-Before any new epic starts, run:
+Before changing core parity rows, run:
 
 ```bash
 uv run --no-sync python -m tools.eeglab_parity_matrix --json
+```
+
+Before changing final epic rows, run:
+
+```bash
+uv run --no-sync python -m tools.eeglab_final_parity_matrix --json
 ```
 
 Then decide whether the work changes the existing matrix rows or belongs to a

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -6,6 +6,54 @@
 </head>
 <body>
   <h1>EEGPrep Core Parity Implementation Notes</h1>
+  <h1>Issue #158 Final Standalone Parity Audit Notes</h1>
+  <p>Issue #158 establishes the Phase 1 contract for epic #157. It adds an
+  enforceable final-epic matrix for bundled plugin depth, MATLAB object/storage
+  semantics, optional-toolbox workflows, and EEGLAB-style docs architecture
+  without porting feature behavior.</p>
+  <h2>Issue #158 Design Decisions</h2>
+  <ul>
+    <li>Added <code>docs/parity/eeglab_final_parity_matrix.json</code> as a
+    second matrix instead of changing the completed core matrix, so
+    <code>uv run --no-sync python -m tools.eeglab_parity_matrix --json</code>
+    remains the PR #152 core validator.</li>
+    <li>Grouped MATLAB files into workflow rows while the validator still
+    flattens <code>source_paths</code> and requires every discovered final-epic
+    EEGLAB path to be covered exactly once.</li>
+    <li>Excluded MatConvNet and Manopt third-party internals, examples, and
+    tests from file-by-file coverage, while keeping top-level Riemannian ASR
+    and MatConvNet activation decisions explicitly classified.</li>
+    <li>Encoded the EEGLAB-style docs architecture in matrix metadata and in
+    <code>.notes/eeglab-final-parity-audit.md</code> so Phase 7 can write user
+    docs after Phases 2-6 define final behavior.</li>
+  </ul>
+  <h2>Issue #158 Runtime Contract</h2>
+  <ul>
+    <li>Added a runtime-boundary test that scans installed package Python files
+    for vendored <code>src/eegprep/eeglab</code> dependency patterns.</li>
+    <li>Removed the AMICA binary discovery fallback that searched the vendored
+    EEGLAB plugin tree. Supported AMICA discovery remains explicit binary path,
+    <code>AMICA_BINARY</code>, package <code>bin/</code>, and system
+    <code>PATH</code>.</li>
+  </ul>
+  <h2>Issue #158 Tradeoffs</h2>
+  <ul>
+    <li>The final matrix uses <code>optional_dependency</code> for LIMO, PAC,
+    Riemannian ASR, FieldTrip-style STUDY/source workflows, and DIPFIT fitting
+    instead of pretending those computations are available without a tested
+    backend.</li>
+    <li>The matrix assigns ownership to Phases 2-8 even for <code>partial</code>
+    and <code>consolidated</code> rows, because the final epic still needs each
+    owner to provide verification, docs, or explicit limitation evidence.</li>
+  </ul>
+  <h2>Issue #158 Verification Notes</h2>
+  <ul>
+    <li>Focused tests cover committed final matrix validation, unclassified and
+    duplicated source paths, optional-dependency contracts, phase ownership,
+    docs architecture, CLI JSON output, and runtime independence.</li>
+    <li>The final matrix validator reports 31 workflow rows covering 180
+    discovered final-epic EEGLAB reference paths.</li>
+  </ul>
   <h1>Issue #147 Correct MC Random-Symbol Fitting Notes</h1>
   <p>Issue #147 implements the Ramberg-Schmeiser/random-symbol fitting stack
   needed by <code>correct_mc</code> while keeping EEGPrep runtime code independent

--- a/docs/parity/eeglab_final_parity_matrix.json
+++ b/docs/parity/eeglab_final_parity_matrix.json
@@ -1,0 +1,1074 @@
+{
+  "metadata": {
+    "schema_version": 1,
+    "source_audit": ".notes/eeglab-final-parity-audit.md",
+    "source_issue": "https://github.com/sccn/eegprep/issues/158",
+    "parent_epic": "https://github.com/sccn/eegprep/issues/157",
+    "scope": {
+      "description": "Final standalone parity epic matrix for bundled plugin depth, MATLAB object/storage surfaces, optional-toolbox workflows, and EEGLAB-style documentation coverage.",
+      "covered_reference_roots": [
+        "src/eegprep/eeglab/plugins/clean_rawdata/**/*.m except vendored Manopt library examples/tests/runtime internals",
+        "src/eegprep/eeglab/plugins/firfilt/**/*.m",
+        "src/eegprep/eeglab/plugins/ICLabel/**/*.m except vendored MatConvNet internals/tests",
+        "src/eegprep/eeglab/plugins/dipfit/**/*.m",
+        "src/eegprep/eeglab/functions/@eegobj/*.m",
+        "src/eegprep/eeglab/functions/@memmapdata/*.m",
+        "src/eegprep/eeglab/functions/@mmo/*.m",
+        "src/eegprep/eeglab/tutorial_scripts/*.{m,mlx}",
+        "selected core matrix rows that represent optional-toolbox workflows"
+      ]
+    },
+    "status_taxonomy": [
+      "implemented",
+      "partial",
+      "port",
+      "consolidated",
+      "stale_skip",
+      "matlab_runtime_skip",
+      "optional_dependency",
+      "external_plugin",
+      "docs_gap"
+    ],
+    "phase_issues": {
+      "phase_2": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "phase_3": "#160 DIPFIT and source-localization standalone parity",
+      "phase_4": "#161 STUDY statistics, PAC, and LIMO-compatible workflows",
+      "phase_5": "#162 Large-dataset storage and storedisk semantics",
+      "phase_6": "#163 ICLabel, viewprops, and visual diagnostics completion",
+      "phase_7": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "phase_8": "#165 Final integration, QA, release hardening, and evidence"
+    },
+    "optional_dependency_policy": {
+      "standalone_first": "Prefer a tested EEGPrep-owned Python implementation when the workflow is core preprocessing, data structure, GUI, console, or saved-file behavior.",
+      "optional_dependency": "Use optional_dependency only when the scientific computation depends on a substantial external toolbox that can be installed, versioned, tested, and documented without reading the vendored EEGLAB tree.",
+      "external_plugin": "Use external_plugin when the workflow belongs to a third-party EEGLAB ecosystem that should live behind EEGPrep extension contracts instead of core package runtime code.",
+      "user_facing_failure": "Unsupported optional paths must raise clear user-facing limitations, name the missing backend, and link to EEGPrep docs rather than creating placeholder outputs."
+    },
+    "docs_architecture": {
+      "model": "EEGLAB-style user manual, rewritten for standalone EEGPrep Python, Qt GUI, and eegprep-console behavior.",
+      "sections": [
+        {
+          "id": "installation",
+          "title": "Installation and Optional Dependencies",
+          "target": "docs/source/user_guide/installation.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "concepts",
+          "title": "Concepts Guide: EEG Data Structures, Events, Epochs, Channels, ICA, STUDY, and History",
+          "target": "docs/source/user_guide/concepts.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "gui_tutorials",
+          "title": "GUI Tutorials and Menu Workflows",
+          "target": "docs/source/user_guide/gui_tutorials.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "console_and_history",
+          "title": "Command Line, eegprep-console, LASTCOM, ALLCOM, and Script Replay",
+          "target": "docs/source/user_guide/interactive_console.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "preprocessing",
+          "title": "Preprocessing and Filtering Tutorials",
+          "target": "docs/source/user_guide/preprocessing_pipeline.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "ica_and_rejection",
+          "title": "ICA, ICLabel, Rejection, and Visual Diagnostics",
+          "target": "docs/source/user_guide/ica_rejection.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "study_and_statistics",
+          "title": "STUDY, Statistics, PAC, Source Localization, and Optional Backends",
+          "target": "docs/source/user_guide/study_workflows.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "plugins_and_extensions",
+          "title": "Bundled Plugins and External Extensions",
+          "target": "docs/source/user_guide/plugins.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "api_reference",
+          "title": "API Reference",
+          "target": "docs/source/api/index.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "eeglab_migration",
+          "title": "EEGLAB Migration Notes",
+          "target": "docs/source/user_guide/eeglab_migration.rst",
+          "phase_owner": "phase_7"
+        },
+        {
+          "id": "developer_parity",
+          "title": "Developer Parity Contracts and Runtime Boundary",
+          "target": "docs/source/development.rst",
+          "phase_owner": "phase_7"
+        }
+      ]
+    },
+    "source_exclusion_policy": [
+      "Exclude plugins/clean_rawdata/manopt/manopt/** because it is a vendored third-party Manopt library, not an EEGPrep user workflow; Riemannian ASR remains represented by the top-level ASR and Manopt entry rows.",
+      "Exclude plugins/clean_rawdata/manopt/examples/** and plugins/clean_rawdata/manopt/tests/** because they are third-party demos/tests.",
+      "Exclude plugins/ICLabel/matconvnet/** and plugins/ICLabel/tests/** because EEGPrep uses packaged Python ICLabel assets/runtime decisions instead of porting MatConvNet internals."
+    ],
+    "runtime_rule": "Installed eegprep package code must not read, import from, or shell out to src/eegprep/eeglab; that tree is only a development and parity-test oracle."
+  },
+  "rows": [
+    {
+      "row_id": "clean_rawdata-cleaning-pipeline",
+      "title": "clean_rawdata cleaning pipeline and GUI entry point",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/clean_artifacts.m",
+        "plugins/clean_rawdata/clean_channels.m",
+        "plugins/clean_rawdata/clean_channels_nolocs.m",
+        "plugins/clean_rawdata/clean_drifts.m",
+        "plugins/clean_rawdata/clean_flatlines.m",
+        "plugins/clean_rawdata/clean_rawdata.m",
+        "plugins/clean_rawdata/clean_windows.m",
+        "plugins/clean_rawdata/eegplugin_clean_rawdata.m",
+        "plugins/clean_rawdata/pop_clean_rawdata.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.clean_rawdata.clean_artifacts",
+        "eegprep.plugins.clean_rawdata.pop_clean_rawdata"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "EEGPrep has standalone cleaning entry points and menu wiring, but Phase 2 owns the final audit of option parity, GUI defaults, diagnostics, progress behavior, and MATLAB parity evidence.",
+      "user_facing_surface": [
+        "Tools > Clean rawdata",
+        "clean_artifacts",
+        "pop_clean_rawdata"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/plugins.rst"
+      ],
+      "test_notes": "Phase 2 must add focused clean_rawdata option, GUI, console, and MATLAB parity tests before marking this implemented."
+    },
+    {
+      "row_id": "clean_rawdata-standard-asr",
+      "title": "Standard ASR calibration and processing",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/asr_calibrate.m",
+        "plugins/clean_rawdata/asr_process.m",
+        "plugins/clean_rawdata/clean_asr.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.clean_rawdata.asr_calibrate",
+        "eegprep.plugins.clean_rawdata.asr_process",
+        "eegprep.plugins.clean_rawdata.clean_asr"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "The standard ASR path exists, but final standalone parity needs a fresh comparison against the bundled plugin defaults, covariance fitting behavior, and edge-case channel/window handling.",
+      "user_facing_surface": [
+        "clean_asr",
+        "clean_artifacts"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst"
+      ],
+      "test_notes": "Phase 2 should keep deterministic MATLAB parity tests where feasible and document any deliberate numerical tradeoffs."
+    },
+    {
+      "row_id": "clean_rawdata-riemannian-asr",
+      "title": "Riemannian ASR and Manopt-backed behavior",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/asr_calibrate_r.m",
+        "plugins/clean_rawdata/asr_process_r.m",
+        "plugins/clean_rawdata/manopt/buildrelease.m",
+        "plugins/clean_rawdata/manopt/checkinstall.m",
+        "plugins/clean_rawdata/manopt/importmanopt.m",
+        "plugins/clean_rawdata/manopt/manopt_version.m",
+        "plugins/clean_rawdata/rasr_nonlinear_eigenspace.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "optional_dependency",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "optional_dependency": {
+        "name": "Riemannian manifold optimizer for ASR",
+        "dependency_type": "scientific optional backend",
+        "fallback_behavior": "Use the supported standard ASR path or raise a clear limitation when a user explicitly requests Riemannian ASR.",
+        "user_message": "Riemannian ASR is not silently emulated in standalone EEGPrep until a tested Python manifold-optimization backend is selected.",
+        "phase_contract": "Phase 2 must decide whether to implement a Python backend or keep a documented optional-dependency limitation with tests for the failure path."
+      },
+      "rationale": "EEGLAB bundles Manopt for Riemannian ASR, but EEGPrep should not vendor or read that MATLAB library at runtime. The product decision belongs to the clean_rawdata phase.",
+      "user_facing_surface": [
+        "clean_asr",
+        "clean_artifacts"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/installation.rst"
+      ],
+      "test_notes": "Validator requires the optional dependency contract; Phase 2 must test either the chosen backend or the explicit limitation."
+    },
+    {
+      "row_id": "clean_rawdata-private-numerics",
+      "title": "clean_rawdata private numerical helpers",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/private/block_geometric_median.m",
+        "plugins/clean_rawdata/private/design_fir.m",
+        "plugins/clean_rawdata/private/design_kaiser.m",
+        "plugins/clean_rawdata/private/filter_fast.m",
+        "plugins/clean_rawdata/private/filtfilt_fast.m",
+        "plugins/clean_rawdata/private/fit_eeg_distribution.m",
+        "plugins/clean_rawdata/private/geometric_median.m",
+        "plugins/clean_rawdata/private/sphericalSplineInterpolate.m",
+        "plugins/clean_rawdata/private/window_func.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.clean_rawdata.private.stats",
+        "eegprep.plugins.clean_rawdata.private.sigproc",
+        "eegprep.plugins.clean_rawdata.private.sphericalSplineInterpolate"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "Most numerical helper responsibilities are consolidated into Python modules, but Phase 2 owns a full helper-by-helper parity audit for the final plugin contract.",
+      "user_facing_surface": [
+        "clean_artifacts",
+        "clean_channels",
+        "clean_windows"
+      ],
+      "docs_targets": [
+        "docs/source/api/preprocessing.rst"
+      ],
+      "test_notes": "Phase 2 should extend the existing utility tests only where the helper behavior remains product-relevant."
+    },
+    {
+      "row_id": "clean_rawdata-matlab-helper-shims",
+      "title": "clean_rawdata MATLAB helper and GUI shims",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/private/findjobj.m",
+        "plugins/clean_rawdata/private/hlp_handleerror.m",
+        "plugins/clean_rawdata/private/hlp_microcache.m",
+        "plugins/clean_rawdata/private/hlp_split.m",
+        "plugins/clean_rawdata/private/hlp_varargin2struct.m"
+      ],
+      "eegprep_equivalent": [
+        "native Python exceptions",
+        "Python keyword arguments",
+        "NumPy chunking helpers"
+      ],
+      "status": "consolidated",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "These MATLAB convenience helpers should stay folded into Python error handling, kwargs, and array utilities rather than becoming public EEGPrep files.",
+      "user_facing_surface": [],
+      "docs_targets": [
+        "docs/source/development.rst"
+      ],
+      "test_notes": "Phase 2 should keep these consolidated unless a concrete clean_rawdata workflow exposes missing behavior."
+    },
+    {
+      "row_id": "clean_rawdata-vis-artifacts",
+      "title": "clean_rawdata artifact visualization",
+      "area": "bundled_plugin_clean_rawdata",
+      "source_paths": [
+        "plugins/clean_rawdata/vis_artifacts.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "Users expect pre/post cleaning diagnostics comparable to EEGLAB's vis_artifacts; this should be a native EEGPrep plotting or GUI surface, not a MATLAB figure port.",
+      "user_facing_surface": [
+        "clean_artifacts diagnostics"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "test_notes": "Phase 2 should add visual or data-level diagnostics tests and attach GUI evidence when a GUI surface is added."
+    },
+    {
+      "row_id": "firfilt-current-filter-api",
+      "title": "FIRFilt current filtering APIs",
+      "area": "bundled_plugin_firfilt",
+      "source_paths": [
+        "plugins/firfilt/fir_filterdcpadded.m",
+        "plugins/firfilt/firfilt.m",
+        "plugins/firfilt/firws.m",
+        "plugins/firfilt/firwsord.m",
+        "plugins/firfilt/pop_eegfiltnew.m",
+        "plugins/firfilt/pop_firma.m",
+        "plugins/firfilt/pop_firpm.m",
+        "plugins/firfilt/pop_firws.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.firfilt.firws",
+        "eegprep.plugins.firfilt.pop_eegfiltnew",
+        "eegprep.plugins.firfilt.pop_firws"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "Core FIR filtering exists, but Phase 2 owns complete option coverage, boundary semantics, GUI defaults, and report parity.",
+      "user_facing_surface": [
+        "Tools > Filter the data",
+        "pop_eegfiltnew",
+        "pop_firws"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/api/signal_processing.rst"
+      ],
+      "test_notes": "Phase 2 should extend FIRFilt parity and GUI tests around transition bandwidth, windows, min-phase behavior, and boundary events."
+    },
+    {
+      "row_id": "firfilt-order-dialogs",
+      "title": "FIRFilt order calculators and window helpers",
+      "area": "bundled_plugin_firfilt",
+      "source_paths": [
+        "plugins/firfilt/invfirwsord.m",
+        "plugins/firfilt/invkaiserbeta.m",
+        "plugins/firfilt/kaiserbeta.m",
+        "plugins/firfilt/pop_firpmord.m",
+        "plugins/firfilt/pop_firwsord.m",
+        "plugins/firfilt/pop_kaiserbeta.m",
+        "plugins/firfilt/pop_xfirws.m",
+        "plugins/firfilt/windows.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "EEGLAB users rely on these helpers for filter-order planning and dialog workflows; EEGPrep should provide Python equivalents or native GUI controls where the workflow remains useful.",
+      "user_facing_surface": [
+        "FIRFilt order dialogs",
+        "filter design helpers"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst"
+      ],
+      "test_notes": "Phase 2 should add deterministic numeric tests for order formulas and GUI tests for any dialog surfaces."
+    },
+    {
+      "row_id": "firfilt-boundary-reports-plots",
+      "title": "FIRFilt boundary helpers, reports, and response plots",
+      "area": "bundled_plugin_firfilt",
+      "source_paths": [
+        "plugins/firfilt/eegplugin_firfilt.m",
+        "plugins/firfilt/findboundaries.m",
+        "plugins/firfilt/firfiltreport.m",
+        "plugins/firfilt/firfiltsplit.m",
+        "plugins/firfilt/minphaserceps.m",
+        "plugins/firfilt/plotfresp.m",
+        "plugins/firfilt/private/firgauss.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_2",
+      "phase_issue": "#159 clean_rawdata and FIRFilt bundled-plugin completion",
+      "rationale": "Boundary-aware filtering, user-readable reports, and frequency-response plots are user-visible FIRFilt behavior that remains to be made explicit in EEGPrep.",
+      "user_facing_surface": [
+        "filter reports",
+        "frequency response plots"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "test_notes": "Phase 2 must cover first/last boundary events and plot/report generation without MATLAB figure dependencies."
+    },
+    {
+      "row_id": "iclabel-classification-pipeline",
+      "title": "ICLabel classification pipeline",
+      "area": "bundled_plugin_iclabel_viewprops",
+      "source_paths": [
+        "plugins/ICLabel/ICL_feature_extractor.m",
+        "plugins/ICLabel/eeg_autocorr.m",
+        "plugins/ICLabel/eeg_autocorr_fftw.m",
+        "plugins/ICLabel/eeg_autocorr_welch.m",
+        "plugins/ICLabel/eeg_rpsd.m",
+        "plugins/ICLabel/eegplugin_iclabel.m",
+        "plugins/ICLabel/iclabel.m",
+        "plugins/ICLabel/pop_icflag.m",
+        "plugins/ICLabel/pop_iclabel.m",
+        "plugins/ICLabel/run_ICL.m",
+        "plugins/ICLabel/topoplotFast.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.ICLabel.ICL_feature_extractor",
+        "eegprep.plugins.ICLabel.iclabel",
+        "eegprep.plugins.ICLabel.pop_iclabel",
+        "eegprep.plugins.ICLabel.pop_icflag"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_6",
+      "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
+      "rationale": "The classification pipeline and bundled netICL asset exist, but Phase 6 owns final label-statistics, network/runtime, GUI, and visual diagnostics parity.",
+      "user_facing_surface": [
+        "Tools > Classify components using ICLabel",
+        "iclabel",
+        "pop_iclabel",
+        "pop_icflag"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/ica_rejection.rst",
+        "docs/source/api/ica.rst"
+      ],
+      "test_notes": "Phase 6 should preserve existing feature parity tests and add diagnostics coverage before marking this implemented."
+    },
+    {
+      "row_id": "iclabel-label-statistics",
+      "title": "ICLabel label statistics",
+      "area": "bundled_plugin_iclabel_viewprops",
+      "source_paths": [
+        "plugins/ICLabel/eeg_icalabelstat.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_6",
+      "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
+      "rationale": "EEGLAB exposes component label statistics that are useful for review, rejection, and reporting; EEGPrep should add a standalone equivalent.",
+      "user_facing_surface": [
+        "ICLabel statistics"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/ica_rejection.rst"
+      ],
+      "test_notes": "Phase 6 should test label distributions and edge cases such as missing ICA, missing labels, and multiple datasets."
+    },
+    {
+      "row_id": "iclabel-viewprops-component-browser",
+      "title": "Viewprops component browser",
+      "area": "bundled_plugin_iclabel_viewprops",
+      "source_paths": [
+        "plugins/ICLabel/viewprops/eegplugin_viewprops.m",
+        "plugins/ICLabel/viewprops/pop_prop_extended.m",
+        "plugins/ICLabel/viewprops/pop_viewprops.m",
+        "plugins/ICLabel/viewprops/scrollplot.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.ICLabel.pop_prop_extended",
+        "eegprep.plugins.ICLabel.pop_viewprops"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_6",
+      "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
+      "rationale": "EEGPrep has native component-property surfaces, but Phase 6 must close visual diagnostics parity across scalp maps, spectra, ERP/image panels, ICLabel labels, and DIPFIT overlays.",
+      "user_facing_surface": [
+        "Plot > Component properties",
+        "pop_viewprops",
+        "pop_prop_extended"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/ica_rejection.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "test_notes": "Phase 6 should use visual parity capture and mixed GUI/console tests for component browsing workflows."
+    },
+    {
+      "row_id": "iclabel-matconvnet-activation",
+      "title": "MatConvNet activation shim",
+      "area": "bundled_plugin_iclabel_viewprops",
+      "source_paths": [
+        "plugins/ICLabel/activate_matconvnet.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "matlab_runtime_skip",
+      "responsible_phase": "none",
+      "phase_issue": null,
+      "rationale": "This modifies MATLAB paths and MatConvNet state. EEGPrep must use packaged Python runtime assets and must not activate vendored MATLAB libraries.",
+      "user_facing_surface": [],
+      "docs_targets": [
+        "docs/source/development.rst"
+      ],
+      "test_notes": "Runtime-boundary tests should continue preventing package code from reading src/eegprep/eeglab."
+    },
+    {
+      "row_id": "iclabel-developer-tests-and-packaging",
+      "title": "ICLabel developer tests and packaging helpers",
+      "area": "bundled_plugin_iclabel_viewprops",
+      "source_paths": [
+        "plugins/ICLabel/run_tests.m",
+        "plugins/ICLabel/zipper.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "stale_skip",
+      "responsible_phase": "none",
+      "phase_issue": null,
+      "rationale": "These are MATLAB plugin developer helpers, not EEGPrep user workflows or runtime behavior.",
+      "user_facing_surface": [],
+      "docs_targets": [
+        "docs/source/development.rst"
+      ],
+      "test_notes": "No runtime parity tests required; EEGPrep has its own Python test and packaging workflow.",
+      "stale_policy": {
+        "menu_reachable": false,
+        "documented_user_api": false,
+        "called_by_in_scope_workflow": false,
+        "required_by_parity_tests": false,
+        "needed_as_phase_helper": false,
+        "likely_user_alias": false
+      }
+    },
+    {
+      "row_id": "dipfit-settings-and-metadata",
+      "title": "DIPFIT settings and dataset metadata",
+      "area": "bundled_plugin_dipfit",
+      "source_paths": [
+        "plugins/dipfit/channelselection.m",
+        "plugins/dipfit/dipfit_1_to_2.m",
+        "plugins/dipfit/dipfitdefs.m",
+        "plugins/dipfit/eegplugin_dipfit.m",
+        "plugins/dipfit/pop_dipfit_settings.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.dipfit.pop_dipfit_settings",
+        "eegprep.plugins.dipfit.menu"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_3",
+      "phase_issue": "#160 DIPFIT and source-localization standalone parity",
+      "rationale": "EEGPrep stores EEGLAB-compatible DIPFIT metadata and menu surfaces, but Phase 3 must finish settings validation, templates, help, and console history parity.",
+      "user_facing_surface": [
+        "Tools > Locate dipoles using DIPFIT > Head model and settings",
+        "pop_dipfit_settings"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/plugins.rst"
+      ],
+      "test_notes": "Phase 3 should test settings round trips, command history, and saved dataset compatibility."
+    },
+    {
+      "row_id": "dipfit-fieldtrip-backed-fitting",
+      "title": "DIPFIT fitting and FieldTrip-backed source localization",
+      "area": "bundled_plugin_dipfit",
+      "source_paths": [
+        "plugins/dipfit/LORETA_Talairach_BAs.m",
+        "plugins/dipfit/dipfit_erpeeg.m",
+        "plugins/dipfit/dipfit_gridsearch.m",
+        "plugins/dipfit/dipfit_nonlinear.m",
+        "plugins/dipfit/dipfit_reject.m",
+        "plugins/dipfit/pop_dipfit_batch.m",
+        "plugins/dipfit/pop_dipfit_gridsearch.m",
+        "plugins/dipfit/pop_dipfit_headmodel.m",
+        "plugins/dipfit/pop_dipfit_loreta.m",
+        "plugins/dipfit/pop_dipfit_manual.m",
+        "plugins/dipfit/pop_dipfit_nonlinear.m",
+        "plugins/dipfit/pop_leadfield.m",
+        "plugins/dipfit/pop_multifit.m",
+        "plugins/dipfit/traditionaldipfit.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.dipfit.pop_dipfit_gridsearch",
+        "eegprep.plugins.dipfit.pop_dipfit_nonlinear",
+        "eegprep.plugins.dipfit.pop_multifit"
+      ],
+      "status": "optional_dependency",
+      "responsible_phase": "phase_3",
+      "phase_issue": "#160 DIPFIT and source-localization standalone parity",
+      "optional_dependency": {
+        "name": "FieldTrip-compatible source-localization backend",
+        "dependency_type": "scientific optional backend",
+        "fallback_behavior": "Validate inputs and raise explicit missing-backend limitations unless Phase 3 selects and tests a Python backend.",
+        "user_message": "DIPFIT fitting is not silently emulated in standalone EEGPrep without a tested source-localization backend.",
+        "phase_contract": "Phase 3 must either implement tested standalone fitting or keep limitation wrappers, help resources, and docs that name the missing backend."
+      },
+      "rationale": "EEGLAB delegates this work to FieldTrip/source-localization internals. EEGPrep should not produce fake dipole fits; it needs a real backend decision.",
+      "user_facing_surface": [
+        "DIPFIT grid search",
+        "DIPFIT nonlinear fit",
+        "DIPFIT batch/manual fit",
+        "leadfield and LORETA workflows"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/installation.rst"
+      ],
+      "test_notes": "Phase 3 must test the selected backend or test the explicit limitation paths and GUI/console history."
+    },
+    {
+      "row_id": "dipfit-plotting",
+      "title": "DIPFIT dipole plotting",
+      "area": "bundled_plugin_dipfit",
+      "source_paths": [
+        "plugins/dipfit/adjustcylinder2.m",
+        "plugins/dipfit/dipplot.m",
+        "plugins/dipfit/plot3dmeshalign.m",
+        "plugins/dipfit/pop_dipplot.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.plugins.dipfit.pop_dipplot"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_3",
+      "phase_issue": "#160 DIPFIT and source-localization standalone parity",
+      "rationale": "EEGPrep can plot existing dipole positions, but MRI slices, mesh alignment, and full EEGLAB visual parity remain Phase 3 work.",
+      "user_facing_surface": [
+        "pop_dipplot",
+        "DIPFIT visual diagnostics"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "test_notes": "Phase 3 should add visual evidence for dipole plotting and no-backend behavior."
+    },
+    {
+      "row_id": "dipfit-atlas-coordinates-and-transforms",
+      "title": "DIPFIT atlas, coordinate, and transform helpers",
+      "area": "bundled_plugin_dipfit",
+      "source_paths": [
+        "plugins/dipfit/eeg_compatlas.m",
+        "plugins/dipfit/eeglab2fieldtrip.m",
+        "plugins/dipfit/electroderealign.m",
+        "plugins/dipfit/fieldtripchan2eeglab.m",
+        "plugins/dipfit/headcoordinates.m",
+        "plugins/dipfit/homogenous2traditional.m",
+        "plugins/dipfit/load_afni_atlas.m",
+        "plugins/dipfit/mni2tal.m",
+        "plugins/dipfit/mni2tal_matrix.m",
+        "plugins/dipfit/private/globalrescale.m",
+        "plugins/dipfit/private/match_str.m",
+        "plugins/dipfit/private/rigidbody.m",
+        "plugins/dipfit/private/rotate.m",
+        "plugins/dipfit/private/scale.m",
+        "plugins/dipfit/private/traditional.m",
+        "plugins/dipfit/private/translate.m",
+        "plugins/dipfit/private/warp_apply.m",
+        "plugins/dipfit/private/warp_error.m",
+        "plugins/dipfit/private/warp_optim.m",
+        "plugins/dipfit/sph2spm.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.functions.sigprocfunc.coregister",
+        "eegprep.plugins.dipfit._utils"
+      ],
+      "status": "partial",
+      "responsible_phase": "phase_3",
+      "phase_issue": "#160 DIPFIT and source-localization standalone parity",
+      "rationale": "Some transform logic exists in standalone Python helpers, but Phase 3 must finish coordinate-system coverage, atlas limitations, and FieldTrip conversion boundaries.",
+      "user_facing_surface": [
+        "DIPFIT settings",
+        "coregistration",
+        "source-localization helpers"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/api/signal_processing.rst"
+      ],
+      "test_notes": "Phase 3 should add deterministic transform tests and document coordinate-system assumptions."
+    },
+    {
+      "row_id": "eegobj-python-dataset-contract",
+      "title": "MATLAB @eegobj class facade",
+      "area": "object_storage",
+      "source_paths": [
+        "functions/@eegobj/display.m",
+        "functions/@eegobj/eegobj.m",
+        "functions/@eegobj/fieldnames.m",
+        "functions/@eegobj/horzcat2.m",
+        "functions/@eegobj/isfield.m",
+        "functions/@eegobj/isstruct.m",
+        "functions/@eegobj/length.m",
+        "functions/@eegobj/orderfields.m",
+        "functions/@eegobj/rmfield.m",
+        "functions/@eegobj/subsasgn.m",
+        "functions/@eegobj/subsref.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.functions.eegobj.EEGobj",
+        "EEG dict semantics",
+        "eegprep.functions.adminfunc.EEGPrepSession"
+      ],
+      "status": "consolidated",
+      "responsible_phase": "phase_5",
+      "phase_issue": "#162 Large-dataset storage and storedisk semantics",
+      "rationale": "EEGPrep should preserve EEG dict semantics and session behavior rather than porting MATLAB object overloads one-for-one.",
+      "user_facing_surface": [
+        "EEG",
+        "ALLEEG",
+        "EEGPrepSession"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/concepts.rst",
+        "docs/source/user_guide/interactive_console.rst"
+      ],
+      "test_notes": "Phase 5 should verify object/storage behavior through public EEG dict, save/load, GUI, and console workflows."
+    },
+    {
+      "row_id": "eegobj-simpletest",
+      "title": "@eegobj MATLAB developer simpletest",
+      "area": "object_storage",
+      "source_paths": [
+        "functions/@eegobj/simpletest.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "stale_skip",
+      "responsible_phase": "none",
+      "phase_issue": null,
+      "rationale": "This is a MATLAB class developer test, not a user workflow. EEGPrep uses Python unit and integration tests instead.",
+      "user_facing_surface": [],
+      "docs_targets": [
+        "docs/source/development.rst"
+      ],
+      "test_notes": "No parity port required; validator coverage prevents it from being forgotten.",
+      "stale_policy": {
+        "menu_reachable": false,
+        "documented_user_api": false,
+        "called_by_in_scope_workflow": false,
+        "required_by_parity_tests": false,
+        "needed_as_phase_helper": false,
+        "likely_user_alias": false
+      }
+    },
+    {
+      "row_id": "memmapdata-python-lazy-array-backend",
+      "title": "MATLAB @memmapdata large-array behavior",
+      "area": "object_storage",
+      "source_paths": [
+        "functions/@memmapdata/display.m",
+        "functions/@memmapdata/double.m",
+        "functions/@memmapdata/end.m",
+        "functions/@memmapdata/isnumeric.m",
+        "functions/@memmapdata/length.m",
+        "functions/@memmapdata/memmapdata.m",
+        "functions/@memmapdata/ndims.m",
+        "functions/@memmapdata/reshape.m",
+        "functions/@memmapdata/size.m",
+        "functions/@memmapdata/subsasgn.m",
+        "functions/@memmapdata/subsref.m",
+        "functions/@memmapdata/sum.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_5",
+      "phase_issue": "#162 Large-dataset storage and storedisk semantics",
+      "rationale": "Phase 5 should design Python-native lazy array and storedisk semantics if EEGPrep supports large datasets, instead of porting MATLAB class overloads directly.",
+      "user_facing_surface": [
+        "large datasets",
+        "option_memmapdata",
+        "save/load workflows"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/concepts.rst",
+        "docs/source/development.rst"
+      ],
+      "test_notes": "Phase 5 must test first/last sample access, mutation, save/load, GUI refresh, and console state if a backend is implemented."
+    },
+    {
+      "row_id": "mmo-python-storedisk-backend",
+      "title": "MATLAB @mmo memory-mapped object operations",
+      "area": "object_storage",
+      "source_paths": [
+        "functions/@mmo/binaryopp.m",
+        "functions/@mmo/bsxfun.m",
+        "functions/@mmo/changefile.m",
+        "functions/@mmo/checkcopies_local.m",
+        "functions/@mmo/checkworkspace.m",
+        "functions/@mmo/ctranspose.m",
+        "functions/@mmo/display.m",
+        "functions/@mmo/double.m",
+        "functions/@mmo/end.m",
+        "functions/@mmo/fft.m",
+        "functions/@mmo/isnumeric.m",
+        "functions/@mmo/length.m",
+        "functions/@mmo/mmo.m",
+        "functions/@mmo/ndims.m",
+        "functions/@mmo/permute.m",
+        "functions/@mmo/reshape.m",
+        "functions/@mmo/size.m",
+        "functions/@mmo/subsasgn.m",
+        "functions/@mmo/subsasgn_old.m",
+        "functions/@mmo/subsref.m",
+        "functions/@mmo/sum.m",
+        "functions/@mmo/transpose.m",
+        "functions/@mmo/unitaryopp.m",
+        "functions/@mmo/var.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "port",
+      "responsible_phase": "phase_5",
+      "phase_issue": "#162 Large-dataset storage and storedisk semantics",
+      "rationale": "These MATLAB overloads represent storedisk-era memory-mapped operations. EEGPrep needs an explicit Python storage contract, not a same-name class port.",
+      "user_facing_surface": [
+        "option_storedisk",
+        "large STUDY data",
+        "memory-mapped processing"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/concepts.rst",
+        "docs/source/development.rst"
+      ],
+      "test_notes": "Phase 5 should prove array operations, persistence, and GUI/console synchronization for any Python-native backend."
+    },
+    {
+      "row_id": "optional-limo-workflows",
+      "title": "LIMO-compatible STUDY workflows",
+      "area": "optional_toolbox_workflow",
+      "source_paths": [
+        "functions/studyfunc/pop_limo.m",
+        "functions/studyfunc/pop_limoresults.m",
+        "functions/studyfunc/std_limo.m",
+        "functions/studyfunc/std_limodesign.m",
+        "functions/studyfunc/std_limoresults.m",
+        "functions/studyfunc/std_readfilelimo.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.functions.studyfunc.pop_limo",
+        "eegprep.functions.studyfunc.std_limo"
+      ],
+      "status": "optional_dependency",
+      "responsible_phase": "phase_4",
+      "phase_issue": "#161 STUDY statistics, PAC, and LIMO-compatible workflows",
+      "optional_dependency": {
+        "name": "LIMO-compatible statistics backend",
+        "dependency_type": "external statistics workflow",
+        "fallback_behavior": "Keep explicit NotImplementedError limitations until EEGPrep owns or integrates a tested LIMO-compatible backend.",
+        "user_message": "EEGPrep does not silently emulate EEGLAB LIMO result computation or browsing.",
+        "phase_contract": "Phase 4 must decide whether limitation wrappers are sufficient or implement a real tested backend and docs."
+      },
+      "rationale": "LIMO is a separate MATLAB toolbox-level workflow. EEGPrep can expose familiar names only when behavior is real or clearly unavailable.",
+      "user_facing_surface": [
+        "STUDY LIMO menus",
+        "pop_limo",
+        "std_limo"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/installation.rst"
+      ],
+      "test_notes": "Phase 4 should keep limitation tests or add backend tests; placeholder LIMO outputs are not acceptable."
+    },
+    {
+      "row_id": "optional-pac-workflows",
+      "title": "PAC compute, cache, and plot workflows",
+      "area": "optional_toolbox_workflow",
+      "source_paths": [
+        "functions/studyfunc/std_pac.m",
+        "functions/studyfunc/std_pacplot.m",
+        "functions/studyfunc/std_readpac.m",
+        "functions/timefreqfunc/pac.m",
+        "functions/timefreqfunc/pac_cont.m"
+      ],
+      "eegprep_equivalent": [
+        "eegprep.functions.timefreqfunc.pac",
+        "eegprep.functions.timefreqfunc.pac_cont",
+        "eegprep.functions.studyfunc.std_pac",
+        "eegprep.functions.studyfunc.std_readpac"
+      ],
+      "status": "optional_dependency",
+      "responsible_phase": "phase_4",
+      "phase_issue": "#161 STUDY statistics, PAC, and LIMO-compatible workflows",
+      "optional_dependency": {
+        "name": "EEGPrep-owned PAC backend",
+        "dependency_type": "scientific analysis backend",
+        "fallback_behavior": "Read only explicit EEGPrep-owned pacdata caches and raise clear limitations for unimplemented PAC computation.",
+        "user_message": "PAC computation is unavailable until EEGPrep ships a tested PAC backend.",
+        "phase_contract": "Phase 4 must implement PAC compute/cache/plot behavior or keep documented limitation functions with tests."
+      },
+      "rationale": "PAC combines time-frequency decomposition, coupling metrics, cache files, and plotting. A same-name stub would mislead users.",
+      "user_facing_surface": [
+        "PAC computation",
+        "STUDY PAC plotting",
+        "std_readpac"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst"
+      ],
+      "test_notes": "Phase 4 should test cache semantics and any backend math against deterministic references."
+    },
+    {
+      "row_id": "optional-fieldtrip-study-neighbors",
+      "title": "FieldTrip-style STUDY neighbor, interpolation, and dipole cluster workflows",
+      "area": "optional_toolbox_workflow",
+      "source_paths": [
+        "functions/studyfunc/std_dipoleclusters.m",
+        "functions/studyfunc/std_dipplot.m",
+        "functions/studyfunc/std_interp.m",
+        "functions/studyfunc/std_prepare_neighbors.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "optional_dependency",
+      "responsible_phase": "phase_4",
+      "phase_issue": "#161 STUDY statistics, PAC, and LIMO-compatible workflows",
+      "optional_dependency": {
+        "name": "FieldTrip-style STUDY neighbor and source workflow backend",
+        "dependency_type": "scientific optional backend",
+        "fallback_behavior": "Use EEGPrep-native interpolation where it exists and raise clear limitations for FieldTrip-specific STUDY/source workflows.",
+        "user_message": "FieldTrip-dependent STUDY source and neighbor workflows require a tested standalone backend before EEGPrep can compute them.",
+        "phase_contract": "Phase 4 must coordinate with Phase 3 for DIPFIT assumptions and document the backend boundary."
+      },
+      "rationale": "These workflows combine STUDY, source localization, and FieldTrip-style neighborhood definitions. They must be real optional integrations or clear limitations.",
+      "user_facing_surface": [
+        "STUDY interpolation",
+        "STUDY dipole clusters",
+        "neighbor preparation"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst"
+      ],
+      "test_notes": "Phase 4 should test user-facing limitation paths and any implemented backend coordination with Phase 3 DIPFIT outputs."
+    },
+    {
+      "row_id": "docs-history-console-migration",
+      "title": "History, console, and EEGLAB command migration tutorial",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/eeglab_history.m"
+      ],
+      "eegprep_equivalent": [
+        "docs/source/user_guide/interactive_console.rst",
+        "docs/source/user_guide/eeglab_migration.rst"
+      ],
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "EEGLAB users need an explicit guide from MATLAB command history to EEGPrep console history, LASTCOM, ALLCOM, and replayable Python commands.",
+      "user_facing_surface": [
+        "eegprep-console",
+        "history replay"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/interactive_console.rst",
+        "docs/source/user_guide/eeglab_migration.rst"
+      ],
+      "test_notes": "Phase 7 should add docs build coverage and examples that match actual console behavior."
+    },
+    {
+      "row_id": "docs-event-processing-tutorials",
+      "title": "Event processing tutorials",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/event_processing_single_dataset.m",
+        "tutorial_scripts/event_processing_study.m"
+      ],
+      "eegprep_equivalent": null,
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "Event latency, urevent, epoch, and STUDY event handling need tutorial coverage with explicit MATLAB/Python indexing boundaries.",
+      "user_facing_surface": [
+        "events",
+        "epochs",
+        "STUDY events"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/concepts.rst",
+        "docs/source/user_guide/eeglab_migration.rst"
+      ],
+      "test_notes": "Phase 7 should keep examples aligned with tested pop_adjustevents, epoching, and STUDY behavior."
+    },
+    {
+      "row_id": "docs-study-tutorials",
+      "title": "STUDY creation, ERP, and group workflow tutorials",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/plot_study_erp.mlx",
+        "tutorial_scripts/simple_study_pipeline.m",
+        "tutorial_scripts/simple_study_pipeline_octave.m",
+        "tutorial_scripts/study_script.m"
+      ],
+      "eegprep_equivalent": [
+        "docs/source/user_guide/study_workflows.rst"
+      ],
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "Current STUDY docs describe implemented surfaces, but Phase 7 needs EEGLAB-style task tutorials that include GUI, console, scripting, cache, and limitations.",
+      "user_facing_surface": [
+        "STUDY",
+        "group workflows",
+        "ERP"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst"
+      ],
+      "test_notes": "Phase 7 should build examples around completed Phase 4 behavior and avoid documenting intentions as implemented features."
+    },
+    {
+      "row_id": "docs-source-reconstruction-tutorials",
+      "title": "Source reconstruction tutorials",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/source_reconstruction_advanced.mlx",
+        "tutorial_scripts/source_reconstruction_custom_mri.m",
+        "tutorial_scripts/source_reconstruction_eeg.mlx"
+      ],
+      "eegprep_equivalent": null,
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "DIPFIT and source reconstruction docs must be written after Phase 3 defines what is implemented, optional, or explicitly unavailable.",
+      "user_facing_surface": [
+        "DIPFIT",
+        "source reconstruction"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/plugins.rst"
+      ],
+      "test_notes": "Phase 7 should describe actual Phase 3 behavior and optional backend setup, with clear limitation callouts."
+    },
+    {
+      "row_id": "docs-time-frequency-and-movie-tutorials",
+      "title": "Time-frequency and EEG movie tutorials",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/make_eeg_movie.m",
+        "tutorial_scripts/time_freq_all_elec.mlx"
+      ],
+      "eegprep_equivalent": null,
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "Time-frequency docs should reflect completed core parity plus explicit limitations around movie/visual workflows that are not standalone EEGPrep features yet.",
+      "user_facing_surface": [
+        "time-frequency analysis",
+        "visualization tutorials"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "test_notes": "Phase 7 should base runnable examples on tested EEGPrep functions and classify non-ported visual workflows clearly."
+    },
+    {
+      "row_id": "docs-bids-face-experiment-tutorial",
+      "title": "BIDS face-experiment tutorial",
+      "area": "documentation",
+      "source_paths": [
+        "tutorial_scripts/bids_process_face_experiment.mlx"
+      ],
+      "eegprep_equivalent": [
+        "docs/source/user_guide/bids_workflow.rst"
+      ],
+      "status": "docs_gap",
+      "responsible_phase": "phase_7",
+      "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
+      "rationale": "BIDS documentation should include an EEGLAB-style end-to-end tutorial that is accurate to EEGPrep's standalone BIDS import/export and preprocessing behavior.",
+      "user_facing_surface": [
+        "BIDS workflow",
+        "batch preprocessing"
+      ],
+      "docs_targets": [
+        "docs/source/user_guide/bids_workflow.rst",
+        "docs/source/examples/index.rst"
+      ],
+      "test_notes": "Phase 7 should keep the tutorial runnable against EEGPrep sample or synthetic data and covered by docs build checks."
+    }
+  ]
+}

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -263,6 +263,44 @@ examples, options, or resources are needed at runtime, convert them into
 EEGPrep-owned packaged resources instead of reaching into the vendored
 reference tree.
 
+EEGLAB Final Standalone Parity Matrix
+=====================================
+
+The final standalone parity epic uses a second machine-readable matrix at
+``docs/parity/eeglab_final_parity_matrix.json``. It extends the core matrix into
+the remaining product surfaces that are not simple core-function parity rows:
+bundled plugin depth, MATLAB object/storage semantics, optional-toolbox
+workflows, and documentation/tutorial coverage.
+
+Rows group source files into user workflows, but every discovered final-epic
+EEGLAB reference path must be covered exactly once. The validator discovers:
+
+- ``plugins/clean_rawdata``, ``plugins/firfilt``, ``plugins/ICLabel``, and
+  ``plugins/dipfit`` files, excluding vendored third-party MatConvNet and
+  Manopt internals, examples, and tests;
+- ``functions/@eegobj``, ``functions/@memmapdata``, and ``functions/@mmo``;
+- EEGLAB tutorial scripts under ``tutorial_scripts``;
+- selected optional-toolbox workflow rows that point back to the core matrix.
+
+Final matrix statuses are ``implemented``, ``partial``, ``port``,
+``consolidated``, ``stale_skip``, ``matlab_runtime_skip``,
+``optional_dependency``, ``external_plugin``, and ``docs_gap``. Non-skip rows
+must name a responsible Phase 2-8 issue. Skip rows must use
+``responsible_phase: "none"``. ``optional_dependency`` rows must name the
+backend decision, fallback behavior, user-facing message, and phase contract so
+later agents do not silently fake external-toolbox behavior.
+
+Validate the final matrix with:
+
+.. code-block:: bash
+
+   uv run --no-sync python -m tools.eeglab_final_parity_matrix --json
+
+The docs architecture for the final epic is recorded in the matrix metadata and
+in ``.notes/eeglab-final-parity-audit.md``. It is modeled after EEGLAB's user
+docs but must describe EEGPrep's standalone Python, Qt GUI, and
+``eegprep-console`` behavior, not MATLAB runtime behavior.
+
 Building Documentation
 ======================
 

--- a/src/eegprep/functions/sigprocfunc/runamica.py
+++ b/src/eegprep/functions/sigprocfunc/runamica.py
@@ -196,8 +196,7 @@ def _find_amica_binary(amica_binary=None):
     1. Explicit amica_binary argument.
     2. AMICA_BINARY environment variable.
     3. Source-tree development binary in src/eegprep/bin/ if present.
-    4. EEGLAB submodule plugins directory.
-    5. System PATH.
+    4. System PATH.
 
     Parameters
     ----------
@@ -244,18 +243,7 @@ def _find_amica_binary(amica_binary=None):
     if os.path.isfile(vendored) and os.access(vendored, os.X_OK):
         return vendored
 
-    # 4. EEGLAB submodule plugins
-    eeglab_dir = os.path.join(PACKAGE_ROOT, 'eeglab')
-    if os.path.isdir(eeglab_dir):
-        plugins_dir = os.path.join(eeglab_dir, 'plugins')
-        if os.path.isdir(plugins_dir):
-            for entry in os.listdir(plugins_dir):
-                if entry.startswith('amica'):
-                    candidate = os.path.join(plugins_dir, entry, binary_name)
-                    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-                        return candidate
-
-    # 5. System PATH
+    # 4. System PATH
     found = shutil.which(binary_name)
     if found is not None:
         return found

--- a/tests/test_eeglab_final_parity_matrix.py
+++ b/tests/test_eeglab_final_parity_matrix.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.eeglab_final_parity_matrix import (
+    VALID_STATUSES,
+    discover_final_eeglab_paths,
+    load_matrix,
+    validate_matrix_file,
+    validate_matrix_payload,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = REPO_ROOT / "docs/parity/eeglab_final_parity_matrix.json"
+
+
+def test_committed_final_parity_matrix_validates() -> None:
+    _require_eeglab_reference()
+
+    report = validate_matrix_file(MATRIX_PATH, REPO_ROOT)
+
+    assert report.ok, [error.as_text() for error in report.errors]
+    assert report.row_count == 31
+    assert report.expected_eeglab_count == len(discover_final_eeglab_paths(REPO_ROOT)) == 180
+
+
+def test_final_matrix_uses_complete_status_taxonomy() -> None:
+    payload = load_matrix(MATRIX_PATH)
+    statuses = {row["status"] for row in payload["rows"]}
+
+    assert tuple(payload["metadata"]["status_taxonomy"]) == VALID_STATUSES
+    assert statuses <= set(VALID_STATUSES)
+    assert {"optional_dependency", "docs_gap"} <= statuses
+
+
+def test_final_matrix_discovers_final_epic_paths_without_third_party_bloat() -> None:
+    _require_eeglab_reference()
+
+    paths = discover_final_eeglab_paths(REPO_ROOT)
+
+    assert "plugins/clean_rawdata/asr_process_r.m" in paths
+    assert "plugins/ICLabel/viewprops/pop_viewprops.m" in paths
+    assert "functions/@memmapdata/memmapdata.m" in paths
+    assert "tutorial_scripts/eeglab_history.m" in paths
+    assert "plugins/ICLabel/matconvnet/matlab/vl_setupnn.m" not in paths
+    assert "plugins/clean_rawdata/manopt/examples/nonlinear_eigenspace.m" not in paths
+
+
+def test_final_validator_fails_when_expected_path_is_unclassified() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    removed = changed["rows"][0]["source_paths"].pop(0)
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert f"missing classification for {removed}" in _messages(report)
+
+
+def test_final_validator_fails_when_expected_path_is_duplicated() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    duplicated = changed["rows"][0]["source_paths"][0]
+    changed["rows"][1]["source_paths"].append(duplicated)
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert f"duplicates expected EEGLAB source_path {duplicated!r}" in _messages(report)
+
+
+def test_final_validator_requires_optional_dependency_contract() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    row = next(row for row in changed["rows"] if row["status"] == "optional_dependency")
+    row.pop("optional_dependency")
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert "optional_dependency: is required for optional_dependency rows" in _messages(report)
+
+
+def test_final_validator_rejects_inconsistent_phase_ownership() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    row = next(row for row in changed["rows"] if row["status"] == "port")
+    row["responsible_phase"] = "none"
+    row["phase_issue"] = None
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert "responsible_phase: is required for 'port'" in _messages(report)
+
+
+def test_final_validator_rejects_phase_on_skip_rows() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    row = next(row for row in changed["rows"] if row["status"] == "stale_skip")
+    row["responsible_phase"] = "phase_7"
+    row["phase_issue"] = changed["metadata"]["phase_issues"]["phase_7"]
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert "responsible_phase: must be none for skip rows" in _messages(report)
+    assert "phase_issue: must be null for skip rows" in _messages(report)
+
+
+def test_final_validator_requires_docs_architecture_sections() -> None:
+    _require_eeglab_reference()
+
+    payload = load_matrix(MATRIX_PATH)
+    changed = copy.deepcopy(payload)
+    changed["metadata"]["docs_architecture"]["sections"] = [
+        section for section in changed["metadata"]["docs_architecture"]["sections"] if section["id"] != "concepts"
+    ]
+
+    report = validate_matrix_payload(changed, REPO_ROOT)
+
+    assert not report.ok
+    assert "must define section 'concepts'" in _messages(report)
+
+
+def test_final_cli_json_report_is_machine_readable(capsys) -> None:
+    _require_eeglab_reference()
+
+    from tools.eeglab_final_parity_matrix import main
+
+    exit_code = main([str(MATRIX_PATH), "--json"])
+
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert exit_code == 0
+    assert report["ok"] is True
+    assert report["expected_eeglab_count"] == 180
+
+
+def _require_eeglab_reference() -> None:
+    if discover_final_eeglab_paths(REPO_ROOT):
+        return
+    pytest.skip("EEGLAB reference tree is not initialized under src/eegprep/eeglab")
+
+
+def _messages(report) -> str:
+    return "\n".join(error.as_text() for error in report.errors)

--- a/tests/test_runtime_eeglab_independence.py
+++ b/tests/test_runtime_eeglab_independence.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "src/eegprep"
+
+FORBIDDEN_PATTERNS = (
+    ("vendored reference literal", re.compile(r"src/eegprep/eeglab")),
+    (
+        "package-root eeglab path join",
+        re.compile(r"PACKAGE_ROOT[^\n]*(?:os\.path\.join|\bjoinpath\b|/)[^\n]*['\"]eeglab['\"]"),
+    ),
+    ("eegprep.eeglab import", re.compile(r"(?:from|import)\s+eegprep\.eeglab\b")),
+    (
+        "importlib resources vendored tree",
+        re.compile(r"resources\.(?:files|open_[a-z_]+)\([^\n]*['\"]eegprep\.eeglab['\"]"),
+    ),
+)
+
+
+def test_runtime_package_code_does_not_depend_on_vendored_eeglab_tree() -> None:
+    offenders: list[str] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if "src/eegprep/eeglab" in path.as_posix():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for label, pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(text):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {label}")
+
+    assert offenders == []

--- a/tools/eeglab_final_parity_matrix.py
+++ b/tools/eeglab_final_parity_matrix.py
@@ -1,0 +1,451 @@
+"""Validate the final EEGPrep standalone parity matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+MATRIX_RELATIVE_PATH = Path("docs/parity/eeglab_final_parity_matrix.json")
+
+PLUGIN_ROOTS = ("clean_rawdata", "firfilt", "ICLabel", "dipfit")
+OBJECT_STORAGE_FOLDERS = ("@eegobj", "@memmapdata", "@mmo")
+TUTORIAL_EXTENSIONS = {".m", ".mlx"}
+EXCLUDED_REFERENCE_PREFIXES = (
+    "plugins/clean_rawdata/manopt/manopt/",
+    "plugins/clean_rawdata/manopt/examples/",
+    "plugins/clean_rawdata/manopt/tests/",
+    "plugins/ICLabel/matconvnet/",
+    "plugins/ICLabel/tests/",
+)
+
+VALID_AREAS = (
+    "bundled_plugin_clean_rawdata",
+    "bundled_plugin_firfilt",
+    "bundled_plugin_iclabel_viewprops",
+    "bundled_plugin_dipfit",
+    "object_storage",
+    "optional_toolbox_workflow",
+    "documentation",
+)
+VALID_STATUSES = (
+    "implemented",
+    "partial",
+    "port",
+    "consolidated",
+    "stale_skip",
+    "matlab_runtime_skip",
+    "optional_dependency",
+    "external_plugin",
+    "docs_gap",
+)
+VALID_PHASES = ("none", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6", "phase_7", "phase_8")
+SKIP_STATUSES = {"stale_skip", "matlab_runtime_skip", "external_plugin"}
+EQUIVALENT_REQUIRED_STATUSES = {"implemented", "partial", "consolidated"}
+OPTIONAL_DEPENDENCY_FIELDS = ("name", "dependency_type", "fallback_behavior", "user_message", "phase_contract")
+OPTIONAL_DEPENDENCY_POLICY_FIELDS = (
+    "standalone_first",
+    "optional_dependency",
+    "external_plugin",
+    "user_facing_failure",
+)
+REQUIRED_DOC_SECTION_IDS = (
+    "installation",
+    "concepts",
+    "gui_tutorials",
+    "console_and_history",
+    "preprocessing",
+    "ica_and_rejection",
+    "study_and_statistics",
+    "plugins_and_extensions",
+    "api_reference",
+    "eeglab_migration",
+    "developer_parity",
+)
+REQUIRED_ROW_FIELDS = (
+    "row_id",
+    "title",
+    "area",
+    "source_paths",
+    "eegprep_equivalent",
+    "status",
+    "responsible_phase",
+    "phase_issue",
+    "rationale",
+    "user_facing_surface",
+    "docs_targets",
+    "test_notes",
+)
+STALE_POLICY_FIELDS = (
+    "menu_reachable",
+    "documented_user_api",
+    "called_by_in_scope_workflow",
+    "required_by_parity_tests",
+    "needed_as_phase_helper",
+    "likely_user_alias",
+)
+ISSUE_RE = re.compile(r"^#[1-9][0-9]*")
+
+
+@dataclass(frozen=True)
+class FinalMatrixValidationError:
+    location: str
+    message: str
+
+    def as_text(self) -> str:
+        return f"{self.location}: {self.message}"
+
+
+@dataclass(frozen=True)
+class FinalMatrixValidationReport:
+    errors: tuple[FinalMatrixValidationError, ...]
+    row_count: int
+    expected_eeglab_count: int
+    status_counts: dict[str, int]
+    area_counts: dict[str, int]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "errors": [error.as_text() for error in self.errors],
+            "row_count": self.row_count,
+            "expected_eeglab_count": self.expected_eeglab_count,
+            "status_counts": self.status_counts,
+            "area_counts": self.area_counts,
+        }
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def discover_final_eeglab_paths(repo_root: Path) -> set[str]:
+    """Return EEGLAB reference paths covered by the final parity epic."""
+
+    eeglab_root = repo_root / "src/eegprep/eeglab"
+    if not eeglab_root.is_dir():
+        return set()
+
+    paths: set[str] = set()
+    plugin_root = eeglab_root / "plugins"
+    for plugin in PLUGIN_ROOTS:
+        for path in sorted((plugin_root / plugin).rglob("*.m")):
+            relative = path.relative_to(eeglab_root).as_posix()
+            if not _is_excluded_reference_path(relative):
+                paths.add(relative)
+
+    functions_root = eeglab_root / "functions"
+    for folder in OBJECT_STORAGE_FOLDERS:
+        for path in sorted((functions_root / folder).glob("*.m")):
+            paths.add(path.relative_to(eeglab_root).as_posix())
+
+    tutorial_root = eeglab_root / "tutorial_scripts"
+    for path in sorted(tutorial_root.iterdir() if tutorial_root.is_dir() else ()):
+        if path.is_file() and path.suffix in TUTORIAL_EXTENSIONS:
+            paths.add(path.relative_to(eeglab_root).as_posix())
+
+    return paths
+
+
+def load_matrix(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError("Final parity matrix root must be a JSON object")
+    return payload
+
+
+def validate_matrix_file(matrix_path: Path | None = None, repo_root: Path | None = None) -> FinalMatrixValidationReport:
+    root = repo_root or default_repo_root()
+    path = matrix_path or root / MATRIX_RELATIVE_PATH
+    return validate_matrix_payload(load_matrix(path), root)
+
+
+def validate_matrix_payload(payload: dict[str, Any], repo_root: Path) -> FinalMatrixValidationReport:
+    errors: list[FinalMatrixValidationError] = []
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        errors.append(FinalMatrixValidationError("rows", "must be a list"))
+        rows = []
+
+    phase_issues = _validate_metadata(payload.get("metadata"), errors)
+    expected_paths = discover_final_eeglab_paths(repo_root)
+    seen_expected_paths: dict[str, str] = {}
+    seen_row_ids: set[str] = set()
+    status_counts: Counter[str] = Counter()
+    area_counts: Counter[str] = Counter()
+
+    for index, row in enumerate(rows):
+        location = f"rows[{index}]"
+        if not isinstance(row, dict):
+            errors.append(FinalMatrixValidationError(location, "must be an object"))
+            continue
+        _validate_row(row, location, phase_issues, errors)
+
+        row_id = row.get("row_id")
+        if isinstance(row_id, str):
+            if row_id in seen_row_ids:
+                errors.append(FinalMatrixValidationError(location, f"duplicates row_id {row_id!r}"))
+            seen_row_ids.add(row_id)
+
+        for source_path in _source_paths(row):
+            if not _source_path_exists(repo_root, source_path):
+                errors.append(FinalMatrixValidationError(location, f"source_path does not exist: {source_path}"))
+                continue
+            if source_path not in expected_paths:
+                continue
+            previous = seen_expected_paths.get(source_path)
+            if previous is not None:
+                errors.append(
+                    FinalMatrixValidationError(
+                        location,
+                        f"duplicates expected EEGLAB source_path {source_path!r} already covered by {previous}",
+                    )
+                )
+            else:
+                seen_expected_paths[source_path] = str(row_id)
+
+        status = row.get("status")
+        if isinstance(status, str):
+            status_counts[status] += 1
+        area = row.get("area")
+        if isinstance(area, str):
+            area_counts[area] += 1
+
+    if not expected_paths:
+        errors.append(
+            FinalMatrixValidationError(
+                "coverage",
+                "EEGLAB reference tree is missing or empty; initialize src/eegprep/eeglab before validating coverage",
+            )
+        )
+    else:
+        for missing_path in sorted(expected_paths - set(seen_expected_paths)):
+            errors.append(FinalMatrixValidationError("coverage", f"missing classification for {missing_path}"))
+
+    return FinalMatrixValidationReport(
+        errors=tuple(errors),
+        row_count=len(rows),
+        expected_eeglab_count=len(expected_paths),
+        status_counts=dict(sorted(status_counts.items())),
+        area_counts=dict(sorted(area_counts.items())),
+    )
+
+
+def _validate_metadata(metadata: Any, errors: list[FinalMatrixValidationError]) -> dict[str, str]:
+    if not isinstance(metadata, dict):
+        errors.append(FinalMatrixValidationError("metadata", "must be an object"))
+        return {}
+    if metadata.get("schema_version") != 1:
+        errors.append(FinalMatrixValidationError("metadata.schema_version", "must be 1"))
+    if tuple(metadata.get("status_taxonomy", ())) != VALID_STATUSES:
+        errors.append(
+            FinalMatrixValidationError("metadata.status_taxonomy", "must match the validator status taxonomy")
+        )
+
+    phase_issues = metadata.get("phase_issues")
+    if not isinstance(phase_issues, dict):
+        errors.append(FinalMatrixValidationError("metadata.phase_issues", "must be an object"))
+        phase_issues = {}
+    for phase in VALID_PHASES:
+        if phase == "none":
+            continue
+        value = phase_issues.get(phase)
+        if not isinstance(value, str) or not ISSUE_RE.match(value):
+            errors.append(FinalMatrixValidationError(f"metadata.phase_issues.{phase}", "must cite the phase issue"))
+
+    policy = metadata.get("optional_dependency_policy")
+    if not isinstance(policy, dict):
+        errors.append(FinalMatrixValidationError("metadata.optional_dependency_policy", "must be an object"))
+    else:
+        for field in OPTIONAL_DEPENDENCY_POLICY_FIELDS:
+            if not isinstance(policy.get(field), str) or not policy[field]:
+                errors.append(
+                    FinalMatrixValidationError(f"metadata.optional_dependency_policy.{field}", "must be defined")
+                )
+
+    docs_architecture = metadata.get("docs_architecture")
+    if not isinstance(docs_architecture, dict):
+        errors.append(FinalMatrixValidationError("metadata.docs_architecture", "must be an object"))
+    else:
+        section_ids = {
+            section.get("id") for section in docs_architecture.get("sections", []) if isinstance(section, dict)
+        }
+        for section_id in REQUIRED_DOC_SECTION_IDS:
+            if section_id not in section_ids:
+                errors.append(
+                    FinalMatrixValidationError(
+                        "metadata.docs_architecture.sections",
+                        f"must define section {section_id!r}",
+                    )
+                )
+
+    exclusions = metadata.get("source_exclusion_policy")
+    if not isinstance(exclusions, list):
+        errors.append(FinalMatrixValidationError("metadata.source_exclusion_policy", "must be a list"))
+    elif not exclusions:
+        errors.append(FinalMatrixValidationError("metadata.source_exclusion_policy", "must not be empty"))
+
+    return {str(key): str(value) for key, value in phase_issues.items()} if isinstance(phase_issues, dict) else {}
+
+
+def _validate_row(
+    row: dict[str, Any],
+    location: str,
+    phase_issues: dict[str, str],
+    errors: list[FinalMatrixValidationError],
+) -> None:
+    for field in REQUIRED_ROW_FIELDS:
+        if field not in row:
+            errors.append(FinalMatrixValidationError(location, f"missing required field {field!r}"))
+
+    row_id = row.get("row_id")
+    if not isinstance(row_id, str) or not row_id:
+        errors.append(FinalMatrixValidationError(f"{location}.row_id", "must be a non-empty string"))
+
+    title = row.get("title")
+    if not isinstance(title, str) or not title:
+        errors.append(FinalMatrixValidationError(f"{location}.title", "must be a non-empty string"))
+
+    area = row.get("area")
+    if area not in VALID_AREAS:
+        errors.append(FinalMatrixValidationError(f"{location}.area", "must be a valid final parity area"))
+
+    paths = row.get("source_paths")
+    if not isinstance(paths, list) or not paths or not all(isinstance(path, str) and path for path in paths):
+        errors.append(FinalMatrixValidationError(f"{location}.source_paths", "must be a non-empty list of strings"))
+    elif len(set(paths)) != len(paths):
+        errors.append(FinalMatrixValidationError(f"{location}.source_paths", "must not contain duplicates"))
+
+    status = row.get("status")
+    if status not in VALID_STATUSES:
+        errors.append(FinalMatrixValidationError(f"{location}.status", "must be a valid status"))
+    elif status in EQUIVALENT_REQUIRED_STATUSES and not _has_equivalent(row.get("eegprep_equivalent")):
+        errors.append(FinalMatrixValidationError(f"{location}.eegprep_equivalent", f"is required for {status!r}"))
+
+    phase = row.get("responsible_phase")
+    if phase not in VALID_PHASES:
+        errors.append(FinalMatrixValidationError(f"{location}.responsible_phase", "must be a valid phase id"))
+    phase_issue = row.get("phase_issue")
+    if status in SKIP_STATUSES:
+        if phase != "none":
+            errors.append(FinalMatrixValidationError(f"{location}.responsible_phase", "must be none for skip rows"))
+        if phase_issue not in (None, ""):
+            errors.append(FinalMatrixValidationError(f"{location}.phase_issue", "must be null for skip rows"))
+    elif status in VALID_STATUSES:
+        if phase == "none":
+            errors.append(FinalMatrixValidationError(f"{location}.responsible_phase", f"is required for {status!r}"))
+        elif phase_issue != phase_issues.get(str(phase)):
+            errors.append(FinalMatrixValidationError(f"{location}.phase_issue", "must match metadata.phase_issues"))
+
+    for field in ("rationale", "test_notes"):
+        value = row.get(field)
+        if not isinstance(value, str) or not value:
+            errors.append(FinalMatrixValidationError(f"{location}.{field}", "must be a non-empty string"))
+
+    for field in ("user_facing_surface", "docs_targets"):
+        value = row.get(field)
+        if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+            errors.append(FinalMatrixValidationError(f"{location}.{field}", "must be a list of strings"))
+
+    if status == "optional_dependency":
+        _validate_optional_dependency(row.get("optional_dependency"), f"{location}.optional_dependency", errors)
+    elif "optional_dependency" in row:
+        errors.append(
+            FinalMatrixValidationError(
+                f"{location}.optional_dependency", "is only allowed for optional_dependency rows"
+            )
+        )
+
+    if status == "docs_gap" and phase != "phase_7":
+        errors.append(FinalMatrixValidationError(f"{location}.responsible_phase", "docs_gap rows belong to phase_7"))
+
+    stale_policy = row.get("stale_policy")
+    if status == "stale_skip":
+        if not isinstance(stale_policy, dict):
+            errors.append(FinalMatrixValidationError(f"{location}.stale_policy", "is required for stale_skip rows"))
+        else:
+            for field in STALE_POLICY_FIELDS:
+                if stale_policy.get(field) is not False:
+                    errors.append(FinalMatrixValidationError(f"{location}.stale_policy.{field}", "must be false"))
+    elif "stale_policy" in row:
+        errors.append(FinalMatrixValidationError(f"{location}.stale_policy", "is only allowed for stale_skip rows"))
+
+
+def _validate_optional_dependency(
+    value: Any,
+    location: str,
+    errors: list[FinalMatrixValidationError],
+) -> None:
+    if not isinstance(value, dict):
+        errors.append(FinalMatrixValidationError(location, "is required for optional_dependency rows"))
+        return
+    for field in OPTIONAL_DEPENDENCY_FIELDS:
+        if not isinstance(value.get(field), str) or not value[field]:
+            errors.append(FinalMatrixValidationError(f"{location}.{field}", "must be a non-empty string"))
+
+
+def _source_paths(row: dict[str, Any]) -> tuple[str, ...]:
+    paths = row.get("source_paths")
+    if not isinstance(paths, list):
+        return ()
+    return tuple(path for path in paths if isinstance(path, str))
+
+
+def _source_path_exists(repo_root: Path, source_path: str) -> bool:
+    if source_path.startswith(("functions/", "plugins/", "tutorial_scripts/")):
+        return (repo_root / "src/eegprep/eeglab" / source_path).exists()
+    if source_path.startswith("docs/"):
+        return (repo_root / source_path).exists()
+    return False
+
+
+def _has_equivalent(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, list):
+        return bool(value) and all(isinstance(item, str) and item for item in value)
+    return False
+
+
+def _is_excluded_reference_path(relative_path: str) -> bool:
+    return any(relative_path.startswith(prefix) for prefix in EXCLUDED_REFERENCE_PREFIXES)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "matrix",
+        nargs="?",
+        type=Path,
+        default=None,
+        help=f"matrix path, default {MATRIX_RELATIVE_PATH}",
+    )
+    parser.add_argument("--json", action="store_true", help="emit a JSON validation report")
+    args = parser.parse_args(argv)
+
+    report = validate_matrix_file(args.matrix)
+    if args.json:
+        print(json.dumps(report.to_jsonable(), indent=2, sort_keys=True))
+    elif report.ok:
+        print(
+            "Final parity matrix OK: "
+            f"{report.row_count} rows cover {report.expected_eeglab_count} final-epic EEGLAB paths."
+        )
+    else:
+        for error in report.errors:
+            print(error.as_text())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add the final epic parity matrix, validator, audit notes, and focused tests for issue #158. The matrix assigns Phase 2-8 ownership across bundled plugins, object/storage, optional-toolbox, and docs surfaces while preserving standalone runtime boundaries.

Closes #158