### PR TITLE
[ICLabel] Complete viewprops diagnostics parity

### DIFF
--- a/.notes/eeglab-migration-gap-audit.md
+++ b/.notes/eeglab-migration-gap-audit.md
@@ -128,9 +128,10 @@ Remaining plugin-depth areas:
 - `firfilt`: lower-level helper coverage such as detailed reports, inverse
   order helpers, minimum-phase helpers, frequency-response plotting, and order
   calculator dialogs.
-- `ICLabel` / viewprops: alternate network artifacts, exact MATLAB helper
-  parity for `eeg_icalabelstat`, and any viewprops helper behavior still
-  replaced by EEGPrep-native Qt/Python paths.
+- `ICLabel` / viewprops: Phase #163 closes the standalone default-network,
+  `eeg_icalabelstat`, and native Qt/Python diagnostic-browser surface. The
+  EEGLAB `lite`/`beta` network artifacts remain explicit MATLAB/Octave
+  passthrough choices rather than silently emulated standalone assets.
 - `DIPFIT`: lower-level grid/nonlinear/reject/dipplot helpers, manual/batch
   dialogs, atlas conversion helpers, and private transform utilities.
 

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -6,6 +6,38 @@
 </head>
 <body>
   <h1>EEGPrep Core Parity Implementation Notes</h1>
+  <h1>Issue #163 ICLabel/Viewprops Diagnostic Parity Notes</h1>
+  <p>Issue #163 closes the Phase 6 final-epic ICLabel/viewprops rows by adding
+  standalone label statistics, making alternate network support explicit, and
+  documenting the native EEGPrep diagnostic workflow.</p>
+  <h2>Issue #163 Design Decisions</h2>
+  <ul>
+    <li>Implemented <code>eeg_icalabelstat</code> as an EEGPrep-owned public
+    helper that preserves EEGLAB threshold-count console output while returning
+    structured Python statistics for reports and tests.</li>
+    <li>Kept standalone Python ICLabel scoped to the packaged default
+    <code>netICL.mat</code>. EEGLAB <code>lite</code> and <code>beta</code>
+    network artifacts are allowed only through MATLAB/Octave engines that have
+    those ICLabel files, and standalone requests raise a clear
+    <code>NotImplementedError</code>.</li>
+    <li>Classified the current native Qt/matplotlib <code>pop_viewprops</code>
+    and <code>pop_prop_extended</code> surfaces as the maintained standalone
+    parity path instead of porting MATLAB figure helper internals one for one.</li>
+  </ul>
+  <h2>Issue #163 Verification Notes</h2>
+  <ul>
+    <li>Focused tests cover deterministic ICLabel statistics, missing/malformed
+    classifier state, rejected/kept tallies, sample-data ICA with ICLabel state,
+    standalone alternate-network failures, GUI wrapper history, and
+    viewprops/property-dashboard behavior.</li>
+    <li>Docs and help now cover <code>pop_iclabel</code>, <code>pop_icflag</code>,
+    <code>eeg_icalabelstat</code>, <code>pop_viewprops</code>, and
+    <code>pop_prop_extended</code> as one component-review workflow.</li>
+    <li>Computer Use QA exercised the real Qt <code>pop_icflag</code> Cancel
+    path, <code>pop_icflag</code> OK/default-threshold path, and
+    <code>pop_viewprops</code> component dialog OK path; returned commands and
+    rejection vectors matched expectations.</li>
+  </ul>
   <h1>Issue #158 Final Standalone Parity Audit Notes</h1>
   <p>Issue #158 establishes the Phase 1 contract for epic #157. It adds an
   enforceable final-epic matrix for bundled plugin depth, MATLAB object/storage

--- a/docs/parity/eeglab_final_parity_matrix.json
+++ b/docs/parity/eeglab_final_parity_matrix.json
@@ -409,17 +409,19 @@
       ],
       "eegprep_equivalent": [
         "eegprep.plugins.ICLabel.ICL_feature_extractor",
+        "eegprep.plugins.ICLabel.eeg_icalabelstat",
         "eegprep.plugins.ICLabel.iclabel",
         "eegprep.plugins.ICLabel.pop_iclabel",
         "eegprep.plugins.ICLabel.pop_icflag"
       ],
-      "status": "partial",
+      "status": "implemented",
       "responsible_phase": "phase_6",
       "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
-      "rationale": "The classification pipeline and bundled netICL asset exist, but Phase 6 owns final label-statistics, network/runtime, GUI, and visual diagnostics parity.",
+      "rationale": "EEGPrep has standalone ICLabel feature extraction, default netICL classification, ICLabel flagging, label statistics, menu wiring, and history-capable pop wrappers. The default Python network is packaged; EEGLAB lite/beta artifacts are explicit MATLAB/Octave passthrough choices and raise a clear standalone limitation instead of being silently ignored.",
       "user_facing_surface": [
         "Tools > Classify components using ICLabel",
         "iclabel",
+        "eeg_icalabelstat",
         "pop_iclabel",
         "pop_icflag"
       ],
@@ -427,7 +429,7 @@
         "docs/source/user_guide/ica_rejection.rst",
         "docs/source/api/ica.rst"
       ],
-      "test_notes": "Phase 6 should preserve existing feature parity tests and add diagnostics coverage before marking this implemented."
+      "test_notes": "Covered by ICLabel feature/parity tests, GUI pop wrapper tests, sample-data ICLabel-state statistics tests, and explicit standalone alternate-network limitation tests."
     },
     {
       "row_id": "iclabel-label-statistics",
@@ -436,18 +438,22 @@
       "source_paths": [
         "plugins/ICLabel/eeg_icalabelstat.m"
       ],
-      "eegprep_equivalent": null,
-      "status": "port",
+      "eegprep_equivalent": [
+        "eegprep.plugins.ICLabel.eeg_icalabelstat"
+      ],
+      "status": "implemented",
       "responsible_phase": "phase_6",
       "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
-      "rationale": "EEGLAB exposes component label statistics that are useful for review, rejection, and reporting; EEGPrep should add a standalone equivalent.",
+      "rationale": "EEGPrep now provides an EEGPrep-owned `eeg_icalabelstat` helper that preserves EEGLAB threshold-count output and returns structured Python statistics for reports, rejection review, and tests.",
       "user_facing_surface": [
+        "eeg_icalabelstat",
         "ICLabel statistics"
       ],
       "docs_targets": [
-        "docs/source/user_guide/ica_rejection.rst"
+        "docs/source/user_guide/ica_rejection.rst",
+        "docs/source/api/ica.rst"
       ],
-      "test_notes": "Phase 6 should test label distributions and edge cases such as missing ICA, missing labels, and multiple datasets."
+      "test_notes": "Covered by deterministic label-distribution tests, missing/malformed ICLabel-state tests, class-specific threshold tests, rejected/kept tally tests, packaged help, and sample-data ICA/ICLabel-state integration coverage."
     },
     {
       "row_id": "iclabel-viewprops-component-browser",
@@ -463,12 +469,13 @@
         "eegprep.plugins.ICLabel.pop_prop_extended",
         "eegprep.plugins.ICLabel.pop_viewprops"
       ],
-      "status": "partial",
+      "status": "implemented",
       "responsible_phase": "phase_6",
       "phase_issue": "#163 ICLabel, viewprops, and visual diagnostics completion",
-      "rationale": "EEGPrep has native component-property surfaces, but Phase 6 must close visual diagnostics parity across scalp maps, spectra, ERP/image panels, ICLabel labels, and DIPFIT overlays.",
+      "rationale": "EEGPrep has native Qt/matplotlib component-property surfaces for viewprops: component and channel overview entry points, browser-backed activity traces, extended component dashboards with scalp maps, spectra, ERP/image summaries, ICLabel probability panels, accept/reject controls, and DIPFIT overlays when localized models are present.",
       "user_facing_surface": [
-        "Plot > Component properties",
+        "Plot > View extended channel properties",
+        "Plot > View extended component properties",
         "pop_viewprops",
         "pop_prop_extended"
       ],
@@ -476,7 +483,7 @@
         "docs/source/user_guide/ica_rejection.rst",
         "docs/source/user_guide/visual_parity.rst"
       ],
-      "test_notes": "Phase 6 should use visual parity capture and mixed GUI/console tests for component browsing workflows."
+      "test_notes": "Covered by pop_viewprops/pop_prop_extended GUI and data-model tests, browser-backed activity tests, rejection dashboard commit/cancel tests, menu/session sync tests, visual parity cases, and sample-data history integration coverage."
     },
     {
       "row_id": "iclabel-matconvnet-activation",

--- a/docs/source/api/generated/eegprep.eeg_icalabelstat.rst
+++ b/docs/source/api/generated/eegprep.eeg_icalabelstat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeg\_icalabelstat
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeg_icalabelstat

--- a/docs/source/api/ica.rst
+++ b/docs/source/api/ica.rst
@@ -20,6 +20,8 @@ Component Classification
 
 .. autofunction:: eegprep.iclabel
 
+.. autofunction:: eegprep.eeg_icalabelstat
+
 Feature Extraction
 ==================
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -241,6 +241,7 @@ for now.
    eegprep.plugin_menu
    eegprep.format_plugin_menu
    eegprep.pop_clean_rawdata
+   eegprep.eeg_icalabelstat
    eegprep.pop_iclabel
    eegprep.pop_icflag
    eegprep.pop_prop_extended

--- a/docs/source/user_guide/ica_rejection.rst
+++ b/docs/source/user_guide/ica_rejection.rst
@@ -1,0 +1,64 @@
+.. _ica_rejection:
+
+=============================================
+ICA, ICLabel, Rejection, and Visual Diagnostics
+=============================================
+
+EEGPrep follows the EEGLAB component-review workflow: compute ICA, label
+components, inspect the labels and diagnostic displays, flag likely artifacts,
+then remove flagged components when the review is complete.
+
+ICLabel Workflow
+================
+
+Run ICA before calling ICLabel:
+
+.. code-block:: python
+
+    from eegprep import eeg_icalabelstat, pop_icflag, pop_iclabel, pop_subcomp, pop_viewprops
+
+    EEG = pop_iclabel(EEG, "default")
+    stats = eeg_icalabelstat(EEG, threshold=0.9)
+    figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1, 2, 3])
+    EEG = pop_icflag(EEG)
+    EEG = pop_subcomp(EEG, [])
+
+`pop_iclabel` stores class probabilities in
+`EEG.etc.ic_classification.ICLabel.classifications`. The class order is Brain,
+Muscle, Eye, Heart, Line Noise, Channel Noise, and Other.
+
+The standalone Python engine ships the default ICLabel network (`netICL.mat`).
+The EEGLAB `lite` and `beta` network artifacts are not bundled in the Python
+package; requesting them with `engine=None` raises a clear limitation. They can
+still be requested through `engine="matlab"` or `engine="octave"` when that
+runtime has an EEGLAB ICLabel checkout with those artifacts.
+
+Label Statistics
+================
+
+`eeg_icalabelstat` mirrors EEGLAB's threshold-count summary and returns the same
+information in a Python dictionary:
+
+.. code-block:: python
+
+    stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+    print(stats["counts"])
+    print(stats["component_indices"])
+
+The returned values include per-class counts above threshold, 1-based component
+indices, mean probabilities, dominant-class counts, and rejected/kept tallies
+from `EEG.reject.gcompreject`.
+
+Visual Diagnostics
+==================
+
+`pop_viewprops(EEG, typecomp=0)` opens EEGPrep's native component-property
+browser. With ICLabel classifications present, component mode opens the
+`pop_prop_extended` dashboard with scalp map, activity browser, ERP/image
+summary, spectrum, class probabilities, component accept/reject controls, and
+DIPFIT projections when localized dipoles are already stored in `EEG.dipfit`.
+
+The activity browser uses EEGLAB-facing 1-based component indices and preserves
+event display state through the `scroll_event` option. Dashboard reject toggles
+write pending marks to `EEG.reject.gcompreject` only when the user presses OK,
+so GUI review and `eegprep-console` history remain synchronized.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -49,6 +49,7 @@ Core Concepts
    :maxdepth: 2
 
    preprocessing_pipeline
+   ica_rejection
    configuration
 
 Data Workflows
@@ -81,6 +82,7 @@ Quick Reference
 - :ref:`interactive_console` - Use the GUI and Python console together
 - :ref:`extension_curation` - Review extension trust, curation, catalog, and compatibility policy
 - :ref:`preprocessing_pipeline` - Understand preprocessing steps
+- :ref:`ica_rejection` - Review ICLabel labels, flag components, and inspect diagnostics
 - :ref:`bids_workflow` - Process BIDS datasets
 - :ref:`study_workflows` - Use current STUDY creation, save/load, and plotting surfaces
 - :ref:`visual_parity` - Compare future EEGPREP UI states against EEGLAB

--- a/docs/source/user_guide/preprocessing_pipeline.rst
+++ b/docs/source/user_guide/preprocessing_pipeline.rst
@@ -284,13 +284,19 @@ Automatically classify ICA components using ICLabel:
 
 .. code-block:: python
 
-    from eegprep import iclabel
+    from eegprep import eeg_icalabelstat, pop_iclabel, pop_viewprops
 
-    eeg = iclabel(eeg)
+    eeg = pop_iclabel(eeg, 'default')
 
-    # Access component labels
-    print(eeg.etc.ic_classification.ICLabel.classes)
-    print(eeg.etc.ic_classification.ICLabel.classifications)
+    # Access component labels and probability matrix
+    labels = eeg['etc']['ic_classification']['ICLabel']['classes']
+    probabilities = eeg['etc']['ic_classification']['ICLabel']['classifications']
+    print(labels)
+    print(probabilities)
+
+    # Review threshold-count summaries and diagnostic displays
+    stats = eeg_icalabelstat(eeg, threshold=0.9)
+    figures = pop_viewprops(eeg, typecomp=0, chanorcomp=[1, 2, 3])
 
 **Component types**:
 
@@ -306,15 +312,16 @@ Automatically classify ICA components using ICLabel:
 
 .. code-block:: python
 
-    # Remove muscle and eye components
-    artifact_components = []
-    for i, label in enumerate(eeg.etc.ic_classification.ICLabel.classes):
-        if label in ['Muscle', 'Eye']:
-            artifact_components.append(i)
+    from eegprep import pop_icflag, pop_subcomp
 
-    # Remove components
-    eeg.icaact = None  # Clear cached ICA activity
-    eeg = pop_select(eeg, 'nochannel', artifact_components)
+    # Flag high-confidence muscle and eye components, then remove flagged ICs
+    eeg = pop_icflag(eeg)
+    eeg = pop_subcomp(eeg, [])
+
+Standalone Python EEGPrep ships the default ICLabel network. The EEGLAB
+``lite`` and ``beta`` artifacts are not bundled in the Python package; they are
+explicit MATLAB/Octave passthrough choices when that runtime provides the
+corresponding ICLabel files.
 
 Pipeline Visualization
 ======================

--- a/src/eegprep/__init__.py
+++ b/src/eegprep/__init__.py
@@ -83,6 +83,7 @@ _LAZY_EXPORTS = {
     "eeg_decodechan": ("eegprep.functions.popfunc.eeg_decodechan", "eeg_decodechan"),
     "eeg_eeg2mne": ("eegprep.functions.miscfunc.eeg_eeg2mne", "eeg_eeg2mne"),
     "eeg_eegrej": ("eegprep.functions.popfunc.eeg_eegrej", "eeg_eegrej"),
+    "eeg_icalabelstat": ("eegprep.plugins.ICLabel.eeg_icalabelstat", "eeg_icalabelstat"),
     "eeg_emptyset": ("eegprep.functions.popfunc.eeg_emptyset", "eeg_emptyset"),
     "eeg_multieegplot": ("eegprep.functions.popfunc.eeg_multieegplot", "eeg_multieegplot"),
     "eegplot": ("eegprep.functions.sigprocfunc.eegplot", "eegplot"),

--- a/src/eegprep/plugins/ICLabel/eeg_icalabelstat.py
+++ b/src/eegprep/plugins/ICLabel/eeg_icalabelstat.py
@@ -1,4 +1,4 @@
-"""ICLabel component summary statistics."""
+"""EEGLAB ICLabel component summary statistics."""
 
 from __future__ import annotations
 
@@ -19,6 +19,10 @@ def eeg_icalabelstat(
     stream: TextIO | None = None,
 ) -> dict[str, Any]:
     """Return and optionally print ICLabel class statistics.
+
+    This mirrors EEGLAB's ``plugins/ICLabel/eeg_icalabelstat.m`` summary,
+    including class order and the historical ``IClabel`` console label, while
+    returning structured Python statistics for programmatic use.
 
     Args:
         EEG: EEGPrep/EEGLAB-style dataset with ICLabel classifications under

--- a/src/eegprep/plugins/ICLabel/eeg_icalabelstat.py
+++ b/src/eegprep/plugins/ICLabel/eeg_icalabelstat.py
@@ -1,0 +1,146 @@
+"""ICLabel component summary statistics."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, TextIO
+
+import numpy as np
+
+
+DEFAULT_ICLABEL_CLASSES = ("Brain", "Muscle", "Eye", "Heart", "Line Noise", "Channel Noise", "Other")
+
+
+def eeg_icalabelstat(
+    EEG: dict[str, Any],
+    threshold: float | list[float] | tuple[float, ...] | np.ndarray = 0.9,
+    *,
+    verbose: bool = True,
+    stream: TextIO | None = None,
+) -> dict[str, Any]:
+    """Return and optionally print ICLabel class statistics.
+
+    Args:
+        EEG: EEGPrep/EEGLAB-style dataset with ICLabel classifications under
+            ``EEG["etc"]["ic_classification"]["ICLabel"]``.
+        threshold: Scalar probability threshold applied to every class, or one
+            threshold per ICLabel class.
+        verbose: Print EEGLAB-style summary lines when true.
+        stream: Destination for printed summary lines. Defaults to stdout.
+
+    Returns:
+        Dictionary containing class names, thresholds, per-class counts,
+        1-based component indices above threshold, mean probabilities, dominant
+        class counts, and current rejected/kept tallies.
+    """
+    iclabel_state = _iclabel_state(EEG)
+    classifications = _classification_matrix(iclabel_state)
+    classes = _class_names(iclabel_state, classifications.shape[1])
+    thresholds = _threshold_vector(threshold, len(classes))
+    flags = _rejection_flags(EEG, classifications.shape[0])
+
+    above_threshold = classifications > thresholds[np.newaxis, :]
+    counts = np.sum(above_threshold, axis=0).astype(int)
+    component_indices = [
+        (np.flatnonzero(above_threshold[:, class_index]) + 1).astype(int).tolist()
+        for class_index in range(len(classes))
+    ]
+    rejected_counts = np.sum(above_threshold & flags[:, np.newaxis], axis=0).astype(int)
+    kept_counts = np.sum(above_threshold & ~flags[:, np.newaxis], axis=0).astype(int)
+    dominant_class_indices = np.argmax(classifications, axis=1)
+
+    stats = {
+        "classes": classes,
+        "threshold": thresholds,
+        "component_count": int(classifications.shape[0]),
+        "counts": counts,
+        "component_indices": component_indices,
+        "mean_probability": np.mean(classifications, axis=0),
+        "dominant_counts": np.bincount(dominant_class_indices, minlength=len(classes)).astype(int),
+        "dominant_class_indices": (dominant_class_indices + 1).astype(int),
+        "rejected_component_count": int(np.sum(flags)),
+        "kept_component_count": int(classifications.shape[0] - np.sum(flags)),
+        "rejected_counts": rejected_counts,
+        "kept_counts": kept_counts,
+    }
+    if verbose:
+        _print_summary(stats, stream or sys.stdout)
+    return stats
+
+
+def _iclabel_state(EEG: dict[str, Any]) -> dict[str, Any]:
+    try:
+        state = EEG["etc"]["ic_classification"]["ICLabel"]
+    except KeyError as exc:
+        raise ValueError("No ICLabel classifications found. Run pop_iclabel first.") from exc
+    if not isinstance(state, dict):
+        raise ValueError("No ICLabel classifications found. Run pop_iclabel first.")
+    return state
+
+
+def _classification_matrix(iclabel_state: dict[str, Any]) -> np.ndarray:
+    try:
+        classifications = np.asarray(iclabel_state["classifications"], dtype=float)
+    except KeyError as exc:
+        raise ValueError("No ICLabel classifications found. Run pop_iclabel first.") from exc
+    if classifications.ndim != 2 or classifications.size == 0:
+        raise ValueError("ICLabel classifications must be a non-empty 2D array.")
+    if not np.isfinite(classifications).all():
+        raise ValueError("ICLabel classifications must contain finite probabilities.")
+    return classifications
+
+
+def _class_names(iclabel_state: dict[str, Any], class_count: int) -> list[str]:
+    classes = iclabel_state.get("classes")
+    if classes is None or np.asarray(classes, dtype=object).size == 0:
+        if class_count == len(DEFAULT_ICLABEL_CLASSES):
+            return list(DEFAULT_ICLABEL_CLASSES)
+        raise ValueError("ICLabel classes are missing and classifications do not have the 7 standard columns.")
+    names = [_string_name(value) for value in np.asarray(classes, dtype=object).ravel().tolist()]
+    if len(names) != class_count:
+        raise ValueError(f"ICLabel class list has {len(names)} labels for {class_count} probability columns.")
+    return names
+
+
+def _string_name(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _threshold_vector(threshold: float | list[float] | tuple[float, ...] | np.ndarray, class_count: int) -> np.ndarray:
+    values = np.asarray(threshold, dtype=float)
+    if values.ndim == 0 or values.size == 1:
+        thresholds = np.repeat(float(values.reshape(-1)[0]), class_count)
+    else:
+        thresholds = values.reshape(-1)
+        if thresholds.size != class_count:
+            raise ValueError(f"threshold must be scalar or contain {class_count} values.")
+    if not np.isfinite(thresholds).all() or (thresholds < 0).any() or (thresholds > 1).any():
+        raise ValueError("ICLabel thresholds must be finite probabilities between 0 and 1.")
+    return thresholds.astype(float, copy=True)
+
+
+def _rejection_flags(EEG: dict[str, Any], component_count: int) -> np.ndarray:
+    reject = EEG.get("reject") or {}
+    flags = reject.get("gcompreject") if isinstance(reject, dict) else None
+    if flags is None:
+        return np.zeros(component_count, dtype=bool)
+    normalized = np.asarray(flags).reshape(-1)
+    if normalized.size != component_count:
+        raise ValueError("EEG.reject.gcompreject must match the number of ICLabel components.")
+    return normalized.astype(bool)
+
+
+def _print_summary(stats: dict[str, Any], stream: TextIO) -> None:
+    classes = stats["classes"]
+    counts = stats["counts"]
+    thresholds = stats["threshold"]
+    component_count = stats["component_count"]
+    for class_name, count, class_threshold in zip(classes, counts, thresholds):
+        label = f'IClabel class "{class_name}"'
+        percent = int(np.round(float(class_threshold) * 100))
+        print(f"{label:>30}: {int(count)}/{component_count} components at {percent}% threshold", file=stream)
+
+
+__all__ = ["DEFAULT_ICLABEL_CLASSES", "eeg_icalabelstat"]

--- a/src/eegprep/plugins/ICLabel/iclabel.py
+++ b/src/eegprep/plugins/ICLabel/iclabel.py
@@ -6,6 +6,9 @@ import os
 import numpy as np
 
 
+_SUPPORTED_ALGORITHMS = ('default', 'lite', 'beta')
+
+
 def iclabel(EEG, algorithm='default', engine=None):
     """Apply ICLabel to classify independent components.
 
@@ -27,16 +30,7 @@ def iclabel(EEG, algorithm='default', engine=None):
     EEG : dict
         EEGLAB EEG structure with ICLabel classifications added
     """
-    try:
-        import torch
-    except ImportError as e:
-        raise ImportError(
-            f"PyTorch is not installed in your environment ({e}). "
-            f"To include torch, install eegprep as eegprep[all] or "
-            f"install the torch package manually (see Getting Started "
-            f"on pytorch.org for specifics for your platform)."
-        ) from e
-
+    algorithm = _normalize_algorithm(algorithm)
     EEG = deepcopy(EEG)
 
     # Check if using MATLAB or Octave implementation
@@ -55,6 +49,22 @@ def iclabel(EEG, algorithm='default', engine=None):
 
     # Default Python implementation
     elif engine is None:
+        if algorithm != 'default':
+            raise NotImplementedError(
+                "EEGPrep standalone Python ICLabel only ships the default network (netICL.mat). "
+                f"The '{algorithm}' network is available only with engine='matlab' or engine='octave' "
+                "and an EEGLAB ICLabel checkout that provides that artifact."
+            )
+        try:
+            import torch
+        except ImportError as e:
+            raise ImportError(
+                f"PyTorch is not installed in your environment ({e}). "
+                f"To include torch, install eegprep as eegprep[all] or "
+                f"install the torch package manually (see Getting Started "
+                f"on pytorch.org for specifics for your platform)."
+            ) from e
+
         from eegprep.plugins.ICLabel.iclabel_net import ICLabelNet
         from eegprep import ICL_feature_extractor
 
@@ -104,3 +114,10 @@ def iclabel(EEG, algorithm='default', engine=None):
         return EEG
     else:
         raise ValueError(f"Unsupported engine: {engine}. Should be None, 'matlab', or 'octave'")
+
+
+def _normalize_algorithm(algorithm):
+    normalized = 'default' if algorithm is None else str(algorithm).lower()
+    if normalized not in _SUPPORTED_ALGORITHMS:
+        raise ValueError("algorithm must be one of 'default', 'lite', or 'beta'")
+    return normalized

--- a/src/eegprep/plugins/ICLabel/pop_icflag.py
+++ b/src/eegprep/plugins/ICLabel/pop_icflag.py
@@ -10,6 +10,7 @@ import numpy as np
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.popfunc._pop_utils import format_history_value
+from eegprep.plugins.ICLabel.eeg_icalabelstat import eeg_icalabelstat
 from eegprep.plugins.ICLabel.eeg_icflag import eeg_icflag
 
 
@@ -53,6 +54,9 @@ def pop_icflag(
     if gui is None:
         gui = thresholds is None
     if gui:
+        if thresholds is None and not isinstance(EEG, list):
+            _require_iclabel(EEG)
+            eeg_icalabelstat(EEG)
         result = _run_gui(renderer=renderer)
         if result is None:
             return (EEG, "") if return_com else EEG

--- a/src/eegprep/plugins/ICLabel/pop_iclabel.py
+++ b/src/eegprep/plugins/ICLabel/pop_iclabel.py
@@ -52,6 +52,7 @@ def pop_iclabel_dialog_spec() -> DialogSpec:
         eeglab_source="plugins/ICLabel/pop_iclabel.m",
         geometry=((1,), (1,)),
         size=(356, 199),
+        show_help_button=False,
         controls=(
             ControlSpec("text", "Select which icversion of ICLabel to use:"),
             ControlSpec("popupmenu", "Default (recommended)|Lite|Beta", tag="icversion", value=1),

--- a/src/eegprep/plugins/ICLabel/pop_iclabel.py
+++ b/src/eegprep/plugins/ICLabel/pop_iclabel.py
@@ -52,7 +52,6 @@ def pop_iclabel_dialog_spec() -> DialogSpec:
         eeglab_source="plugins/ICLabel/pop_iclabel.m",
         geometry=((1,), (1,)),
         size=(356, 199),
-        help_text="pophelp('pop_iclabel')",
         controls=(
             ControlSpec("text", "Select which icversion of ICLabel to use:"),
             ControlSpec("popupmenu", "Default (recommended)|Lite|Beta", tag="icversion", value=1),

--- a/src/eegprep/resources/help/eeg_icalabelstat.md
+++ b/src/eegprep/resources/help/eeg_icalabelstat.md
@@ -16,6 +16,8 @@ Behavior:
 
 - Prints EEGLAB-style class counts such as the number of Muscle components
   above the selected probability threshold.
+- Mirrors the ICLabel plugin `eeg_icalabelstat.m` console summary, including
+  the historical `IClabel` label capitalization used by EEGLAB.
 - Returns a dictionary with class names, thresholds, per-class counts,
   1-based component indices above threshold, mean probabilities, dominant
   class counts, and rejected/kept tallies based on `EEG.reject.gcompreject`.

--- a/src/eegprep/resources/help/eeg_icalabelstat.md
+++ b/src/eegprep/resources/help/eeg_icalabelstat.md
@@ -1,0 +1,29 @@
+EEG_ICALABELSTAT - Summarize ICLabel component probabilities.
+
+Usage:
+
+    stats = eeg_icalabelstat(EEG)
+    stats = eeg_icalabelstat(EEG, threshold=0.8, verbose=False)
+
+Inputs:
+
+- `EEG`: EEGPrep/EEGLAB-style dataset with ICLabel classifications in
+  `EEG.etc.ic_classification.ICLabel`.
+- `threshold`: scalar probability threshold, or one threshold per ICLabel
+  class. The default is `0.9`.
+
+Behavior:
+
+- Prints EEGLAB-style class counts such as the number of Muscle components
+  above the selected probability threshold.
+- Returns a dictionary with class names, thresholds, per-class counts,
+  1-based component indices above threshold, mean probabilities, dominant
+  class counts, and rejected/kept tallies based on `EEG.reject.gcompreject`.
+- Uses the standard ICLabel class order when the classification matrix has
+  seven columns and class names are not stored.
+
+Example:
+
+    EEG = pop_iclabel(EEG, 'default')
+    stats = eeg_icalabelstat(EEG, 0.9)
+    print(stats["counts"])

--- a/src/eegprep/resources/help/pop_icflag.md
+++ b/src/eegprep/resources/help/pop_icflag.md
@@ -14,7 +14,8 @@ Graphical interface:
 
 Calling `pop_icflag(EEG)` opens an EEGLAB-style threshold dialog. Blank
 fields ignore a class. By default, Muscle and Eye components with probability
-between 0.9 and 1 are flagged.
+between 0.9 and 1 are flagged. Before the dialog opens, EEGPrep prints the
+same per-class ICLabel threshold summary exposed by `eeg_icalabelstat`.
 
 Behavior:
 
@@ -22,6 +23,8 @@ Behavior:
 - Flagged components are stored in `EEG.reject.gcompreject`.
 - Existing rejection fields are preserved.
 - This function flags components only; use `pop_subcomp` to remove them from the data.
+- Use `eeg_icalabelstat(EEG)` directly when you want label counts for a report
+  without changing rejection marks.
 
 Example:
 

--- a/src/eegprep/resources/help/pop_iclabel.md
+++ b/src/eegprep/resources/help/pop_iclabel.md
@@ -4,7 +4,7 @@ Usage:
 
     EEG = pop_iclabel(EEG)
     EEG = pop_iclabel(EEG, 'default')
-    EEG, command = pop_iclabel(EEG, 'lite', return_com=True)
+    EEG, command = pop_iclabel(EEG, 'default', return_com=True)
 
 Inputs:
 
@@ -22,6 +22,10 @@ Behavior:
 - Results are stored in `EEG.etc.ic_classification.ICLabel`.
 - The result includes the ICLabel class names, per-component class probabilities, and the selected version string.
 - Lists of datasets are processed one dataset at a time with the same selected version.
+- Standalone Python EEGPrep ships the default ICLabel network (`netICL.mat`).
+  The EEGLAB `lite` and `beta` network artifacts are explicit MATLAB/Octave
+  passthrough choices and raise a clear limitation when requested with the
+  standalone Python engine.
 
 Example:
 

--- a/tests/test_gui_pop_iclabel.py
+++ b/tests/test_gui_pop_iclabel.py
@@ -39,14 +39,31 @@ class PopIclabelGuiTests(unittest.TestCase):
     def test_gui_result_runs_iclabel_and_returns_history(self):
         class Renderer:
             def run(self, spec, initial_values=None):
-                return {"icversion": 2}
+                return {"icversion": 1}
 
         eeg = _eeg()
-        updated = dict(eeg, etc={"ic_classification": {"ICLabel": {"version": "lite"}}})
+        updated = dict(eeg, etc={"ic_classification": {"ICLabel": {"version": "default"}}})
         with mock.patch("eegprep.plugins.ICLabel.pop_iclabel.iclabel", return_value=updated) as classify:
             out, com = pop_iclabel(eeg, gui=True, renderer=Renderer(), return_com=True)
 
-        classify.assert_called_once_with(eeg, algorithm="lite", engine=None)
+        classify.assert_called_once_with(eeg, algorithm="default", engine=None)
+        self.assertEqual(out["etc"]["ic_classification"]["ICLabel"]["version"], "default")
+        self.assertEqual(com, "EEG = pop_iclabel(EEG, 'default');")
+
+    def test_python_engine_rejects_unbundled_lite_and_beta_networks(self):
+        eeg = _eeg()
+
+        with self.assertRaisesRegex(NotImplementedError, "standalone Python ICLabel only ships the default network"):
+            pop_iclabel(eeg, "lite")
+
+    def test_matlab_engine_can_request_lite_network(self):
+        eeg = _eeg()
+        updated = dict(eeg, etc={"ic_classification": {"ICLabel": {"version": "lite"}}})
+
+        with mock.patch("eegprep.plugins.ICLabel.pop_iclabel.iclabel", return_value=updated) as classify:
+            out, com = pop_iclabel(eeg, "lite", engine="matlab", return_com=True)
+
+        classify.assert_called_once_with(eeg, algorithm="lite", engine="matlab")
         self.assertEqual(out["etc"]["ic_classification"]["ICLabel"]["version"], "lite")
         self.assertEqual(com, "EEG = pop_iclabel(EEG, 'lite');")
 

--- a/tests/test_gui_pop_iclabel.py
+++ b/tests/test_gui_pop_iclabel.py
@@ -28,6 +28,8 @@ class PopIclabelGuiTests(unittest.TestCase):
         self.assertEqual(spec.title, "ICLabel")
         self.assertEqual(spec.function_name, "pop_iclabel")
         self.assertEqual(spec.eeglab_source, "plugins/ICLabel/pop_iclabel.m")
+        self.assertIsNone(spec.help_text)
+        self.assertFalse(spec.show_help_button)
         self.assertEqual(
             [(control.style, control.string, control.tag) for control in spec.controls],
             [

--- a/tests/test_iclabel_statistics.py
+++ b/tests/test_iclabel_statistics.py
@@ -55,9 +55,11 @@ def test_eeg_icalabelstat_matches_eeglab_threshold_counts_and_prints_summary(cap
     np.testing.assert_array_equal(stats["rejected_counts"], [0, 1, 1, 0, 0, 0, 0])
     np.testing.assert_array_equal(stats["kept_counts"], [0, 0, 0, 0, 0, 0, 0])
 
-    output = capsys.readouterr().out
-    assert 'IClabel class "Muscle": 1/4 components at 90% threshold' in output
-    assert 'IClabel class "Eye": 1/4 components at 90% threshold' in output
+    lines = capsys.readouterr().out.splitlines()
+    assert len(lines) == len(ICLABEL_CLASSES)
+    assert lines[0].strip() == 'IClabel class "Brain": 0/4 components at 90% threshold'
+    assert lines[1].strip() == 'IClabel class "Muscle": 1/4 components at 90% threshold'
+    assert lines[2].strip() == 'IClabel class "Eye": 1/4 components at 90% threshold'
 
 
 def test_eeg_icalabelstat_accepts_class_specific_thresholds_and_default_classes() -> None:

--- a/tests/test_iclabel_statistics.py
+++ b/tests/test_iclabel_statistics.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from eegprep import pop_loadset
+from eegprep.functions.guifunc.pophelp import pophelp_text
+from eegprep.plugins.ICLabel.eeg_icalabelstat import eeg_icalabelstat
+from eegprep.plugins.ICLabel.iclabel import iclabel
+from eegprep.plugins.ICLabel.pop_icflag import ICLABEL_CLASSES
+from eegprep.plugins.ICLabel.pop_viewprops import pop_viewprops
+
+
+def _classified_eeg() -> dict:
+    return {
+        "setname": "classified",
+        "data": np.zeros((4, 100)),
+        "nbchan": 4,
+        "pnts": 100,
+        "trials": 1,
+        "srate": 100.0,
+        "icaweights": np.eye(4),
+        "icasphere": np.eye(4),
+        "icawinv": np.eye(4),
+        "icachansind": np.arange(4),
+        "reject": {"gcompreject": np.array([0, 1, 1, 0])},
+        "etc": {
+            "ic_classification": {
+                "ICLabel": {
+                    "classes": list(ICLABEL_CLASSES),
+                    "classifications": np.array(
+                        [
+                            [0.70, 0.10, 0.10, 0.03, 0.02, 0.03, 0.02],
+                            [0.02, 0.94, 0.02, 0.01, 0.00, 0.00, 0.01],
+                            [0.05, 0.02, 0.91, 0.01, 0.00, 0.00, 0.01],
+                            [0.80, 0.05, 0.05, 0.02, 0.02, 0.03, 0.03],
+                        ]
+                    ),
+                }
+            }
+        },
+    }
+
+
+def test_eeg_icalabelstat_matches_eeglab_threshold_counts_and_prints_summary(capsys) -> None:
+    stats = eeg_icalabelstat(_classified_eeg(), threshold=0.9)
+
+    assert stats["classes"] == list(ICLABEL_CLASSES)
+    assert stats["component_count"] == 4
+    np.testing.assert_array_equal(stats["counts"], [0, 1, 1, 0, 0, 0, 0])
+    assert stats["component_indices"][1] == [2]
+    assert stats["component_indices"][2] == [3]
+    np.testing.assert_array_equal(stats["rejected_counts"], [0, 1, 1, 0, 0, 0, 0])
+    np.testing.assert_array_equal(stats["kept_counts"], [0, 0, 0, 0, 0, 0, 0])
+
+    output = capsys.readouterr().out
+    assert 'IClabel class "Muscle": 1/4 components at 90% threshold' in output
+    assert 'IClabel class "Eye": 1/4 components at 90% threshold' in output
+
+
+def test_eeg_icalabelstat_accepts_class_specific_thresholds_and_default_classes() -> None:
+    eeg = _classified_eeg()
+    eeg["etc"]["ic_classification"]["ICLabel"].pop("classes")
+
+    stats = eeg_icalabelstat(eeg, threshold=[0.6, 0.9, 0.9, 0.5, 0.5, 0.5, 0.5], verbose=False)
+
+    assert stats["classes"] == list(ICLABEL_CLASSES)
+    np.testing.assert_array_equal(stats["counts"], [2, 1, 1, 0, 0, 0, 0])
+    np.testing.assert_allclose(stats["threshold"], [0.6, 0.9, 0.9, 0.5, 0.5, 0.5, 0.5])
+    np.testing.assert_array_equal(stats["dominant_counts"], [2, 1, 1, 0, 0, 0, 0])
+
+
+def test_eeg_icalabelstat_rejects_missing_or_malformed_iclabel_state() -> None:
+    eeg = _classified_eeg()
+    eeg["etc"] = {}
+
+    with pytest.raises(ValueError, match="No ICLabel classifications"):
+        eeg_icalabelstat(eeg, verbose=False)
+
+    malformed = _classified_eeg()
+    malformed["etc"]["ic_classification"]["ICLabel"]["classes"] = ["Brain"]
+    with pytest.raises(ValueError, match="ICLabel class list has 1 labels"):
+        eeg_icalabelstat(malformed, verbose=False)
+
+
+def test_sample_data_ica_iclabel_state_drives_statistics_and_viewprops_history() -> None:
+    eeg = pop_loadset("sample_data/eeglab_data_with_ica_tmp.set")
+    classifications = np.zeros((eeg["icaweights"].shape[0], len(ICLABEL_CLASSES)), dtype=float)
+    classifications[:, 0] = 0.8
+    classifications[0, 1] = 0.95
+    classifications[1, 2] = 0.96
+    eeg = copy.deepcopy(eeg)
+    eeg.setdefault("etc", {})["ic_classification"] = {
+        "ICLabel": {"classes": list(ICLABEL_CLASSES), "classifications": classifications}
+    }
+
+    stats = eeg_icalabelstat(eeg, threshold=0.9, verbose=False)
+    _figures, command = pop_viewprops(eeg, 0, [1, 2], plot=False, return_com=True)
+
+    assert stats["component_count"] == 32
+    np.testing.assert_array_equal(stats["counts"][:3], [0, 1, 1])
+    assert command == "pop_viewprops(EEG, 0, [1 2], [], [], 1, '');"
+
+
+def test_python_iclabel_rejects_unbundled_alternate_networks_before_runtime_dependencies() -> None:
+    eeg = _classified_eeg()
+
+    with pytest.raises(NotImplementedError, match="standalone Python ICLabel only ships the default network"):
+        iclabel(eeg, algorithm="lite", engine=None)
+
+
+def test_eeg_icalabelstat_help_is_packaged() -> None:
+    help_text, source_path = pophelp_text("eeg_icalabelstat")
+
+    assert "EEG_ICALABELSTAT" in help_text
+    assert source_path == "eegprep/resources/help/eeg_icalabelstat.md"
+
+
+def test_eeg_icalabelstat_is_public_lazy_export() -> None:
+    from eegprep import eeg_icalabelstat as exported
+
+    assert exported is eeg_icalabelstat


### PR DESCRIPTION
Add `eeg_icalabelstat` with EEGLAB-style threshold summaries, explicit standalone ICLabel network limits, and focused ICLabel/viewprops tests. Document the component review workflow and mark the Phase 6 parity rows implemented while preserving native EEGPrep diagnostic displays.

Limitations called out intentionally:
- Standalone Python ICLabel ships only the bundled default `netICL.mat`; `lite` and `beta` remain explicit MATLAB/Octave-engine paths unless their artifacts are packaged later.
- `pop_iclabel` intentionally has no dialog Help button because the ICLabel plugin `inputdlg3` call does not pass a help callback; packaged `pophelp` text remains available.
- `eeg_icalabelstat` keeps EEGLAB console-style `print` output by default, with `verbose=False` and `stream=` available for non-console callers.

Closes #163