### PR TITLE
Build standalone EEGPrep Sphinx manual and tutorials

### DIFF
--- a/.agents/skills/eeglab-gui-visual-parity/SKILL.md
+++ b/.agents/skills/eeglab-gui-visual-parity/SKILL.md
@@ -11,6 +11,9 @@ same controls, labels, order, enabled state, layout, and obvious hierarchy.
 EEGLAB users must feel at home while using EEGPrep, so compare alignment,
 arrangement, button placement, text fields, labels, defaults, enabled states,
 and workflow before accepting a GUI as complete. Remember, while we are doing a porting project, EEGPrep must work well standalone and must be a delight to use for EEG Researchers.
+When the GUI behavior, menu path, help surface, command history, or
+GUI/`eegprep-console` synchronization changes, update the relevant Sphinx
+workflow docs and packaged help resources in the same branch.
 
 ## Work From The Repo Root
 

--- a/.agents/skills/eegprep-extension-development/SKILL.md
+++ b/.agents/skills/eegprep-extension-development/SKILL.md
@@ -6,7 +6,8 @@ description: Build EEGPrep external extension packages with SDK registration, de
 # EEGPrep Extension Development
 
 Use this skill to build extension packages that work as standalone Python
-packages and feel natural to EEGLAB users inside EEGPrep.
+packages and feel natural inside EEGPrep, including for researchers migrating
+from EEGLAB.
 
 ## Start Here
 
@@ -96,6 +97,11 @@ must not import heavy code, start Qt, read data files, or call EEGLAB.
   Python indexing internally.
 - Package GUI Help and `pophelp` text as Markdown resources and declare them
   with `ExtensionResource`.
+- Update the relevant Sphinx docs when an extension changes user-facing menus,
+  workflows, console/history behavior, optional dependency expectations,
+  package data, curation metadata, or troubleshooting guidance. Keep the docs
+  centered on standalone EEGPrep behavior, with EEGLAB comparisons only where
+  they clarify migration or compatibility.
 - Put data/model resources in the package and access them with
   `importlib.resources` or declared `ExtensionResource` records. Do not read
   from `src/eegprep/eeglab` at runtime.

--- a/.agents/skills/eegprep-feature-development/SKILL.md
+++ b/.agents/skills/eegprep-feature-development/SKILL.md
@@ -34,8 +34,15 @@ Use this workflow when building a new EEGPrep feature.
    workspace contract: return `(EEG, com)` with `return_com=True`, update
    GUI state through `EEGPrepSession`, and keep `EEG`/`ALLEEG`/history visible
    from both the GUI and the console. Make the GUI-plus-console workflow feel
-   seamless for EEGLAB users who switch between menus/dialogs, command history,
+   seamless for researchers who switch between menus/dialogs, command history,
    and workspace inspection.
+   Whenever a user-facing API, GUI, console, workflow, plugin, or help behavior
+   changes, update the relevant Sphinx docs and packaged help resources in the
+   same branch. The docs should describe EEGPrep as a standalone Python/Qt
+   application first, with EEGLAB comparisons only where they help users
+   migrate, understand parity decisions, or handle file/indexing boundaries.
+   For mixed GUI plus `eegprep-console` features, document both the user
+   workflow and the `EEGPrepSession` state that stays synchronized.
 
 6. For features that involve a GUI component, use the
    [`eeglab-gui-visual-parity`](../eeglab-gui-visual-parity/SKILL.md) skill to

--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ matlab/clean_rawdata
 
 # Sphinx documentation
 docs/build/
+docs/_build/
 docs/source/auto_examples/
 !docs/source/auto_examples/index.rst

--- a/.notes/implementation-notes.html
+++ b/.notes/implementation-notes.html
@@ -6,6 +6,37 @@
 </head>
 <body>
   <h1>EEGPrep Core Parity Implementation Notes</h1>
+  <h1>Issue #164 EEGLAB-Style Sphinx Documentation Notes</h1>
+  <p>Issue #164 turns the final-epic documentation into a coherent standalone
+  EEGPrep manual modeled after EEGLAB's learning path but written for Python,
+  the Qt GUI, <code>eegprep-console</code>, and EEGPrep-owned packaged
+  resources.</p>
+  <h2>Issue #164 Design Decisions</h2>
+  <ul>
+    <li>Reorganized the docs around user workflows rather than API categories:
+    quickstart, concepts, GUI tutorials, console history, scripting, MNE
+    interoperability, preprocessing, ICLabel review, EEGBrowser, STUDY, bundled
+    plugins, extension authoring, and EEGLAB migration.</li>
+    <li>Kept tutorial examples grounded in checked-in <code>sample_data</code>
+    files where possible, and used explicit <code>return_com=True</code>
+    examples to teach history replay.</li>
+    <li>Added a complete public <code>pop_*</code> API index plus missing
+    packaged help topics for <code>pop_chansel</code>,
+    <code>pop_load_frombids</code>, and <code>pop_loadset_h5</code>.</li>
+    <li>Improved Sphinx presentation through the existing pydata theme and
+    local CSS rather than adding a new docs framework or external runtime
+    dependency.</li>
+  </ul>
+  <h2>Issue #164 Tradeoffs</h2>
+  <ul>
+    <li>Docs describe implemented EEGPrep behavior and explicit backend limits;
+    they do not promise MATLAB-only LIMO, FieldTrip STUDY source statistics,
+    MRI BEM creation, AFNI atlas clipping, or unavailable ICLabel network
+    artifacts as standalone features.</li>
+    <li>Examples avoid executing heavy ICA/source workflows in the docs build,
+    but the manual points to sample-data paths and current public APIs so users
+    can run the workflows interactively.</li>
+  </ul>
   <h1>Issue #163 ICLabel/Viewprops Diagnostic Parity Notes</h1>
   <p>Issue #163 closes the Phase 6 final-epic ICLabel/viewprops rows by adding
   standalone label statistics, making alternate network support explicit, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Primary references:
 - GUI/menu actions must update datasets and history through `EEGPrepSession` helpers such as `store_current`, `add_history`, and `notify_changed`; do not mutate GUI-only state that the console cannot see.
 - User-facing `pop_*` functions should support `return_com=True` and return EEGLAB-style history commands. The console wrappers rely on `(EEG, com)` results to auto-store bare calls like `pop_reref(EEG, [])`.
 - When adding or changing a GUI-reachable function, test both interaction directions when relevant: GUI action then console inspection, and console command then GUI refresh/history.
+- When GUI/console synchronization, history behavior, dataset selection, STUDY state, or registered menu actions change, update the Sphinx workflow docs so users understand how to move between the GUI and `eegprep-console`, and update developer notes when `EEGPrepSession` contracts change.
 - Menu placeholders must carry phase/exclusion metadata in `menu_placeholders.py`; mark EEGBrowser/eegplot-style scrolling workflows with an explicit exclusion instead of treating them as ordinary TODOs.
 
 ## Code Style
@@ -90,7 +91,8 @@ Primary references:
 
 - Public APIs need concise docstrings. Use the style already present in nearby code; Google-style is preferred for new public functions.
 - Skip docstrings for trivial private helpers with clear names.
-- When adding a feature or changing user-facing behavior, update Sphinx docs under `docs/source/`. Update examples/API pages when relevant.
+- Any user-facing EEGPrep change must include matching Sphinx updates under `docs/source/` in the same branch unless the change has no user-visible behavior. Update workflow/tutorial pages, examples, generated or hand-written API pages, troubleshooting notes, and migration notes where relevant.
+- Write docs from an EEGPrep standalone user point of view. Use EEGLAB comparisons when they clarify migration, parity, file compatibility, or indexing boundaries, but do not frame normal EEGPrep behavior as merely "EEGLAB-style."
 - When adding a user-facing function or GUI dialog with a Help button, add or update the corresponding Markdown help resource in `src/eegprep/resources/help/`, for example `src/eegprep/resources/help/pop_reref.md`.
 - Keep comments for module/class behavior, subtle logic, or non-obvious boolean arguments. Do not restate code.
 - Delete stale comments when you encounter them in touched code.

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,481 +1,282 @@
-/* Custom CSS for eegprep documentation */
-
-/* ============================================================================
-   Color Scheme and Theme Customization
-   ============================================================================ */
+/* EEGPrep documentation theme refinements. */
 
 :root {
-  /* Primary colors */
-  --primary-color: #0066cc;
-  --primary-dark: #0052a3;
-  --primary-light: #3385d6;
-
-  /* Secondary colors */
-  --secondary-color: #6c757d;
-  --secondary-light: #adb5bd;
-
-  /* Accent colors */
-  --accent-color: #ff6b6b;
-  --accent-light: #ff8787;
-
-  /* Success, warning, error colors */
-  --success-color: #28a745;
-  --warning-color: #ffc107;
-  --error-color: #dc3545;
-
-  /* Neutral colors */
-  --text-dark: #212529;
-  --text-light: #6c757d;
-  --bg-light: #f8f9fa;
-  --bg-white: #ffffff;
-  --border-color: #dee2e6;
+  --eegprep-ink: #1f2933;
+  --eegprep-muted: #5d6975;
+  --eegprep-panel: #f6f8fb;
+  --eegprep-panel-strong: #eef3f7;
+  --eegprep-line: #d7e0e8;
+  --eegprep-teal: #14706f;
+  --eegprep-teal-dark: #0f5251;
+  --eegprep-blue: #245f8f;
+  --eegprep-plum: #6d4774;
+  --eegprep-amber: #b86b26;
+  --eegprep-red: #b94040;
+  --pst-color-primary: var(--eegprep-teal);
+  --pst-color-secondary: var(--eegprep-blue);
+  --pst-color-link: var(--eegprep-teal);
+  --pst-color-link-hover: var(--eegprep-teal-dark);
+  --pst-font-size-base: 0.98rem;
+  --pst-font-family-base: "Avenir Next", Avenir, "Segoe UI", Helvetica, Arial, sans-serif;
+  --pst-font-family-heading: "Avenir Next", Avenir, "Segoe UI", Helvetica, Arial, sans-serif;
+  --pst-font-family-monospace: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --sd-color-primary: var(--eegprep-teal);
+  --sd-color-secondary: var(--eegprep-blue);
 }
 
-/* Dark mode color scheme */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text-dark: #e9ecef;
-    --text-light: #adb5bd;
-    --bg-light: #343a40;
-    --bg-white: #212529;
-    --border-color: #495057;
-  }
+html[data-theme="dark"] {
+  --eegprep-ink: #e8edf2;
+  --eegprep-muted: #abb7c4;
+  --eegprep-panel: #18212b;
+  --eegprep-panel-strong: #202c38;
+  --eegprep-line: #344553;
+  --eegprep-teal: #58b8ad;
+  --eegprep-teal-dark: #8dd3cb;
+  --eegprep-blue: #7fb0df;
+  --eegprep-plum: #c5a5cf;
+  --eegprep-amber: #e0a05e;
+  --eegprep-red: #e38383;
 }
-
-/* ============================================================================
-   Font Customization
-   ============================================================================ */
-
-/* Import Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 16px;
-  line-height: 1.6;
-  color: var(--text-dark);
+  color: var(--eegprep-ink);
+  font-variant-numeric: tabular-nums;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-weight: 600;
-  line-height: 1.3;
-  margin-top: 1.5em;
-  margin-bottom: 0.5em;
+.bd-main .bd-content .bd-article-container {
+  max-width: 960px;
 }
 
-h1 {
-  font-size: 2.5rem;
+.bd-main .bd-content .bd-article-container h1 {
+  color: var(--eegprep-ink);
+  font-size: clamp(2.1rem, 4vw, 3.35rem);
+  letter-spacing: 0;
+  line-height: 1.05;
+  margin-bottom: 0.85rem;
+}
+
+.bd-main .bd-content .bd-article-container h2 {
+  border-bottom: 1px solid var(--eegprep-line);
+  color: var(--eegprep-ink);
+  font-size: 1.65rem;
+  letter-spacing: 0;
+  margin-top: 2.5rem;
+  padding-bottom: 0.45rem;
+}
+
+.bd-main .bd-content .bd-article-container h3 {
+  color: var(--eegprep-teal-dark);
+  font-size: 1.22rem;
+  letter-spacing: 0;
+  margin-top: 1.8rem;
+}
+
+.bd-main .bd-content .bd-article-container h4 {
+  color: var(--eegprep-blue);
+  font-size: 1.05rem;
+}
+
+.bd-article-container p,
+.bd-article-container li {
+  line-height: 1.68;
+}
+
+.bd-sidebar-primary {
+  border-right: 1px solid var(--eegprep-line);
+}
+
+.bd-sidebar-secondary {
+  border-left: 1px solid var(--eegprep-line);
+}
+
+.navbar-brand img {
+  max-height: 46px;
+}
+
+.navbar-nav li a.nav-link,
+.bd-sidebar .nav li a {
+  letter-spacing: 0;
+}
+
+.eegprep-hero {
+  background:
+    linear-gradient(115deg, rgba(20, 112, 111, 0.14), rgba(36, 95, 143, 0.08) 48%, rgba(184, 107, 38, 0.1)),
+    var(--eegprep-panel);
+  border: 1px solid var(--eegprep-line);
+  border-radius: 8px;
+  margin: 1rem 0 1.5rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.eegprep-hero p {
+  color: var(--eegprep-muted);
+  font-size: 1.08rem;
+  margin-bottom: 0;
+  max-width: 760px;
+}
+
+.eegprep-kicker {
+  color: var(--eegprep-teal-dark);
+  font-size: 0.78rem;
   font-weight: 700;
-  color: var(--primary-dark);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.65rem;
+  text-transform: uppercase;
 }
 
-h2 {
-  font-size: 2rem;
-  color: var(--primary-dark);
-  border-bottom: 2px solid var(--primary-light);
-  padding-bottom: 0.5rem;
+.sd-card {
+  border: 1px solid var(--eegprep-line);
+  border-radius: 8px;
+  box-shadow: none;
 }
 
-h3 {
-  font-size: 1.5rem;
-  color: var(--primary-color);
+.sd-card:hover {
+  border-color: var(--eegprep-teal);
+  box-shadow: 0 8px 28px rgba(31, 41, 51, 0.08);
+  transform: translateY(-1px);
 }
 
-h4 {
-  font-size: 1.25rem;
+.sd-card-title {
+  color: var(--eegprep-ink);
+  font-weight: 700;
 }
 
-h5 {
-  font-size: 1.1rem;
+.sd-card-text {
+  color: var(--eegprep-muted);
 }
 
-h6 {
-  font-size: 1rem;
+.eegprep-path {
+  counter-reset: path-step;
+  display: grid;
+  gap: 0.85rem;
+  margin: 1.25rem 0;
 }
 
-/* ============================================================================
-   Code Block Styling
-   ============================================================================ */
-
-code, pre {
-  font-family: 'JetBrains Mono', 'Courier New', monospace;
-  font-size: 0.9em;
+.eegprep-path > p,
+.eegprep-path > div {
+  background: var(--eegprep-panel);
+  border: 1px solid var(--eegprep-line);
+  border-radius: 8px;
+  margin: 0;
+  padding: 0.9rem 1rem 0.9rem 3.1rem;
+  position: relative;
 }
 
-pre {
-  background-color: var(--bg-light);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 1rem;
-  overflow-x: auto;
-  line-height: 1.5;
-}
-
-pre code {
-  background-color: transparent;
-  border: none;
-  padding: 0;
-  color: var(--text-dark);
-}
-
-code {
-  background-color: var(--bg-light);
-  border: 1px solid var(--border-color);
-  border-radius: 3px;
-  padding: 0.2em 0.4em;
-  color: var(--accent-color);
-}
-
-/* Syntax highlighting for code blocks */
-.highlight {
-  background-color: var(--bg-light);
-  border-radius: 6px;
-  padding: 1rem;
-}
-
-.highlight pre {
-  background-color: transparent;
-  border: none;
-  padding: 0;
-}
-
-/* ============================================================================
-   Links and Buttons
-   ============================================================================ */
-
-a {
-  color: var(--primary-color);
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
-
-a:hover {
-  color: var(--primary-dark);
-  text-decoration: underline;
-}
-
-a:visited {
-  color: var(--primary-dark);
-}
-
-button, .btn {
-  background-color: var(--primary-color);
+.eegprep-path > p::before,
+.eegprep-path > div::before {
+  background: var(--eegprep-teal);
+  border-radius: 999px;
   color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
+  content: counter(path-step);
+  counter-increment: path-step;
+  font-size: 0.8rem;
+  font-weight: 700;
+  height: 1.55rem;
+  left: 1rem;
+  line-height: 1.55rem;
+  position: absolute;
+  text-align: center;
+  top: 0.95rem;
+  width: 1.55rem;
 }
 
-button:hover, .btn:hover {
-  background-color: var(--primary-dark);
+.eegprep-callout {
+  background: var(--eegprep-panel);
+  border: 1px solid var(--eegprep-line);
+  border-left: 4px solid var(--eegprep-teal);
+  border-radius: 8px;
+  margin: 1.25rem 0;
+  padding: 1rem 1.1rem;
 }
 
-/* ============================================================================
-   Admonitions (Notes, Warnings, etc.)
-   ============================================================================ */
+.eegprep-callout strong {
+  color: var(--eegprep-teal-dark);
+}
 
 .admonition {
-  border-left: 4px solid var(--border-color);
-  border-radius: 4px;
-  padding: 1rem;
-  margin: 1rem 0;
-  background-color: var(--bg-light);
+  border: 1px solid var(--eegprep-line);
+  border-left-width: 4px;
+  border-radius: 8px;
+  box-shadow: none;
 }
 
 .admonition.note {
-  border-left-color: var(--primary-color);
-  background-color: rgba(0, 102, 204, 0.05);
+  border-left-color: var(--eegprep-blue);
 }
 
-.admonition.warning {
-  border-left-color: var(--warning-color);
-  background-color: rgba(255, 193, 7, 0.05);
+.admonition.tip,
+.admonition.hint {
+  border-left-color: var(--eegprep-teal);
 }
 
-.admonition.danger, .admonition.error {
-  border-left-color: var(--error-color);
-  background-color: rgba(220, 53, 69, 0.05);
+.admonition.warning,
+.admonition.attention {
+  border-left-color: var(--eegprep-amber);
 }
 
-.admonition.tip, .admonition.hint {
-  border-left-color: var(--success-color);
-  background-color: rgba(40, 167, 69, 0.05);
+.admonition.error,
+.admonition.danger {
+  border-left-color: var(--eegprep-red);
 }
 
 .admonition-title {
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+  font-weight: 700;
 }
 
-/* ============================================================================
-   Tables
-   ============================================================================ */
-
-table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 1rem 0;
+code.literal {
+  border-radius: 5px;
+  padding: 0.1rem 0.28rem;
 }
 
-th {
-  background-color: var(--primary-light);
-  color: white;
-  padding: 0.75rem;
-  text-align: left;
-  font-weight: 600;
+div.highlight {
+  border-radius: 8px;
+  border: 1px solid var(--eegprep-line);
 }
 
-td {
-  border: 1px solid var(--border-color);
-  padding: 0.75rem;
+table.docutils {
+  border: 1px solid var(--eegprep-line);
+  border-radius: 8px;
+  display: block;
+  overflow-x: auto;
 }
 
-tr:nth-child(even) {
-  background-color: var(--bg-light);
+table.docutils thead th {
+  background: var(--eegprep-panel-strong);
+  border-bottom: 1px solid var(--eegprep-line);
+  color: var(--eegprep-ink);
 }
 
-tr:hover {
-  background-color: rgba(0, 102, 204, 0.05);
+table.docutils td,
+table.docutils th {
+  border-color: var(--eegprep-line);
+  padding: 0.65rem 0.75rem;
+  vertical-align: top;
 }
 
-/* ============================================================================
-   Lists
-   ============================================================================ */
-
-ul, ol {
-  margin: 1rem 0;
-  padding-left: 2rem;
+table.docutils tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--eegprep-panel) 55%, transparent);
 }
 
-li {
-  margin: 0.5rem 0;
+.toctree-wrapper ul {
+  line-height: 1.55;
 }
 
-/* ============================================================================
-   Responsive Design
-   ============================================================================ */
+.prev-next-area a {
+  border-radius: 8px;
+}
 
-/* Mobile devices */
 @media (max-width: 768px) {
-  body {
-    font-size: 14px;
+  .bd-main .bd-content .bd-article-container {
+    padding-left: 0.9rem;
+    padding-right: 0.9rem;
   }
 
-  h1 {
-    font-size: 2rem;
+  .eegprep-hero {
+    padding: 1rem;
   }
 
-  h2 {
-    font-size: 1.5rem;
-  }
-
-  h3 {
-    font-size: 1.25rem;
-  }
-
-  pre {
-    padding: 0.75rem;
-    font-size: 0.85em;
-  }
-
-  table {
-    font-size: 0.9em;
-  }
-
-  th, td {
-    padding: 0.5rem;
-  }
-}
-
-/* Tablets */
-@media (max-width: 1024px) {
-  body {
-    font-size: 15px;
-  }
-
-  h1 {
-    font-size: 2.2rem;
-  }
-
-  h2 {
-    font-size: 1.75rem;
-  }
-}
-
-/* ============================================================================
-   Dark Mode Support
-   ============================================================================ */
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: var(--bg-white);
-    color: var(--text-dark);
-  }
-
-  pre {
-    background-color: var(--bg-light);
-    border-color: var(--border-color);
-  }
-
-  code {
-    background-color: var(--bg-light);
-    border-color: var(--border-color);
-  }
-
-  .highlight {
-    background-color: var(--bg-light);
-  }
-
-  .admonition {
-    background-color: var(--bg-light);
-    border-color: var(--border-color);
-  }
-
-  tr:nth-child(even) {
-    background-color: var(--bg-light);
-  }
-
-  tr:hover {
-    background-color: rgba(0, 102, 204, 0.1);
-  }
-}
-
-/* ============================================================================
-   Sphinx-specific Styling
-   ============================================================================ */
-
-/* Sidebar styling */
-.sidebar {
-  background-color: var(--bg-light);
-  border-right: 1px solid var(--border-color);
-}
-
-/* Navigation styling */
-.nav-link {
-  color: var(--text-dark);
-  transition: color 0.2s ease;
-}
-
-.nav-link:hover {
-  color: var(--primary-color);
-}
-
-.nav-link.active {
-  color: var(--primary-color);
-  font-weight: 600;
-  border-left: 3px solid var(--primary-color);
-  padding-left: calc(1rem - 3px);
-}
-
-/* Breadcrumb styling */
-.breadcrumb {
-  background-color: var(--bg-light);
-  border-radius: 4px;
-  padding: 0.75rem 1rem;
-  margin: 1rem 0;
-}
-
-.breadcrumb-item {
-  color: var(--text-light);
-}
-
-.breadcrumb-item.active {
-  color: var(--text-dark);
-  font-weight: 600;
-}
-
-/* Search box styling */
-.search-box {
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  padding: 0.5rem;
-}
-
-.search-box:focus {
-  border-color: var(--primary-color);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.1);
-}
-
-/* Search styling - minimal overrides for pydata-sphinx-theme */
-/* The theme handles most search box styling, we just ensure proper form control sizing */
-.bd-search input.form-control {
-  min-height: 2.25rem;
-  padding: 0.375rem 0.5rem;
-  font-size: 0.95rem;
-}
-
-/* Search result alignment */
-.search-results {
-  text-align: left;
-  padding: 0.5rem 0;
-}
-
-/* ============================================================================
-   Utility Classes
-   ============================================================================ */
-
-.text-muted {
-  color: var(--text-light);
-}
-
-.text-primary {
-  color: var(--primary-color);
-}
-
-.text-success {
-  color: var(--success-color);
-}
-
-.text-warning {
-  color: var(--warning-color);
-}
-
-.text-danger {
-  color: var(--error-color);
-}
-
-.bg-light {
-  background-color: var(--bg-light);
-}
-
-.border {
-  border: 1px solid var(--border-color);
-}
-
-.rounded {
-  border-radius: 4px;
-}
-
-.shadow {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-/* ============================================================================
-   Print Styles
-   ============================================================================ */
-
-@media print {
-  body {
-    background-color: white;
-    color: black;
-  }
-
-  a {
-    color: black;
-    text-decoration: underline;
-  }
-
-  pre {
-    background-color: #f5f5f5;
-    border: 1px solid #ddd;
-  }
-
-  .sidebar, .navbar {
-    display: none;
+  .eegprep-path > p,
+  .eegprep-path > div {
+    padding-left: 2.75rem;
   }
 }

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -10,31 +10,39 @@ Main Pipeline
 =============
 
 .. autofunction:: eegprep.bids_preproc
+   :no-index:
 
 .. autofunction:: eegprep.bids_list_eeg_files
+   :no-index:
 
 Data Validation
 ===============
 
 .. autofunction:: eegprep.eeg_checkset
+   :no-index:
 
 Interactive Session
 ===================
 
 .. autoclass:: eegprep.EEGPrepSession
+   :no-index:
    :members:
 
 .. autoclass:: eegprep.EEGPrepConsoleWorkspace
+   :no-index:
    :members:
 
 .. autofunction:: eegprep.plugin_menu
+   :no-index:
 
 .. autofunction:: eegprep.plugin_status
+   :no-index:
 
 Object-Oriented Interface
 ==========================
 
 .. autoclass:: eegprep.EEGobj
+   :no-index:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api/extensions.rst
+++ b/docs/source/api/extensions.rst
@@ -81,7 +81,7 @@ Author Test Harness
 ``ExtensionTestHarness`` provides reusable assertions for extension authors. It
 checks that a spec validates, menus reference declared actions or ``pop_*``
 functions, help resources exist, lazy targets load, and callable actions or
-``pop_*`` functions return EEGLAB-style ``(EEG, com)`` results when tested by
+``pop_*`` functions return history-aware ``(EEG, com)`` results when tested by
 the author.
 
 Extension Manager and catalog

--- a/docs/source/api/extensions.rst
+++ b/docs/source/api/extensions.rst
@@ -127,7 +127,6 @@ API Reference
 =============
 
 .. autosummary::
-   :toctree: generated/
 
    eegprep.CATALOG_SCHEMA_VERSION
    eegprep.CatalogValidationIssue
@@ -167,13 +166,16 @@ API Reference
    eegprep.build_safe_update_commands
 
 .. automodule:: eegprep.extensions
+   :no-index:
    :members:
    :undoc-members:
 
 .. automodule:: eegprep.extension_catalog
+   :no-index:
    :members:
    :undoc-members:
 
 .. automodule:: eegprep.extension_testing
+   :no-index:
    :members:
    :undoc-members:

--- a/docs/source/api/generated/eegprep.CATALOG_SCHEMA_VERSION.rst
+++ b/docs/source/api/generated/eegprep.CATALOG_SCHEMA_VERSION.rst
@@ -1,0 +1,6 @@
+﻿eegprep.CATALOG\_SCHEMA\_VERSION
+================================
+
+.. currentmodule:: eegprep
+
+.. autodata:: CATALOG_SCHEMA_VERSION

--- a/docs/source/api/generated/eegprep.CallbackSpec.rst
+++ b/docs/source/api/generated/eegprep.CallbackSpec.rst
@@ -1,0 +1,28 @@
+﻿eegprep.CallbackSpec
+====================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: CallbackSpec
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~CallbackSpec.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~CallbackSpec.matlab_callback
+      ~CallbackSpec.name
+      ~CallbackSpec.params

--- a/docs/source/api/generated/eegprep.CatalogSourceType.rst
+++ b/docs/source/api/generated/eegprep.CatalogSourceType.rst
@@ -1,0 +1,76 @@
+﻿eegprep.CatalogSourceType
+=========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: CatalogSourceType
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~CatalogSourceType.encode
+      ~CatalogSourceType.replace
+      ~CatalogSourceType.split
+      ~CatalogSourceType.rsplit
+      ~CatalogSourceType.join
+      ~CatalogSourceType.capitalize
+      ~CatalogSourceType.casefold
+      ~CatalogSourceType.title
+      ~CatalogSourceType.center
+      ~CatalogSourceType.count
+      ~CatalogSourceType.expandtabs
+      ~CatalogSourceType.find
+      ~CatalogSourceType.partition
+      ~CatalogSourceType.index
+      ~CatalogSourceType.ljust
+      ~CatalogSourceType.lower
+      ~CatalogSourceType.lstrip
+      ~CatalogSourceType.rfind
+      ~CatalogSourceType.rindex
+      ~CatalogSourceType.rjust
+      ~CatalogSourceType.rstrip
+      ~CatalogSourceType.rpartition
+      ~CatalogSourceType.splitlines
+      ~CatalogSourceType.strip
+      ~CatalogSourceType.swapcase
+      ~CatalogSourceType.translate
+      ~CatalogSourceType.upper
+      ~CatalogSourceType.startswith
+      ~CatalogSourceType.endswith
+      ~CatalogSourceType.removeprefix
+      ~CatalogSourceType.removesuffix
+      ~CatalogSourceType.isascii
+      ~CatalogSourceType.islower
+      ~CatalogSourceType.isupper
+      ~CatalogSourceType.istitle
+      ~CatalogSourceType.isspace
+      ~CatalogSourceType.isdecimal
+      ~CatalogSourceType.isdigit
+      ~CatalogSourceType.isnumeric
+      ~CatalogSourceType.isalpha
+      ~CatalogSourceType.isalnum
+      ~CatalogSourceType.isidentifier
+      ~CatalogSourceType.isprintable
+      ~CatalogSourceType.zfill
+      ~CatalogSourceType.format
+      ~CatalogSourceType.format_map
+      ~CatalogSourceType.maketrans
+      ~CatalogSourceType.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~CatalogSourceType.PYPI
+      ~CatalogSourceType.GIT
+      ~CatalogSourceType.LOCAL
+      ~CatalogSourceType.PRIVATE

--- a/docs/source/api/generated/eegprep.CatalogValidationIssue.rst
+++ b/docs/source/api/generated/eegprep.CatalogValidationIssue.rst
@@ -1,0 +1,29 @@
+﻿eegprep.CatalogValidationIssue
+==============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: CatalogValidationIssue
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~CatalogValidationIssue.__init__
+      ~CatalogValidationIssue.format
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~CatalogValidationIssue.entry_id
+      ~CatalogValidationIssue.field
+      ~CatalogValidationIssue.message

--- a/docs/source/api/generated/eegprep.CatalogValidationOptions.rst
+++ b/docs/source/api/generated/eegprep.CatalogValidationOptions.rst
@@ -1,0 +1,31 @@
+﻿eegprep.CatalogValidationOptions
+================================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: CatalogValidationOptions
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~CatalogValidationOptions.__init__
+      ~CatalogValidationOptions.entry_points_provider
+      ~CatalogValidationOptions.version_provider
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~CatalogValidationOptions.allow_private
+      ~CatalogValidationOptions.check_import
+      ~CatalogValidationOptions.check_installed
+      ~CatalogValidationOptions.current_eegprep_version

--- a/docs/source/api/generated/eegprep.CatalogValidationReport.rst
+++ b/docs/source/api/generated/eegprep.CatalogValidationReport.rst
@@ -1,0 +1,29 @@
+﻿eegprep.CatalogValidationReport
+===============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: CatalogValidationReport
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~CatalogValidationReport.__init__
+      ~CatalogValidationReport.format
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~CatalogValidationReport.ok
+      ~CatalogValidationReport.errors
+      ~CatalogValidationReport.warnings

--- a/docs/source/api/generated/eegprep.ConsoleDatasetResult.rst
+++ b/docs/source/api/generated/eegprep.ConsoleDatasetResult.rst
@@ -1,0 +1,16 @@
+﻿eegprep.ConsoleDatasetResult
+============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ConsoleDatasetResult
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ConsoleDatasetResult.__init__

--- a/docs/source/api/generated/eegprep.ConsolePopResult.rst
+++ b/docs/source/api/generated/eegprep.ConsolePopResult.rst
@@ -1,0 +1,16 @@
+﻿eegprep.ConsolePopResult
+========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ConsolePopResult
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ConsolePopResult.__init__

--- a/docs/source/api/generated/eegprep.ControlSpec.rst
+++ b/docs/source/api/generated/eegprep.ControlSpec.rst
@@ -1,0 +1,33 @@
+﻿eegprep.ControlSpec
+===================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ControlSpec
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ControlSpec.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ControlSpec.callback
+      ~ControlSpec.enabled
+      ~ControlSpec.font_weight
+      ~ControlSpec.string
+      ~ControlSpec.tag
+      ~ControlSpec.tooltip
+      ~ControlSpec.value
+      ~ControlSpec.style

--- a/docs/source/api/generated/eegprep.DialogSpec.rst
+++ b/docs/source/api/generated/eegprep.DialogSpec.rst
@@ -1,0 +1,44 @@
+﻿eegprep.DialogSpec
+==================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: DialogSpec
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~DialogSpec.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~DialogSpec.button_size
+      ~DialogSpec.cancel_first
+      ~DialogSpec.cancel_label
+      ~DialogSpec.content_margins
+      ~DialogSpec.extra_stylesheet
+      ~DialogSpec.geomvert
+      ~DialogSpec.help_label
+      ~DialogSpec.help_text
+      ~DialogSpec.known_differences
+      ~DialogSpec.ok_label
+      ~DialogSpec.row_spacing
+      ~DialogSpec.scrollable
+      ~DialogSpec.show_help_button
+      ~DialogSpec.size
+      ~DialogSpec.title
+      ~DialogSpec.controls
+      ~DialogSpec.geometry
+      ~DialogSpec.function_name
+      ~DialogSpec.eeglab_source

--- a/docs/source/api/generated/eegprep.EEGPrepConsoleWorkspace.rst
+++ b/docs/source/api/generated/eegprep.EEGPrepConsoleWorkspace.rst
@@ -1,0 +1,22 @@
+﻿eegprep.EEGPrepConsoleWorkspace
+===============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: EEGPrepConsoleWorkspace
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~EEGPrepConsoleWorkspace.__init__
+      ~EEGPrepConsoleWorkspace.accept_pop_result
+      ~EEGPrepConsoleWorkspace.after_execute
+      ~EEGPrepConsoleWorkspace.close
+      ~EEGPrepConsoleWorkspace.execute_history_command
+      ~EEGPrepConsoleWorkspace.pop_wrapper
+      ~EEGPrepConsoleWorkspace.pull_from_session

--- a/docs/source/api/generated/eegprep.EEGPrepSession.rst
+++ b/docs/source/api/generated/eegprep.EEGPrepSession.rst
@@ -1,0 +1,58 @@
+﻿eegprep.EEGPrepSession
+======================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: EEGPrepSession
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~EEGPrepSession.__init__
+      ~EEGPrepSession.add_change_listener
+      ~EEGPrepSession.add_command_echo_listener
+      ~EEGPrepSession.add_gui_action_listener
+      ~EEGPrepSession.add_history
+      ~EEGPrepSession.begin_gui_action
+      ~EEGPrepSession.clear_all
+      ~EEGPrepSession.clone_current
+      ~EEGPrepSession.current_eeg
+      ~EEGPrepSession.current_set_value
+      ~EEGPrepSession.dataset_summaries
+      ~EEGPrepSession.delete_current
+      ~EEGPrepSession.echo_command
+      ~EEGPrepSession.end_gui_action
+      ~EEGPrepSession.gui_action
+      ~EEGPrepSession.mark_current_saved
+      ~EEGPrepSession.menu_statuses
+      ~EEGPrepSession.notify_changed
+      ~EEGPrepSession.remove_change_listener
+      ~EEGPrepSession.remove_command_echo_listener
+      ~EEGPrepSession.remove_gui_action_listener
+      ~EEGPrepSession.retrieve
+      ~EEGPrepSession.select_study
+      ~EEGPrepSession.selected_dataset_indices
+      ~EEGPrepSession.set_study
+      ~EEGPrepSession.store_current
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~EEGPrepSession.CURRENTSTUDY
+      ~EEGPrepSession.LASTCOM
+      ~EEGPrepSession.STUDY
+      ~EEGPrepSession.EEG
+      ~EEGPrepSession.ALLEEG
+      ~EEGPrepSession.CURRENTSET
+      ~EEGPrepSession.ALLCOM
+      ~EEGPrepSession.PLUGINLIST

--- a/docs/source/api/generated/eegprep.EEG_OPTIONS.rst
+++ b/docs/source/api/generated/eegprep.EEG_OPTIONS.rst
@@ -3,4 +3,8 @@
 
 .. currentmodule:: eegprep
 
-.. autodata:: EEG_OPTIONS
+.. data:: EEG_OPTIONS
+
+   Dictionary of default EEGPrep option values. Common keys include
+   ``option_storedisk``, ``option_savetwofiles``, ``option_memmapdata``, and
+   ``option_computeica``.

--- a/docs/source/api/generated/eegprep.EEGobj.rst
+++ b/docs/source/api/generated/eegprep.EEGobj.rst
@@ -14,8 +14,3 @@
    .. autosummary::
 
       ~EEGobj.__init__
-
-
-
-
-

--- a/docs/source/api/generated/eegprep.EEGobj.rst
+++ b/docs/source/api/generated/eegprep.EEGobj.rst
@@ -4,13 +4,3 @@
 .. currentmodule:: eegprep
 
 .. autoclass:: EEGobj
-
-
-   .. automethod:: __init__
-
-
-   .. rubric:: Methods
-
-   .. autosummary::
-
-      ~EEGobj.__init__

--- a/docs/source/api/generated/eegprep.EXTENSION_COMPATIBILITY_POLICY.rst
+++ b/docs/source/api/generated/eegprep.EXTENSION_COMPATIBILITY_POLICY.rst
@@ -1,0 +1,6 @@
+﻿eegprep.EXTENSION\_COMPATIBILITY\_POLICY
+========================================
+
+.. currentmodule:: eegprep
+
+.. autodata:: EXTENSION_COMPATIBILITY_POLICY

--- a/docs/source/api/generated/eegprep.EXTENSION_CURATION_POLICY_URL.rst
+++ b/docs/source/api/generated/eegprep.EXTENSION_CURATION_POLICY_URL.rst
@@ -1,0 +1,6 @@
+﻿eegprep.EXTENSION\_CURATION\_POLICY\_URL
+========================================
+
+.. currentmodule:: eegprep
+
+.. autodata:: EXTENSION_CURATION_POLICY_URL

--- a/docs/source/api/generated/eegprep.EXTENSION_NAMING_PREFIX.rst
+++ b/docs/source/api/generated/eegprep.EXTENSION_NAMING_PREFIX.rst
@@ -1,0 +1,6 @@
+﻿eegprep.EXTENSION\_NAMING\_PREFIX
+=================================
+
+.. currentmodule:: eegprep
+
+.. autodata:: EXTENSION_NAMING_PREFIX

--- a/docs/source/api/generated/eegprep.EXTENSION_TRUST_MESSAGE.rst
+++ b/docs/source/api/generated/eegprep.EXTENSION_TRUST_MESSAGE.rst
@@ -1,0 +1,6 @@
+﻿eegprep.EXTENSION\_TRUST\_MESSAGE
+=================================
+
+.. currentmodule:: eegprep
+
+.. autodata:: EXTENSION_TRUST_MESSAGE

--- a/docs/source/api/generated/eegprep.ExtensionAction.rst
+++ b/docs/source/api/generated/eegprep.ExtensionAction.rst
@@ -1,0 +1,31 @@
+﻿eegprep.ExtensionAction
+=======================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionAction
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionAction.__init__
+      ~ExtensionAction.load
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionAction.description
+      ~ExtensionAction.display_name
+      ~ExtensionAction.name
+      ~ExtensionAction.target
+      ~ExtensionAction.capabilities

--- a/docs/source/api/generated/eegprep.ExtensionCatalog.rst
+++ b/docs/source/api/generated/eegprep.ExtensionCatalog.rst
@@ -1,0 +1,31 @@
+﻿eegprep.ExtensionCatalog
+========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionCatalog
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionCatalog.__init__
+      ~ExtensionCatalog.by_name
+      ~ExtensionCatalog.by_package
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionCatalog.available
+      ~ExtensionCatalog.source
+      ~ExtensionCatalog.entries
+      ~ExtensionCatalog.errors

--- a/docs/source/api/generated/eegprep.ExtensionCatalogEntry.rst
+++ b/docs/source/api/generated/eegprep.ExtensionCatalogEntry.rst
@@ -1,0 +1,39 @@
+﻿eegprep.ExtensionCatalogEntry
+=============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionCatalogEntry
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionCatalogEntry.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionCatalogEntry.description
+      ~ExtensionCatalogEntry.display_name
+      ~ExtensionCatalogEntry.docs_url
+      ~ExtensionCatalogEntry.eegprep_requires
+      ~ExtensionCatalogEntry.install_target
+      ~ExtensionCatalogEntry.maintainer
+      ~ExtensionCatalogEntry.package_name
+      ~ExtensionCatalogEntry.repository_url
+      ~ExtensionCatalogEntry.source_label
+      ~ExtensionCatalogEntry.source_type
+      ~ExtensionCatalogEntry.source_url
+      ~ExtensionCatalogEntry.version
+      ~ExtensionCatalogEntry.name
+      ~ExtensionCatalogEntry.capabilities

--- a/docs/source/api/generated/eegprep.ExtensionDependency.rst
+++ b/docs/source/api/generated/eegprep.ExtensionDependency.rst
@@ -1,0 +1,28 @@
+﻿eegprep.ExtensionDependency
+===========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionDependency
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionDependency.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionDependency.optional
+      ~ExtensionDependency.version_spec
+      ~ExtensionDependency.package

--- a/docs/source/api/generated/eegprep.ExtensionLoadError.rst
+++ b/docs/source/api/generated/eegprep.ExtensionLoadError.rst
@@ -1,0 +1,6 @@
+﻿eegprep.ExtensionLoadError
+==========================
+
+.. currentmodule:: eegprep
+
+.. autoexception:: ExtensionLoadError

--- a/docs/source/api/generated/eegprep.ExtensionMenu.rst
+++ b/docs/source/api/generated/eegprep.ExtensionMenu.rst
@@ -1,0 +1,37 @@
+﻿eegprep.ExtensionMenu
+=====================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionMenu
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionMenu.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionMenu.action
+      ~ExtensionMenu.checked
+      ~ExtensionMenu.enabled
+      ~ExtensionMenu.insert_after
+      ~ExtensionMenu.insert_before
+      ~ExtensionMenu.label
+      ~ExtensionMenu.separator
+      ~ExtensionMenu.tag
+      ~ExtensionMenu.userdata
+      ~ExtensionMenu.visibility
+      ~ExtensionMenu.path
+      ~ExtensionMenu.children

--- a/docs/source/api/generated/eegprep.ExtensionPopFunction.rst
+++ b/docs/source/api/generated/eegprep.ExtensionPopFunction.rst
@@ -1,0 +1,29 @@
+﻿eegprep.ExtensionPopFunction
+============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionPopFunction
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionPopFunction.__init__
+      ~ExtensionPopFunction.load
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionPopFunction.description
+      ~ExtensionPopFunction.name
+      ~ExtensionPopFunction.target

--- a/docs/source/api/generated/eegprep.ExtensionRecord.rst
+++ b/docs/source/api/generated/eegprep.ExtensionRecord.rst
@@ -1,0 +1,34 @@
+﻿eegprep.ExtensionRecord
+=======================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionRecord
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionRecord.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionRecord.enabled
+      ~ExtensionRecord.entry_point_name
+      ~ExtensionRecord.is_active
+      ~ExtensionRecord.package_name
+      ~ExtensionRecord.source_type
+      ~ExtensionRecord.spec
+      ~ExtensionRecord.name
+      ~ExtensionRecord.status
+      ~ExtensionRecord.errors

--- a/docs/source/api/generated/eegprep.ExtensionRegistry.rst
+++ b/docs/source/api/generated/eegprep.ExtensionRegistry.rst
@@ -1,0 +1,28 @@
+﻿eegprep.ExtensionRegistry
+=========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionRegistry
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionRegistry.__init__
+      ~ExtensionRegistry.discover
+      ~ExtensionRegistry.get
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionRegistry.records

--- a/docs/source/api/generated/eegprep.ExtensionResource.rst
+++ b/docs/source/api/generated/eegprep.ExtensionResource.rst
@@ -1,0 +1,30 @@
+﻿eegprep.ExtensionResource
+=========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionResource
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionResource.__init__
+      ~ExtensionResource.exists
+      ~ExtensionResource.read_bytes
+      ~ExtensionResource.read_text
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionResource.package
+      ~ExtensionResource.path

--- a/docs/source/api/generated/eegprep.ExtensionSourceType.rst
+++ b/docs/source/api/generated/eegprep.ExtensionSourceType.rst
@@ -1,0 +1,76 @@
+﻿eegprep.ExtensionSourceType
+===========================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionSourceType
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionSourceType.encode
+      ~ExtensionSourceType.replace
+      ~ExtensionSourceType.split
+      ~ExtensionSourceType.rsplit
+      ~ExtensionSourceType.join
+      ~ExtensionSourceType.capitalize
+      ~ExtensionSourceType.casefold
+      ~ExtensionSourceType.title
+      ~ExtensionSourceType.center
+      ~ExtensionSourceType.count
+      ~ExtensionSourceType.expandtabs
+      ~ExtensionSourceType.find
+      ~ExtensionSourceType.partition
+      ~ExtensionSourceType.index
+      ~ExtensionSourceType.ljust
+      ~ExtensionSourceType.lower
+      ~ExtensionSourceType.lstrip
+      ~ExtensionSourceType.rfind
+      ~ExtensionSourceType.rindex
+      ~ExtensionSourceType.rjust
+      ~ExtensionSourceType.rstrip
+      ~ExtensionSourceType.rpartition
+      ~ExtensionSourceType.splitlines
+      ~ExtensionSourceType.strip
+      ~ExtensionSourceType.swapcase
+      ~ExtensionSourceType.translate
+      ~ExtensionSourceType.upper
+      ~ExtensionSourceType.startswith
+      ~ExtensionSourceType.endswith
+      ~ExtensionSourceType.removeprefix
+      ~ExtensionSourceType.removesuffix
+      ~ExtensionSourceType.isascii
+      ~ExtensionSourceType.islower
+      ~ExtensionSourceType.isupper
+      ~ExtensionSourceType.istitle
+      ~ExtensionSourceType.isspace
+      ~ExtensionSourceType.isdecimal
+      ~ExtensionSourceType.isdigit
+      ~ExtensionSourceType.isnumeric
+      ~ExtensionSourceType.isalpha
+      ~ExtensionSourceType.isalnum
+      ~ExtensionSourceType.isidentifier
+      ~ExtensionSourceType.isprintable
+      ~ExtensionSourceType.zfill
+      ~ExtensionSourceType.format
+      ~ExtensionSourceType.format_map
+      ~ExtensionSourceType.maketrans
+      ~ExtensionSourceType.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionSourceType.BUNDLED
+      ~ExtensionSourceType.INSTALLED
+      ~ExtensionSourceType.CURATED
+      ~ExtensionSourceType.UNKNOWN

--- a/docs/source/api/generated/eegprep.ExtensionSpec.rst
+++ b/docs/source/api/generated/eegprep.ExtensionSpec.rst
@@ -1,0 +1,43 @@
+﻿eegprep.ExtensionSpec
+=====================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionSpec
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionSpec.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionSpec.api_version
+      ~ExtensionSpec.description
+      ~ExtensionSpec.display_name
+      ~ExtensionSpec.docs_url
+      ~ExtensionSpec.eegprep_requires
+      ~ExtensionSpec.entry_point_name
+      ~ExtensionSpec.maintainer
+      ~ExtensionSpec.package_name
+      ~ExtensionSpec.source_type
+      ~ExtensionSpec.version
+      ~ExtensionSpec.name
+      ~ExtensionSpec.capabilities
+      ~ExtensionSpec.dependencies
+      ~ExtensionSpec.menus
+      ~ExtensionSpec.actions
+      ~ExtensionSpec.pop_functions
+      ~ExtensionSpec.help_resources
+      ~ExtensionSpec.package_data_resources

--- a/docs/source/api/generated/eegprep.ExtensionStatus.rst
+++ b/docs/source/api/generated/eegprep.ExtensionStatus.rst
@@ -1,0 +1,81 @@
+﻿eegprep.ExtensionStatus
+=======================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionStatus
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionStatus.encode
+      ~ExtensionStatus.replace
+      ~ExtensionStatus.split
+      ~ExtensionStatus.rsplit
+      ~ExtensionStatus.join
+      ~ExtensionStatus.capitalize
+      ~ExtensionStatus.casefold
+      ~ExtensionStatus.title
+      ~ExtensionStatus.center
+      ~ExtensionStatus.count
+      ~ExtensionStatus.expandtabs
+      ~ExtensionStatus.find
+      ~ExtensionStatus.partition
+      ~ExtensionStatus.index
+      ~ExtensionStatus.ljust
+      ~ExtensionStatus.lower
+      ~ExtensionStatus.lstrip
+      ~ExtensionStatus.rfind
+      ~ExtensionStatus.rindex
+      ~ExtensionStatus.rjust
+      ~ExtensionStatus.rstrip
+      ~ExtensionStatus.rpartition
+      ~ExtensionStatus.splitlines
+      ~ExtensionStatus.strip
+      ~ExtensionStatus.swapcase
+      ~ExtensionStatus.translate
+      ~ExtensionStatus.upper
+      ~ExtensionStatus.startswith
+      ~ExtensionStatus.endswith
+      ~ExtensionStatus.removeprefix
+      ~ExtensionStatus.removesuffix
+      ~ExtensionStatus.isascii
+      ~ExtensionStatus.islower
+      ~ExtensionStatus.isupper
+      ~ExtensionStatus.istitle
+      ~ExtensionStatus.isspace
+      ~ExtensionStatus.isdecimal
+      ~ExtensionStatus.isdigit
+      ~ExtensionStatus.isnumeric
+      ~ExtensionStatus.isalpha
+      ~ExtensionStatus.isalnum
+      ~ExtensionStatus.isidentifier
+      ~ExtensionStatus.isprintable
+      ~ExtensionStatus.zfill
+      ~ExtensionStatus.format
+      ~ExtensionStatus.format_map
+      ~ExtensionStatus.maketrans
+      ~ExtensionStatus.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionStatus.BUNDLED
+      ~ExtensionStatus.INSTALLED
+      ~ExtensionStatus.CURATED
+      ~ExtensionStatus.DISABLED
+      ~ExtensionStatus.INCOMPATIBLE
+      ~ExtensionStatus.FAILED_IMPORT
+      ~ExtensionStatus.INVALID_SPEC
+      ~ExtensionStatus.MISSING_DEPENDENCY
+      ~ExtensionStatus.UNKNOWN

--- a/docs/source/api/generated/eegprep.ExtensionTestHarness.rst
+++ b/docs/source/api/generated/eegprep.ExtensionTestHarness.rst
@@ -1,0 +1,27 @@
+﻿eegprep.ExtensionTestHarness
+============================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionTestHarness
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionTestHarness.__init__
+      ~ExtensionTestHarness.assert_action_callable
+      ~ExtensionTestHarness.assert_action_history_result
+      ~ExtensionTestHarness.assert_actions_load
+      ~ExtensionTestHarness.assert_all_static_contracts
+      ~ExtensionTestHarness.assert_help_resources_exist
+      ~ExtensionTestHarness.assert_menus_register
+      ~ExtensionTestHarness.assert_pop_function_callable
+      ~ExtensionTestHarness.assert_pop_function_history_result
+      ~ExtensionTestHarness.assert_pop_functions_load
+      ~ExtensionTestHarness.assert_spec_valid
+      ~ExtensionTestHarness.from_entry_point

--- a/docs/source/api/generated/eegprep.ExtensionValidationResult.rst
+++ b/docs/source/api/generated/eegprep.ExtensionValidationResult.rst
@@ -1,0 +1,30 @@
+﻿eegprep.ExtensionValidationResult
+=================================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: ExtensionValidationResult
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ExtensionValidationResult.__init__
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ExtensionValidationResult.errors
+      ~ExtensionValidationResult.ok
+      ~ExtensionValidationResult.invalid_spec
+      ~ExtensionValidationResult.incompatible
+      ~ExtensionValidationResult.missing_dependency

--- a/docs/source/api/generated/eegprep.LazyImport.rst
+++ b/docs/source/api/generated/eegprep.LazyImport.rst
@@ -1,0 +1,28 @@
+﻿eegprep.LazyImport
+==================
+
+.. currentmodule:: eegprep
+
+.. autoclass:: LazyImport
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~LazyImport.__init__
+      ~LazyImport.load
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~LazyImport.module
+      ~LazyImport.attr

--- a/docs/source/api/generated/eegprep.angtimewarp.rst
+++ b/docs/source/api/generated/eegprep.angtimewarp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.angtimewarp
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: angtimewarp

--- a/docs/source/api/generated/eegprep.assert_extension_entry_point_loads.rst
+++ b/docs/source/api/generated/eegprep.assert_extension_entry_point_loads.rst
@@ -1,0 +1,6 @@
+﻿eegprep.assert\_extension\_entry\_point\_loads
+==============================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: assert_extension_entry_point_loads

--- a/docs/source/api/generated/eegprep.bootstat.rst
+++ b/docs/source/api/generated/eegprep.bootstat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.bootstat
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: bootstat

--- a/docs/source/api/generated/eegprep.build_safe_install_commands.rst
+++ b/docs/source/api/generated/eegprep.build_safe_install_commands.rst
@@ -1,0 +1,6 @@
+﻿eegprep.build\_safe\_install\_commands
+======================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: build_safe_install_commands

--- a/docs/source/api/generated/eegprep.build_safe_update_commands.rst
+++ b/docs/source/api/generated/eegprep.build_safe_update_commands.rst
@@ -1,0 +1,6 @@
+﻿eegprep.build\_safe\_update\_commands
+=====================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: build_safe_update_commands

--- a/docs/source/api/generated/eegprep.bundled_plugins.rst
+++ b/docs/source/api/generated/eegprep.bundled_plugins.rst
@@ -1,0 +1,6 @@
+﻿eegprep.bundled\_plugins
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: bundled_plugins

--- a/docs/source/api/generated/eegprep.check_extension_compatibility.rst
+++ b/docs/source/api/generated/eegprep.check_extension_compatibility.rst
@@ -1,0 +1,6 @@
+﻿eegprep.check\_extension\_compatibility
+=======================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: check_extension_compatibility

--- a/docs/source/api/generated/eegprep.correct_mc.rst
+++ b/docs/source/api/generated/eegprep.correct_mc.rst
@@ -1,0 +1,6 @@
+﻿eegprep.correct\_mc
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: correct_mc

--- a/docs/source/api/generated/eegprep.correctfit.rst
+++ b/docs/source/api/generated/eegprep.correctfit.rst
@@ -1,0 +1,6 @@
+﻿eegprep.correctfit
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: correctfit

--- a/docs/source/api/generated/eegprep.crossf.rst
+++ b/docs/source/api/generated/eegprep.crossf.rst
@@ -1,0 +1,6 @@
+﻿eegprep.crossf
+==============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: crossf

--- a/docs/source/api/generated/eegprep.discover_extensions.rst
+++ b/docs/source/api/generated/eegprep.discover_extensions.rst
@@ -1,0 +1,6 @@
+﻿eegprep.discover\_extensions
+============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: discover_extensions

--- a/docs/source/api/generated/eegprep.eeg_amica.rst
+++ b/docs/source/api/generated/eegprep.eeg_amica.rst
@@ -4,4 +4,3 @@ eegprep.eeg_amica
 .. currentmodule:: eegprep
 
 .. autofunction:: eeg_amica
-

--- a/docs/source/api/generated/eegprep.eeg_emptyset.rst
+++ b/docs/source/api/generated/eegprep.eeg_emptyset.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeg\_emptyset
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeg_emptyset

--- a/docs/source/api/generated/eegprep.eeg_multieegplot.rst
+++ b/docs/source/api/generated/eegprep.eeg_multieegplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeg\_multieegplot
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeg_multieegplot

--- a/docs/source/api/generated/eegprep.eeg_retrieve.rst
+++ b/docs/source/api/generated/eegprep.eeg_retrieve.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeg\_retrieve
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeg_retrieve

--- a/docs/source/api/generated/eegprep.eeg_runica.rst
+++ b/docs/source/api/generated/eegprep.eeg_runica.rst
@@ -4,4 +4,3 @@ eegprep.eeg_runica
 .. currentmodule:: eegprep
 
 .. autofunction:: eeg_runica
-

--- a/docs/source/api/generated/eegprep.eeg_store.rst
+++ b/docs/source/api/generated/eegprep.eeg_store.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeg\_store
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeg_store

--- a/docs/source/api/generated/eegprep.eeglab.rst
+++ b/docs/source/api/generated/eegprep.eeglab.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eeglab
+==============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eeglab

--- a/docs/source/api/generated/eegprep.eegplot.rst
+++ b/docs/source/api/generated/eegprep.eegplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.eegplot
+===============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: eegplot

--- a/docs/source/api/generated/eegprep.extension_version_satisfies.rst
+++ b/docs/source/api/generated/eegprep.extension_version_satisfies.rst
@@ -1,0 +1,6 @@
+﻿eegprep.extension\_version\_satisfies
+=====================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: extension_version_satisfies

--- a/docs/source/api/generated/eegprep.firfiltreport.rst
+++ b/docs/source/api/generated/eegprep.firfiltreport.rst
@@ -1,0 +1,6 @@
+﻿eegprep.firfiltreport
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: firfiltreport

--- a/docs/source/api/generated/eegprep.firws.rst
+++ b/docs/source/api/generated/eegprep.firws.rst
@@ -1,0 +1,6 @@
+﻿eegprep.firws
+=============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: firws

--- a/docs/source/api/generated/eegprep.firwsord.rst
+++ b/docs/source/api/generated/eegprep.firwsord.rst
@@ -1,0 +1,6 @@
+﻿eegprep.firwsord
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: firwsord

--- a/docs/source/api/generated/eegprep.format_plugin_menu.rst
+++ b/docs/source/api/generated/eegprep.format_plugin_menu.rst
@@ -1,0 +1,6 @@
+﻿eegprep.format\_plugin\_menu
+============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: format_plugin_menu

--- a/docs/source/api/generated/eegprep.gui.rst
+++ b/docs/source/api/generated/eegprep.gui.rst
@@ -1,0 +1,6 @@
+﻿eegprep.gui
+===========
+
+.. currentmodule:: eegprep
+
+.. autofunction:: gui

--- a/docs/source/api/generated/eegprep.inputgui.rst
+++ b/docs/source/api/generated/eegprep.inputgui.rst
@@ -1,0 +1,6 @@
+﻿eegprep.inputgui
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: inputgui

--- a/docs/source/api/generated/eegprep.listdlg2.rst
+++ b/docs/source/api/generated/eegprep.listdlg2.rst
@@ -1,0 +1,6 @@
+﻿eegprep.listdlg2
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: listdlg2

--- a/docs/source/api/generated/eegprep.load_catalog_entries.rst
+++ b/docs/source/api/generated/eegprep.load_catalog_entries.rst
@@ -1,0 +1,6 @@
+﻿eegprep.load\_catalog\_entries
+==============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: load_catalog_entries

--- a/docs/source/api/generated/eegprep.load_extension_catalog.rst
+++ b/docs/source/api/generated/eegprep.load_extension_catalog.rst
@@ -1,0 +1,6 @@
+﻿eegprep.load\_extension\_catalog
+================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: load_extension_catalog

--- a/docs/source/api/generated/eegprep.newcrossf.rst
+++ b/docs/source/api/generated/eegprep.newcrossf.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newcrossf
+=================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newcrossf

--- a/docs/source/api/generated/eegprep.newtimef.rst
+++ b/docs/source/api/generated/eegprep.newtimef.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newtimef
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newtimef

--- a/docs/source/api/generated/eegprep.newtimefbaseln.rst
+++ b/docs/source/api/generated/eegprep.newtimefbaseln.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newtimefbaseln
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newtimefbaseln

--- a/docs/source/api/generated/eegprep.newtimefitc.rst
+++ b/docs/source/api/generated/eegprep.newtimefitc.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newtimefitc
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newtimefitc

--- a/docs/source/api/generated/eegprep.newtimefpowerunit.rst
+++ b/docs/source/api/generated/eegprep.newtimefpowerunit.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newtimefpowerunit
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newtimefpowerunit

--- a/docs/source/api/generated/eegprep.newtimeftrialbaseln.rst
+++ b/docs/source/api/generated/eegprep.newtimeftrialbaseln.rst
@@ -1,0 +1,6 @@
+﻿eegprep.newtimeftrialbaseln
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: newtimeftrialbaseln

--- a/docs/source/api/generated/eegprep.optimal_kmeans.rst
+++ b/docs/source/api/generated/eegprep.optimal_kmeans.rst
@@ -1,0 +1,6 @@
+﻿eegprep.optimal\_kmeans
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: optimal_kmeans

--- a/docs/source/api/generated/eegprep.pac.rst
+++ b/docs/source/api/generated/eegprep.pac.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pac
+===========
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pac

--- a/docs/source/api/generated/eegprep.pac_cont.rst
+++ b/docs/source/api/generated/eegprep.pac_cont.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pac\_cont
+=================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pac_cont

--- a/docs/source/api/generated/eegprep.plotfresp.rst
+++ b/docs/source/api/generated/eegprep.plotfresp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.plotfresp
+=================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: plotfresp

--- a/docs/source/api/generated/eegprep.plugin_menu.rst
+++ b/docs/source/api/generated/eegprep.plugin_menu.rst
@@ -1,0 +1,6 @@
+﻿eegprep.plugin\_menu
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: plugin_menu

--- a/docs/source/api/generated/eegprep.plugin_status.rst
+++ b/docs/source/api/generated/eegprep.plugin_status.rst
@@ -1,0 +1,6 @@
+﻿eegprep.plugin\_status
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: plugin_status

--- a/docs/source/api/generated/eegprep.pop_addindepvar.rst
+++ b/docs/source/api/generated/eegprep.pop_addindepvar.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_addindepvar
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_addindepvar

--- a/docs/source/api/generated/eegprep.pop_chanplot.rst
+++ b/docs/source/api/generated/eegprep.pop_chanplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_chanplot
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_chanplot

--- a/docs/source/api/generated/eegprep.pop_clean_rawdata.rst
+++ b/docs/source/api/generated/eegprep.pop_clean_rawdata.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_clean\_rawdata
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_clean_rawdata

--- a/docs/source/api/generated/eegprep.pop_clust.rst
+++ b/docs/source/api/generated/eegprep.pop_clust.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_clust
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_clust

--- a/docs/source/api/generated/eegprep.pop_clustedit.rst
+++ b/docs/source/api/generated/eegprep.pop_clustedit.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_clustedit
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_clustedit

--- a/docs/source/api/generated/eegprep.pop_crossf.rst
+++ b/docs/source/api/generated/eegprep.pop_crossf.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_crossf
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_crossf

--- a/docs/source/api/generated/eegprep.pop_delset.rst
+++ b/docs/source/api/generated/eegprep.pop_delset.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_delset
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_delset

--- a/docs/source/api/generated/eegprep.pop_dipfit_gridsearch.rst
+++ b/docs/source/api/generated/eegprep.pop_dipfit_gridsearch.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipfit\_gridsearch
+===============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipfit_gridsearch

--- a/docs/source/api/generated/eegprep.pop_dipfit_headmodel.rst
+++ b/docs/source/api/generated/eegprep.pop_dipfit_headmodel.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipfit\_headmodel
+==============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipfit_headmodel

--- a/docs/source/api/generated/eegprep.pop_dipfit_loreta.rst
+++ b/docs/source/api/generated/eegprep.pop_dipfit_loreta.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipfit\_loreta
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipfit_loreta

--- a/docs/source/api/generated/eegprep.pop_dipfit_nonlinear.rst
+++ b/docs/source/api/generated/eegprep.pop_dipfit_nonlinear.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipfit\_nonlinear
+==============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipfit_nonlinear

--- a/docs/source/api/generated/eegprep.pop_dipfit_settings.rst
+++ b/docs/source/api/generated/eegprep.pop_dipfit_settings.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipfit\_settings
+=============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipfit_settings

--- a/docs/source/api/generated/eegprep.pop_dipplot.rst
+++ b/docs/source/api/generated/eegprep.pop_dipplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_dipplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_dipplot

--- a/docs/source/api/generated/eegprep.pop_editoptions.rst
+++ b/docs/source/api/generated/eegprep.pop_editoptions.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_editoptions
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_editoptions

--- a/docs/source/api/generated/eegprep.pop_eventstat.rst
+++ b/docs/source/api/generated/eegprep.pop_eventstat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_eventstat
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_eventstat

--- a/docs/source/api/generated/eegprep.pop_exportbids.rst
+++ b/docs/source/api/generated/eegprep.pop_exportbids.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_exportbids
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_exportbids

--- a/docs/source/api/generated/eegprep.pop_firma.rst
+++ b/docs/source/api/generated/eegprep.pop_firma.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_firma
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_firma

--- a/docs/source/api/generated/eegprep.pop_firpm.rst
+++ b/docs/source/api/generated/eegprep.pop_firpm.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_firpm
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_firpm

--- a/docs/source/api/generated/eegprep.pop_firpmord.rst
+++ b/docs/source/api/generated/eegprep.pop_firpmord.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_firpmord
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_firpmord

--- a/docs/source/api/generated/eegprep.pop_firws.rst
+++ b/docs/source/api/generated/eegprep.pop_firws.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_firws
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_firws

--- a/docs/source/api/generated/eegprep.pop_firwsord.rst
+++ b/docs/source/api/generated/eegprep.pop_firwsord.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_firwsord
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_firwsord

--- a/docs/source/api/generated/eegprep.pop_icflag.rst
+++ b/docs/source/api/generated/eegprep.pop_icflag.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_icflag
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_icflag

--- a/docs/source/api/generated/eegprep.pop_iclabel.rst
+++ b/docs/source/api/generated/eegprep.pop_iclabel.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_iclabel
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_iclabel

--- a/docs/source/api/generated/eegprep.pop_importbids.rst
+++ b/docs/source/api/generated/eegprep.pop_importbids.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_importbids
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_importbids

--- a/docs/source/api/generated/eegprep.pop_importgroupvar.rst
+++ b/docs/source/api/generated/eegprep.pop_importgroupvar.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_importgroupvar
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_importgroupvar

--- a/docs/source/api/generated/eegprep.pop_interp.rst
+++ b/docs/source/api/generated/eegprep.pop_interp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_interp
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_interp

--- a/docs/source/api/generated/eegprep.pop_kaiserbeta.rst
+++ b/docs/source/api/generated/eegprep.pop_kaiserbeta.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_kaiserbeta
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_kaiserbeta

--- a/docs/source/api/generated/eegprep.pop_leadfield.rst
+++ b/docs/source/api/generated/eegprep.pop_leadfield.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_leadfield
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_leadfield

--- a/docs/source/api/generated/eegprep.pop_listfactors.rst
+++ b/docs/source/api/generated/eegprep.pop_listfactors.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_listfactors
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_listfactors

--- a/docs/source/api/generated/eegprep.pop_loadstudy.rst
+++ b/docs/source/api/generated/eegprep.pop_loadstudy.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_loadstudy
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_loadstudy

--- a/docs/source/api/generated/eegprep.pop_multifit.rst
+++ b/docs/source/api/generated/eegprep.pop_multifit.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_multifit
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_multifit

--- a/docs/source/api/generated/eegprep.pop_newcrossf.rst
+++ b/docs/source/api/generated/eegprep.pop_newcrossf.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_newcrossf
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_newcrossf

--- a/docs/source/api/generated/eegprep.pop_newset.rst
+++ b/docs/source/api/generated/eegprep.pop_newset.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_newset
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_newset

--- a/docs/source/api/generated/eegprep.pop_newtimef.rst
+++ b/docs/source/api/generated/eegprep.pop_newtimef.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_newtimef
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_newtimef

--- a/docs/source/api/generated/eegprep.pop_preclust.rst
+++ b/docs/source/api/generated/eegprep.pop_preclust.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_preclust
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_preclust

--- a/docs/source/api/generated/eegprep.pop_precomp.rst
+++ b/docs/source/api/generated/eegprep.pop_precomp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_precomp
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_precomp

--- a/docs/source/api/generated/eegprep.pop_prop_extended.rst
+++ b/docs/source/api/generated/eegprep.pop_prop_extended.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_prop\_extended
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_prop_extended

--- a/docs/source/api/generated/eegprep.pop_savestudy.rst
+++ b/docs/source/api/generated/eegprep.pop_savestudy.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_savestudy
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_savestudy

--- a/docs/source/api/generated/eegprep.pop_signalstat.rst
+++ b/docs/source/api/generated/eegprep.pop_signalstat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_signalstat
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_signalstat

--- a/docs/source/api/generated/eegprep.pop_study.rst
+++ b/docs/source/api/generated/eegprep.pop_study.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_study
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_study

--- a/docs/source/api/generated/eegprep.pop_studyerp.rst
+++ b/docs/source/api/generated/eegprep.pop_studyerp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_studyerp
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_studyerp

--- a/docs/source/api/generated/eegprep.pop_studywizard.rst
+++ b/docs/source/api/generated/eegprep.pop_studywizard.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_studywizard
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_studywizard

--- a/docs/source/api/generated/eegprep.pop_timef.rst
+++ b/docs/source/api/generated/eegprep.pop_timef.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_timef
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_timef

--- a/docs/source/api/generated/eegprep.pop_viewprops.rst
+++ b/docs/source/api/generated/eegprep.pop_viewprops.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_viewprops
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_viewprops

--- a/docs/source/api/generated/eegprep.pop_xfirws.rst
+++ b/docs/source/api/generated/eegprep.pop_xfirws.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pop\_xfirws
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pop_xfirws

--- a/docs/source/api/generated/eegprep.pophelp.rst
+++ b/docs/source/api/generated/eegprep.pophelp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.pophelp
+===============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: pophelp

--- a/docs/source/api/generated/eegprep.robust_kmeans.rst
+++ b/docs/source/api/generated/eegprep.robust_kmeans.rst
@@ -1,0 +1,6 @@
+﻿eegprep.robust\_kmeans
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: robust_kmeans

--- a/docs/source/api/generated/eegprep.rsadjust.rst
+++ b/docs/source/api/generated/eegprep.rsadjust.rst
@@ -1,0 +1,6 @@
+﻿eegprep.rsadjust
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: rsadjust

--- a/docs/source/api/generated/eegprep.rsfit.rst
+++ b/docs/source/api/generated/eegprep.rsfit.rst
@@ -1,0 +1,6 @@
+﻿eegprep.rsfit
+=============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: rsfit

--- a/docs/source/api/generated/eegprep.rsget.rst
+++ b/docs/source/api/generated/eegprep.rsget.rst
@@ -1,0 +1,6 @@
+﻿eegprep.rsget
+=============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: rsget

--- a/docs/source/api/generated/eegprep.rspdfsolv.rst
+++ b/docs/source/api/generated/eegprep.rspdfsolv.rst
@@ -1,0 +1,6 @@
+﻿eegprep.rspdfsolv
+=================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: rspdfsolv

--- a/docs/source/api/generated/eegprep.rspfunc.rst
+++ b/docs/source/api/generated/eegprep.rspfunc.rst
@@ -1,0 +1,6 @@
+﻿eegprep.rspfunc
+===============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: rspfunc

--- a/docs/source/api/generated/eegprep.select_multiple_datasets.rst
+++ b/docs/source/api/generated/eegprep.select_multiple_datasets.rst
@@ -1,0 +1,6 @@
+﻿eegprep.select\_multiple\_datasets
+==================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: select_multiple_datasets

--- a/docs/source/api/generated/eegprep.signalstat.rst
+++ b/docs/source/api/generated/eegprep.signalstat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.signalstat
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: signalstat

--- a/docs/source/api/generated/eegprep.std_addvarlevel.rst
+++ b/docs/source/api/generated/eegprep.std_addvarlevel.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_addvarlevel
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_addvarlevel

--- a/docs/source/api/generated/eegprep.std_apcluster.rst
+++ b/docs/source/api/generated/eegprep.std_apcluster.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_apcluster
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_apcluster

--- a/docs/source/api/generated/eegprep.std_builddesignmat.rst
+++ b/docs/source/api/generated/eegprep.std_builddesignmat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_builddesignmat
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_builddesignmat

--- a/docs/source/api/generated/eegprep.std_centroid.rst
+++ b/docs/source/api/generated/eegprep.std_centroid.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_centroid
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_centroid

--- a/docs/source/api/generated/eegprep.std_checkconsist.rst
+++ b/docs/source/api/generated/eegprep.std_checkconsist.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_checkconsist
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_checkconsist

--- a/docs/source/api/generated/eegprep.std_checkdatasession.rst
+++ b/docs/source/api/generated/eegprep.std_checkdatasession.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_checkdatasession
+=============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_checkdatasession

--- a/docs/source/api/generated/eegprep.std_checkdesign.rst
+++ b/docs/source/api/generated/eegprep.std_checkdesign.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_checkdesign
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_checkdesign

--- a/docs/source/api/generated/eegprep.std_checkfiles.rst
+++ b/docs/source/api/generated/eegprep.std_checkfiles.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_checkfiles
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_checkfiles

--- a/docs/source/api/generated/eegprep.std_combtrialinfo.rst
+++ b/docs/source/api/generated/eegprep.std_combtrialinfo.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_combtrialinfo
+==========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_combtrialinfo

--- a/docs/source/api/generated/eegprep.std_dipoleclusters.rst
+++ b/docs/source/api/generated/eegprep.std_dipoleclusters.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_dipoleclusters
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_dipoleclusters

--- a/docs/source/api/generated/eegprep.std_dipplot.rst
+++ b/docs/source/api/generated/eegprep.std_dipplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_dipplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_dipplot

--- a/docs/source/api/generated/eegprep.std_erpplot.rst
+++ b/docs/source/api/generated/eegprep.std_erpplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_erpplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_erpplot

--- a/docs/source/api/generated/eegprep.std_erspplot.rst
+++ b/docs/source/api/generated/eegprep.std_erspplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_erspplot
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_erspplot

--- a/docs/source/api/generated/eegprep.std_findoutlierclust.rst
+++ b/docs/source/api/generated/eegprep.std_findoutlierclust.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_findoutlierclust
+=============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_findoutlierclust

--- a/docs/source/api/generated/eegprep.std_findsameica.rst
+++ b/docs/source/api/generated/eegprep.std_findsameica.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_findsameica
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_findsameica

--- a/docs/source/api/generated/eegprep.std_getindvar.rst
+++ b/docs/source/api/generated/eegprep.std_getindvar.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_getindvar
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_getindvar

--- a/docs/source/api/generated/eegprep.std_gettrialsind.rst
+++ b/docs/source/api/generated/eegprep.std_gettrialsind.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_gettrialsind
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_gettrialsind

--- a/docs/source/api/generated/eegprep.std_indvarmatch.rst
+++ b/docs/source/api/generated/eegprep.std_indvarmatch.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_indvarmatch
+========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_indvarmatch

--- a/docs/source/api/generated/eegprep.std_interp.rst
+++ b/docs/source/api/generated/eegprep.std_interp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_interp
+===================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_interp

--- a/docs/source/api/generated/eegprep.std_itcplot.rst
+++ b/docs/source/api/generated/eegprep.std_itcplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_itcplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_itcplot

--- a/docs/source/api/generated/eegprep.std_limodesign.rst
+++ b/docs/source/api/generated/eegprep.std_limodesign.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_limodesign
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_limodesign

--- a/docs/source/api/generated/eegprep.std_maketrialinfo.rst
+++ b/docs/source/api/generated/eegprep.std_maketrialinfo.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_maketrialinfo
+==========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_maketrialinfo

--- a/docs/source/api/generated/eegprep.std_pac.rst
+++ b/docs/source/api/generated/eegprep.std_pac.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_pac
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_pac

--- a/docs/source/api/generated/eegprep.std_pacplot.rst
+++ b/docs/source/api/generated/eegprep.std_pacplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_pacplot
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_pacplot

--- a/docs/source/api/generated/eegprep.std_prepare_neighbors.rst
+++ b/docs/source/api/generated/eegprep.std_prepare_neighbors.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_prepare\_neighbors
+===============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_prepare_neighbors

--- a/docs/source/api/generated/eegprep.std_readdata.rst
+++ b/docs/source/api/generated/eegprep.std_readdata.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readdata
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readdata

--- a/docs/source/api/generated/eegprep.std_readerp.rst
+++ b/docs/source/api/generated/eegprep.std_readerp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readerp
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readerp

--- a/docs/source/api/generated/eegprep.std_readersp.rst
+++ b/docs/source/api/generated/eegprep.std_readersp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readersp
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readersp

--- a/docs/source/api/generated/eegprep.std_readitc.rst
+++ b/docs/source/api/generated/eegprep.std_readitc.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readitc
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readitc

--- a/docs/source/api/generated/eegprep.std_readpac.rst
+++ b/docs/source/api/generated/eegprep.std_readpac.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readpac
+====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readpac

--- a/docs/source/api/generated/eegprep.std_readspec.rst
+++ b/docs/source/api/generated/eegprep.std_readspec.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readspec
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readspec

--- a/docs/source/api/generated/eegprep.std_readtopo.rst
+++ b/docs/source/api/generated/eegprep.std_readtopo.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_readtopo
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_readtopo

--- a/docs/source/api/generated/eegprep.std_rebuilddesign.rst
+++ b/docs/source/api/generated/eegprep.std_rebuilddesign.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_rebuilddesign
+==========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_rebuilddesign

--- a/docs/source/api/generated/eegprep.std_rmalldatafields.rst
+++ b/docs/source/api/generated/eegprep.std_rmalldatafields.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_rmalldatafields
+============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_rmalldatafields

--- a/docs/source/api/generated/eegprep.std_rmdat.rst
+++ b/docs/source/api/generated/eegprep.std_rmdat.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_rmdat
+==================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_rmdat

--- a/docs/source/api/generated/eegprep.std_saveindvar.rst
+++ b/docs/source/api/generated/eegprep.std_saveindvar.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_saveindvar
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_saveindvar

--- a/docs/source/api/generated/eegprep.std_selectdataset.rst
+++ b/docs/source/api/generated/eegprep.std_selectdataset.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_selectdataset
+==========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_selectdataset

--- a/docs/source/api/generated/eegprep.std_selsubject.rst
+++ b/docs/source/api/generated/eegprep.std_selsubject.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_selsubject
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_selsubject

--- a/docs/source/api/generated/eegprep.std_specplot.rst
+++ b/docs/source/api/generated/eegprep.std_specplot.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_specplot
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_specplot

--- a/docs/source/api/generated/eegprep.std_substudy.rst
+++ b/docs/source/api/generated/eegprep.std_substudy.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_substudy
+=====================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_substudy

--- a/docs/source/api/generated/eegprep.std_uniformfiles.rst
+++ b/docs/source/api/generated/eegprep.std_uniformfiles.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_uniformfiles
+=========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_uniformfiles

--- a/docs/source/api/generated/eegprep.std_uniformsetinds.rst
+++ b/docs/source/api/generated/eegprep.std_uniformsetinds.rst
@@ -1,0 +1,6 @@
+﻿eegprep.std\_uniformsetinds
+===========================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: std_uniformsetinds

--- a/docs/source/api/generated/eegprep.tf_cycle_calc.rst
+++ b/docs/source/api/generated/eegprep.tf_cycle_calc.rst
@@ -1,0 +1,6 @@
+﻿eegprep.tf\_cycle\_calc
+=======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: tf_cycle_calc

--- a/docs/source/api/generated/eegprep.timef.rst
+++ b/docs/source/api/generated/eegprep.timef.rst
@@ -1,0 +1,6 @@
+﻿eegprep.timef
+=============
+
+.. currentmodule:: eegprep
+
+.. autofunction:: timef

--- a/docs/source/api/generated/eegprep.timefreq.rst
+++ b/docs/source/api/generated/eegprep.timefreq.rst
@@ -1,0 +1,6 @@
+﻿eegprep.timefreq
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: timefreq

--- a/docs/source/api/generated/eegprep.timewarp.rst
+++ b/docs/source/api/generated/eegprep.timewarp.rst
@@ -1,0 +1,6 @@
+﻿eegprep.timewarp
+================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: timewarp

--- a/docs/source/api/generated/eegprep.validate_catalog_entries.rst
+++ b/docs/source/api/generated/eegprep.validate_catalog_entries.rst
@@ -1,0 +1,6 @@
+﻿eegprep.validate\_catalog\_entries
+==================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: validate_catalog_entries

--- a/docs/source/api/generated/eegprep.validate_catalog_file.rst
+++ b/docs/source/api/generated/eegprep.validate_catalog_file.rst
@@ -1,0 +1,6 @@
+﻿eegprep.validate\_catalog\_file
+===============================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: validate_catalog_file

--- a/docs/source/api/generated/eegprep.validate_extension_spec.rst
+++ b/docs/source/api/generated/eegprep.validate_extension_spec.rst
@@ -1,0 +1,6 @@
+﻿eegprep.validate\_extension\_spec
+=================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: validate_extension_spec

--- a/docs/source/api/generated/eegprep.vis_artifacts.rst
+++ b/docs/source/api/generated/eegprep.vis_artifacts.rst
@@ -1,0 +1,6 @@
+﻿eegprep.vis\_artifacts
+======================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: vis_artifacts

--- a/docs/source/api/generated/eegprep.vis_artifacts_diagnostics.rst
+++ b/docs/source/api/generated/eegprep.vis_artifacts_diagnostics.rst
@@ -1,0 +1,6 @@
+﻿eegprep.vis\_artifacts\_diagnostics
+===================================
+
+.. currentmodule:: eegprep
+
+.. autofunction:: vis_artifacts_diagnostics

--- a/docs/source/api/ica.rst
+++ b/docs/source/api/ica.rst
@@ -10,19 +10,25 @@ ICA Decomposition
 =================
 
 .. autofunction:: eegprep.eeg_amica
+   :no-index:
 
 .. autofunction:: eegprep.eeg_picard
+   :no-index:
 
 .. autofunction:: eegprep.eeg_runica
+   :no-index:
 
 Component Classification
 ========================
 
 .. autofunction:: eegprep.iclabel
+   :no-index:
 
 .. autofunction:: eegprep.eeg_icalabelstat
+   :no-index:
 
 Feature Extraction
 ==================
 
 .. autofunction:: eegprep.ICL_feature_extractor
+   :no-index:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -223,8 +223,6 @@ Utilities
    eegprep.eeg_decodechan
    eegprep.eeg_lat2point
    eegprep.eeg_point2lat
-   eegprep.bids_list_eeg_files
-   eegprep.bids_preproc
 
 BIDS Pipeline
 =============
@@ -234,7 +232,6 @@ BIDS Pipeline
 
    eegprep.bids_preproc
    eegprep.bids_list_eeg_files
-   eegprep.pop_load_frombids
    eegprep.pop_importbids
    eegprep.pop_exportbids
 
@@ -258,10 +255,6 @@ for now.
    eegprep.pop_icflag
    eegprep.pop_prop_extended
    eegprep.pop_viewprops
-   eegprep.pop_eegfiltnew
-   eegprep.pop_firws
-   eegprep.pop_firpm
-   eegprep.pop_firma
    eegprep.firws
    eegprep.firwsord
    eegprep.pop_dipfit_settings
@@ -296,8 +289,14 @@ them.
    eegprep.ExtensionRegistry
    eegprep.ExtensionRecord
    eegprep.ExtensionStatus
+   eegprep.ExtensionSourceType
+   eegprep.ExtensionCatalog
+   eegprep.ExtensionCatalogEntry
+   eegprep.CatalogSourceType
    eegprep.ExtensionAction
    eegprep.ExtensionPopFunction
+   eegprep.ExtensionMenu
+   eegprep.ExtensionDependency
    eegprep.ExtensionResource
    eegprep.ExtensionLoadError
    eegprep.ExtensionValidationResult
@@ -311,6 +310,9 @@ them.
    eegprep.validate_catalog_entries
    eegprep.validate_catalog_file
    eegprep.validate_extension_spec
+   eegprep.load_extension_catalog
+   eegprep.build_safe_install_commands
+   eegprep.build_safe_update_commands
 
 STUDY Workflows
 ===============
@@ -383,7 +385,7 @@ measure plotting, component preclustering, clustering, and cluster editing.
 Configuration
 ==============
 
-.. autosummary::
-   :toctree: generated/
+.. toctree::
+   :maxdepth: 1
 
-   eegprep.EEG_OPTIONS
+   generated/eegprep.EEG_OPTIONS

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -15,6 +15,7 @@ This section contains the complete API documentation for eegprep. The API is org
    signal_processing
    statistics
    io
+   pop_functions
    extensions
    utils
 

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -13,74 +13,103 @@ BIDS Loading
    :no-index:
 
 .. autofunction:: eegprep.pop_importbids
+   :no-index:
 
 .. autofunction:: eegprep.pop_exportbids
+   :no-index:
 
 Generic Import
 ==============
 
 .. autofunction:: eegprep.pop_importdata
+   :no-index:
 
 .. autofunction:: eegprep.pop_fileio
+   :no-index:
 
 .. autofunction:: eegprep.pop_biosig
+   :no-index:
 
 .. autofunction:: eegprep.pop_importevent
+   :no-index:
 
 .. autofunction:: eegprep.pop_importepoch
+   :no-index:
 
 .. autofunction:: eegprep.pop_chanevent
+   :no-index:
 
 .. autofunction:: eegprep.pop_importpres
+   :no-index:
 
 .. autofunction:: eegprep.pop_importerplab
+   :no-index:
 
 Channel Locations
 =================
 
 .. autofunction:: eegprep.pop_readlocs
+   :no-index:
 
 .. autofunction:: eegprep.pop_writelocs
+   :no-index:
 
 .. autofunction:: eegprep.readlocs
+   :no-index:
 
 .. autofunction:: eegprep.writelocs
+   :no-index:
 
 .. autofunction:: eegprep.convertlocs
+   :no-index:
 
 .. autofunction:: eegprep.chancenter
+   :no-index:
 
 .. autofunction:: eegprep.pop_chancenter
+   :no-index:
 
 .. autofunction:: eegprep.pop_chancoresp
+   :no-index:
 
 .. autofunction:: eegprep.readegilocs
+   :no-index:
 
 .. autofunction:: eegprep.readelp
+   :no-index:
 
 .. autofunction:: eegprep.readeetraklocs
+   :no-index:
 
 Long-Tail Import Helpers
 ========================
 
 .. autofunction:: eegprep.pop_loadbci
+   :no-index:
 
 .. autofunction:: eegprep.pop_snapread
+   :no-index:
 
 .. autofunction:: eegprep.snapread
+   :no-index:
 
 .. autofunction:: eegprep.floatread
+   :no-index:
 
 .. autofunction:: eegprep.floatwrite
+   :no-index:
 
 EEGLAB Format
 =============
 
 .. autofunction:: eegprep.pop_loadset
+   :no-index:
 
 .. autofunction:: eegprep.pop_loadset_h5
+   :no-index:
 
 .. autofunction:: eegprep.pop_saveset
+   :no-index:
 
 ``pop_saveset(..., savemode="twofiles")`` writes a ``.set`` header plus
 ``.fdt`` float32 sidecar. ``EEG_OPTIONS["option_savetwofiles"]``
@@ -92,6 +121,7 @@ Text And External Export
 ========================
 
 .. autofunction:: eegprep.pop_export
+   :no-index:
 
 ``pop_export`` supports text export options including ICA export,
 time/electrode rows, transpose, ERP averaging, precision, separator, and a
@@ -101,151 +131,223 @@ accept documented safe numeric keywords. Power operators require small constant
 exponents.
 
 .. autofunction:: eegprep.pop_expica
+   :no-index:
 
 .. autofunction:: eegprep.pop_expevents
+   :no-index:
 
 .. autofunction:: eegprep.pop_writeeeg
+   :no-index:
 
 History And STUDY Files
 =======================
 
 .. autofunction:: eegprep.pop_saveh
+   :no-index:
 
 .. autofunction:: eegprep.pop_runscript
+   :no-index:
 
 .. autofunction:: eegprep.pop_study
+   :no-index:
 
 .. autofunction:: eegprep.pop_studywizard
+   :no-index:
 
 .. autofunction:: eegprep.pop_studyerp
+   :no-index:
 
 .. autofunction:: eegprep.pop_studydesign
+   :no-index:
 
 .. autofunction:: eegprep.pop_loadstudy
+   :no-index:
 
 .. autofunction:: eegprep.pop_savestudy
+   :no-index:
 
 .. autofunction:: eegprep.pop_precomp
+   :no-index:
 
 .. autofunction:: eegprep.pop_chanplot
+   :no-index:
 
 .. autofunction:: eegprep.std_editset
+   :no-index:
 
 .. autofunction:: eegprep.std_checkset
+   :no-index:
 
 .. autofunction:: eegprep.std_checkdatasetinfo
+   :no-index:
 
 .. autofunction:: eegprep.std_checkconsist
+   :no-index:
 
 .. autofunction:: eegprep.std_checkdesign
+   :no-index:
 
 .. autofunction:: eegprep.std_makedesign
+   :no-index:
 
 .. autofunction:: eegprep.std_addvarlevel
+   :no-index:
 
 .. autofunction:: eegprep.std_builddesignmat
+   :no-index:
 
 .. autofunction:: eegprep.std_limodesign
+   :no-index:
 
 .. autofunction:: eegprep.std_getindvar
+   :no-index:
 
 .. autofunction:: eegprep.std_indvarmatch
+   :no-index:
 
 .. autofunction:: eegprep.std_selectdataset
+   :no-index:
 
 .. autofunction:: eegprep.std_gettrialsind
+   :no-index:
 
 .. autofunction:: eegprep.std_maketrialinfo
+   :no-index:
 
 .. autofunction:: eegprep.std_combtrialinfo
+   :no-index:
 
 .. autofunction:: eegprep.std_rebuilddesign
+   :no-index:
 
 .. autofunction:: eegprep.std_saveindvar
+   :no-index:
 
 .. autofunction:: eegprep.pop_addindepvar
+   :no-index:
 
 .. autofunction:: eegprep.pop_importgroupvar
+   :no-index:
 
 .. autofunction:: eegprep.pop_listfactors
+   :no-index:
 
 .. autofunction:: eegprep.std_precomp
+   :no-index:
 
 .. autofunction:: eegprep.std_readdata
+   :no-index:
 
 .. autofunction:: eegprep.std_readerp
+   :no-index:
 
 .. autofunction:: eegprep.std_readspec
+   :no-index:
 
 .. autofunction:: eegprep.std_readersp
+   :no-index:
 
 .. autofunction:: eegprep.std_readitc
+   :no-index:
 
 .. autofunction:: eegprep.std_readtopo
+   :no-index:
 
 .. autofunction:: eegprep.std_readpac
+   :no-index:
 
 .. autofunction:: eegprep.std_pac
+   :no-index:
 
 .. autofunction:: eegprep.std_pacplot
+   :no-index:
 
 .. autofunction:: eegprep.std_prepare_neighbors
+   :no-index:
 
 .. autofunction:: eegprep.std_interp
+   :no-index:
 
 .. autofunction:: eegprep.std_dipplot
+   :no-index:
 
 .. autofunction:: eegprep.std_dipoleclusters
+   :no-index:
 
 .. autofunction:: eegprep.std_savedat
+   :no-index:
 
 .. autofunction:: eegprep.std_checkfiles
+   :no-index:
 
 .. autofunction:: eegprep.std_checkdatasession
+   :no-index:
 
 .. autofunction:: eegprep.std_uniformfiles
+   :no-index:
 
 .. autofunction:: eegprep.std_uniformsetinds
+   :no-index:
 
 .. autofunction:: eegprep.std_findsameica
+   :no-index:
 
 .. autofunction:: eegprep.std_selsubject
+   :no-index:
 
 .. autofunction:: eegprep.std_substudy
+   :no-index:
 
 .. autofunction:: eegprep.std_rmdat
+   :no-index:
 
 .. autofunction:: eegprep.std_rmalldatafields
+   :no-index:
 
 .. autofunction:: eegprep.std_erpplot
+   :no-index:
 
 .. autofunction:: eegprep.std_specplot
+   :no-index:
 
 .. autofunction:: eegprep.std_erspplot
+   :no-index:
 
 .. autofunction:: eegprep.std_itcplot
+   :no-index:
 
 .. autofunction:: eegprep.optimal_kmeans
+   :no-index:
 
 .. autofunction:: eegprep.robust_kmeans
+   :no-index:
 
 .. autofunction:: eegprep.std_apcluster
+   :no-index:
 
 .. autofunction:: eegprep.std_centroid
+   :no-index:
 
 .. autofunction:: eegprep.std_findoutlierclust
+   :no-index:
 
 .. autofunction:: eegprep.pop_limo
+   :no-index:
 
 .. autofunction:: eegprep.pop_limoresults
+   :no-index:
 
 .. autofunction:: eegprep.std_selectdesign
+   :no-index:
 
 Format Conversion
 =================
 
 .. autofunction:: eegprep.eeg_eeg2mne
+   :no-index:
 
 .. autofunction:: eegprep.eeg_mne2eeg
+   :no-index:
 
 .. autofunction:: eegprep.eeg_mne2eeg_epochs
+   :no-index:

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -10,6 +10,7 @@ BIDS Loading
 ============
 
 .. autofunction:: eegprep.pop_load_frombids
+   :no-index:
 
 .. autofunction:: eegprep.pop_importbids
 
@@ -81,8 +82,8 @@ EEGLAB Format
 
 .. autofunction:: eegprep.pop_saveset
 
-``pop_saveset(..., savemode="twofiles")`` writes an EEGLAB-style ``.set``
-header plus ``.fdt`` float32 sidecar. ``EEG_OPTIONS["option_savetwofiles"]``
+``pop_saveset(..., savemode="twofiles")`` writes a ``.set`` header plus
+``.fdt`` float32 sidecar. ``EEG_OPTIONS["option_savetwofiles"]``
 uses that layout by default, and ``EEG_OPTIONS["option_memmapdata"]`` makes
 ``pop_loadset`` expose sidecar data through a NumPy-compatible memory map. See
 :ref:`large_dataset_storage` for storedisk session behavior and limitations.
@@ -92,7 +93,7 @@ Text And External Export
 
 .. autofunction:: eegprep.pop_export
 
-``pop_export`` supports EEGLAB-style text export options including ICA export,
+``pop_export`` supports text export options including ICA export,
 time/electrode rows, transpose, ERP averaging, precision, separator, and a
 standalone numeric ``expr`` transform applied to the exported array ``x``.
 Most expression function calls are positional; ``clip`` and ``nan_to_num`` also

--- a/docs/source/api/pop_functions.rst
+++ b/docs/source/api/pop_functions.rst
@@ -1,0 +1,145 @@
+.. _pop_functions_api:
+
+============================
+EEGLAB-Style pop_ Wrappers
+============================
+
+This page lists the public ``pop_*`` wrappers exported by ``eegprep``. Use
+``return_com=True`` on history-relevant wrappers when you need the replayable
+EEGLAB-style command string. In normal Python, assign returned values
+explicitly; in ``eegprep-console``, registered wrappers can update the shared
+session automatically.
+
+.. autosummary::
+   :nosignatures:
+
+   eegprep.pop_addindepvar
+   eegprep.pop_adjustevents
+   eegprep.pop_autorej
+   eegprep.pop_averef
+   eegprep.pop_biosig
+   eegprep.pop_chancenter
+   eegprep.pop_chancoresp
+   eegprep.pop_chanedit
+   eegprep.pop_chanevent
+   eegprep.pop_chanplot
+   eegprep.pop_chansel
+   eegprep.pop_clean_rawdata
+   eegprep.pop_clust
+   eegprep.pop_clustedit
+   eegprep.pop_comments
+   eegprep.pop_compareerps
+   eegprep.pop_comperp
+   eegprep.pop_copyset
+   eegprep.pop_crossf
+   eegprep.pop_delset
+   eegprep.pop_dipfit_gridsearch
+   eegprep.pop_dipfit_headmodel
+   eegprep.pop_dipfit_loreta
+   eegprep.pop_dipfit_nonlinear
+   eegprep.pop_dipfit_settings
+   eegprep.pop_dipplot
+   eegprep.pop_editeventfield
+   eegprep.pop_editeventvals
+   eegprep.pop_editoptions
+   eegprep.pop_editset
+   eegprep.pop_eegfilt
+   eegprep.pop_eegfiltnew
+   eegprep.pop_eegplot
+   eegprep.pop_eegthresh
+   eegprep.pop_envtopo
+   eegprep.pop_epoch
+   eegprep.pop_erpimage
+   eegprep.pop_eventstat
+   eegprep.pop_expevents
+   eegprep.pop_expica
+   eegprep.pop_export
+   eegprep.pop_exportbids
+   eegprep.pop_fileio
+   eegprep.pop_fileio_brainvision_mat
+   eegprep.pop_findmatchingcomps
+   eegprep.pop_firma
+   eegprep.pop_firpm
+   eegprep.pop_firpmord
+   eegprep.pop_firws
+   eegprep.pop_firwsord
+   eegprep.pop_fusechanrej
+   eegprep.pop_headplot
+   eegprep.pop_icathresh
+   eegprep.pop_icflag
+   eegprep.pop_iclabel
+   eegprep.pop_importbids
+   eegprep.pop_importdata
+   eegprep.pop_importepoch
+   eegprep.pop_importerplab
+   eegprep.pop_importevent
+   eegprep.pop_importgroupvar
+   eegprep.pop_importpres
+   eegprep.pop_interp
+   eegprep.pop_jointprob
+   eegprep.pop_kaiserbeta
+   eegprep.pop_leadfield
+   eegprep.pop_limo
+   eegprep.pop_limoresults
+   eegprep.pop_listfactors
+   eegprep.pop_load_frombids
+   eegprep.pop_loadbci
+   eegprep.pop_loadset
+   eegprep.pop_loadset_h5
+   eegprep.pop_loadstudy
+   eegprep.pop_mergeset
+   eegprep.pop_multifit
+   eegprep.pop_newcrossf
+   eegprep.pop_newset
+   eegprep.pop_newtimef
+   eegprep.pop_plotdata
+   eegprep.pop_plottopo
+   eegprep.pop_preclust
+   eegprep.pop_precomp
+   eegprep.pop_prop
+   eegprep.pop_prop_extended
+   eegprep.pop_readlocs
+   eegprep.pop_rejchan
+   eegprep.pop_rejchanspec
+   eegprep.pop_rejcont
+   eegprep.pop_rejepoch
+   eegprep.pop_rejkurt
+   eegprep.pop_rejmenu
+   eegprep.pop_rejspec
+   eegprep.pop_rejtrend
+   eegprep.pop_reref
+   eegprep.pop_resample
+   eegprep.pop_rmbase
+   eegprep.pop_rmdat
+   eegprep.pop_runica
+   eegprep.pop_runscript
+   eegprep.pop_saveh
+   eegprep.pop_saveset
+   eegprep.pop_savestudy
+   eegprep.pop_select
+   eegprep.pop_selectcomps
+   eegprep.pop_selectevent
+   eegprep.pop_signalstat
+   eegprep.pop_snapread
+   eegprep.pop_spectopo
+   eegprep.pop_study
+   eegprep.pop_studydesign
+   eegprep.pop_studyerp
+   eegprep.pop_studywizard
+   eegprep.pop_subcomp
+   eegprep.pop_timef
+   eegprep.pop_timtopo
+   eegprep.pop_topochansel
+   eegprep.pop_topoplot
+   eegprep.pop_viewprops
+   eegprep.pop_writeeeg
+   eegprep.pop_writelocs
+   eegprep.pop_xfirws
+
+Coverage Notes
+==============
+
+Major user-facing workflows are described in the user guide. Thin compatibility
+wrappers, legacy import/export helpers, and plotting helpers are discoverable
+here and through their function docstrings. Packaged GUI Help topics live under
+``src/eegprep/resources/help`` and are opened by ``pophelp``.

--- a/docs/source/api/pop_functions.rst
+++ b/docs/source/api/pop_functions.rst
@@ -1,14 +1,14 @@
 .. _pop_functions_api:
 
 ============================
-EEGLAB-Style pop_ Wrappers
+Interactive Pop Workflow API
 ============================
 
 This page lists the public ``pop_*`` wrappers exported by ``eegprep``. Use
 ``return_com=True`` on history-relevant wrappers when you need the replayable
-EEGLAB-style command string. In normal Python, assign returned values
-explicitly; in ``eegprep-console``, registered wrappers can update the shared
-session automatically.
+command string. In normal Python, assign returned values explicitly; in
+``eegprep-console``, registered wrappers can update the shared session
+automatically.
 
 .. autosummary::
    :nosignatures:

--- a/docs/source/api/preprocessing.rst
+++ b/docs/source/api/preprocessing.rst
@@ -10,29 +10,40 @@ Artifact Removal
 ================
 
 .. autofunction:: eegprep.clean_artifacts
+   :no-index:
 
 .. autofunction:: eegprep.clean_asr
+   :no-index:
 
 .. autofunction:: eegprep.clean_flatlines
+   :no-index:
 
 .. autofunction:: eegprep.clean_drifts
+   :no-index:
 
 .. autofunction:: eegprep.clean_windows
+   :no-index:
 
 Channel Operations
 ==================
 
 .. autofunction:: eegprep.clean_channels
+   :no-index:
 
 .. autofunction:: eegprep.clean_channels_nolocs
+   :no-index:
 
 .. autofunction:: eegprep.eeg_interp
+   :no-index:
 
 .. autofunction:: eegprep.pop_interp
+   :no-index:
 
 Signal Processing
 =================
 
 .. autofunction:: eegprep.pop_resample
+   :no-index:
 
 .. autofunction:: eegprep.pop_rmbase
+   :no-index:

--- a/docs/source/api/signal_processing.rst
+++ b/docs/source/api/signal_processing.rst
@@ -10,102 +10,145 @@ Spectral Analysis
 =================
 
 .. autofunction:: eegprep.eeg_autocorr
+   :no-index:
 
 .. autofunction:: eegprep.eeg_autocorr_welch
+   :no-index:
 
 .. autofunction:: eegprep.eeg_rpsd
+   :no-index:
 
 Time-Frequency And Statistics
 =============================
 
 .. autofunction:: eegprep.newtimef
+   :no-index:
 
 .. autofunction:: eegprep.newcrossf
+   :no-index:
 
 .. autofunction:: eegprep.timefreq
+   :no-index:
 
 .. autofunction:: eegprep.timef
+   :no-index:
 
 .. autofunction:: eegprep.crossf
+   :no-index:
 
 .. autofunction:: eegprep.pac
+   :no-index:
 
 .. autofunction:: eegprep.pac_cont
+   :no-index:
 
 .. autofunction:: eegprep.dftfilt
+   :no-index:
 
 .. autofunction:: eegprep.dftfilt2
+   :no-index:
 
 .. autofunction:: eegprep.dftfilt3
+   :no-index:
 
 .. autofunction:: eegprep.timewarp
+   :no-index:
 
 .. autofunction:: eegprep.angtimewarp
+   :no-index:
 
 .. autofunction:: eegprep.tf_cycle_calc
+   :no-index:
 
 .. autofunction:: eegprep.newtimefbaseln
+   :no-index:
 
 .. autofunction:: eegprep.newtimeftrialbaseln
+   :no-index:
 
 .. autofunction:: eegprep.newtimefitc
+   :no-index:
 
 .. autofunction:: eegprep.newtimefpowerunit
+   :no-index:
 
 .. autofunction:: eegprep.bootstat
+   :no-index:
 
 .. autofunction:: eegprep.correct_mc
+   :no-index:
 
 .. autofunction:: eegprep.correctfit
+   :no-index:
 
 .. autofunction:: eegprep.rsadjust
+   :no-index:
 
 .. autofunction:: eegprep.rsfit
+   :no-index:
 
 .. autofunction:: eegprep.rsget
+   :no-index:
 
 .. autofunction:: eegprep.rspdfsolv
+   :no-index:
 
 .. autofunction:: eegprep.rspfunc
+   :no-index:
 
 .. autofunction:: eegprep.signalstat
+   :no-index:
 
 .. autofunction:: eegprep.pop_newtimef
+   :no-index:
 
 .. autofunction:: eegprep.pop_newcrossf
+   :no-index:
 
 .. autofunction:: eegprep.pop_timef
+   :no-index:
 
 .. autofunction:: eegprep.pop_crossf
+   :no-index:
 
 .. autofunction:: eegprep.pop_signalstat
+   :no-index:
 
 .. autofunction:: eegprep.pop_eventstat
+   :no-index:
 
 Browser
 ========
 
 .. autofunction:: eegprep.eegplot
+   :no-index:
 
 .. autofunction:: eegprep.eeg_multieegplot
+   :no-index:
 
 Resampling
 ==========
 
 .. autofunction:: eegprep.pop_resample
+   :no-index:
 
 Baseline Removal
 ================
 
 .. autofunction:: eegprep.rmbase
+   :no-index:
 
 .. autofunction:: eegprep.pop_rmbase
+   :no-index:
 
 Topography
 ==========
 
 .. autofunction:: eegprep.cart2topo
+   :no-index:
 
 .. autofunction:: eegprep.pop_topoplot
+   :no-index:
 
 .. autofunction:: eegprep.topoplot
+   :no-index:

--- a/docs/source/api/statistics.rst
+++ b/docs/source/api/statistics.rst
@@ -13,35 +13,49 @@ Condition Tests
 ===============
 
 .. autofunction:: eegprep.functions.statistics.statcond
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.ttest_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.ttest2_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.anova1_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.anova1rm_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.anova2_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.anova2rm_cell
+   :no-index:
 
 Multiple Comparisons And Surrogates
 ===================================
 
 .. autofunction:: eegprep.functions.statistics.fdr
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.stat_surrogate_pvals
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.stat_surrogate_ci
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.surrogdistrib
+   :no-index:
 
 Data Helpers
 ============
 
 .. autofunction:: eegprep.functions.statistics.concatdata
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.corrcoef_cell
+   :no-index:
 
 .. autofunction:: eegprep.functions.statistics.teststat
+   :no-index:

--- a/docs/source/api/utils.rst
+++ b/docs/source/api/utils.rst
@@ -10,16 +10,19 @@ Data Comparison
 ===============
 
 .. autofunction:: eegprep.eeg_compare
+   :no-index:
 
 Channel Operations
 ==================
 
 .. autofunction:: eegprep.eeg_decodechan
+   :no-index:
 
 Visualization
 =============
 
 .. autofunction:: eegprep.topoplot
+   :no-index:
 
 Utility Modules
 ===============
@@ -28,6 +31,7 @@ Coordinate Utilities
 --------------------
 
 .. automodule:: eegprep.plugins.EEG_BIDS.coords
+   :no-index:
    :members:
    :undoc-members:
 
@@ -35,6 +39,7 @@ Spatial Utilities
 -----------------
 
 .. automodule:: eegprep.plugins.clean_rawdata.private.sphericalSplineInterpolate
+   :no-index:
    :members:
    :undoc-members:
 
@@ -42,6 +47,7 @@ Statistical Utilities
 ---------------------
 
 .. automodule:: eegprep.plugins.clean_rawdata.private.stats
+   :no-index:
    :members:
    :undoc-members:
 
@@ -49,5 +55,6 @@ Signal Processing Utilities
 ---------------------------
 
 .. automodule:: eegprep.plugins.clean_rawdata.private.sigproc
+   :no-index:
    :members:
    :undoc-members:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,7 @@ All notable changes to EEGPrep are documented in this file. The format is based 
 Version History
 ===============
 
-For a complete list of releases and detailed release notes, see the `GitHub Releases <https://github.com/NeuroTechX/eegprep/releases>`_ page.
+For a complete list of releases and detailed release notes, see the `GitHub Releases <https://github.com/sccn/eegprep/releases>`_ page.
 
 Release Notes
 =============
@@ -173,7 +173,7 @@ To set up a development environment, see the :doc:`development` guide.
 Reporting Issues
 ================
 
-Found a bug? Please report it on `GitHub Issues <https://github.com/NeuroTechX/eegprep/issues>`_.
+Found a bug? Please report it on `GitHub Issues <https://github.com/sccn/eegprep/issues>`_.
 
 When reporting issues, please include:
 
@@ -186,7 +186,8 @@ When reporting issues, please include:
 Feature Requests
 ================
 
-Have an idea for a new feature? Open a `GitHub Discussion <https://github.com/NeuroTechX/eegprep/discussions>`_ or create an issue with the "enhancement" label.
+Have an idea for a new feature? Create an issue with the "enhancement" label on
+`GitHub Issues <https://github.com/sccn/eegprep/issues>`_.
 
 When requesting features, please include:
 
@@ -264,7 +265,7 @@ Special thanks to:
 
 - EEGLAB developers for pioneering EEG preprocessing
 - MNE-Python team for excellent neuroimaging tools
-- NeuroTechX community for support and contributions
+- SCCN and the EEG research community for support and contributions
 
 Getting Help
 ============
@@ -273,6 +274,6 @@ Getting Help
 - Review the :doc:`user_guide/index` for usage information
 - See :doc:`examples/index` for practical examples
 - Check :doc:`development` for development setup
-- Open an issue on `GitHub <https://github.com/NeuroTechX/eegprep/issues>`_
+- Open an issue on `GitHub <https://github.com/sccn/eegprep/issues>`_
 
-For more information, visit the `GitHub Repository <https://github.com/NeuroTechX/eegprep>`_.
+For more information, visit the `GitHub Repository <https://github.com/sccn/eegprep>`_.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,6 @@ html_context = {
 autodoc_default_options = {
     "members": True,
     "member-order": "bysource",
-    "special-members": "__init__",
     "undoc-members": False,
     "show-inheritance": True,
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,10 @@
 import sys
 from pathlib import Path
 
+DOCS_SOURCE = Path(__file__).parent
+
 # Add the source directory to the path so we can import eegprep
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+sys.path.insert(0, str(DOCS_SOURCE.parent.parent / "src"))
 
 # -- Project information -------------------------------------------------------
 project = "eegprep"
@@ -51,6 +53,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_title = "EEGPrep manual"
+html_favicon = "_static/logo.jpg"
 
 html_theme_options = {
     "logo": {
@@ -67,7 +71,7 @@ html_theme_options = {
     "footer_start": ["copyright"],
     "footer_end": ["sphinx-version"],
     "secondary_sidebar_items": ["page-toc"],
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 5,
     # Social and repository links
     "icon_links": [
         {
@@ -80,7 +84,7 @@ html_theme_options = {
     "show_nav_level": 2,
     "use_edit_page_button": False,
     # Search settings
-    "search_bar_text": "Search documentation...",
+    "search_bar_text": "Search the EEGPrep manual...",
     # Sidebar behavior
     "collapse_navigation": False,
 }
@@ -105,6 +109,7 @@ autodoc_default_options = {
 
 autodoc_typehints = "description"
 autodoc_typehints_format = "short"
+autosummary_generate_overwrite = False
 
 # -- Options for Napoleon (Google-style docstrings) ---------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
@@ -140,13 +145,13 @@ intersphinx_mapping = {
 
 sphinx_gallery_conf = {
     # Directory where example scripts are located
-    "examples_dirs": "examples",
+    "examples_dirs": str(DOCS_SOURCE / "examples"),
     # Directory where gallery will be generated
     "gallery_dirs": "auto_examples",
     # Pattern for example filenames
     "filename_pattern": "/plot_",
     # Pattern for files to ignore
-    "ignore_pattern": r"__init__\.py",
+    "ignore_pattern": r"(__init__\.py|examples/extensions/)",
     # Whether to execute examples
     "plot_gallery": True,
     # Whether to download all examples

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -163,25 +163,25 @@ Use Google-style docstrings:
 
         Returns
         -------
-        EEGobj
-            The preprocessed EEG object.
+        dict
+            The preprocessed EEG dictionary.
 
         Raises
         ------
         ValueError
             If filter_type is not recognized.
         TypeError
-            If eeg is not an EEGobj instance.
+            If eeg is not an EEG dictionary.
 
         Examples
         --------
-        >>> import eegprep
-        >>> eeg = eegprep.EEGobj.load('data.set')
-        >>> eeg_clean = eegprep.preprocess_eeg(eeg, freq_range=(1, 50))
+        >>> from eegprep import pop_eegfiltnew, pop_loadset
+        >>> EEG = pop_loadset("data.set")
+        >>> EEG, com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=50, return_com=True)
 
         Notes
         -----
-        This function modifies the EEG object in place and returns it.
+        This function returns the updated EEG dictionary.
 
         See Also
         --------

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -298,9 +298,10 @@ Validate the final matrix with:
    uv run --no-sync python -m tools.eeglab_final_parity_matrix --json
 
 The docs architecture for the final epic is recorded in the matrix metadata and
-in ``.notes/eeglab-final-parity-audit.md``. It is modeled after EEGLAB's user
-docs but must describe EEGPrep's standalone Python, Qt GUI, and
-``eegprep-console`` behavior, not MATLAB runtime behavior.
+in ``.notes/eeglab-final-parity-audit.md``. It should be useful to EEG
+researchers first: describe EEGPrep's standalone Python package, Qt GUI, and
+``eegprep-console`` behavior accurately, and use EEGLAB comparisons only where
+they help users migrate or understand familiar concepts.
 
 Building Documentation
 ======================

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -308,13 +308,22 @@ Building Documentation
 Build HTML Documentation
 ------------------------
 
-Navigate to the docs directory and build:
+Sync the docs extra, then build with the same command used by the Phase 7
+acceptance criteria:
+
+.. code-block:: bash
+
+    uv sync --group dev --extra docs
+    uv run --no-sync sphinx-build -b html docs/source docs/_build/html
+
+The ``docs/Makefile`` target remains available for local iteration:
 
 .. code-block:: bash
 
     uv run make -C docs html
 
-The built documentation is in ``docs/build/html/``.
+The direct Sphinx command writes to ``docs/_build/html/``. The Makefile target
+writes to ``docs/build/html/``.
 
 View Documentation Locally
 ---------------------------

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -90,7 +90,7 @@ All gallery examples are designed to be self-contained and executable:
 4. **Documentation** - Each example includes detailed comments explaining each step
 
 The user guide tutorials use the repository's checked-in ``sample_data`` files
-when the workflow is easier to understand with EEGLAB-style datasets:
+when the workflow is easier to understand with tutorial datasets:
 
 - :ref:`quickstart`
 - :ref:`gui_tutorials`

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -82,12 +82,20 @@ These examples show package-level imports and interactive-session patterns:
 Running the Examples
 ====================
 
-All examples are designed to be self-contained and executable:
+All gallery examples are designed to be self-contained and executable:
 
 1. **Synthetic Data** - Examples use synthetic data to avoid external dependencies
 2. **No Setup Required** - All necessary imports and data generation are included
 3. **Visualization** - Examples generate plots showing preprocessing effects
 4. **Documentation** - Each example includes detailed comments explaining each step
+
+The user guide tutorials use the repository's checked-in ``sample_data`` files
+when the workflow is easier to understand with EEGLAB-style datasets:
+
+- :ref:`quickstart`
+- :ref:`gui_tutorials`
+- :ref:`scripting_workflows`
+- :ref:`mne_integration`
 
 Example Structure
 =================

--- a/docs/source/examples/plot_artifact_removal.py
+++ b/docs/source/examples/plot_artifact_removal.py
@@ -17,6 +17,8 @@ The workflow includes:
 This example shows how different artifact removal strategies affect EEG data
 quality and how to choose appropriate methods for your analysis.
 
+Background references include [1]_ and [2]_.
+
 References
 ----------
 .. [1] Jas, M., Engemann, D. A., Bekhti, Y., Raimondo, F., & Gramfort, A.

--- a/docs/source/examples/plot_basic_preprocessing.py
+++ b/docs/source/examples/plot_basic_preprocessing.py
@@ -16,6 +16,8 @@ The workflow includes:
 This example is self-contained and executable, requiring only synthetic data
 generation. It serves as a template for preprocessing real EEG datasets.
 
+Background references include [1]_ and [2]_.
+
 References
 ----------
 .. [1] Delorme, A., & Makeig, S. (2004). EEGLAB: an open source toolbox for

--- a/docs/source/examples/plot_bids_pipeline.py
+++ b/docs/source/examples/plot_bids_pipeline.py
@@ -19,6 +19,8 @@ The workflow includes:
 This example shows how eegprep integrates with BIDS to provide a
 standardized, reproducible preprocessing workflow.
 
+Background references include [1]_ and [2]_.
+
 References
 ----------
 .. [1] Gorgolewski, K. J., Auer, T., Calhoun, V. D., Craddock, R. C.,

--- a/docs/source/examples/plot_channel_interpolation.py
+++ b/docs/source/examples/plot_channel_interpolation.py
@@ -26,6 +26,8 @@ The workflow includes:
 This example demonstrates best practices for channel quality control
 and recovery in EEG preprocessing pipelines.
 
+Background references include [1]_ and [2]_.
+
 References
 ----------
 .. [1] Perrin, F., Pernier, J., Bertrand, O., & Echallier, J. F. (1989).

--- a/docs/source/examples/plot_ica_and_iclabel.py
+++ b/docs/source/examples/plot_ica_and_iclabel.py
@@ -21,6 +21,8 @@ The workflow includes:
 This example demonstrates best practices for ICA-based artifact removal,
 a standard approach in modern EEG preprocessing pipelines.
 
+Background references include [1]_ and [2]_.
+
 References
 ----------
 .. [1] Pion-Tonachini, L., Kreutz-Delgado, K., & Makeig, S. (2019).

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -85,18 +85,21 @@ EEGPrep supports multiple formats:
 
 .. code-block:: python
 
-    import eegprep
+    from pathlib import Path
+
+    import mne
+    from eegprep import bids_list_eeg_files, eeg_mne2eeg, pop_load_frombids, pop_loadset
 
     # Load EEGLAB .set file
-    eeg = eegprep.EEGobj.load('data.set')
+    EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
 
-    # Load from BIDS dataset
-    eeg = eegprep.pop_load_frombids('/path/to/bids', 'sub-001')
+    # Load from a BIDS dataset
+    files = bids_list_eeg_files("/path/to/bids-root", subjects=["001"])
+    EEG = pop_load_frombids(files[0])
 
     # Load from MNE-Python
-    import mne
-    raw = mne.io.read_raw_edf('data.edf')
-    eeg = eegprep.eeg_mne2eeg(raw)
+    raw = mne.io.read_raw_edf("data.edf", preload=True)
+    EEG = eeg_mne2eeg(raw)
 
 What data formats are supported?
 --------------------------------
@@ -117,19 +120,18 @@ Apply preprocessing steps in sequence:
 
 .. code-block:: python
 
-    import eegprep
+    from eegprep import pop_clean_rawdata, pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
 
     # Load data
-    eeg = eegprep.EEGobj.load('data.set')
+    EEG = pop_loadset("data.set")
 
-    # Apply preprocessing pipeline
-    eeg = eegprep.clean_flatlines(eeg)
-    eeg = eegprep.clean_channels(eeg)
-    eeg = eegprep.clean_artifacts(eeg)
-    eeg = eegprep.clean_drifts(eeg)
+    # Apply preprocessing steps
+    EEG, filter_com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False, return_com=True)
+    EEG, resample_com = pop_resample(EEG, 128, return_com=True)
+    EEG, clean_com = pop_clean_rawdata(EEG, BurstCriterion=20, return_com=True)
 
     # Save processed data
-    eeg.save('data_processed.set')
+    pop_saveset(EEG, "data_processed.set")
 
 How do I save processed data?
 -----------------------------
@@ -178,20 +180,15 @@ Yes! EEGPrep integrates seamlessly with MNE-Python:
 How do I work with BIDS datasets?
 ---------------------------------
 
-Load and process BIDS data:
+Load and process data, then export a BIDS-style folder:
 
 .. code-block:: python
 
-    import eegprep
+    from eegprep import pop_clean_rawdata, pop_exportbids, pop_loadset
 
-    # Load from BIDS
-    eeg = eegprep.pop_load_frombids('/path/to/bids', 'sub-001', 'ses-01')
-
-    # Process
-    eeg = eegprep.clean_artifacts(eeg)
-
-    # Save back to BIDS
-    eeg.save_bids('/path/to/bids', 'sub-001', 'ses-01')
+    EEG = pop_loadset("data.set")
+    EEG, clean_com = pop_clean_rawdata(EEG, BurstCriterion=20, return_com=True)
+    pop_exportbids(EEG, "/path/to/bids-export", subject="001", task="rest")
 
 Performance FAQ
 ===============
@@ -419,7 +416,7 @@ BIDS (Brain Imaging Data Structure) is a standard for organizing neuroimaging da
 - Easy sharing
 - Automated processing
 
-Learn more: `BIDS Documentation <https://bids-standard.github.io/>`_
+Learn more: `BIDS Specification <https://bids-specification.readthedocs.io/en/stable/>`_
 
 How do I convert data to BIDS?
 ------------------------------
@@ -428,10 +425,10 @@ Use the BIDS converter:
 
 .. code-block:: python
 
-    import eegprep
+    from eegprep import pop_exportbids, pop_loadset
 
-    eeg = eegprep.EEGobj.load('data.set')
-    eeg.save_bids('/path/to/bids', 'sub-001', 'ses-01')
+    EEG = pop_loadset("data.set")
+    pop_exportbids(EEG, "/path/to/bids-export", subject="001", task="rest")
 
 What's the difference between .set and .fdt files?
 --------------------------------------------------

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -276,6 +276,6 @@ Additional Resources
 ====================
 
 - `EEGLAB Wiki <https://sccn.ucsd.edu/wiki/EEGLAB>`_ - EEGLAB documentation
-- `MNE-Python Glossary <https://mne.tools/stable/glossary.html>`_ - MNE-Python glossary
+- `MNE-Python Glossary <https://mne.tools/stable/documentation/glossary.html>`_ - MNE-Python glossary
 - `Signal Processing Basics <https://en.wikipedia.org/wiki/Signal_processing>`_ - Wikipedia overview
 - `EEG Analysis Tutorials <https://mne.tools/stable/auto_tutorials/index.html>`_ - MNE-Python tutorials

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,75 +1,123 @@
-.. eegprep documentation master file, created by sphinx-quickstart on 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-========
-eegprep
-========
-
-A comprehensive Python EEG preprocessing pipeline for neuroscience research.
+=======
+EEGPrep
+=======
 
 .. raw:: html
 
-   <div style="text-align: center; margin: 2rem 0;">
-      <p style="font-size: 1.1rem; margin-bottom: 0.5rem;">Get started with:</p>
-      <div style="background-color: #f5f5f5; padding: 1rem; border-radius: 0.5rem; display: inline-block; border-left: 4px solid #0066cc;">
-         <code style="font-size: 1.1rem; color: #0066cc; font-weight: 500;">uv add eegprep</code>
-      </div>
+   <div class="eegprep-hero">
+     <div class="eegprep-kicker">Standalone Python manual for EEGLAB users</div>
+     <p>EEGPrep ports core EEGLAB preprocessing ideas, names, data structures,
+     GUI workflows, command history, and bundled plugin behavior into a Python
+     package that can run without a MATLAB or EEGLAB checkout.</p>
    </div>
+
+Use this manual as a working path, not only as an API index. Start with the
+sample datasets in ``sample_data/``, move between the Qt GUI and
+``eegprep-console``, then reuse the recorded ``pop_*`` commands in scripts.
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Start and Load Data
+      :link: user_guide/quickstart
+      :link-type: doc
+
+      Install EEGPrep, launch the GUI/console, load ``eeglab_data.set``, inspect
+      the EEG structure, and save the result.
+
+   .. grid-item-card:: Learn the Data Model
+      :link: user_guide/concepts
+      :link-type: doc
+
+      Understand ``EEG``, ``ALLEEG``, events, epochs, channel locations, ICA
+      fields, STUDY, and history replay.
+
+   .. grid-item-card:: Follow GUI Workflows
+      :link: user_guide/gui_tutorials
+      :link-type: doc
+
+      Run EEGLAB-style menus for filtering, rejection, ICA, ICLabel, EEGBrowser,
+      STUDY, and DIPFIT while tracking console state.
+
+   .. grid-item-card:: Script the Same Steps
+      :link: user_guide/scripting_workflows
+      :link-type: doc
+
+      Convert menu history into reusable Python scripts and batch workflows.
+
+Manual
+======
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Workflows
 
-   api/index
    user_guide/index
    examples/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   api/index
+   faq
+   glossary
+   references
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Project
+
    contributing
    development
-   faq
-   references
    changelog
-   glossary
 
-Quick Start
-===========
+Five-Minute Script
+==================
 
-See the :ref:`quickstart` guide for a full walk-through of loading, preprocessing, and saving EEG data. A minimal example:
+Load the checked-in EEGLAB tutorial dataset, run two common preprocessing steps,
+and keep the replayable command strings.
 
 .. code-block:: python
 
-   from eegprep import pop_loadset, pop_saveset, clean_artifacts
+   from pathlib import Path
+   from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
 
-   eeg = pop_loadset('sample_data.set')
-   eeg = clean_artifacts(eeg)
-   pop_saveset(eeg, 'sample_data_preprocessed.set')
+   sample = Path("sample_data") / "eeglab_data.set"
+   EEG = pop_loadset(sample)
 
-Features
-========
+   EEG, filter_com = pop_eegfiltnew(EEG, locutoff=1.0, hicutoff=40.0, return_com=True)
+   EEG, resample_com = pop_resample(EEG, 64, return_com=True)
+   pop_saveset(EEG, Path("sample_data") / "eeglab_data_preprocessed.set")
 
-- **Comprehensive preprocessing**: Artifact removal, channel cleaning, and data quality assessment
-- **ICA-based component classification**: Automatic IC labeling using ICLabel
-- **BIDS compatibility**: Direct support for BIDS-formatted EEG datasets
-- **MNE integration**: Seamless conversion between eegprep and MNE-Python formats
-- **Flexible pipeline**: Mix and match preprocessing steps for your specific needs
-- **Well-documented**: Extensive API documentation and user guides
+   print(filter_com)
+   print(resample_com)
 
-Quick Links
-===========
+Where EEGLAB Users Should Go First
+==================================
 
-- :doc:`API Reference <api/index>` - Complete API documentation
-- :doc:`User Guide <user_guide/index>` - Detailed usage guides and tutorials
-- :doc:`Examples <examples/index>` - Example scripts and notebooks
-- :doc:`Contributing <contributing>` - Contributing guidelines and code of conduct
-- :doc:`Development <development>` - Development setup and debugging
-- :doc:`FAQ <faq>` - Frequently asked questions
-- :doc:`References <references>` - Key publications and related tools
-- :doc:`Changelog <changelog>` - Version history and release notes
-- :doc:`Glossary <glossary>` - EEG and signal processing terminology
-- `GitHub Repository <https://github.com/sccn/eegprep>`_ - Source code and issue tracker
+.. list-table::
+   :header-rows: 1
 
-Indices and tables
-==================
+   * - If you know EEGLAB as...
+     - Start here in EEGPrep
+   * - ``EEG`` / ``ALLEEG`` / ``CURRENTSET``
+     - :doc:`user_guide/concepts`
+   * - GUI menus plus MATLAB command history
+     - :doc:`user_guide/gui_tutorials` and :doc:`user_guide/interactive_console`
+   * - ``pop_*`` scripts
+     - :doc:`user_guide/scripting_workflows` and :doc:`api/pop_functions`
+   * - clean_rawdata, FIRFilt, ICLabel, DIPFIT, EEG-BIDS
+     - :doc:`user_guide/plugins`
+   * - EEGBrowser and visual rejection
+     - :doc:`user_guide/eegbrowser`
+   * - STUDY workflows
+     - :doc:`user_guide/study_workflows`
+   * - MNE-Python interop
+     - :doc:`user_guide/mne_integration`
+
+Indices
+=======
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,10 +5,11 @@ EEGPrep
 .. raw:: html
 
    <div class="eegprep-hero">
-     <div class="eegprep-kicker">Standalone Python manual for EEGLAB users</div>
-     <p>EEGPrep ports core EEGLAB preprocessing ideas, names, data structures,
-     GUI workflows, command history, and bundled plugin behavior into a Python
-     package that can run without a MATLAB or EEGLAB checkout.</p>
+     <div class="eegprep-kicker">Standalone EEG preprocessing for researchers</div>
+     <p>EEGPrep is a Python application for loading, cleaning, reviewing, and
+     scripting EEG datasets. It keeps familiar EEG workflow concepts where they
+     help, but the package, GUI, console, help, examples, and documentation are
+     EEGPrep-owned and work without a MATLAB or EEGLAB checkout.</p>
    </div>
 
 Use this manual as a working path, not only as an API index. Start with the
@@ -32,12 +33,19 @@ sample datasets in ``sample_data/``, move between the Qt GUI and
       Understand ``EEG``, ``ALLEEG``, events, epochs, channel locations, ICA
       fields, STUDY, and history replay.
 
+   .. grid-item-card:: Work in GUI and Console
+      :link: user_guide/gui_console_session
+      :link-type: doc
+
+      Keep the main window and ``eegprep-console`` side by side: run menu
+      actions, inspect ``EEG`` and history, then continue from Python.
+
    .. grid-item-card:: Follow GUI Workflows
       :link: user_guide/gui_tutorials
       :link-type: doc
 
-      Run EEGLAB-style menus for filtering, rejection, ICA, ICLabel, EEGBrowser,
-      STUDY, and DIPFIT while tracking console state.
+      Run menu workflows for filtering, rejection, ICA, ICLabel, EEGBrowser,
+      STUDY, and DIPFIT while tracking the same session from the console.
 
    .. grid-item-card:: Script the Same Steps
       :link: user_guide/scripting_workflows
@@ -75,8 +83,8 @@ Manual
 Five-Minute Script
 ==================
 
-Load the checked-in EEGLAB tutorial dataset, run two common preprocessing steps,
-and keep the replayable command strings.
+Load the checked-in tutorial dataset, run two common preprocessing steps, and
+keep the replayable command strings.
 
 .. code-block:: python
 
@@ -104,7 +112,8 @@ Where EEGLAB Users Should Go First
    * - ``EEG`` / ``ALLEEG`` / ``CURRENTSET``
      - :doc:`user_guide/concepts`
    * - GUI menus plus MATLAB command history
-     - :doc:`user_guide/gui_tutorials` and :doc:`user_guide/interactive_console`
+     - :doc:`user_guide/gui_console_session`, :doc:`user_guide/gui_tutorials`,
+       and :doc:`user_guide/interactive_console`
    * - ``pop_*`` scripts
      - :doc:`user_guide/scripting_workflows` and :doc:`api/pop_functions`
    * - clean_rawdata, FIRFilt, ICLabel, DIPFIT, EEG-BIDS

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -156,13 +156,11 @@ Forums and Communities
 
 **GitHub**
 
-- `EEGPrep Issues <https://github.com/NeuroTechX/eegprep/issues>`_ - Report bugs and ask questions
-- `EEGPrep Discussions <https://github.com/NeuroTechX/eegprep/discussions>`_ - Community discussions
+- `EEGPrep Issues <https://github.com/sccn/eegprep/issues>`_ - Report bugs and ask questions
 
-**NeuroTalk**
+**EEG Community Lists**
 
-- `NeuroTalk Forums <https://www.neurotalk.org/>`_ - Neuroscience discussion forums
-- EEG and neuroimaging discussions
+- `EEGLAB mailing list <https://sccn.ucsd.edu/mailman/listinfo/eeglablist>`_ - EEG and neuroimaging discussions
 
 **Stack Overflow**
 
@@ -199,16 +197,16 @@ If you use EEGPrep in your research, please cite it as:
       title={EEGPrep: A comprehensive Python EEG preprocessing pipeline},
       author={EEGPrep Contributors},
       year={2024},
-      url={https://github.com/NeuroTechX/eegprep}
+      url={https://github.com/sccn/eegprep}
     }
 
 **APA Format**:
 
-EEGPrep Contributors. (2024). EEGPrep: A comprehensive Python EEG preprocessing pipeline. Retrieved from https://github.com/NeuroTechX/eegprep
+EEGPrep Contributors. (2024). EEGPrep: A comprehensive Python EEG preprocessing pipeline. Retrieved from https://github.com/sccn/eegprep
 
 **Chicago Format**:
 
-EEGPrep Contributors. "EEGPrep: A comprehensive Python EEG preprocessing pipeline." Accessed 2024. https://github.com/NeuroTechX/eegprep.
+EEGPrep Contributors. "EEGPrep: A comprehensive Python EEG preprocessing pipeline." Accessed 2024. https://github.com/sccn/eegprep.
 
 Citing Dependencies
 -------------------
@@ -265,14 +263,14 @@ Acknowledgments
 Contributors
 ------------
 
-EEGPrep is developed and maintained by the NeuroTechX community. We thank all contributors who have helped improve the project through code contributions, bug reports, and feedback.
+EEGPrep is developed and maintained by SCCN contributors and the EEG research community. We thank all contributors who have helped improve the project through code contributions, bug reports, and feedback.
 
 Funding
 -------
 
 EEGPrep development has been supported by:
 
-- NeuroTechX community
+- SCCN and EEG community contributors
 - Open-source software initiatives
 - Academic institutions
 
@@ -298,7 +296,7 @@ Getting Help with References
 
 - Check the :doc:`user_guide/index` for implementation details
 - Review :doc:`examples/index` for practical examples
-- Search `GitHub Issues <https://github.com/NeuroTechX/eegprep/issues>`_ for related discussions
+- Search `GitHub Issues <https://github.com/sccn/eegprep/issues>`_ for related discussions
 - Contact the maintainers for citation questions
 
 For more information about EEG analysis methods, see the :doc:`glossary` for terminology definitions.

--- a/docs/source/sg_execution_times.rst
+++ b/docs/source/sg_execution_times.rst
@@ -6,7 +6,7 @@
 
 Computation times
 =================
-**00:06.094** total execution time for 5 files **from all galleries**:
+**00:05.502** total execution time for 6 files **from all galleries**:
 
 .. container::
 
@@ -33,17 +33,20 @@ Computation times
      - Time
      - Mem (MB)
    * - :ref:`sphx_glr_auto_examples_plot_artifact_removal.py` (``examples/plot_artifact_removal.py``)
-     - 00:02.858
+     - 00:02.674
      - 0.0
    * - :ref:`sphx_glr_auto_examples_plot_ica_and_iclabel.py` (``examples/plot_ica_and_iclabel.py``)
-     - 00:01.413
+     - 00:01.287
      - 0.0
    * - :ref:`sphx_glr_auto_examples_plot_basic_preprocessing.py` (``examples/plot_basic_preprocessing.py``)
-     - 00:01.268
+     - 00:01.154
      - 0.0
    * - :ref:`sphx_glr_auto_examples_plot_channel_interpolation.py` (``examples/plot_channel_interpolation.py``)
-     - 00:00.359
+     - 00:00.339
      - 0.0
    * - :ref:`sphx_glr_auto_examples_plot_bids_pipeline.py` (``examples/plot_bids_pipeline.py``)
-     - 00:00.197
+     - 00:00.048
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_plot_public_api_and_plugins.py` (``examples/plot_public_api_and_plugins.py``)
+     - 00:00.000
      - 0.0

--- a/docs/source/user_guide/advanced_topics.rst
+++ b/docs/source/user_guide/advanced_topics.rst
@@ -4,628 +4,246 @@
 Advanced Topics
 ===============
 
-This guide covers advanced topics for experienced users, including custom preprocessing chains, extending the pipeline, MNE-Python integration, parallel processing, and performance optimization.
+This page collects patterns for experienced EEGPrep users who are building lab
+pipelines, batch scripts, or small extensions. The examples use EEGPrep's
+current dictionary-based EEG data model and explicit ``pop_*`` calls.
 
-Custom Preprocessing Chains
-===========================
+Custom Pipelines
+================
 
-Building Custom Pipelines
---------------------------
-
-Create a custom preprocessing pipeline tailored to your specific needs:
-
-.. code-block:: python
-
-    from eegprep import (
-        clean_flatlines,
-        clean_channels,
-        pop_resample,
-        pop_eegfiltnew,
-        eeg_picard,
-        iclabel,
-        eeg_interp
-    )
-
-    def custom_pipeline(eeg, params=None):
-        """Custom preprocessing pipeline with logging"""
-
-        if params is None:
-            params = {}
-
-        # Set defaults
-        flatline_crit = params.get('flatline_criterion', 5)
-        highpass = params.get('highpass', 1)
-        lowpass = params.get('lowpass', 100)
-        resample_rate = params.get('resample_rate', 250)
-        asr_crit = params.get('asr_criterion', 20)
-
-        print(f"Starting preprocessing with {eeg.nbchan} channels")
-
-        # Step 1: Remove flatlines
-        print("Step 1: Removing flatlines...")
-        eeg = clean_flatlines(eeg, flatline_criterion=flatline_crit)
-        print(f"  Channels remaining: {eeg.nbchan}")
-
-        # Step 2: Remove noisy channels
-        print("Step 2: Removing noisy channels...")
-        eeg = clean_channels(eeg)
-        print(f"  Channels remaining: {eeg.nbchan}")
-
-        # Step 3: Interpolate removed channels
-        print("Step 3: Interpolating removed channels...")
-        eeg = eeg_interp(eeg)
-
-        # Step 4: Resample
-        print(f"Step 4: Resampling to {resample_rate} Hz...")
-        eeg = pop_resample(eeg, resample_rate)
-
-        # Step 5: Filter
-        print(f"Step 5: Filtering {highpass}-{lowpass} Hz...")
-        eeg = pop_eegfiltnew(eeg, locutoff=highpass, hicutoff=lowpass)
-
-        # Step 6: ICA
-        print("Step 6: Running ICA...")
-        eeg = eeg_picard(eeg)
-        print(f"  Components: {eeg.icaweights.shape[0]}")
-
-        # Step 7: Component classification
-        print("Step 7: Classifying components...")
-        eeg = iclabel(eeg)
-
-        print("Preprocessing complete!")
-        return eeg
-
-    # Use custom pipeline
-    params = {
-        'flatline_criterion': 5,
-        'highpass': 1,
-        'lowpass': 100,
-        'resample_rate': 250,
-        'asr_criterion': 20
-    }
-    eeg = custom_pipeline(eeg, params)
-
-Conditional Preprocessing
---------------------------
-
-Apply different preprocessing based on data characteristics:
+A reliable custom pipeline is just a Python function that accepts an EEG
+dictionary, returns an EEG dictionary, and records command strings when you want
+to reproduce the workflow later.
 
 .. code-block:: python
 
-    from eegprep import clean_artifacts, eeg_rpsd
+   from pathlib import Path
 
-    def adaptive_preprocessing(eeg):
-        """Adapt preprocessing based on data quality"""
+   from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
 
-        # Assess data quality
-        psd = eeg_rpsd(eeg)
-        noise_level = psd[50:100].mean()
+   def tutorial_pipeline(EEG, *, output_rate=64):
+       history = []
 
-        if noise_level > 100:
-            # High noise: aggressive preprocessing
-            print("High noise detected: using aggressive preprocessing")
-            eeg = clean_artifacts(
-                eeg,
-                asr_criterion=15,
-                flatline_criterion=3
-            )
-        elif noise_level > 50:
-            # Medium noise: standard preprocessing
-            print("Medium noise detected: using standard preprocessing")
-            eeg = clean_artifacts(eeg)
-        else:
-            # Low noise: conservative preprocessing
-            print("Low noise detected: using conservative preprocessing")
-            eeg = clean_artifacts(
-                eeg,
-                asr_criterion=25,
-                flatline_criterion=10
-            )
+       EEG, com = pop_eegfiltnew(
+           EEG,
+           locutoff=1,
+           hicutoff=40,
+           plotfreqz=False,
+           return_com=True,
+       )
+       history.append(com)
 
-        return eeg
+       EEG, com = pop_resample(EEG, output_rate, return_com=True)
+       history.append(com)
 
-    eeg = adaptive_preprocessing(eeg)
+       return EEG, history
 
-Extending the Pipeline
-======================
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   EEG, history = tutorial_pipeline(EEG)
+   Path("tutorial_outputs").mkdir(exist_ok=True)
+   pop_saveset(EEG, Path("tutorial_outputs") / "eeglab_data_pipeline.set")
 
-Creating Custom Functions
---------------------------
-
-Create custom preprocessing functions that integrate with eegprep:
+Use dictionary fields, not object attributes:
 
 .. code-block:: python
 
-    from eegprep import EEGobj
-    import numpy as np
+   print(EEG["nbchan"], EEG["pnts"], EEG["srate"])
+   print(EEG["data"].shape)
+   print(EEG.get("history", ""))
 
-    def custom_artifact_removal(eeg, threshold=3):
-        """Custom artifact removal based on amplitude threshold"""
+Conditional Steps
+=================
 
-        if not isinstance(eeg, EEGobj):
-            raise TypeError("Input must be an EEGobj")
-
-        # Find samples exceeding threshold
-        artifact_samples = np.where(
-            np.abs(eeg.data).max(axis=0) > threshold * np.std(eeg.data)
-        )[0]
-
-        # Mark artifacts
-        if not hasattr(eeg, 'removed_windows'):
-            eeg.removed_windows = []
-
-        eeg.removed_windows.extend(artifact_samples)
-
-        print(f"Marked {len(artifact_samples)} artifact samples")
-        return eeg
-
-    # Use custom function
-    eeg = custom_artifact_removal(eeg, threshold=5)
-
-Creating Preprocessing Decorators
-----------------------------------
-
-Use decorators to add functionality to preprocessing functions:
+Inspect the current EEG dictionary and make explicit decisions:
 
 .. code-block:: python
 
-    import time
-    from functools import wraps
+   from eegprep import pop_clean_rawdata, pop_iclabel, pop_runica
 
-    def timing_decorator(func):
-        """Decorator to measure function execution time"""
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            start = time.time()
-            result = func(*args, **kwargs)
-            elapsed = time.time() - start
-            print(f"{func.__name__} took {elapsed:.2f} seconds")
-            return result
-        return wrapper
+   def clean_and_optionally_label(EEG, *, run_ica=False):
+       EEG, clean_com = pop_clean_rawdata(
+           EEG,
+           FlatlineCriterion=5,
+           ChannelCriterion=0.8,
+           LineNoiseCriterion=4,
+           Highpass=(0.25, 0.75),
+           BurstCriterion=20,
+           WindowCriterion=0.25,
+           return_com=True,
+       )
+       history = [clean_com]
 
-    def logging_decorator(func):
-        """Decorator to log function calls"""
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            print(f"Calling {func.__name__}")
-            result = func(*args, **kwargs)
-            print(f"Completed {func.__name__}")
-            return result
-        return wrapper
+       if run_ica and EEG["pnts"] > 30 * EEG["nbchan"]:
+           EEG, ica_com = pop_runica(EEG, icatype="picard", gui=False, return_com=True)
+           EEG, label_com = pop_iclabel(EEG, "default", return_com=True)
+           history.extend([ica_com, label_com])
 
-    # Apply decorators
-    @timing_decorator
-    @logging_decorator
-    def my_preprocessing(eeg):
-        from eegprep import clean_artifacts
-        return clean_artifacts(eeg)
+       return EEG, history
 
-    eeg = my_preprocessing(eeg)
+This style keeps scientific choices visible in code review and lab notebooks.
 
-Integration with MNE-Python
-============================
-
-Converting Between Formats
----------------------------
-
-Convert between eegprep and MNE-Python formats:
-
-.. code-block:: python
-
-    from eegprep import eeg_eeg2mne, eeg_mne2eeg
-    import mne
-
-    # Convert eegprep to MNE
-    raw = eeg_eeg2mne(eeg)
-
-    # Use MNE functions
-    raw.plot()
-    raw.compute_psd().plot()
-
-    # Convert back to eegprep
-    eeg = eeg_mne2eeg(raw)
-
-Using MNE Preprocessing
------------------------
-
-Combine eegprep and MNE preprocessing:
-
-.. code-block:: python
-
-    from eegprep import eeg_eeg2mne, eeg_mne2eeg, clean_artifacts
-    import mne
-
-    # Preprocess with eegprep
-    eeg = clean_artifacts(eeg)
-
-    # Convert to MNE
-    raw = eeg_eeg2mne(eeg)
-
-    # Apply MNE preprocessing
-    raw.filter(l_freq=1, h_freq=100)
-    raw.set_eeg_reference('average')
-
-    # Convert back
-    eeg = eeg_mne2eeg(raw)
-
-Epoching with MNE
------------------
-
-Create epochs using MNE and convert to eegprep:
-
-.. code-block:: python
-
-    from eegprep import eeg_eeg2mne, eeg_mne2eeg_epochs
-    import mne
-
-    # Convert to MNE
-    raw = eeg_eeg2mne(eeg)
-
-    # Create epochs
-    events = mne.find_events(raw)
-    epochs = mne.Epochs(raw, events, event_id=1, tmin=-0.2, tmax=0.5)
-
-    # Convert back to eegprep
-    eeg = eeg_mne2eeg_epochs(epochs)
-
-Parallel Processing
-===================
-
-Batch Processing with Multiprocessing
---------------------------------------
-
-Process multiple subjects in parallel:
-
-.. code-block:: python
-
-    from multiprocessing import Pool
-    from eegprep import pop_loadset, clean_artifacts, pop_saveset
-    import os
-
-    def process_subject(subject_id):
-        """Process a single subject"""
-
-        # Load data
-        input_file = f'sample_data/sub-{subject_id:02d}.set'
-        eeg = pop_loadset(input_file)
-
-        # Preprocess
-        eeg = clean_artifacts(eeg)
-
-        # Save
-        output_file = f'sample_data/preprocessed/sub-{subject_id:02d}_preprocessed.set'
-        pop_saveset(eeg, output_file)
-
-        return f"Processed subject {subject_id}"
-
-    # Process subjects in parallel
-    subject_ids = range(1, 11)  # Subjects 1-10
-
-    with Pool(processes=4) as pool:
-        results = pool.map(process_subject, subject_ids)
-
-    for result in results:
-        print(result)
-
-Using joblib for Parallel Processing
--------------------------------------
-
-Use joblib for more flexible parallel processing:
-
-.. code-block:: python
-
-    from joblib import Parallel, delayed
-    from eegprep import pop_loadset, clean_artifacts, pop_saveset
-
-    def process_subject(subject_id):
-        """Process a single subject"""
-        input_file = f'sample_data/sub-{subject_id:02d}.set'
-        eeg = pop_loadset(input_file)
-        eeg = clean_artifacts(eeg)
-        output_file = f'sample_data/preprocessed/sub-{subject_id:02d}_preprocessed.set'
-        pop_saveset(eeg, output_file)
-        return f"Processed subject {subject_id}"
-
-    # Process with joblib
-    results = Parallel(n_jobs=4)(
-        delayed(process_subject)(i) for i in range(1, 11)
-    )
-
-    for result in results:
-        print(result)
-
-GPU Acceleration
-----------------
-
-Use GPU acceleration for faster processing:
-
-.. code-block:: python
-
-    import torch
-    from eegprep import clean_artifacts
-
-    # Check GPU availability
-    if torch.cuda.is_available():
-        print(f"GPU available: {torch.cuda.get_device_name(0)}")
-        device = 'cuda'
-    else:
-        print("GPU not available, using CPU")
-        device = 'cpu'
-
-    # Preprocess with GPU
-    eeg = clean_artifacts(eeg, device=device)
-
-Performance Optimization
+Custom Marking Functions
 ========================
 
-Memory Optimization
--------------------
-
-Reduce memory usage for large datasets:
+If a lab-specific quality-control step marks samples or channels, write into
+clear EEG dictionary fields and keep NumPy indexing internal:
 
 .. code-block:: python
 
-    from eegprep import pop_loadset, pop_saveset
-    import numpy as np
+   import numpy as np
 
-    def process_in_chunks(filename, chunk_size=10):
-        """Process data in chunks to reduce memory usage"""
+   def mark_large_sample_artifacts(EEG, *, z_threshold=6):
+       data = np.asarray(EEG["data"])
+       channel_scale = np.std(data, axis=1, keepdims=True)
+       channel_scale[channel_scale == 0] = 1
+       z = np.abs(data / channel_scale)
+       bad_samples = np.flatnonzero(z.max(axis=0) > z_threshold)
 
-        # Load data
-        eeg = pop_loadset(filename)
+       reject = EEG.setdefault("reject", {})
+       reject["manual_bad_samples"] = (bad_samples + 1).tolist()
+       return EEG
 
-        # Process in chunks
-        n_chunks = int(np.ceil(eeg.pnts / (chunk_size * eeg.srate)))
+The stored sample numbers are one-based because they are user-facing EEG
+metadata. Direct array slicing remains zero-based Python.
 
-        for i in range(n_chunks):
-            start = i * chunk_size * eeg.srate
-            end = min((i + 1) * chunk_size * eeg.srate, eeg.pnts)
+Batch Processing
+================
 
-            print(f"Processing chunk {i+1}/{n_chunks}")
-            # Process chunk
-            chunk_data = eeg.data[:, start:end]
-            # ... process chunk ...
-
-        return eeg
-
-Computation Optimization
-------------------------
-
-Speed up preprocessing:
+For small local batches, use ``pathlib`` and keep outputs outside the immutable
+sample files:
 
 .. code-block:: python
 
-    from eegprep import clean_artifacts, EEG_OPTIONS
+   from pathlib import Path
 
-    # Use optimized parameters
-    options = EEG_OPTIONS()
-    options.ica_ncomps = 30  # Reduce components
-    options.filter_order = 2  # Reduce filter order
-    options.asr_wlen = 1.0   # Increase window length
+   from eegprep import pop_loadset, pop_saveset
 
-    # Preprocess with optimized settings
-    eeg = clean_artifacts(eeg, options=options)
+   input_files = sorted(Path("sample_data").glob("eeglab_data*.set"))
+   output_dir = Path("tutorial_outputs") / "batch"
+   output_dir.mkdir(parents=True, exist_ok=True)
 
-Caching Results
----------------
+   for input_file in input_files:
+       EEG = pop_loadset(input_file)
+       EEG, history = tutorial_pipeline(EEG)
+       EEG["etc"] = {**EEG.get("etc", {}), "eegprep_history": history}
+       pop_saveset(EEG, output_dir / input_file.name)
 
-Cache preprocessing results to avoid recomputation:
+For BIDS studies, prefer ``bids_preproc`` so file discovery, derivative paths,
+and sidecar handling stay consistent. See :ref:`bids_workflow`.
 
-.. code-block:: python
+Multiprocessing Pattern
+=======================
 
-    import pickle
-    import hashlib
-    from eegprep import pop_loadset, clean_artifacts
-
-    def get_preprocessed_data(filename, params):
-        """Get preprocessed data with caching"""
-
-        # Create cache key
-        cache_key = hashlib.md5(
-            f"{filename}{str(params)}".encode()
-        ).hexdigest()
-        cache_file = f"cache/{cache_key}.pkl"
-
-        # Check cache
-        try:
-            with open(cache_file, 'rb') as f:
-                eeg = pickle.load(f)
-            print(f"Loaded from cache: {cache_file}")
-            return eeg
-        except FileNotFoundError:
-            pass
-
-        # Preprocess
-        eeg = pop_loadset(filename)
-        eeg = clean_artifacts(eeg, **params)
-
-        # Save to cache
-        with open(cache_file, 'wb') as f:
-            pickle.dump(eeg, f)
-
-        return eeg
-
-Profiling and Benchmarking
---------------------------
-
-Profile preprocessing to identify bottlenecks:
+Python multiprocessing requires a main guard. Keep the worker function
+top-level so it can be imported by child processes:
 
 .. code-block:: python
 
-    import cProfile
-    import pstats
-    from eegprep import clean_artifacts
+   from concurrent.futures import ProcessPoolExecutor
+   from pathlib import Path
 
-    def profile_preprocessing(eeg):
-        """Profile preprocessing function"""
+   from eegprep import pop_loadset, pop_saveset
 
-        profiler = cProfile.Profile()
-        profiler.enable()
+   def process_one(path_text):
+       path = Path(path_text)
+       EEG = pop_loadset(path)
+       EEG, history = tutorial_pipeline(EEG)
+       output = Path("tutorial_outputs") / "parallel" / path.name
+       output.parent.mkdir(parents=True, exist_ok=True)
+       pop_saveset(EEG, output)
+       return path.name, history
 
-        # Run preprocessing
-        eeg = clean_artifacts(eeg)
+   if __name__ == "__main__":
+       files = [str(path) for path in Path("sample_data").glob("eeglab_data*.set")]
+       with ProcessPoolExecutor(max_workers=2) as pool:
+           for name, history in pool.map(process_one, files):
+               print(name, history[-1] if history else "")
 
-        profiler.disable()
+Avoid sending a live ``EEGPrepSession`` or Qt GUI object into worker processes.
+Use filenames and returned results at process boundaries.
 
-        # Print statistics
-        stats = pstats.Stats(profiler)
-        stats.sort_stats('cumulative')
-        stats.print_stats(10)  # Print top 10 functions
+MNE Interoperability
+====================
 
-        return eeg
-
-Best Practices
-==============
-
-Code Organization
------------------
-
-Organize custom preprocessing code:
-
-.. code-block:: python
-
-    # preprocessing/pipelines.py
-    from eegprep import clean_artifacts
-
-    class PreprocessingPipeline:
-        """Base class for preprocessing pipelines"""
-
-        def __init__(self, params=None):
-            self.params = params or {}
-
-        def run(self, eeg):
-            raise NotImplementedError
-
-    class RestingStatePipeline(PreprocessingPipeline):
-        """Resting state preprocessing pipeline"""
-
-        def run(self, eeg):
-            return clean_artifacts(
-                eeg,
-                highpass=1,
-                lowpass=100,
-                asr_criterion=20
-            )
-
-    class ERPPipeline(PreprocessingPipeline):
-        """ERP preprocessing pipeline"""
-
-        def run(self, eeg):
-            return clean_artifacts(
-                eeg,
-                highpass=0.1,
-                lowpass=30,
-                asr_criterion=15
-            )
-
-    # Usage
-    pipeline = RestingStatePipeline()
-    eeg = pipeline.run(eeg)
-
-Error Handling
---------------
-
-Implement robust error handling:
+Use MNE when you need MNE-specific algorithms, then convert back to an EEGPrep
+dictionary for EEGPrep GUI review or ``pop_*`` workflows:
 
 .. code-block:: python
 
-    from eegprep import pop_loadset, clean_artifacts, pop_saveset
-    import logging
+   from pathlib import Path
 
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger(__name__)
+   from eegprep import eeg_eeg2mne, eeg_mne2eeg, pop_loadset
 
-    def safe_preprocessing(filename, output_file):
-        """Preprocess with error handling"""
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   raw = eeg_eeg2mne(EEG)
+   raw.filter(l_freq=1, h_freq=40)
+   EEG = eeg_mne2eeg(raw)
 
-        try:
-            # Load data
-            logger.info(f"Loading {filename}")
-            eeg = pop_loadset(filename)
+For full examples, see :ref:`mne_integration`.
 
-            # Preprocess
-            logger.info("Preprocessing...")
-            eeg = clean_artifacts(eeg)
+Memory and Storage
+==================
 
-            # Save
-            logger.info(f"Saving to {output_file}")
-            pop_saveset(eeg, output_file)
-
-            logger.info("Success!")
-            return True
-
-        except FileNotFoundError as e:
-            logger.error(f"File not found: {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Unexpected error: {e}")
-            return False
-
-Documentation
---------------
-
-Document custom functions:
+Large projects should use the storage options instead of keeping every dataset
+resident:
 
 .. code-block:: python
 
-    def custom_preprocessing(eeg, threshold=3):
-        """
-        Apply custom artifact removal.
+   from pathlib import Path
 
-        Parameters
-        ----------
-        eeg : EEGobj
-            Input EEG data
-        threshold : float, optional
-            Amplitude threshold in standard deviations (default: 3)
+   from eegprep import EEG_OPTIONS, pop_loadset, pop_saveset
 
-        Returns
-        -------
-        eeg : EEGobj
-            Preprocessed EEG data
+   old_options = dict(EEG_OPTIONS)
+   try:
+       EEG_OPTIONS["option_savetwofiles"] = 1
+       EEG_OPTIONS["option_memmapdata"] = 1
+       EEG = pop_loadset("sample_data/eeglab_data.set")
+       output_dir = Path("tutorial_outputs") / "storage"
+       output_dir.mkdir(parents=True, exist_ok=True)
+       output_file = output_dir / "subject01.set"
+       pop_saveset(EEG, output_file)
+       EEG = pop_loadset(output_file)
+   finally:
+       EEG_OPTIONS.clear()
+       EEG_OPTIONS.update(old_options)
 
-        Examples
-        --------
-        >>> eeg = custom_preprocessing(eeg, threshold=5)
-        """
-        # Implementation
-        return eeg
+See :ref:`large_dataset_storage` for ``option_storedisk`` and two-file storage
+details.
 
-Testing
--------
+Extending EEGPrep
+=================
 
-Test custom preprocessing functions:
+Use the extension SDK for reusable lab tools instead of patching EEGPrep
+internals. A good extension:
+
+* registers an ``eegprep.extensions`` entry point;
+* exposes user-facing ``pop_*`` functions with ``return_com=True`` support;
+* packages Markdown help resources;
+* uses ``EEGPrepSession`` helpers when adding GUI actions;
+* documents the workflow in Sphinx docs and packaged help.
+
+See :ref:`extensions` and :ref:`extension_curation` for the extension contract.
+
+Testing Custom Workflows
+========================
+
+Use the checked-in sample files for smoke tests and keep assertions tied to EEG
+dictionary behavior:
 
 .. code-block:: python
 
-    import unittest
-    from eegprep import pop_loadset
+   from pathlib import Path
 
-    class TestCustomPreprocessing(unittest.TestCase):
+   from eegprep import pop_loadset
 
-        def setUp(self):
-            """Load test data"""
-            self.eeg = pop_loadset('test_data.set')
+   def test_tutorial_pipeline_preserves_eeg_shape():
+       EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+       output, history = tutorial_pipeline(EEG)
 
-        def test_preprocessing_runs(self):
-            """Test that preprocessing runs without error"""
-            eeg = custom_preprocessing(self.eeg)
-            self.assertIsNotNone(eeg)
+       assert output["nbchan"] == EEG["nbchan"]
+       assert output["pnts"] < EEG["pnts"]
+       assert history
 
-        def test_preprocessing_preserves_shape(self):
-            """Test that preprocessing preserves data shape"""
-            eeg = custom_preprocessing(self.eeg)
-            self.assertEqual(eeg.nbchan, self.eeg.nbchan)
-
-    if __name__ == '__main__':
-        unittest.main()
-
-Next Steps
-==========
-
-Now that you understand advanced topics:
-
-1. Review the :ref:`preprocessing_pipeline` guide for detailed preprocessing steps
-2. Explore the :ref:`configuration` guide for parameter tuning
-3. Check the :ref:`bids_workflow` for batch processing
-4. Review the :ref:`api_reference` for detailed function documentation
+For GUI/console synchronization changes, add coverage near
+``tests/test_console_workspace.py`` so ``EEG``, ``ALLEEG``, ``CURRENTSET``,
+``LASTCOM``, ``ALLCOM``, ``STUDY``, and ``CURRENTSTUDY`` stay synchronized.

--- a/docs/source/user_guide/bids_workflow.rst
+++ b/docs/source/user_guide/bids_workflow.rst
@@ -4,496 +4,284 @@
 BIDS Workflow
 =============
 
-This guide covers working with Brain Imaging Data Structure (BIDS) formatted datasets in eegprep. BIDS is a standardized format for organizing neuroimaging data, making it easier to share and process datasets consistently.
+EEGPrep can load BIDS EEG files, export EEGPrep datasets into a small
+BIDS-style folder, and run the bundled BIDS preprocessing helper across a BIDS
+root. This page uses the checked-in ``sample_data`` files where EEGPrep can
+create a tutorial folder locally, and it uses ``/path/to/bids-root`` whenever
+you must provide a real lab BIDS dataset.
 
-BIDS Dataset Structure
-======================
+The repository does not ship a complete BIDS study. For a real analysis, start
+with a BIDS-valid dataset from your lab and validate it with the BIDS Validator
+before batch preprocessing.
 
-A typical BIDS EEG dataset has the following structure:
+BIDS EEG Layout
+===============
 
-.. code-block:: text
-
-    dataset/
-    ├── sub-01/
-    │   ├── ses-01/
-    │   │   └── eeg/
-    │   │       ├── sub-01_ses-01_task-rest_eeg.set
-    │   │       ├── sub-01_ses-01_task-rest_eeg.fdt
-    │   │       ├── sub-01_ses-01_task-rest_channels.tsv
-    │   │       ├── sub-01_ses-01_task-rest_eeg.json
-    │   │       └── sub-01_ses-01_task-rest_events.tsv
-    │   └── ses-02/
-    │       └── eeg/
-    │           └── ...
-    ├── sub-02/
-    │   └── ses-01/
-    │       └── eeg/
-    │           └── ...
-    ├── derivatives/
-    │   └── eegprep/
-    │       ├── sub-01/
-    │       │   └── ses-01/
-    │       │       └── eeg/
-    │       │           └── sub-01_ses-01_task-rest_eeg_preprocessed.set
-    │       └── sub-02/
-    │           └── ...
-    ├── README
-    ├── CHANGES
-    ├── dataset_description.json
-    ├── participants.tsv
-    └── participants.json
-
-Key BIDS Files:
-
-- **_eeg.set**: EEGLAB format EEG data
-- **_eeg.fdt**: EEGLAB data file (binary)
-- **_channels.tsv**: Channel information (name, type, units)
-- **_eeg.json**: EEG metadata (sampling rate, reference, etc.)
-- **_events.tsv**: Event markers and timing
-- **dataset_description.json**: Dataset metadata
-- **participants.tsv**: Participant information
-
-Loading BIDS Data
-=================
-
-Using pop_load_frombids
------------------------
-
-Load a single file from a BIDS dataset:
-
-.. code-block:: python
-
-    from eegprep import pop_load_frombids
-
-    # Load a specific file
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset',
-        subject='01',
-        session='01',
-        task='rest'
-    )
-
-    print(f"Loaded: {eeg.nbchan} channels, {eeg.pnts} samples")
-    print(f"Sampling rate: {eeg.srate} Hz")
-
-**Parameters**:
-
-- ``bids_root``: Path to the BIDS dataset root directory
-- ``subject``: Subject ID (without 'sub-' prefix)
-- ``session``: Session ID (optional, without 'ses-' prefix)
-- ``task``: Task name (optional)
-- ``run``: Run number (optional)
-
-Loading with Additional Parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: python
-
-    from eegprep import pop_load_frombids
-
-    # Load with specific run and additional options
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset',
-        subject='01',
-        session='01',
-        task='oddball',
-        run='01',
-        preload=True  # Load data into memory
-    )
-
-Listing Available Files
------------------------
-
-Find all EEG files in a BIDS dataset:
-
-.. code-block:: python
-
-    from eegprep import bids_list_eeg_files
-
-    # List all EEG files
-    files = bids_list_eeg_files('sample_data/bids_dataset')
-
-    for file_info in files:
-        print(f"Subject: {file_info['subject']}")
-        print(f"Session: {file_info['session']}")
-        print(f"Task: {file_info['task']}")
-        print(f"File: {file_info['file']}")
-        print()
-
-Running Batch Preprocessing
-============================
-
-Using bids_preproc
-------------------
-
-Process all files in a BIDS dataset with a single command:
-
-.. code-block:: python
-
-    from eegprep import bids_preproc
-
-    # Run preprocessing on entire dataset
-    bids_preproc(
-        bids_root='sample_data/bids_dataset',
-        output_dir='sample_data/bids_dataset/derivatives/eegprep',
-        overwrite=False
-    )
-
-**Parameters**:
-
-- ``bids_root``: Path to BIDS dataset root
-- ``output_dir``: Output directory for preprocessed data
-- ``overwrite``: Whether to overwrite existing files
-- ``n_jobs``: Number of parallel jobs (default: 1)
-
-Batch Processing with Custom Parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: python
-
-    from eegprep import bids_preproc
-
-    # Custom preprocessing parameters
-    bids_preproc(
-        bids_root='sample_data/bids_dataset',
-        output_dir='sample_data/bids_dataset/derivatives/eegprep',
-        preproc_params={
-            'flatline_criterion': 5,
-            'highpass': 1,
-            'lowpass': 100,
-            'asr_criterion': 20,
-            'ica': True,
-            'iclabel': True
-        },
-        n_jobs=4  # Use 4 parallel jobs
-    )
-
-Parallel Processing
-~~~~~~~~~~~~~~~~~~~
-
-Process multiple subjects in parallel:
-
-.. code-block:: python
-
-    from eegprep import bids_preproc
-
-    # Process with 8 parallel jobs
-    bids_preproc(
-        bids_root='sample_data/bids_dataset',
-        output_dir='sample_data/bids_dataset/derivatives/eegprep',
-        n_jobs=8,
-        verbose=True
-    )
-
-**Note**: The number of jobs should not exceed the number of CPU cores available.
-
-Processing Specific Subjects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: python
-
-    from eegprep import bids_preproc
-
-    # Process only specific subjects
-    bids_preproc(
-        bids_root='sample_data/bids_dataset',
-        output_dir='sample_data/bids_dataset/derivatives/eegprep',
-        subjects=['01', '02', '03']
-    )
-
-Output Structure
-================
-
-After running :func:`eegprep.bids_preproc`, the output is organized in the derivatives directory:
+A typical EEG BIDS dataset stores one raw data file plus sidecars for each
+recording:
 
 .. code-block:: text
 
-    dataset/derivatives/eegprep/
-    ├── sub-01/
-    │   ├── ses-01/
-    │   │   └── eeg/
-    │   │       ├── sub-01_ses-01_task-rest_eeg_preprocessed.set
-    │   │       ├── sub-01_ses-01_task-rest_eeg_preprocessed.fdt
-    │   │       ├── sub-01_ses-01_task-rest_channels.tsv
-    │   │       └── sub-01_ses-01_task-rest_eeg.json
-    │   └── ses-02/
-    │       └── eeg/
-    │           └── ...
-    ├── sub-02/
-    │   └── ...
-    ├── dataset_description.json
-    └── README
+   dataset/
+   |-- dataset_description.json
+   |-- participants.tsv
+   `-- sub-01/
+       `-- eeg/
+           |-- sub-01_task-rest_run-01_eeg.set
+           |-- sub-01_task-rest_run-01_eeg.fdt
+           |-- sub-01_task-rest_run-01_channels.tsv
+           |-- sub-01_task-rest_run-01_events.tsv
+           `-- sub-01_task-rest_run-01_eeg.json
 
-Derivatives Format
-------------------
+EEGPrep's BIDS loader supports EEGLAB ``.set``/``.fdt``, BrainVision
+``.vhdr``, EDF, and BDF EEG files. Sidecars can replace or merge metadata,
+events, and channel information into the returned EEG dictionary.
 
-The derivatives directory follows BIDS format with:
-
-- **_preprocessed.set**: Preprocessed EEG data
-- **_preprocessed.fdt**: Preprocessed data file
-- **channels.tsv**: Updated channel information
-- **eeg.json**: Updated metadata
-- **dataset_description.json**: Derivatives dataset description
-
-Loading Preprocessed Data
---------------------------
-
-Load preprocessed data from derivatives:
-
-.. code-block:: python
-
-    from eegprep import pop_load_frombids
-
-    # Load preprocessed data
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset/derivatives/eegprep',
-        subject='01',
-        session='01',
-        task='rest'
-    )
-
-Integration with Other Tools
-=============================
-
-Integration with MNE-Python
-----------------------------
-
-Convert eegprep data to MNE format:
-
-.. code-block:: python
-
-    from eegprep import eeg_eeg2mne
-    import mne
-
-    # Convert to MNE Raw object
-    raw = eeg_eeg2mne(eeg)
-
-    # Now use MNE functions
-    raw.plot()
-    raw.compute_psd().plot()
-
-Converting Back to eegprep
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: python
-
-    from eegprep import eeg_mne2eeg
-
-    # Convert MNE Raw back to eegprep format
-    eeg = eeg_mne2eeg(raw)
-
-Integration with EEGLAB
------------------------
-
-Save preprocessed data in EEGLAB format:
-
-.. code-block:: python
-
-    from eegprep import pop_saveset
-
-    # Save as EEGLAB .set file
-    pop_saveset(eeg, 'preprocessed_data.set')
-
-Load EEGLAB files:
-
-.. code-block:: python
-
-    from eegprep import pop_loadset
-
-    # Load EEGLAB .set file
-    eeg = pop_loadset('data.set')
-
-Working with BIDS Metadata
-===========================
-
-Accessing Channel Information
-------------------------------
-
-.. code-block:: python
-
-    from eegprep import pop_load_frombids
-
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset',
-        subject='01',
-        session='01',
-        task='rest'
-    )
-
-    # Access channel information
-    for i, chan in enumerate(eeg.chanlocs):
-        print(f"Channel {i}: {chan['labels']}")
-        print(f"  Type: {chan['type']}")
-        print(f"  Location: ({chan['X']}, {chan['Y']}, {chan['Z']})")
-
-Accessing Event Information
-----------------------------
-
-.. code-block:: python
-
-    # Access events
-    if hasattr(eeg, 'event'):
-        for event in eeg.event:
-            print(f"Event type: {event['type']}")
-            print(f"Latency: {event['latency']} samples")
-            print(f"Duration: {event['duration']} samples")
-
-Accessing Metadata
--------------------
-
-.. code-block:: python
-
-    # Access BIDS metadata
-    if hasattr(eeg, 'etc') and 'bids' in eeg.etc:
-        bids_info = eeg.etc.bids
-        print(f"Task: {bids_info.get('task')}")
-        print(f"Sampling rate: {bids_info.get('srate')} Hz")
-
-Common BIDS Workflows
-=====================
-
-Complete Preprocessing Workflow
--------------------------------
-
-.. code-block:: python
-
-    from eegprep import (
-        pop_load_frombids,
-        clean_artifacts,
-        iclabel,
-        pop_saveset
-    )
-
-    # 1. Load data
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset',
-        subject='01',
-        session='01',
-        task='rest'
-    )
-
-    # 2. Preprocess
-    eeg = clean_artifacts(
-        eeg,
-        highpass=1,
-        lowpass=100,
-        ica=True,
-        iclabel=True
-    )
-
-    # 3. Save to derivatives
-    pop_saveset(
-        eeg,
-        'sample_data/bids_dataset/derivatives/eegprep/sub-01/ses-01/eeg/sub-01_ses-01_task-rest_eeg_preprocessed.set'
-    )
-
-Batch Processing with Quality Control
---------------------------------------
-
-.. code-block:: python
-
-    from eegprep import bids_preproc, bids_list_eeg_files
-    import json
-
-    # 1. List all files
-    files = bids_list_eeg_files('sample_data/bids_dataset')
-    print(f"Found {len(files)} EEG files")
-
-    # 2. Run preprocessing
-    bids_preproc(
-        bids_root='sample_data/bids_dataset',
-        output_dir='sample_data/bids_dataset/derivatives/eegprep',
-        n_jobs=4
-    )
-
-    # 3. Create processing report
-    report = {
-        'total_files': len(files),
-        'preprocessing_date': '2024-01-01',
-        'parameters': {
-            'highpass': 1,
-            'lowpass': 100,
-            'ica': True
-        }
-    }
-
-    with open('preprocessing_report.json', 'w') as f:
-        json.dump(report, f, indent=2)
-
-Troubleshooting BIDS Workflows
+Create a Small Tutorial Export
 ==============================
 
-File Not Found
---------------
-
-**Problem**: ``FileNotFoundError`` when loading BIDS data
-
-**Solution**:
-
-1. Verify BIDS dataset structure
-2. Check subject and session IDs
-3. Use :func:`eegprep.bids_list_eeg_files` to find available files
+Use ``pop_exportbids`` when you want a local folder to inspect the path layout
+without downloading a public BIDS dataset:
 
 .. code-block:: python
 
-    from eegprep import bids_list_eeg_files
+   from pathlib import Path
 
-    files = bids_list_eeg_files('sample_data/bids_dataset')
-    for f in files:
-        print(f"sub-{f['subject']}_ses-{f['session']}_task-{f['task']}")
+   from eegprep import bids_list_eeg_files, pop_exportbids, pop_load_frombids, pop_loadset
 
-Invalid BIDS Format
--------------------
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   export_root = Path("tutorial_outputs") / "bids_demo"
+   export_root.mkdir(parents=True, exist_ok=True)
 
-**Problem**: Data doesn't conform to BIDS standard
+   bids_root = pop_exportbids(EEG, export_root, subject="01", task="tutorial")
+   eeg_files = bids_list_eeg_files(bids_root)
+   print(eeg_files)
 
-**Solution**:
+   EEG = pop_load_frombids(eeg_files[0])
+   print(EEG["setname"], EEG["nbchan"], EEG["pnts"], EEG["srate"])
 
-1. Validate BIDS dataset using the BIDS Validator
-2. Check dataset_description.json
-3. Verify file naming conventions
+This export is useful for learning EEGPrep's BIDS file handling. It is not a
+replacement for a curated experimental BIDS dataset with full study metadata.
 
-Parallel Processing Errors
----------------------------
+List Files in a Real BIDS Root
+==============================
 
-**Problem**: Errors when using ``n_jobs > 1``
+Use ``bids_list_eeg_files`` to discover supported EEG recordings:
 
-**Solution**:
+.. code-block:: python
 
-1. Start with ``n_jobs=1`` to identify the issue
-2. Check for file locking issues
-3. Ensure output directory is writable
-4. Reduce ``n_jobs`` if system resources are limited
+   from eegprep import bids_list_eeg_files
 
-Memory Issues
--------------
+   files = bids_list_eeg_files(
+       "/path/to/bids-root",
+       subjects=["01", "02"],
+       tasks=["rest"],
+   )
 
-**Problem**: Out of memory errors during batch processing
+   for filename in files:
+       print(filename)
 
-**Solution**:
+The function returns file paths as strings. Query values use raw BIDS
+identifiers such as ``"01"`` and ``"rest"``, not prefixed values such as
+``"sub-01"`` or ``"task-rest"``.
 
-1. Reduce ``n_jobs`` to process fewer files in parallel
-2. Process subjects in smaller batches
-3. Increase available system RAM
-4. Use a machine with more memory
+Load One BIDS EEG File
+======================
 
-Best Practices
-==============
+``pop_load_frombids`` takes a concrete EEG data-file path, not a root/query
+combination:
 
-1. **Validate BIDS format**: Use the BIDS Validator before processing
-2. **Backup original data**: Keep a copy of raw data before preprocessing
-3. **Document parameters**: Record preprocessing parameters in a configuration file
-4. **Quality control**: Visually inspect preprocessed data
-5. **Version control**: Track eegprep version used for reproducibility
-6. **Parallel processing**: Use ``n_jobs`` to speed up batch processing
-7. **Monitor progress**: Use ``verbose=True`` to track processing status
+.. code-block:: python
 
-Next Steps
-==========
+   from eegprep import pop_load_frombids
 
-Now that you understand BIDS workflows:
+   EEG, report = pop_load_frombids(
+       "/path/to/bids-root/sub-01/eeg/sub-01_task-rest_run-01_eeg.set",
+       bidsmetadata=True,
+       bidschanloc=True,
+       bidsevent="replace",
+       return_report=True,
+   )
 
-1. Read the :ref:`preprocessing_pipeline` guide for detailed preprocessing steps
-2. Explore the :ref:`configuration` guide for parameter tuning
-3. Check the :ref:`advanced_topics` for custom pipelines
-4. Review the :ref:`api_reference` for detailed function documentation
+   print(report["ImporterUsed"])
+   print(EEG["nbchan"], EEG["pnts"], EEG["srate"])
+
+Common loading options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Use
+   * - ``bidsmetadata=True``
+     - Apply metadata from BIDS sidecars to the EEG dictionary.
+   * - ``bidschanloc=True``
+     - Apply BIDS channel metadata and coordinates when available.
+   * - ``bidsevent="replace"``
+     - Replace file events with events from the BIDS sidecar. Use ``"merge"``,
+       ``"append"``, or ``False`` when your dataset needs a different policy.
+   * - ``eventtype="trial_type"``
+     - Choose the event sidecar column to use as the EEG event type.
+   * - ``infer_locations=None``
+     - Infer locations only when no channel locations are present. Pass
+       ``True``, ``False``, or a montage filename for explicit behavior.
+
+Preprocess a BIDS Dataset
+=========================
+
+``bids_preproc`` can process one EEG file or every supported file under a BIDS
+root. Use capitalized option names for the current EEGPrep API:
+
+.. code-block:: python
+
+   from eegprep import bids_preproc
+
+   bids_preproc(
+       "/path/to/bids-root",
+       OutputDir="/path/to/bids-root/derivatives/eegprep",
+       Subjects=["01", "02"],
+       Tasks=["rest"],
+       SamplingRate=128,
+       Highpass=(0.25, 0.75),
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4.0,
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+       WithInterp=True,
+       WithICA=False,
+       WithICLabel=False,
+       SkipIfPresent=True,
+       NumJobs=1,
+   )
+
+Important processing options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Use
+   * - ``OutputDir``
+     - Destination for derivative files. The default is
+       ``{root}/derivatives/eegprep``.
+   * - ``Subjects`` / ``Sessions`` / ``Runs`` / ``Tasks``
+     - Filter which BIDS files are processed.
+   * - ``SamplingRate``
+     - Resample final data when set.
+   * - ``Highpass``
+     - Initial drift-removal transition band, or ``"off"``.
+   * - ``FlatlineCriterion``, ``ChannelCriterion``, ``LineNoiseCriterion``
+     - Channel cleaning criteria.
+   * - ``BurstCriterion`` and ``WindowCriterion``
+     - ASR repair/rejection and final window rejection criteria.
+   * - ``WithInterp``
+     - Reinterpolate removed channels after cleaning.
+   * - ``WithICA`` / ``ICAAlgorithm`` / ``WithPicard``
+     - Run ICA after cleaning. Use this only when the data length and runtime
+       budget are appropriate.
+   * - ``WithICLabel``
+     - Classify components after ICA.
+   * - ``ReturnData``
+     - Return final EEG dictionaries instead of only writing derivatives. This
+       can use substantial memory for large studies.
+   * - ``NumJobs`` / ``ReservePerJob``
+     - Control multiprocessing. Use an ``if __name__ == "__main__":`` guard in
+       scripts that launch multiple processes.
+
+For exploratory runs, start with one subject, ``NumJobs=1``, and
+``ReturnData=False``. Then inspect the derivative files and reports before
+expanding to the full dataset.
+
+Batch Script Pattern
+====================
+
+Keep paths and options explicit in lab scripts:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from eegprep import bids_list_eeg_files, bids_preproc
+
+   bids_root = Path("/path/to/bids-root")
+   output_root = bids_root / "derivatives" / "eegprep"
+
+   files = bids_list_eeg_files(str(bids_root), subjects=["01"], tasks=["rest"])
+   if not files:
+       raise RuntimeError("No matching BIDS EEG files were found.")
+
+   bids_preproc(
+       str(bids_root),
+       OutputDir=str(output_root),
+       Subjects=["01"],
+       Tasks=["rest"],
+       WithInterp=True,
+       WithICA=False,
+       SkipIfPresent=True,
+   )
+
+Load Derivatives
+================
+
+Derivative files written as EEGLAB ``.set`` files can be loaded directly with
+``pop_loadset``. When the derivative folder also contains BIDS sidecars, use
+``bids_list_eeg_files`` plus ``pop_load_frombids``:
+
+.. code-block:: python
+
+   from eegprep import bids_list_eeg_files, pop_load_frombids
+
+   derivative_files = bids_list_eeg_files("/path/to/bids-root/derivatives/eegprep")
+   EEG = pop_load_frombids(derivative_files[0])
+
+GUI and Console Workflow
+========================
+
+The GUI exposes BIDS import/export menu actions through the bundled EEG-BIDS
+plugin menus. In a shared session, use:
+
+.. code-block:: bash
+
+   uv run eegprep-console --full
+
+Then choose ``File > Import data > From BIDS folder structure`` or
+``File > Export > To BIDS folder structure``. Successful menu actions update
+``EEG``, ``ALLEEG``, ``CURRENTSET``, ``LASTCOM``, and ``ALLCOM`` in the shared
+session just like other loading and saving workflows.
+
+Troubleshooting
+===============
+
+No Files Found
+--------------
+
+If ``bids_list_eeg_files`` returns an empty list:
+
+* pass the BIDS root or a path inside that BIDS tree;
+* use raw identifiers such as ``"01"`` rather than ``"sub-01"``;
+* check that EEG data files end in ``.set``, ``.vhdr``, ``.edf``, or ``.bdf``;
+* confirm that files use the BIDS ``suffix-eeg`` naming pattern.
+
+Wrong Events or Labels
+----------------------
+
+Use ``return_report=True`` with ``pop_load_frombids`` and inspect the report.
+Then adjust ``bidsevent`` or ``eventtype``. For example, set
+``bidsevent=False`` to keep events stored in the raw EEG file, or set
+``eventtype="value"`` when your event sidecar stores condition labels in a
+non-default column.
+
+Batch Job Uses Too Much Memory
+------------------------------
+
+Start with ``NumJobs=1`` and ``ReturnData=False``. Add ``ReservePerJob`` only
+after a serial run shows the peak RAM needed for one dataset. Avoid enabling ICA
+or ICLabel until the cleaning-only derivative workflow is correct.
+
+Stale Derivative Results
+------------------------
+
+``SkipIfPresent=True`` skips files that already have matching derivatives. When
+changing preprocessing parameters, either remove the old derivative folder, set
+``SkipIfPresent=False``, or enable ``UseHashes=True`` so parameter changes are
+reflected in intermediate file names.

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -4,17 +4,16 @@
 Concepts Guide
 ==============
 
-EEGPrep keeps EEGLAB's user-facing vocabulary because it is the most useful
-mental model for many EEG researchers. The runtime is Python, but the main
-objects, command names, history behavior, and menu flow are designed so EEGLAB
-users can predict what will happen.
+EEGPrep uses plain Python objects while keeping the EEG workflow vocabulary many
+researchers already know. The main objects, command names, history behavior,
+and menu flow are designed to be predictable for EEG researchers, including
+people coming from EEGLAB.
 
 Workspace Names
 ===============
 
 ``eegprep-console --full`` opens a Qt GUI and an IPython console against one
-shared ``EEGPrepSession``. The console starts with the familiar EEGLAB
-workspace names:
+shared ``EEGPrepSession``. The console starts with familiar workspace names:
 
 .. list-table::
    :header-rows: 1
@@ -90,14 +89,14 @@ Practical rules:
 * Use event ``latency`` values as EEGLAB-facing sample positions when reading
   or writing event metadata.
 * Use Python zero-based indexing when slicing ``EEG["data"]``.
-* Most ``pop_*`` command strings print EEGLAB-facing values so history can be
-  understood by EEGLAB users.
+* Most ``pop_*`` command strings print user-facing values so history can be
+  read and reused later.
 * ``icachansind`` is normalized to zero-based integer indices after loading a
   MATLAB ``.set`` file, then converted back to one-based values when saving.
 
 For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
 indexing. User-facing epoch and component selectors in GUI dialogs use
-EEGLAB-style one-based values.
+one-based values.
 
 Channel Locations
 =================
@@ -108,14 +107,14 @@ Channel Locations
 names so topographic plotting, interpolation, DIPFIT, ICLabel features, and
 STUDY channel measures can share the same metadata.
 
-Use ``pop_chanedit`` or ``pop_readlocs`` when working through EEGLAB-style
-dialogs. Use ``readlocs`` or direct dictionary updates only when scripting and
-you already know the channel table shape you need.
+Use ``pop_chanedit`` or ``pop_readlocs`` when working through interactive
+channel-location dialogs. Use ``readlocs`` or direct dictionary updates only
+when scripting and you already know the channel table shape you need.
 
 ICA and ICLabel Fields
 ======================
 
-ICA workflows write the same core fields EEGLAB users expect:
+ICA workflows write the core fields used throughout EEGPrep:
 
 * ``icaweights`` and ``icasphere`` store the unmixing transform.
 * ``icawinv`` stores scalp maps.

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -1,0 +1,179 @@
+.. _concepts:
+
+==============
+Concepts Guide
+==============
+
+EEGPrep keeps EEGLAB's user-facing vocabulary because it is the most useful
+mental model for many EEG researchers. The runtime is Python, but the main
+objects, command names, history behavior, and menu flow are designed so EEGLAB
+users can predict what will happen.
+
+Workspace Names
+===============
+
+``eegprep-console --full`` opens a Qt GUI and an IPython console against one
+shared ``EEGPrepSession``. The console starts with the familiar EEGLAB
+workspace names:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Meaning in EEGPrep
+   * - ``EEG``
+     - The current EEG dataset dictionary.
+   * - ``ALLEEG``
+     - List of loaded EEG dataset dictionaries.
+   * - ``CURRENTSET``
+     - Current dataset selection, exposed as ``0`` when empty, a scalar for one
+       selected dataset, or a list for multi-dataset selection.
+   * - ``LASTCOM``
+     - Last replayable command string returned by a GUI or ``pop_*`` action.
+   * - ``ALLCOM``
+     - Ordered command history for the interactive session.
+   * - ``STUDY``
+     - Current group-level STUDY dictionary.
+   * - ``CURRENTSTUDY``
+     - ``1`` when a STUDY is active, otherwise ``0``.
+
+These are normal Python names in the console namespace, not hidden globals.
+GUI actions update them through the shared session. Console calls update the GUI
+when they go through ``eegprep-console`` wrappers.
+
+The EEG Dataset Dictionary
+==========================
+
+EEGPrep datasets are plain dictionaries with EEGLAB field names. Continuous data
+is channel-major, usually ``(nbchan, pnts)``. Epoched data is usually
+``(nbchan, pnts, trials)``.
+
+Core fields include:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Purpose
+   * - ``data``
+     - NumPy array, memory-mapped array, or retrieved in-memory data.
+   * - ``nbchan``, ``pnts``, ``trials``
+     - Channel count, points per trial, and trial count.
+   * - ``srate``, ``xmin``, ``xmax``, ``times``
+     - Sampling rate, time limits in seconds, and time vector in milliseconds.
+   * - ``chanlocs``
+     - Channel metadata such as labels, types, and locations.
+   * - ``event`` and ``urevent``
+     - Event records and original event references.
+   * - ``epoch``
+     - Per-epoch metadata for epoched datasets.
+   * - ``icaweights``, ``icasphere``, ``icawinv``, ``icaact``
+     - ICA decomposition fields and activations.
+   * - ``icachansind``
+     - Channels used for ICA. Stored internally as Python zero-based indices.
+   * - ``reject``
+     - Manual, automatic, and component rejection marks.
+   * - ``history``
+     - Dataset-level command history.
+   * - ``etc``
+     - Structured extension metadata, including ICLabel classifications.
+
+Events, Epochs, and Indexing
+============================
+
+EEGLAB event latencies are user-facing sample positions. EEGPrep preserves that
+public convention in command strings and event records. Python array slicing is
+still zero-based internally.
+
+Practical rules:
+
+* Use event ``latency`` values as EEGLAB-facing sample positions when reading
+  or writing event metadata.
+* Use Python zero-based indexing when slicing ``EEG["data"]``.
+* Most ``pop_*`` command strings print EEGLAB-facing values so history can be
+  understood by EEGLAB users.
+* ``icachansind`` is normalized to zero-based integer indices after loading a
+  MATLAB ``.set`` file, then converted back to one-based values when saving.
+
+For epoched data, ``EEG["data"][:, :, trial_index]`` is zero-based Python
+indexing. User-facing epoch and component selectors in GUI dialogs use
+EEGLAB-style one-based values.
+
+Channel Locations
+=================
+
+``chanlocs`` is a list-like channel table. Common keys are ``labels``, ``type``,
+``theta``, ``radius``, ``X``, ``Y``, ``Z``, ``sph_theta``, ``sph_phi``, and
+``sph_radius``. Channel location readers and editors keep the EEGLAB field
+names so topographic plotting, interpolation, DIPFIT, ICLabel features, and
+STUDY channel measures can share the same metadata.
+
+Use ``pop_chanedit`` or ``pop_readlocs`` when working through EEGLAB-style
+dialogs. Use ``readlocs`` or direct dictionary updates only when scripting and
+you already know the channel table shape you need.
+
+ICA and ICLabel Fields
+======================
+
+ICA workflows write the same core fields EEGLAB users expect:
+
+* ``icaweights`` and ``icasphere`` store the unmixing transform.
+* ``icawinv`` stores scalp maps.
+* ``icaact`` can be cached or recomputed from the decomposition.
+* ``reject.gcompreject`` stores component rejection flags.
+* ``etc.ic_classification.ICLabel.classifications`` stores ICLabel class
+  probabilities in the order Brain, Muscle, Eye, Heart, Line Noise, Channel
+  Noise, Other.
+
+Run ``pop_runica`` before ``pop_iclabel``. Use ``pop_viewprops`` or
+``pop_prop_extended`` to review component properties, labels, and DIPFIT
+projections when available.
+
+STUDY Structure
+===============
+
+EEGPrep STUDY dictionaries cover the implemented standalone group-analysis
+surface:
+
+* ``datasetinfo`` records dataset membership and metadata.
+* ``design`` records independent variables and selected designs.
+* ``changrp`` stores channel measure caches such as ERP, spectrum, ERSP, ITC,
+  and PAC.
+* ``cluster`` stores component measure caches and clustering metadata.
+
+The current implementation keeps measure caches in EEGPrep-owned JSON-safe
+structures unless a workflow explicitly writes sidecar data. MATLAB-only LIMO
+result files and external FieldTrip STUDY source statistics are explicit
+backend boundaries; they are not silently emulated.
+
+History and Replay
+==================
+
+The most important EEGLAB workflow is still available: run something from the
+GUI, inspect the command, then reuse it in a script.
+
+.. code-block:: python
+
+   EEG, LASTCOM = pop_resample(EEG, 64, return_com=True)
+   print(LASTCOM)
+   ALLCOM.append(LASTCOM)
+
+Inside ``eegprep-console``, bare calls such as ``pop_resample(EEG, 64)`` can
+auto-store the returned dataset in the shared session. Normal Python scripts do
+not do that; assign returned values explicitly.
+
+Standalone Runtime Boundary
+===========================
+
+The installed EEGPrep package must work without ``src/eegprep/eeglab``. The
+vendored EEGLAB tree is a development reference for parity work, not a runtime
+dependency. Packaged help, bundled plugin data, montages, ICLabel assets, and
+Sphinx documentation are EEGPrep-owned resources.
+
+EEGLAB References Used
+======================
+
+The manual structure follows the EEGLAB tutorial site's emphasis on quickstart,
+concepts, importing, preprocessing, plotting, STUDY, scripting, and data
+structures, while rewriting the content for EEGPrep's Python, Qt GUI, and
+``eegprep-console`` behavior.

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -4,614 +4,201 @@
 Configuration
 =============
 
-This guide covers configuration options for eegprep, including the EEG_OPTIONS object, common parameters, and custom preprocessing chains.
+EEGPrep keeps global options intentionally small. Use explicit function
+arguments for preprocessing choices, and use ``EEG_OPTIONS`` only for session,
+storage, compatibility, and GUI behavior that really is global.
 
-EEG_OPTIONS Overview
-====================
-
-The :class:`eegprep.EEG_OPTIONS` class provides a centralized way to configure eegprep behavior:
+``EEG_OPTIONS`` is a dictionary, not a configuration object:
 
 .. code-block:: python
 
-    from eegprep import EEG_OPTIONS
+   from eegprep import EEG_OPTIONS
 
-    # Access default options
-    options = EEG_OPTIONS()
+   print(dict(EEG_OPTIONS))
+   EEG_OPTIONS["option_allmenus"] = 1
+   EEG_OPTIONS["option_savetwofiles"] = 1
 
-    # View all options
-    print(options)
+Save the previous values when a script changes global options:
 
-    # Modify options
-    options.ica_method = 'picard'
-    options.asr_criterion = 20
+.. code-block:: python
 
-Common Configuration Parameters
+   from eegprep import EEG_OPTIONS
+
+   old_options = dict(EEG_OPTIONS)
+   try:
+       EEG_OPTIONS["option_memmapdata"] = 1
+       # Load or save datasets here.
+   finally:
+       EEG_OPTIONS.clear()
+       EEG_OPTIONS.update(old_options)
+
+Common Global Options
+=====================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key
+     - Effect
+   * - ``option_allmenus``
+     - Show advanced and legacy menu entries in the main GUI.
+   * - ``option_storedisk``
+     - Keep saved non-current ``ALLEEG`` datasets on disk to reduce memory use.
+   * - ``option_savetwofiles``
+     - Make ``pop_saveset`` write a ``.set`` header plus ``.fdt`` sidecar by
+       default.
+   * - ``option_memmapdata``
+     - Memory-map two-file ``.fdt`` data when loading with ``pop_loadset``.
+   * - ``option_boundary99``
+     - Treat numeric ``-99`` events as boundary events for ERPLAB-style data.
+   * - ``option_computeica``
+     - Precompute ICA activations where supported.
+   * - ``option_scaleicarms``
+     - Scale ICA component activations to RMS microvolt during checkset paths.
+   * - ``option_cachesize``
+     - STUDY cache size in MB for implemented STUDY measure workflows.
+
+For storage details, see :ref:`large_dataset_storage`.
+
+Set Options From GUI or Console
 ===============================
 
+Use the Options menu in the GUI, or call ``pop_editoptions`` from
+``eegprep-console``:
+
+.. code-block:: python
+
+   from eegprep import EEG_OPTIONS, pop_editoptions
+
+   com = pop_editoptions(option_allmenus=1, option_savetwofiles=1)
+   print(com)
+   print(EEG_OPTIONS["option_allmenus"])
+
+In a shared GUI/console session, the menu refresh uses the same
+``EEG_OPTIONS`` dictionary.
+
 Preprocessing Parameters
-------------------------
+========================
 
-**Artifact Detection**
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    options = EEG_OPTIONS()
-
-    # Flatline detection
-    options.flatline_criterion = 5  # Duration in seconds
-
-    # ASR (Artifact Subspace Reconstruction)
-    options.asr_criterion = 20      # Standard deviation threshold
-    options.asr_wlen = 0.5          # Window length in seconds
-
-    # Channel noise detection
-    options.ransac_criterion = 0.8  # Correlation threshold
-    options.max_broken_time = 0.5   # Max proportion of broken time
-
-**Filtering**
+Most analysis choices are ordinary function arguments. This keeps scripts
+readable and prevents hidden global state from changing scientific results.
 
 .. code-block:: python
 
-    # High-pass filter
-    options.highpass = 1            # Frequency in Hz
+   from pathlib import Path
 
-    # Low-pass filter
-    options.lowpass = 100           # Frequency in Hz
+   from eegprep import pop_clean_rawdata, pop_eegfiltnew, pop_loadset, pop_resample
 
-    # Filter order
-    options.filter_order = 4        # FIR filter order
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
 
-**Resampling**
+   EEG, filter_com = pop_eegfiltnew(
+       EEG,
+       locutoff=1,
+       hicutoff=40,
+       plotfreqz=False,
+       return_com=True,
+   )
+   EEG, resample_com = pop_resample(EEG, 64, return_com=True)
+   EEG, clean_com = pop_clean_rawdata(
+       EEG,
+       FlatlineCriterion=5,
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4,
+       Highpass=(0.25, 0.75),
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+       return_com=True,
+   )
 
-.. code-block:: python
+   history = [filter_com, resample_com, clean_com]
 
-    # Target sampling rate
-    options.resample_rate = 250     # Hz
-
-**ICA**
-
-.. code-block:: python
-
-    # ICA method
-    options.ica_method = 'picard'   # 'picard' or 'infomax'
-
-    # Number of components
-    options.ica_ncomps = None       # None = number of channels
-
-    # Maximum iterations
-    options.ica_max_iter = 500
-
-**Component Classification**
+The same rule applies to ICA, ICLabel, and BIDS preprocessing:
 
 .. code-block:: python
 
-    # Use ICLabel for component classification
-    options.use_iclabel = True
+   from eegprep import bids_preproc, pop_iclabel, pop_runica
 
-    # ICLabel threshold for artifact removal
-    options.iclabel_threshold = 0.5
+   EEG, ica_com = pop_runica(EEG, icatype="picard", gui=False, return_com=True)
+   EEG, label_com = pop_iclabel(EEG, "default", return_com=True)
 
-Reference and Re-referencing
------------------------------
+   bids_preproc(
+       "/path/to/bids-root",
+       OutputDir="/path/to/bids-root/derivatives/eegprep",
+       Subjects=["01"],
+       Tasks=["rest"],
+       WithInterp=True,
+       WithICA=False,
+       NumJobs=1,
+   )
 
-.. code-block:: python
+Reusable Presets
+================
 
-    # Reference type
-    options.reference = 'average'   # 'average', 'common', or channel name
-
-    # Exclude channels from reference
-    options.reference_exclude = ['HEOG', 'VEOG']
-
-Data Handling
--------------
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    # Keep saved non-current ALLEEG datasets on disk.
-    EEG_OPTIONS["option_storedisk"] = 1
-
-    # Save .set headers and .fdt sidecars by default.
-    EEG_OPTIONS["option_savetwofiles"] = 1
-
-    # Memory-map .fdt sidecars on load.
-    EEG_OPTIONS["option_memmapdata"] = 1
-
-See :ref:`large_dataset_storage` for the exact storedisk, sidecar, and
-memory-mapped data semantics.
-
-Creating Custom Preprocessing Chains
-====================================
-
-Using Configuration Objects
-----------------------------
-
-Create a custom configuration for your preprocessing:
+Represent lab presets as plain dictionaries and pass them explicitly:
 
 .. code-block:: python
 
-    from eegprep import EEG_OPTIONS, clean_artifacts
-
-    # Create custom options
-    custom_options = EEG_OPTIONS()
-    custom_options.highpass = 0.5
-    custom_options.lowpass = 50
-    custom_options.asr_criterion = 15
-    custom_options.ica_method = 'picard'
-
-    # Use custom options in preprocessing
-    eeg = clean_artifacts(eeg, options=custom_options)
-
-Preprocessing Presets
----------------------
-
-Create preset configurations for different use cases:
-
-**Resting State EEG**
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    def get_resting_state_options():
-        """Configuration for resting state EEG preprocessing"""
-        options = EEG_OPTIONS()
-        options.highpass = 1
-        options.lowpass = 100
-        options.asr_criterion = 20
-        options.ica_method = 'picard'
-        options.use_iclabel = True
-        return options
-
-    # Use preset
-    eeg = clean_artifacts(eeg, options=get_resting_state_options())
-
-**Event-Related Potentials (ERP)**
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    def get_erp_options():
-        """Configuration for ERP preprocessing"""
-        options = EEG_OPTIONS()
-        options.highpass = 0.1
-        options.lowpass = 30
-        options.asr_criterion = 15
-        options.ica_method = 'picard'
-        options.use_iclabel = True
-        return options
-
-    # Use preset
-    eeg = clean_artifacts(eeg, options=get_erp_options())
-
-**High-Frequency Activity**
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    def get_hfa_options():
-        """Configuration for high-frequency activity analysis"""
-        options = EEG_OPTIONS()
-        options.highpass = 1
-        options.lowpass = 200
-        options.asr_criterion = 25
-        options.resample_rate = 500
-        options.ica_method = 'picard'
-        return options
-
-    # Use preset
-    eeg = clean_artifacts(eeg, options=get_hfa_options())
-
-**Clinical EEG**
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    def get_clinical_options():
-        """Configuration for clinical EEG preprocessing"""
-        options = EEG_OPTIONS()
-        options.highpass = 0.5
-        options.lowpass = 70
-        options.asr_criterion = 20
-        options.flatline_criterion = 10
-        options.ica_method = 'picard'
-        options.use_iclabel = True
-        return options
-
-    # Use preset
-    eeg = clean_artifacts(eeg, options=get_clinical_options())
-
-Custom Preprocessing Functions
-------------------------------
-
-Create custom preprocessing functions:
-
-.. code-block:: python
-
-    from eegprep import (
-        clean_flatlines,
-        clean_channels,
-        pop_resample,
-        pop_eegfiltnew,
-        eeg_picard,
-        iclabel
-    )
-
-    def custom_preprocessing_pipeline(eeg, options=None):
-        """Custom preprocessing pipeline"""
-
-        # Step 1: Remove flatlines
-        eeg = clean_flatlines(eeg, flatline_criterion=5)
-
-        # Step 2: Remove noisy channels
-        eeg = clean_channels(eeg)
-
-        # Step 3: Resample
-        eeg = pop_resample(eeg, 250)
-
-        # Step 4: Filter
-        eeg = pop_eegfiltnew(eeg, locutoff=1, hicutoff=100)
-
-        # Step 5: ICA
-        eeg = eeg_picard(eeg)
-
-        # Step 6: Component classification
-        eeg = iclabel(eeg)
-
-        return eeg
-
-    # Use custom pipeline
-    eeg = custom_preprocessing_pipeline(eeg)
-
-Advanced Settings
-=================
-
-ICA Configuration
------------------
-
-**Picard Algorithm**
-
-.. code-block:: python
-
-    from eegprep import eeg_picard
-
-    eeg = eeg_picard(
-        eeg,
-        ncomps=None,        # Number of components
-        max_iter=500,       # Maximum iterations
-        tol=1e-7,          # Convergence tolerance
-        ortho=True,        # Orthogonalize components
-        extended=False     # Extended ICA
-    )
-
-**Infomax Algorithm**
-
-.. code-block:: python
-
-    from eegprep import eeg_picard
-
-    # Picard is recommended, but you can adjust parameters
-    eeg = eeg_picard(eeg, ncomps=eeg.nbchan)
-
-ASR Configuration
------------------
-
-**Standard ASR**
-
-.. code-block:: python
-
-    from eegprep import clean_asr
-
-    eeg = clean_asr(
-        eeg,
-        asr_criterion=20,   # Standard deviation threshold
-        asr_wlen=0.5,      # Window length in seconds
-        asr_overlap=0.5    # Window overlap
-    )
-
-**Aggressive ASR**
-
-.. code-block:: python
-
-    from eegprep import clean_asr
-
-    eeg = clean_asr(
-        eeg,
-        asr_criterion=10,   # Lower threshold = more aggressive
-        asr_wlen=0.5,
-        asr_overlap=0.5
-    )
-
-**Conservative ASR**
-
-.. code-block:: python
-
-    from eegprep import clean_asr
-
-    eeg = clean_asr(
-        eeg,
-        asr_criterion=30,   # Higher threshold = more conservative
-        asr_wlen=0.5,
-        asr_overlap=0.5
-    )
-
-Filter Configuration
---------------------
-
-**FIR Filters**
-
-.. code-block:: python
-
-    from eegprep import pop_eegfiltnew
-
-    # FIR filter (default)
-    eeg = pop_eegfiltnew(
-        eeg,
-        locutoff=1,
-        hicutoff=100,
-        filtorder=4,  # Filter order
-        revfilt=0     # Forward filter
-    )
-
-**IIR Filters**
-
-.. code-block:: python
-
-    from eegprep import pop_eegfiltnew
-
-    # IIR filter
-    eeg = pop_eegfiltnew(
-        eeg,
-        locutoff=1,
-        hicutoff=100,
-        filtorder=4,
-        revfilt=0,
-        iir=True  # Use IIR filter
-    )
-
-Resampling Configuration
-------------------------
-
-.. code-block:: python
-
-    from eegprep import pop_resample
-
-    # Resample to 250 Hz
-    eeg = pop_resample(eeg, 250)
-
-    # Resample with specific method
-    eeg = pop_resample(
-        eeg,
-        newrate=250,
-        method='sinc'  # Sinc interpolation
-    )
-
-Configuration Files
-===================
-
-Saving Configuration
---------------------
-
-Save your configuration to a file:
-
-.. code-block:: python
-
-    import json
-    from eegprep import EEG_OPTIONS
-
-    # Create configuration
-    config = {
-        'highpass': 1,
-        'lowpass': 100,
-        'asr_criterion': 20,
-        'ica_method': 'picard',
-        'use_iclabel': True,
-        'resample_rate': 250
-    }
-
-    # Save to JSON
-    with open('preprocessing_config.json', 'w') as f:
-        json.dump(config, f, indent=2)
-
-Loading Configuration
----------------------
-
-Load configuration from a file:
-
-.. code-block:: python
-
-    import json
-    from eegprep import EEG_OPTIONS, clean_artifacts
-
-    # Load configuration
-    with open('preprocessing_config.json', 'r') as f:
-        config = json.load(f)
-
-    # Create options from configuration
-    options = EEG_OPTIONS()
-    for key, value in config.items():
-        setattr(options, key, value)
-
-    # Use configuration
-    eeg = clean_artifacts(eeg, options=options)
-
-Example Configuration Files
-----------------------------
-
-**resting_state_config.json**
-
-.. code-block:: json
-
-    {
-        "highpass": 1,
-        "lowpass": 100,
-        "asr_criterion": 20,
-        "asr_wlen": 0.5,
-        "flatline_criterion": 5,
-        "ransac_criterion": 0.8,
-        "ica_method": "picard",
-        "ica_ncomps": null,
-        "use_iclabel": true,
-        "resample_rate": 250,
-        "reference": "average"
-    }
-
-**erp_config.json**
-
-.. code-block:: json
-
-    {
-        "highpass": 0.1,
-        "lowpass": 30,
-        "asr_criterion": 15,
-        "asr_wlen": 0.5,
-        "flatline_criterion": 5,
-        "ica_method": "picard",
-        "use_iclabel": true,
-        "resample_rate": 250,
-        "reference": "average"
-    }
-
-Parameter Recommendations
+   CLEANING_PRESETS = {
+       "resting": {
+           "FlatlineCriterion": 5,
+           "ChannelCriterion": 0.8,
+           "LineNoiseCriterion": 4,
+           "Highpass": (0.25, 0.75),
+           "BurstCriterion": 20,
+           "WindowCriterion": 0.25,
+       },
+       "erp": {
+           "FlatlineCriterion": 5,
+           "ChannelCriterion": 0.85,
+           "LineNoiseCriterion": 4,
+           "Highpass": (0.1, 0.5),
+           "BurstCriterion": 20,
+           "WindowCriterion": 0.25,
+       },
+   }
+
+   EEG, com = pop_clean_rawdata(EEG, **CLEANING_PRESETS["resting"], return_com=True)
+
+Keep these preset dictionaries in your lab package, notebook, or analysis repo
+so parameter changes are version-controlled with the study.
+
+When to Use Which Surface
 =========================
 
-By Data Type
-------------
+.. list-table::
+   :header-rows: 1
 
-**Resting State EEG**
+   * - Need
+     - Use
+   * - Change menu visibility or storage behavior
+     - ``EEG_OPTIONS`` or ``pop_editoptions``.
+   * - Change filtering, cleaning, resampling, ICA, ICLabel, or BIDS behavior
+     - Explicit function arguments.
+   * - Record replayable commands
+     - ``return_com=True`` and keep the returned command strings.
+   * - Share settings across scripts
+     - A normal Python dictionary or module constant in your analysis code.
+   * - Use the same state model as the GUI
+     - ``EEGPrepSession``; see :ref:`gui_console_session`.
 
-- Highpass: 1 Hz
-- Lowpass: 100 Hz
-- ASR criterion: 20
-- Resample: 250 Hz
+Troubleshooting
+===============
 
-**Event-Related Potentials (ERP)**
+Option Did Not Affect a Processing Step
+---------------------------------------
 
-- Highpass: 0.1 Hz
-- Lowpass: 30 Hz
-- ASR criterion: 15
-- Resample: 250 Hz
+Check whether the function actually reads ``EEG_OPTIONS``. Most processing
+functions are configured through explicit keyword arguments.
 
-**High-Frequency Activity**
+Memory-Mapped Loading Did Not Happen
+------------------------------------
 
-- Highpass: 1 Hz
-- Lowpass: 200 Hz
-- ASR criterion: 25
-- Resample: 500 Hz
+``option_memmapdata`` applies to two-file ``.set``/``.fdt`` datasets. Save with
+``savemode="twofiles"`` or set ``option_savetwofiles`` before saving, then load
+again with ``option_memmapdata`` enabled.
 
-**Clinical EEG**
+Menu Entries Did Not Change
+---------------------------
 
-- Highpass: 0.5 Hz
-- Lowpass: 70 Hz
-- ASR criterion: 20
-- Resample: 250 Hz
-
-By Artifact Type
-----------------
-
-**Muscle Artifacts**
-
-- ASR criterion: 15 (more aggressive)
-- Flatline criterion: 5
-- Use ICLabel: True
-
-**Eye Movement Artifacts**
-
-- Highpass: 0.5 Hz
-- Use ICLabel: True
-- Manual component removal
-
-**Line Noise (50/60 Hz)**
-
-- Notch filter: 50 or 60 Hz
-- Lowpass: 100 Hz
-
-**Drift**
-
-- Highpass: 0.5 Hz
-- ASR criterion: 20
-
-Troubleshooting Configuration
-=============================
-
-Configuration Not Applied
---------------------------
-
-**Problem**: Configuration changes don't affect preprocessing
-
-**Solution**:
-
-1. Verify options are passed to preprocessing function
-2. Check that options object is correctly created
-3. Ensure parameter names are correct
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS, clean_artifacts
-
-    # Correct way
-    options = EEG_OPTIONS()
-    options.highpass = 1
-    eeg = clean_artifacts(eeg, options=options)
-
-    # Incorrect way (won't work)
-    eeg = clean_artifacts(eeg, highpass=1)
-
-Unexpected Results
-------------------
-
-**Problem**: Preprocessing produces unexpected results
-
-**Solution**:
-
-1. Visualize data before and after preprocessing
-2. Check parameter values
-3. Try different parameter combinations
-4. Review the preprocessing pipeline steps
-
-.. code-block:: python
-
-    import matplotlib.pyplot as plt
-
-    # Plot before and after
-    plt.figure(figsize=(12, 6))
-    plt.plot(eeg.data[0, :1000])
-    plt.title('Preprocessed Data')
-    plt.show()
-
-Performance Issues
-------------------
-
-**Problem**: Preprocessing is slow
-
-**Solution**:
-
-1. Reduce number of components in ICA
-2. Increase resampling rate
-3. Use parallel processing for batch jobs
-4. Reduce filter order
-
-.. code-block:: python
-
-    from eegprep import EEG_OPTIONS
-
-    options = EEG_OPTIONS()
-    options.ica_ncomps = 30  # Reduce components
-    options.resample_rate = 250  # Increase rate
-    options.filter_order = 2  # Reduce filter order
-
-Next Steps
-==========
-
-Now that you understand configuration:
-
-1. Read the :ref:`preprocessing_pipeline` guide for detailed preprocessing steps
-2. Explore the :ref:`advanced_topics` for custom pipelines
-3. Check the :ref:`quickstart` for practical examples
-4. Review the :ref:`api_reference` for detailed function documentation
+After changing ``option_allmenus`` in a running GUI, reopen or refresh the main
+window so menu status is rebuilt from the current option dictionary.

--- a/docs/source/user_guide/eegbrowser.rst
+++ b/docs/source/user_guide/eegbrowser.rst
@@ -15,6 +15,19 @@ From the GUI, load or select a dataset and use the Plot menu entries for
 channel data, component activity, or visual rejection. The rejection dialogs can
 also open browser-backed review windows before updating marks or removing data.
 
+With the tutorial data:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Load <code>sample_data/eeglab_data.set</code>.</p>
+     <p>Choose <strong>Plot > Channel data (scroll)</strong>.</p>
+     <p>Use the browser to review channels, events, scaling, and visible time
+     ranges before making rejection decisions.</p>
+     <p>Run <code>LASTCOM</code> in <code>eegprep-console</code> to confirm
+     which browser action was recorded.</p>
+   </div>
+
 From Python or ``eegprep-console``:
 
 .. code-block:: python
@@ -30,6 +43,28 @@ Use ``show=False`` when testing or scripting normalization without opening Qt:
 
    model = eegplot(EEG, winlength=5, dispchans=16, show=False)
 
+Browser Modes
+=============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Workflow
+     - GUI entry
+     - Programmatic entry
+   * - Channel inspection
+     - ``Plot > Channel data (scroll)``
+     - ``eegplot(EEG)`` or ``pop_eegplot(EEG)``
+   * - Component inspection
+     - ``Plot > Component activations (scroll)``
+     - ``pop_eegplot(EEG, icacomp=0, reject=0)``
+   * - Epoched data rejection
+     - ``Tools > Reject data epochs > Reject by inspection``
+     - ``pop_eegplot(EEG, reject=1)``
+   * - ICA rejection marks
+     - ``Tools > Reject data using ICA > Reject by inspection``
+     - ``pop_eegplot(EEG, icacomp=0, reject=1)``
+
 Marks And Rejection
 ===================
 
@@ -42,6 +77,17 @@ marked epochs through ``pop_rejepoch``.
 Component mode uses ICA activations and writes ICA-prefixed rejection fields
 where applicable. Event overlays use EEGLAB one-based event latencies; Python
 array indexing remains zero-based internally.
+
+Accepting Browser Results
+=========================
+
+In ``eegprep-console``, browser accept callbacks keep GUI state, ``EEG``,
+``ALLEEG``, and history synchronized. If a browser action creates a new dataset
+instead of mutating the current one, the session stores that dataset through the
+same dataset helpers used by menu actions.
+
+In normal Python, call the lower-level rejection helpers explicitly after
+reviewing the browser model or marks.
 
 Performance
 ===========

--- a/docs/source/user_guide/eegbrowser.rst
+++ b/docs/source/user_guide/eegbrowser.rst
@@ -4,9 +4,9 @@
 EEGBrowser Workflows
 ====================
 
-EEGPrep includes an EEGLAB-style scrolling browser for inspecting continuous,
-epoched, component, spectral, and overlay data. The browser is available from
-the Plot menu, rejection workflows, Python APIs, and ``eegprep-console``.
+EEGPrep includes a scrolling browser for inspecting continuous, epoched,
+component, spectral, and overlay data. The browser is available from the Plot
+menu, rejection workflows, Python APIs, and ``eegprep-console``.
 
 Opening The Browser
 ===================

--- a/docs/source/user_guide/eeglab_migration.rst
+++ b/docs/source/user_guide/eeglab_migration.rst
@@ -8,7 +8,7 @@ EEGPrep is a Python port, not a MATLAB compatibility layer. Use these notes
 when translating EEGLAB habits into EEGPrep scripts and GUI workflows.
 
 What Carries Over
-================
+=================
 
 .. list-table::
    :header-rows: 1
@@ -60,7 +60,7 @@ Command Translation Examples
 .. list-table::
    :header-rows: 1
 
-   * - EEGLAB-style intent
+   * - Migration intent
      - EEGPrep Python
    * - Load a dataset
      - ``EEG = pop_loadset("sample_data/eeglab_data.set")``
@@ -133,5 +133,5 @@ When to Stay in MNE or MATLAB
 Use MNE-Python when your analysis depends on MNE-native object workflows,
 forward models, reports, or statistics. Use MATLAB EEGLAB when you need an
 unported MATLAB-only plugin or toolbox today. Use EEGPrep when you want
-EEGLAB-style preprocessing and review in Python with standalone package
+familiar preprocessing and review workflows in Python with standalone package
 behavior.

--- a/docs/source/user_guide/eeglab_migration.rst
+++ b/docs/source/user_guide/eeglab_migration.rst
@@ -1,0 +1,137 @@
+.. _eeglab_migration:
+
+========================
+EEGLAB Migration Notes
+========================
+
+EEGPrep is a Python port, not a MATLAB compatibility layer. Use these notes
+when translating EEGLAB habits into EEGPrep scripts and GUI workflows.
+
+What Carries Over
+================
+
+.. list-table::
+   :header-rows: 1
+
+   * - EEGLAB habit
+     - EEGPrep equivalent
+   * - ``pop_loadset``, ``pop_saveset``, ``pop_resample``, ``pop_epoch``
+     - Same public names, Python arguments, and replayable command strings.
+   * - ``EEG``, ``ALLEEG``, ``CURRENTSET``, ``LASTCOM``, ``ALLCOM``
+     - Same workspace names inside ``eegprep-console``.
+   * - GUI menu action then command history
+     - GUI actions update ``LASTCOM`` and ``ALLCOM`` in the shared session.
+   * - ``chanlocs``, ``event``, ``urevent``, ``epoch``, ICA fields
+     - Same dictionary field names.
+   * - Bundled plugins
+     - clean_rawdata, FIRFilt, ICLabel, DIPFIT, and EEG-BIDS are in-package
+       Python ports or explicit standalone boundaries.
+   * - STUDY
+     - Implemented as EEGPrep-owned dictionaries and JSON-safe measure caches.
+
+What Changes
+============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Topic
+     - Migration rule
+   * - Arrays
+     - Use Python/NumPy zero-based indexing when slicing data.
+   * - User-facing selectors
+     - Keep channel, component, dataset, and epoch numbers one-based in GUI
+       dialogs and command strings unless a function documents otherwise.
+   * - Globals
+     - EEGPrep functions take explicit inputs. The shared console namespace is
+       session state, not a hidden global dependency.
+   * - Runtime EEGLAB checkout
+     - Installed EEGPrep does not read from ``src/eegprep/eeglab``.
+   * - Optional toolboxes
+     - MATLAB-only LIMO, FieldTrip STUDY source statistics, MRI BEM creation,
+       AFNI atlas clipping, and unavailable ICLabel network artifacts fail
+       clearly instead of being faked.
+   * - Scripts
+     - Assign return values explicitly outside ``eegprep-console``.
+
+Command Translation Examples
+============================
+
+.. list-table::
+   :header-rows: 1
+
+   * - EEGLAB-style intent
+     - EEGPrep Python
+   * - Load a dataset
+     - ``EEG = pop_loadset("sample_data/eeglab_data.set")``
+   * - Filter
+     - ``EEG = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False)``
+   * - Resample
+     - ``EEG = pop_resample(EEG, 64)``
+   * - Average reference
+     - ``EEG = pop_reref(EEG, [])``
+   * - Epoch
+     - ``EEG = pop_epoch(EEG, ["square"], [-1, 2])``
+   * - Run ICA
+     - ``EEG = pop_runica(EEG, icatype="picard", gui=False)``
+   * - Classify ICs
+     - ``EEG = pop_iclabel(EEG, "default")``
+   * - Create a STUDY
+     - ``STUDY, ALLEEG, com = pop_study(None, ALLEEG, name="My study", return_com=True)``
+
+History Replay
+==============
+
+In MATLAB EEGLAB, menu commands appear in the MATLAB command window. In
+EEGPrep, use ``LASTCOM`` and ``ALLCOM``:
+
+.. code-block:: python
+
+   EEG, LASTCOM = pop_resample(EEG, 64, return_com=True)
+   ALLCOM.append(LASTCOM)
+
+Inside ``eegprep-console``, a bare call can update the current dataset:
+
+.. code-block:: python
+
+   pop_resample(EEG, 64)
+
+In normal Python, assign the return value:
+
+.. code-block:: python
+
+   EEG = pop_resample(EEG, 64)
+
+Indexing Boundaries
+===================
+
+EEGPrep intentionally keeps both conventions visible:
+
+* Python arrays are zero-based: ``EEG["data"][0, :]`` is the first channel.
+* GUI channel/component/dataset selectors are one-based.
+* Event ``latency`` fields are sample positions in the EEGLAB-facing event
+  model.
+* ``icachansind`` is normalized after loading so internal indexing is
+  consistent, then converted back when saving.
+
+Plugin Migration
+================
+
+Bundled plugins are importable from ``eegprep``:
+
+.. code-block:: python
+
+   from eegprep import pop_clean_rawdata, pop_eegfiltnew, pop_iclabel, pop_dipfit_settings
+
+External EEGLAB MATLAB plugins are not loaded by path. EEGPrep extensions are
+normal Python packages discovered through the ``eegprep.extensions`` entry
+point. See :ref:`plugins` and :ref:`extensions` for the package format.
+
+When to Stay in MNE or MATLAB
+=============================
+
+Use MNE-Python when your analysis depends on MNE-native object workflows,
+forward models, reports, or statistics. Use MATLAB EEGLAB when you need an
+unported MATLAB-only plugin or toolbox today. Use EEGPrep when you want
+EEGLAB-style preprocessing and review in Python with standalone package
+behavior.

--- a/docs/source/user_guide/extension_curation.rst
+++ b/docs/source/user_guide/extension_curation.rst
@@ -180,5 +180,5 @@ mistakes before submitting catalog metadata.
        harness.assert_pop_function_history_result("pop_my_extension", sample_eeg)
 
 The harness checks spec validation, menu references, help resources, lazy action
-loads, ``pop_*`` loads, and EEGLAB-style ``(EEG, com)`` console/history results
-for actions or pop functions that the author calls in tests.
+loads, ``pop_*`` loads, and history-aware ``(EEG, com)`` console results for
+actions or pop functions that the author calls in tests.

--- a/docs/source/user_guide/extensions.rst
+++ b/docs/source/user_guide/extensions.rst
@@ -233,15 +233,15 @@ instead of reaching into private EEGPrep modules.
 ``pop_*`` History and Console Rules
 ===================================
 
-Extension ``pop_*`` functions should follow EEGPrep and EEGLAB-facing
-conventions:
+Extension ``pop_*`` functions should follow EEGPrep interactive conventions:
 
 * Accept an EEG dict or EEG-like object explicitly.
 * Return the updated EEG object for data-changing calls.
 * Support ``return_com=True`` and return ``(EEG, com)`` when the call should be
   recorded in history.
-* Use EEGLAB-facing 1-based values in command strings when users provide
-  EEGLAB-style indices, and convert to Python 0-based indexing internally.
+* Use user-facing 1-based values in command strings when users provide
+  channel, component, dataset, epoch, or event positions, and convert to Python
+  0-based indexing internally.
 * Keep GUI and console workflows synchronized through the registered action and
   ``EEGPrepSession`` helpers instead of mutating GUI-only state.
 * Add packaged help resources for GUI Help buttons and ``pophelp`` surfaces.

--- a/docs/source/user_guide/gui_console_session.rst
+++ b/docs/source/user_guide/gui_console_session.rst
@@ -1,0 +1,168 @@
+.. _gui_console_session:
+
+========================
+GUI and Console Together
+========================
+
+EEGPrep is designed for a mixed interactive workflow. You can load and review
+data from the GUI, inspect the live workspace in ``eegprep-console``, run a
+Python command, then return to the GUI without manually copying datasets between
+tools.
+
+The important idea is simple: the GUI and console are two views of one
+``EEGPrepSession``.
+
+When to Use This Workflow
+=========================
+
+Use ``eegprep-console --full`` when you want to:
+
+* learn what each menu action does by reading ``LASTCOM``;
+* inspect ``EEG`` fields immediately after a dialog closes;
+* try a Python command before committing it to a script;
+* compare multiple loaded datasets in ``ALLEEG``;
+* review STUDY state while using Study menu actions;
+* keep a complete ``ALLCOM`` history for a notebook, script, or lab record.
+
+Use ``eegprep-gui --full`` only when you want a GUI-only session and do not
+need live Python inspection.
+
+Daily Workflow
+==============
+
+Start the shared session:
+
+.. code-block:: bash
+
+   uv run eegprep-console --full
+
+Then move between the GUI and console:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Load <code>sample_data/eeglab_data.set</code> with
+     <strong>File > Load existing dataset</strong>.</p>
+     <p>In the console, inspect <code>EEG["data"].shape</code>,
+     <code>CURRENTSET</code>, and <code>LASTCOM</code>.</p>
+     <p>Run <code>pop_resample(EEG, 64)</code> in the console.</p>
+     <p>Return to the GUI and open <strong>Plot > Channel data (scroll)</strong>;
+     the browser sees the resampled current dataset.</p>
+     <p>Open <strong>Tools > Filter the data</strong> from the GUI, press OK,
+     then inspect <code>LASTCOM</code> and <code>ALLCOM[-3:]</code>.</p>
+     <p>Copy the useful commands into a script with explicit assignment.</p>
+   </div>
+
+What Stays Synchronized
+=======================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - What it means
+     - How it updates
+   * - ``EEG``
+     - Current dataset dictionary.
+     - GUI actions and console ``pop_*`` wrappers store the new current
+       dataset through the session.
+   * - ``ALLEEG``
+     - Loaded dataset list.
+     - Load, save-as-new, delete, clone, and dataset-selection actions go
+       through session storage helpers.
+   * - ``CURRENTSET``
+     - Current dataset selection, exposed as ``0``, a scalar, or a list in the
+       console.
+     - Dataset menu changes and console storage calls update the same value.
+   * - ``LASTCOM``
+     - Most recent replayable command string.
+     - Successful GUI actions and history-aware ``pop_*`` calls replace it.
+   * - ``ALLCOM``
+     - Chronological session command history.
+     - The session appends commands once, so GUI and console history stay in
+       the same order.
+   * - ``STUDY`` and ``CURRENTSTUDY``
+     - Current group-analysis state.
+     - Study menu actions and study ``pop_*`` calls update the shared session.
+   * - ``PLUGINLIST``
+     - Bundled and installed extension inventory.
+     - Extension Manager and plugin registry calls read the same runtime
+       registry.
+
+How EEGPrep Implements It
+=========================
+
+``EEGPrepSession`` is the single source of truth for interactive state. The main
+window, menus, dialogs, help actions, dataset menus, Study workflows, Extension
+Manager, and ``eegprep-console`` all read from and write to this session.
+
+GUI actions should update state through session helpers such as
+``store_current()``, ``add_history()``, ``set_study()``, and
+``notify_changed()``. They should not mutate a GUI-only copy of ``EEG`` that
+the console cannot see.
+
+``eegprep-console`` wraps registered ``pop_*`` functions. When a bare call such
+as ``pop_resample(EEG, 64)`` returns a dataset and command string, the wrapper
+stores the returned dataset, updates ``LASTCOM`` and ``ALLCOM``, and tells the
+GUI to refresh. This auto-store behavior belongs to ``eegprep-console`` because
+it has a session to update.
+
+Normal Python scripts keep normal Python semantics:
+
+.. code-block:: python
+
+   EEG, com = pop_resample(EEG, 64, return_com=True)
+
+Use explicit assignment in scripts, notebooks, tests, and batch jobs.
+
+History You Can Reuse
+=====================
+
+After a GUI action:
+
+.. code-block:: python
+
+   print(LASTCOM)
+   for command in ALLCOM[-5:]:
+       print(command)
+
+The recorded commands are meant to be readable and scriptable. When you move
+them out of the console, keep explicit return values:
+
+.. code-block:: python
+
+   EEG, com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, return_com=True)
+   EEG, com = pop_resample(EEG, 64, return_com=True)
+
+Practical Rules
+===============
+
+* Prefer ``eegprep-console --full`` while learning or reviewing data.
+* Use the GUI for inspection-heavy actions and the console for quick checks,
+  summaries, and repeatable commands.
+* Do not edit ``ALLEEG`` by hand in the console unless you are deliberately
+  managing session state yourself.
+* Use ``return_com=True`` when a command should appear in a reproducible script.
+* Remember that GUI selectors are user-facing, while direct NumPy slicing is
+  zero-based Python.
+* Save reviewed datasets explicitly; synchronized state is live session state,
+  not a substitute for saving files.
+
+Troubleshooting State
+=====================
+
+If the GUI and console do not show what you expect, inspect:
+
+.. code-block:: python
+
+   CURRENTSET
+   EEG.get("setname")
+   EEG["data"].shape
+   LASTCOM
+   ALLCOM[-3:]
+   CURRENTSTUDY
+
+If a menu item is disabled, the current dataset or STUDY probably lacks the
+fields that workflow needs. For example, component-review menus need ICA fields,
+and Study plotting menus need an active ``STUDY`` with precomputed measures.
+

--- a/docs/source/user_guide/gui_console_session.rst
+++ b/docs/source/user_guide/gui_console_session.rst
@@ -84,10 +84,10 @@ What Stays Synchronized
    * - ``STUDY`` and ``CURRENTSTUDY``
      - Current group-analysis state.
      - Study menu actions and study ``pop_*`` calls update the shared session.
-   * - ``PLUGINLIST``
+   * - ``session.PLUGINLIST``
      - Bundled and installed extension inventory.
-     - Extension Manager and plugin registry calls read the same runtime
-       registry.
+     - Extension Manager and plugin registry calls store the inventory on the
+       shared session object.
 
 How EEGPrep Implements It
 =========================
@@ -165,4 +165,3 @@ If the GUI and console do not show what you expect, inspect:
 If a menu item is disabled, the current dataset or STUDY probably lacks the
 fields that workflow needs. For example, component-review menus need ICA fields,
 and Study plotting menus need an active ``STUDY`` with precomputed measures.
-

--- a/docs/source/user_guide/gui_tutorials.rst
+++ b/docs/source/user_guide/gui_tutorials.rst
@@ -1,0 +1,222 @@
+.. _gui_tutorials:
+
+=============
+GUI Tutorials
+=============
+
+EEGPrep's GUI is intentionally close to EEGLAB's menu workflow. The difference
+is that ``eegprep-console`` can sit beside the GUI and expose the same session
+as Python names.
+
+Launch
+======
+
+Use the full menu set while learning:
+
+.. code-block:: bash
+
+   uv run eegprep-console --full
+
+Use the GUI-only launcher when you do not need a console:
+
+.. code-block:: bash
+
+   uv run eegprep-gui --full
+
+The console workflow is recommended because it shows ``LASTCOM`` and ``ALLCOM``
+after each menu action.
+
+Load, Inspect, and Save a Dataset
+=================================
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Open <strong>File > Load existing dataset</strong>.</p>
+     <p>Select <code>sample_data/eeglab_data.set</code>.</p>
+     <p>In the console, run <code>EEG["data"].shape</code>,
+     <code>len(ALLEEG)</code>, <code>CURRENTSET</code>, and
+     <code>LASTCOM</code>.</p>
+     <p>Choose <strong>Plot > Channel data (scroll)</strong> to inspect the
+     current dataset in EEGBrowser.</p>
+     <p>Choose <strong>File > Save current dataset as</strong> when you want a
+     new <code>.set</code> file.</p>
+   </div>
+
+Equivalent console calls:
+
+.. code-block:: python
+
+   from pathlib import Path
+   from eegprep import pop_loadset, pop_saveset
+
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   pop_saveset(EEG, Path("sample_data") / "eeglab_data_reviewed.set")
+
+Filter and Resample
+===================
+
+Use these steps for a small, inspectable preprocessing pass on the tutorial
+dataset:
+
+.. list-table::
+   :header-rows: 1
+
+   * - GUI action
+     - Console equivalent
+   * - ``Tools > Filter the data``
+     - ``pop_eegfiltnew(EEG, locutoff=1, hicutoff=40)``
+   * - ``Tools > Change sampling rate``
+     - ``pop_resample(EEG, 64)``
+   * - ``Plot > Channel spectra and maps``
+     - ``pop_spectopo(EEG, 1, [])``
+
+Filtering with ``pop_eegfiltnew`` uses the bundled FIRFilt-style
+Hamming-window FIR defaults. Boundary events are respected when continuous data
+contains breaks. Resampling updates event latencies and clears stale ICA
+activations.
+
+Clean Continuous Data
+=====================
+
+The bundled clean_rawdata workflow is available through the extension menu
+surface and from Python:
+
+.. code-block:: python
+
+   from eegprep import pop_clean_rawdata
+
+   EEG, com = pop_clean_rawdata(
+       EEG,
+       FlatlineCriterion=5,
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4,
+       Highpass=(0.25, 0.75),
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+       return_com=True,
+   )
+
+Run this on continuous data before epoching. If the dialog offers a rejected
+data browser, accepting the browser keeps marks and history synchronized with
+the shared session.
+
+Run ICA and Review ICLabel
+==========================
+
+For a fast review tutorial, load the ICA sample first:
+
+.. code-block:: python
+
+   EEG = pop_loadset("sample_data/eeglab_data_epochs_ica.set")
+
+Then use the GUI:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Choose <strong>Tools > Decompose data by ICA</strong> for datasets that
+     do not already contain ICA fields. The sample above already has ICA.</p>
+     <p>Choose <strong>Tools > Classify components using ICLabel</strong>.</p>
+     <p>Choose <strong>Plot > Component properties</strong> to open the
+     ICLabel-aware property dashboard.</p>
+     <p>Toggle component rejection marks, press OK, and inspect
+     <code>EEG["reject"]["gcompreject"]</code> in the console.</p>
+     <p>Choose <strong>Tools > Remove components from data</strong> only after
+     reviewing labels, scalp maps, spectra, activity, and any DIPFIT fields.</p>
+   </div>
+
+Equivalent console calls:
+
+.. code-block:: python
+
+   from eegprep import eeg_icalabelstat, pop_icflag, pop_iclabel, pop_subcomp, pop_viewprops
+
+   EEG, com = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1, 2, 3])
+   EEG, com = pop_icflag(EEG, return_com=True)
+   EEG, com = pop_subcomp(EEG, [], return_com=True)
+
+Use the empty component list in ``pop_subcomp(EEG, [])`` to remove components
+currently marked in ``EEG.reject.gcompreject``.
+
+Use EEGBrowser for Rejection
+============================
+
+``Plot > Channel data (scroll)`` opens EEGBrowser for inspection. Rejection
+workflows open the same browser in a marking mode. Continuous marks can become
+sample-removal intervals through ``eeg_eegrej``; epoch marks can update
+``EEG.reject.rejmanual`` and then be removed with ``pop_rejepoch``.
+
+See :ref:`eegbrowser` for browser modes, mark fields, and performance behavior.
+
+Create a STUDY
+==============
+
+With multiple datasets loaded in ``ALLEEG``:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Choose <strong>File > Create study > Using all loaded datasets</strong>.</p>
+     <p>Inspect <code>STUDY</code> and <code>CURRENTSTUDY</code> in the console.</p>
+     <p>Choose <strong>Study > Precompute channel measures</strong> for ERP,
+     spectrum, ERSP, or ITC caches.</p>
+     <p>Choose <strong>Study > Plot channel measures</strong> to review cached
+     measures.</p>
+     <p>Choose <strong>File > Save current study as</strong> for a durable
+     <code>.study</code> file.</p>
+   </div>
+
+Equivalent console call:
+
+.. code-block:: python
+
+   STUDY, ALLEEG, com = pop_study(None, ALLEEG, name="Tutorial study", return_com=True)
+
+See :ref:`study_workflows` for design variables, cached measures, clustering,
+PAC, and explicit optional-backend boundaries.
+
+DIPFIT Source Workflow
+======================
+
+Dataset-level DIPFIT helpers are bundled for standalone spherical workflows.
+Use them after ICA:
+
+.. code-block:: python
+
+   from eegprep import pop_dipfit_gridsearch, pop_dipfit_nonlinear, pop_dipfit_settings, pop_dipplot
+
+   EEG, com = pop_dipfit_settings(EEG, model="standardBESA", return_com=True)
+   EEG, com = pop_dipfit_gridsearch(
+       EEG,
+       [1],
+       [-40, -20, 0, 20, 40],
+       [-40, -20, 0, 20, 40],
+       [20, 40, 60],
+       40,
+       return_com=True,
+   )
+   EEG, com = pop_dipfit_nonlinear(EEG, component=1, return_com=True)
+   figures, com = pop_dipplot(EEG, [1], summary="on", return_com=True)
+
+MRI-derived BEM creation, AFNI atlas clipping, LORETA analysis, and STUDY-level
+source statistics remain explicit backend boundaries. EEGPrep raises clear
+errors for unavailable external workflows instead of producing placeholder
+results.
+
+Troubleshooting GUI State
+=========================
+
+If a menu item is disabled, check the current state:
+
+.. code-block:: python
+
+   CURRENTSET
+   CURRENTSTUDY
+   EEG.get("icaweights")
+   EEG.get("trials")
+
+Use ``--full`` to show legacy and advanced menu entries. Use ``--no-plugins``
+to diagnose extension startup problems with only core EEGPrep menus.

--- a/docs/source/user_guide/gui_tutorials.rst
+++ b/docs/source/user_guide/gui_tutorials.rst
@@ -4,9 +4,9 @@
 GUI Tutorials
 =============
 
-EEGPrep's GUI is intentionally close to EEGLAB's menu workflow. The difference
-is that ``eegprep-console`` can sit beside the GUI and expose the same session
-as Python names.
+EEGPrep's GUI is built for practical EEG review: use menus and dialogs for
+visual decisions, keep ``eegprep-console`` beside it for inspection and
+repeatable commands, and save the resulting datasets when review is complete.
 
 Launch
 ======
@@ -24,7 +24,8 @@ Use the GUI-only launcher when you do not need a console:
    uv run eegprep-gui --full
 
 The console workflow is recommended because it shows ``LASTCOM`` and ``ALLCOM``
-after each menu action.
+after each menu action. See :ref:`gui_console_session` for the shared-session
+model and implementation details.
 
 Load, Inspect, and Save a Dataset
 =================================

--- a/docs/source/user_guide/ica_rejection.rst
+++ b/docs/source/user_guide/ica_rejection.rst
@@ -1,64 +1,147 @@
 .. _ica_rejection:
 
-=============================================
+=================================================
 ICA, ICLabel, Rejection, and Visual Diagnostics
-=============================================
+=================================================
 
 EEGPrep follows the EEGLAB component-review workflow: compute ICA, label
-components, inspect the labels and diagnostic displays, flag likely artifacts,
-then remove flagged components when the review is complete.
+components, inspect labels and diagnostic displays, flag likely artifacts, then
+remove flagged components when review is complete.
+
+Use the Sample ICA Dataset
+==========================
+
+The fastest way to learn the workflow is to load the ICA tutorial data:
+
+.. code-block:: python
+
+   from pathlib import Path
+   from eegprep import pop_loadset
+
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set")
+
+The GUI equivalent is ``File > Load existing dataset``.
+
+Run ICA When Needed
+===================
+
+For datasets without ICA fields, use ``Tools > Decompose data by ICA`` or call:
+
+.. code-block:: python
+
+   from eegprep import pop_runica
+
+   EEG, com = pop_runica(EEG, icatype="picard", gui=False, return_com=True)
+
+The default GUI offers runica, robust runica, AMICA, and Picard choices.
+Standalone AMICA requires an AMICA executable configured outside the Python
+package.
 
 ICLabel Workflow
 ================
 
-Run ICA before calling ICLabel:
+Run ICLabel after ICA:
 
 .. code-block:: python
 
-    from eegprep import eeg_icalabelstat, pop_icflag, pop_iclabel, pop_subcomp, pop_viewprops
+   from eegprep import eeg_icalabelstat, pop_icflag, pop_iclabel, pop_subcomp, pop_viewprops
 
-    EEG = pop_iclabel(EEG, "default")
-    stats = eeg_icalabelstat(EEG, threshold=0.9)
-    figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1, 2, 3])
-    EEG = pop_icflag(EEG)
-    EEG = pop_subcomp(EEG, [])
+   EEG, label_com = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1, 2, 3])
+   EEG, flag_com = pop_icflag(EEG, return_com=True)
+   EEG, remove_com = pop_subcomp(EEG, [], return_com=True)
 
-`pop_iclabel` stores class probabilities in
-`EEG.etc.ic_classification.ICLabel.classifications`. The class order is Brain,
-Muscle, Eye, Heart, Line Noise, Channel Noise, and Other.
+``pop_iclabel`` stores class probabilities in
+``EEG["etc"]["ic_classification"]["ICLabel"]["classifications"]``. The class
+order is Brain, Muscle, Eye, Heart, Line Noise, Channel Noise, and Other.
 
-The standalone Python engine ships the default ICLabel network (`netICL.mat`).
-The EEGLAB `lite` and `beta` network artifacts are not bundled in the Python
-package; requesting them with `engine=None` raises a clear limitation. They can
-still be requested through `engine="matlab"` or `engine="octave"` when that
-runtime has an EEGLAB ICLabel checkout with those artifacts.
+GUI Review
+==========
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Choose <strong>Tools > Classify components using ICLabel</strong>.</p>
+     <p>Choose <strong>Plot > Component properties</strong>.</p>
+     <p>Review scalp maps, activity, spectra, ICLabel probabilities, and any
+     stored DIPFIT projection.</p>
+     <p>Toggle component rejection marks and press OK.</p>
+     <p>Inspect <code>EEG["reject"]["gcompreject"]</code>,
+     <code>LASTCOM</code>, and <code>ALLCOM[-1]</code> from
+     <code>eegprep-console</code>.</p>
+     <p>Choose <strong>Tools > Remove components from data</strong> only after
+     review.</p>
+   </div>
+
+Dashboard reject toggles write pending marks to ``EEG.reject.gcompreject`` only
+when the user presses OK, so GUI review and ``eegprep-console`` history remain
+synchronized.
 
 Label Statistics
 ================
 
-`eeg_icalabelstat` mirrors EEGLAB's threshold-count summary and returns the same
-information in a Python dictionary:
+``eeg_icalabelstat`` mirrors EEGLAB's threshold-count summary and returns the
+same information in a Python dictionary:
 
 .. code-block:: python
 
-    stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
-    print(stats["counts"])
-    print(stats["component_indices"])
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   print(stats["counts"])
+   print(stats["component_indices"])
 
-The returned values include per-class counts above threshold, 1-based component
+Returned values include per-class counts above threshold, one-based component
 indices, mean probabilities, dominant-class counts, and rejected/kept tallies
-from `EEG.reject.gcompreject`.
+from ``EEG.reject.gcompreject``.
+
+Flagging Rules
+==============
+
+Use ``pop_icflag`` defaults for an EEGLAB-like first pass, or pass a 7-by-2
+threshold matrix in ICLabel class order:
+
+.. code-block:: python
+
+   import numpy as np
+   from eegprep import pop_icflag
+
+   EEG, com = pop_icflag(
+       EEG,
+       threshold=np.array(
+           [
+               [0, 0],
+               [0.8, 1.0],
+               [0.8, 1.0],
+               [0, 0],
+               [0, 0],
+               [0, 0],
+               [0, 0],
+           ]
+       ),
+       return_com=True,
+   )
+
+Review flags visually before removing components. Automatic labels are a guide,
+not a replacement for expert inspection.
 
 Visual Diagnostics
 ==================
 
-`pop_viewprops(EEG, typecomp=0)` opens EEGPrep's native component-property
+``pop_viewprops(EEG, typecomp=0)`` opens EEGPrep's native component-property
 browser. With ICLabel classifications present, component mode opens the
-`pop_prop_extended` dashboard with scalp map, activity browser, ERP/image
+``pop_prop_extended`` dashboard with scalp map, activity browser, ERP/image
 summary, spectrum, class probabilities, component accept/reject controls, and
-DIPFIT projections when localized dipoles are already stored in `EEG.dipfit`.
+DIPFIT projections when localized dipoles are already stored in ``EEG.dipfit``.
 
-The activity browser uses EEGLAB-facing 1-based component indices and preserves
-event display state through the `scroll_event` option. Dashboard reject toggles
-write pending marks to `EEG.reject.gcompreject` only when the user presses OK,
-so GUI review and `eegprep-console` history remain synchronized.
+The activity browser uses EEGLAB-facing one-based component indices and
+preserves event display state through the ``scroll_event`` option.
+
+Network Availability
+====================
+
+The standalone Python engine ships the default ICLabel network
+(``netICL.mat``). EEGLAB ``lite`` and ``beta`` network artifacts are not
+bundled in the Python package; requesting them with ``engine=None`` raises a
+clear limitation. They can still be requested through ``engine="matlab"`` or
+``engine="octave"`` when that runtime has an EEGLAB ICLabel checkout with those
+artifacts.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -4,192 +4,116 @@
 User Guide
 ==========
 
-Welcome to the eegprep User Guide! This comprehensive guide provides practical documentation for using eegprep in your EEG research and analysis workflows.
+The EEGPrep user guide is organized like a working EEGLAB manual: first the
+workspace and data structures, then GUI workflows, console history, scripting,
+plugins, group analysis, migration notes, and troubleshooting.
 
-Whether you're just getting started with eegprep or looking to master advanced preprocessing techniques, this guide has you covered. We've organized the documentation into logical sections to help you find what you need quickly.
+.. raw:: html
 
-Learning Path
-=============
-
-We recommend following this learning path based on your experience level:
-
-**Beginner**
-  1. Start with :ref:`installation` to set up eegprep
-  2. Follow the :ref:`quickstart` guide for a 5-minute introduction
-  3. Read :ref:`preprocessing_pipeline` to understand the preprocessing workflow
-
-**Intermediate**
-  1. Explore :ref:`configuration` for parameter tuning
-  2. Learn :ref:`bids_workflow` for batch processing
-  3. Review :ref:`preprocessing_pipeline` for detailed step-by-step information
-
-**Advanced**
-  1. Master :ref:`advanced_topics` for custom pipelines
-  2. Explore :ref:`configuration` for advanced settings
-  3. Integrate with :ref:`advanced_topics` for MNE-Python and parallel processing
+   <div class="eegprep-callout">
+     <strong>Recommended path:</strong> run the quick start with
+     <code>sample_data/eeglab_data.set</code>, read the Concepts Guide, then
+     repeat the same workflow once through the GUI and once from
+     <code>eegprep-console</code>.
+   </div>
 
 Getting Started
 ===============
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    installation
    quickstart
-   gui_help_menus
-   extensions
-   eegbrowser
-   interactive_console
-   storage
-   extension_curation
+   concepts
+   eeglab_migration
 
-Core Concepts
-=============
+GUI, Console, and Scripts
+=========================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+
+   gui_tutorials
+   interactive_console
+   scripting_workflows
+   mne_integration
+
+Preprocessing and Review
+========================
+
+.. toctree::
+   :maxdepth: 1
 
    preprocessing_pipeline
    ica_rejection
-   configuration
-
-Data Workflows
-==============
-
-.. toctree::
-   :maxdepth: 2
-
+   eegbrowser
    bids_workflow
-   study_workflows
-   visual_parity
+   storage
 
-Advanced Topics
-===============
+Group and Plugin Workflows
+==========================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
+   study_workflows
+   plugins
+   extensions
+   extension_curation
+
+Admin, Help, and Development
+============================
+
+.. toctree::
+   :maxdepth: 1
+
+   gui_help_menus
+   configuration
+   visual_parity
    advanced_topics
 
-Quick Reference
-===============
+Common Entry Points
+===================
 
-**Common Tasks**
+.. list-table::
+   :header-rows: 1
 
-- :ref:`installation` - Install eegprep
-- :ref:`quickstart` - Load, preprocess, and save EEG data
-- :ref:`gui_help_menus` - Use GUI menus, packaged help, and menu inventory checks
-- :ref:`extensions` - Install, trust, inspect, and use external EEGPrep extensions
-- :ref:`interactive_console` - Use the GUI and Python console together
-- :ref:`extension_curation` - Review extension trust, curation, catalog, and compatibility policy
-- :ref:`preprocessing_pipeline` - Understand preprocessing steps
-- :ref:`ica_rejection` - Review ICLabel labels, flag components, and inspect diagnostics
-- :ref:`bids_workflow` - Process BIDS datasets
-- :ref:`study_workflows` - Use current STUDY creation, save/load, and plotting surfaces
-- :ref:`visual_parity` - Compare future EEGPREP UI states against EEGLAB
-- :ref:`configuration` - Configure preprocessing parameters
-- :ref:`advanced_topics` - Create custom pipelines
+   * - Task
+     - GUI path
+     - Console or Python call
+   * - Load a tutorial dataset
+     - ``File > Load existing dataset``
+     - ``EEG = pop_loadset("sample_data/eeglab_data.set")``
+   * - Inspect channel data
+     - ``Plot > Channel data (scroll)``
+     - ``eegplot(EEG)`` or ``pop_eegplot(EEG)``
+   * - Filter data
+     - ``Tools > Filter the data``
+     - ``pop_eegfiltnew(EEG, locutoff=1, hicutoff=40)``
+   * - Resample data
+     - ``Tools > Change sampling rate``
+     - ``pop_resample(EEG, 64)``
+   * - Run clean_rawdata
+     - ``Tools > Reject data using Clean Rawdata and ASR``
+     - ``pop_clean_rawdata(EEG, BurstCriterion=20)``
+   * - Run ICA
+     - ``Tools > Decompose data by ICA``
+     - ``pop_runica(EEG, icatype="picard", gui=False)``
+   * - Label components
+     - ``Tools > Classify components using ICLabel``
+     - ``pop_iclabel(EEG, "default")``
+   * - Create a STUDY
+     - ``File > Create study > Using all loaded datasets``
+     - ``pop_study(None, ALLEEG, name="My study")``
+   * - Manage extensions
+     - ``File > Manage EEGPrep extensions``
+     - ``plugin_menu(show=False)``
 
-**Key Functions**
+Help Coverage
+=============
 
-- :func:`eegprep.pop_loadset` - Load EEG data
-- :func:`eegprep.pop_saveset` - Save EEG data
-- :func:`eegprep.clean_artifacts` - Comprehensive artifact removal
-- :func:`eegprep.iclabel` - Classify ICA components
-- :func:`eegprep.pop_resample` - Resample data
-- :func:`eegprep.pop_eegfiltnew` - Filter data
-- :func:`eegprep.bids_preproc` - Batch process BIDS datasets
-
-**Configuration**
-
-- :class:`eegprep.EEG_OPTIONS` - Configuration object
-- Preprocessing parameters
-- Custom preprocessing chains
-
-**Integration**
-
-- MNE-Python integration
-- EEGLAB compatibility
-- BIDS support
-
-Documentation Structure
-=======================
-
-**Installation**
-  Complete installation guide covering system requirements, installation methods, optional dependencies, verification, and troubleshooting.
-
-**Quick Start**
-  5-minute introduction to eegprep with practical examples covering loading data, preprocessing, saving results, and visualization.
-
-**Preprocessing Pipeline**
-  Detailed overview of the preprocessing pipeline including all steps, parameter tuning, quality control, and common issues.
-
-**BIDS Workflow**
-  Guide to working with BIDS-formatted datasets including loading, batch processing, output structure, and integration with other tools.
-
-**Configuration**
-  Comprehensive guide to configuring eegprep including EEG_OPTIONS, common parameters, custom preprocessing chains, and advanced settings.
-
-**Advanced Topics**
-  Advanced topics for experienced users including custom pipelines, extending the pipeline, MNE-Python integration, parallel processing, and performance optimization.
-
-Key Concepts
-============
-
-**EEG Data Structure**
-  eegprep uses the EEGobj class to represent EEG data, which is compatible with EEGLAB format.
-
-**Preprocessing Pipeline**
-  The preprocessing pipeline consists of sequential steps: channel selection, artifact removal, channel interpolation, resampling, filtering, ICA decomposition, and component classification.
-
-**BIDS Format**
-  Brain Imaging Data Structure (BIDS) is a standardized format for organizing neuroimaging data, enabling consistent and reproducible analysis.
-
-**ICA Decomposition**
-  Independent Component Analysis (ICA) decomposes EEG data into independent components, which can be classified as brain activity or artifacts.
-
-**Component Classification**
-  ICLabel automatically classifies ICA components into categories such as brain, muscle, eye, heart, line noise, and channel noise.
-
-Getting Help
-============
-
-If you need help:
-
-1. Check the relevant section in this guide
-2. Review the :ref:`api_reference` documentation
-3. Visit the `GitHub Issues <https://github.com/sccn/eegprep/issues>`_ page
-4. Check the `GitHub Discussions <https://github.com/sccn/eegprep/discussions>`_ page
-
-Contributing
-============
-
-We welcome contributions! If you find issues or have suggestions for improving the documentation, please:
-
-1. Open an issue on `GitHub <https://github.com/sccn/eegprep/issues>`_
-2. Submit a pull request with improvements
-3. Share your feedback in `GitHub Discussions <https://github.com/sccn/eegprep/discussions>`_
-
-License
-=======
-
-eegprep is released under the GNU General Public License v3.0. See the LICENSE file for details.
-
-Citation
-========
-
-If you use eegprep in your research, please cite:
-
-.. code-block:: bibtex
-
-    @software{eegprep2024,
-      title={eegprep: A Python package for EEG preprocessing},
-      author={SCCN},
-      year={2024},
-      url={https://github.com/sccn/eegprep}
-    }
-
-Acknowledgments
-===============
-
-eegprep is built on the foundations of EEGLAB and incorporates algorithms and methods from the EEG research community. We acknowledge the contributions of all researchers and developers who have contributed to EEG analysis methods.
+Every implemented GUI Help button and ``pophelp`` topic uses EEGPrep-owned
+Markdown resources packaged under ``src/eegprep/resources/help``. Missing help
+is a packaging error; runtime code does not fall back to the vendored EEGLAB
+reference tree.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -4,17 +4,18 @@
 User Guide
 ==========
 
-The EEGPrep user guide is organized like a working EEGLAB manual: first the
-workspace and data structures, then GUI workflows, console history, scripting,
-plugins, group analysis, migration notes, and troubleshooting.
+The EEGPrep user guide is organized around real research workflows: load data,
+understand the dataset structure, work in the GUI and console together, script
+repeatable steps, review artifacts and components, manage plugins, and run
+group-level analyses.
 
 .. raw:: html
 
    <div class="eegprep-callout">
      <strong>Recommended path:</strong> run the quick start with
      <code>sample_data/eeglab_data.set</code>, read the Concepts Guide, then
-     repeat the same workflow once through the GUI and once from
-     <code>eegprep-console</code>.
+     repeat the same workflow with the GUI and <code>eegprep-console</code>
+     open side by side.
    </div>
 
 Getting Started
@@ -34,6 +35,7 @@ GUI, Console, and Scripts
 .. toctree::
    :maxdepth: 1
 
+   gui_console_session
    gui_tutorials
    interactive_console
    scripting_workflows

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -77,6 +77,12 @@ To install eegprep from source for development:
 ``uv sync`` creates the project environment, installs EEGPrep in editable mode,
 and uses ``uv.lock`` for reproducible dependency resolution.
 
+To develop or build documentation from source, include the docs extra:
+
+.. code-block:: bash
+
+    uv sync --group dev --extra docs
+
 Optional Dependencies
 =====================
 
@@ -151,7 +157,14 @@ To build the documentation locally:
 
 .. code-block:: bash
 
-    uv sync --extra docs
+    uv sync --group dev --extra docs
+    uv run --no-sync sphinx-build -b html docs/source docs/_build/html
+
+The ``docs/Makefile`` target is also available:
+
+.. code-block:: bash
+
+    uv run --no-sync make -C docs html
 
 All Optional Dependencies
 --------------------------

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -298,10 +298,10 @@ Getting Help
 
 If you encounter issues not covered here:
 
-1. Check the `FAQ <faq.rst>`_ section
-2. Review the `Common Issues <common_issues.rst>`_ guide
+1. Check the :doc:`../faq` section
+2. Review the troubleshooting sections in this installation guide and FAQ
 3. Visit the `GitHub Issues <https://github.com/sccn/eegprep/issues>`_ page
-4. Check the `API Documentation <../api/index.rst>`_
+4. Check the :doc:`../api/index`
 
 Next Steps
 ==========

--- a/docs/source/user_guide/interactive_console.rst
+++ b/docs/source/user_guide/interactive_console.rst
@@ -40,15 +40,31 @@ The console starts with EEGLAB-style workspace names already defined:
    CURRENTSTUDY
 
 Actions taken in the GUI update these names in the console. Commands run in the
-console update the same GUI session. For example:
+console update the same GUI session.
+
+Sample Data Walkthrough
+=======================
+
+Start the console and load the tutorial dataset from the GUI with
+``File > Load existing dataset``. Select ``sample_data/eeglab_data.set``. Then
+inspect the shared state:
 
 .. code-block:: python
 
-   pop_reref(EEG, [])
+   EEG["setname"]
+   EEG["data"].shape
+   CURRENTSET
+   LASTCOM
 
-updates the current dataset, refreshes the GUI, and appends the returned command
-to ``ALLCOM``. The console-local ``eegprep`` object wraps ``pop_*`` functions
-the same way, so this also updates the shared session:
+Now run a preprocessing step from the console:
+
+.. code-block:: python
+
+   pop_resample(EEG, 64)
+
+The current dataset is stored back into the session, the GUI refreshes, and the
+returned command is appended to ``ALLCOM``. The console-local ``eegprep`` object
+wraps ``pop_*`` functions the same way, so this also updates the shared session:
 
 .. code-block:: python
 
@@ -62,6 +78,27 @@ Assignment-style calls also work:
 
 This console behavior is specific to ``eegprep-console``. Normal Python imports
 keep standard Python semantics, where returned values must be assigned manually.
+
+History Replay
+==============
+
+Use ``LASTCOM`` for the most recent menu or console command and ``ALLCOM`` for
+the ordered session history:
+
+.. code-block:: python
+
+   print(LASTCOM)
+   for command in ALLCOM[-5:]:
+       print(command)
+
+When you move commands into a script, keep the explicit assignment:
+
+.. code-block:: python
+
+   EEG, com = pop_resample(EEG, 64, return_com=True)
+
+GUI Help, STUDY, and Extensions
+===============================
 
 Help and admin menu actions use the same shared session. For example, loading
 or creating a STUDY from the GUI updates ``STUDY`` and ``CURRENTSTUDY`` in the

--- a/docs/source/user_guide/interactive_console.rst
+++ b/docs/source/user_guide/interactive_console.rst
@@ -27,7 +27,7 @@ native file pickers, launch:
 
    uv run eegprep-console --full --native-file-dialogs
 
-The console starts with EEGLAB-style workspace names already defined:
+The console starts with familiar workspace names already defined:
 
 .. code-block:: python
 
@@ -41,6 +41,9 @@ The console starts with EEGLAB-style workspace names already defined:
 
 Actions taken in the GUI update these names in the console. Commands run in the
 console update the same GUI session.
+
+For the full mixed workflow and implementation model, see
+:ref:`gui_console_session`.
 
 Sample Data Walkthrough
 =======================

--- a/docs/source/user_guide/mne_integration.rst
+++ b/docs/source/user_guide/mne_integration.rst
@@ -1,0 +1,129 @@
+.. _mne_integration:
+
+======================
+MNE-Python Integration
+======================
+
+This page addresses the MNE examples requested in GitHub issue #22. EEGPrep is
+not a replacement for MNE-Python. The intended workflow is to use EEGPrep when
+you want EEGLAB-style preprocessing, ``pop_*`` history, GUI review, and
+standalone plugin ports, then convert to MNE when your downstream analysis
+belongs in MNE.
+
+Install
+=======
+
+MNE-Python is a core dependency in current EEGPrep source installs. If you are
+building a custom environment, make sure it is present:
+
+.. code-block:: bash
+
+   uv add mne
+
+EEGPrep's conversion helpers use MNE's EEGLAB import/export path internally.
+Keep MNE and EEGPrep in the same environment.
+
+EEGPrep to MNE Raw
+==================
+
+Continuous EEGPrep data converts to an MNE ``Raw`` object:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from eegprep import eeg_eeg2mne, pop_loadset
+
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   raw = eeg_eeg2mne(EEG)
+
+   print(raw)
+   print(raw.info["sfreq"])
+
+Use this path when you want to inspect, plot, or analyze an EEGPrep-processed
+dataset with MNE functions.
+
+MNE Raw to EEGPrep
+==================
+
+You can also start from an MNE object and move into EEGPrep:
+
+.. code-block:: python
+
+   import numpy as np
+   import mne
+
+   from eegprep import eeg_mne2eeg, pop_eegfiltnew
+
+   sfreq = 128.0
+   data = 1e-6 * np.random.default_rng(0).normal(size=(4, int(sfreq * 10)))
+   info = mne.create_info(["Fz", "Cz", "Pz", "Oz"], sfreq=sfreq, ch_types="eeg")
+   raw = mne.io.RawArray(data, info)
+   raw.set_annotations(mne.Annotations(onset=[1.0, 5.0], duration=[0.0, 0.0], description=["stim", "stim"]))
+
+   EEG = eeg_mne2eeg(raw)
+   EEG, com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False, return_com=True)
+
+   print(EEG["data"].shape)
+   print(EEG["event"])
+   print(com)
+
+Annotations become EEGPrep event records with EEGLAB-facing sample latencies.
+
+MNE Epochs to EEGPrep
+=====================
+
+``eeg_mne2eeg`` accepts MNE Epochs objects through MNE's EEGLAB exporter. Use
+``eeg_mne2eeg_epochs`` when you specifically need the ICA-aware epochs
+conversion helper; that helper expects both an MNE ``Epochs`` object and an MNE
+``ICA`` object.
+
+.. code-block:: python
+
+   import numpy as np
+   import mne
+
+   from eegprep import eeg_mne2eeg
+
+   sfreq = 128.0
+   info = mne.create_info(["Fz", "Cz", "Pz", "Oz"], sfreq=sfreq, ch_types="eeg")
+   data = 1e-6 * np.random.default_rng(1).normal(size=(3, 4, 128))
+   events = np.array([[0, 0, 1], [128, 0, 1], [256, 0, 2]])
+   epochs = mne.EpochsArray(data, info, events=events, event_id={"target": 1, "standard": 2}, tmin=-0.2)
+
+   EEG = eeg_mne2eeg(epochs)
+   print(EEG["data"].shape)
+   print(EEG["trials"])
+
+Round-Trip Pattern
+==================
+
+A practical workflow is:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Use MNE to read a hardware-specific file format when MNE has the best
+     reader for your data.</p>
+     <p>Convert the MNE object to EEGPrep with <code>eeg_mne2eeg</code>.</p>
+     <p>Run EEGLAB-style preprocessing, GUI review, ICLabel, or STUDY setup in
+     EEGPrep.</p>
+     <p>Convert back with <code>eeg_eeg2mne</code> for MNE source analysis,
+     statistics, reports, or pipelines that require MNE objects.</p>
+   </div>
+
+Boundary Notes
+==============
+
+* EEGPrep stores data in EEGLAB-style dictionaries. MNE stores data in ``Raw``
+  and ``Epochs`` objects with an ``Info`` structure.
+* MNE channel data is usually in volts. EEGLAB ``.set`` readers and writers may
+  display EEG data in microvolt-oriented workflows. Inspect units before
+  comparing absolute amplitudes.
+* EEGPrep event latencies are EEGLAB-facing sample positions. MNE annotations
+  are onset times in seconds and events arrays are sample-index rows.
+* Conversion helpers use temporary EEGLAB files internally, so keep output paths
+  writable and avoid using them inside tight real-time loops.
+* For BIDS projects, use :ref:`bids_workflow` when you want EEGPrep's BIDS
+  metadata handling and use MNE-BIDS/MNE when your downstream analysis is
+  MNE-native.

--- a/docs/source/user_guide/mne_integration.rst
+++ b/docs/source/user_guide/mne_integration.rst
@@ -6,9 +6,8 @@ MNE-Python Integration
 
 This page addresses the MNE examples requested in GitHub issue #22. EEGPrep is
 not a replacement for MNE-Python. The intended workflow is to use EEGPrep when
-you want EEGLAB-style preprocessing, ``pop_*`` history, GUI review, and
-standalone plugin ports, then convert to MNE when your downstream analysis
-belongs in MNE.
+you want EEGPrep preprocessing, ``pop_*`` history, GUI review, and standalone
+plugin ports, then convert to MNE when your downstream analysis belongs in MNE.
 
 Install
 =======
@@ -106,7 +105,7 @@ A practical workflow is:
      <p>Use MNE to read a hardware-specific file format when MNE has the best
      reader for your data.</p>
      <p>Convert the MNE object to EEGPrep with <code>eeg_mne2eeg</code>.</p>
-     <p>Run EEGLAB-style preprocessing, GUI review, ICLabel, or STUDY setup in
+     <p>Run EEGPrep preprocessing, GUI review, ICLabel, or STUDY setup in
      EEGPrep.</p>
      <p>Convert back with <code>eeg_eeg2mne</code> for MNE source analysis,
      statistics, reports, or pipelines that require MNE objects.</p>
@@ -115,8 +114,8 @@ A practical workflow is:
 Boundary Notes
 ==============
 
-* EEGPrep stores data in EEGLAB-style dictionaries. MNE stores data in ``Raw``
-  and ``Epochs`` objects with an ``Info`` structure.
+* EEGPrep stores data in EEG dictionaries. MNE stores data in ``Raw`` and
+  ``Epochs`` objects with an ``Info`` structure.
 * MNE channel data is usually in volts. EEGLAB ``.set`` readers and writers may
   display EEG data in microvolt-oriented workflows. Inspect units before
   comparing absolute amplitudes.

--- a/docs/source/user_guide/plugins.rst
+++ b/docs/source/user_guide/plugins.rst
@@ -1,0 +1,175 @@
+.. _plugins:
+
+===============================
+Bundled Plugins and Extensions
+===============================
+
+EEGPrep ships Python ports of several EEGLAB plugin workflows. They are bundled
+with the package, exposed in the GUI, available from ``eegprep-console``, and
+documented in the API reference. External extensions use a separate Python
+package registry described in :ref:`extensions`.
+
+Bundled Plugin Inventory
+========================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Plugin
+     - Main entry points
+     - Implemented workflow
+   * - clean_rawdata
+     - ``pop_clean_rawdata``, ``clean_artifacts``, ``clean_asr``,
+       ``vis_artifacts``
+     - Drift, flatline, noisy-channel, ASR, window cleaning, and visual artifact
+       review for continuous data.
+   * - FIRFilt
+     - ``pop_eegfiltnew``, ``pop_firws``, ``pop_firpm``, ``pop_firma``,
+       ``pop_xfirws``
+     - EEGLAB-style FIR filtering, filter-order helpers, response reports, and
+       boundary-aware filtering.
+   * - ICLabel
+     - ``pop_iclabel``, ``pop_icflag``, ``eeg_icalabelstat``,
+       ``pop_viewprops``, ``pop_prop_extended``
+     - Default ICLabel network classification, threshold flagging, component
+       dashboards, and label statistics.
+   * - DIPFIT
+     - ``pop_dipfit_settings``, ``pop_dipfit_gridsearch``,
+       ``pop_dipfit_nonlinear``, ``pop_multifit``, ``pop_dipplot``,
+       ``pop_leadfield``
+     - Standalone spherical source-localization workflows for ICA components
+       and explicit limits for unavailable external backends.
+   * - EEG-BIDS
+     - ``pop_importbids``, ``pop_exportbids``, ``pop_load_frombids``,
+       ``bids_preproc``, ``bids_list_eeg_files``
+     - BIDS import/export, metadata loading, and batch preprocessing helpers.
+
+Inspect Installed Plugin Metadata
+=================================
+
+From normal Python or ``eegprep-console``:
+
+.. code-block:: python
+
+   import eegprep
+
+   for plugin in eegprep.bundled_plugins():
+       print(plugin["plugin"], plugin["funcname"], plugin["menu"])
+
+   status, names, records = eegprep.plugin_status("ICLabel", exactmatch=True)
+   print(status, names)
+
+   inventory = eegprep.plugin_menu(show=False)
+   print(eegprep.format_plugin_menu())
+
+The Extension Manager dialog uses the same metadata and adds curated catalog
+records when available.
+
+clean_rawdata and ASR
+=====================
+
+Use the ``pop_*`` wrapper when you want GUI behavior or command history:
+
+.. code-block:: python
+
+   from eegprep import pop_clean_rawdata
+
+   EEG, com = pop_clean_rawdata(
+       EEG,
+       FlatlineCriterion=5,
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4,
+       Highpass=(0.25, 0.75),
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+       return_com=True,
+   )
+
+Use ``clean_artifacts`` when you need lower-level tuple outputs:
+
+.. code-block:: python
+
+   from eegprep import clean_artifacts
+
+   clean_eeg, highpass_state, burst_state, removed_channels = clean_artifacts(EEG)
+
+FIRFilt
+=======
+
+``pop_eegfiltnew`` is the usual filtering entry point:
+
+.. code-block:: python
+
+   EEG, com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False, return_com=True)
+
+Use the lower-level FIRFilt helpers for custom order/window work:
+
+.. code-block:: python
+
+   beta = pop_kaiserbeta(0.001)
+   order = pop_firwsord("kaiser", EEG["srate"], 2, 0.001)
+   EEG, com = pop_firws(
+       EEG,
+       fcutoff=[1, 40],
+       ftype="bandpass",
+       wtype="kaiser",
+       warg=beta,
+       forder=order,
+       return_com=True,
+   )
+
+ICLabel
+=======
+
+The standalone Python engine ships the default ICLabel network. ``lite`` and
+``beta`` network requests require MATLAB or Octave with an EEGLAB ICLabel
+checkout that provides those artifacts.
+
+.. code-block:: python
+
+   EEG, com = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   EEG, com = pop_icflag(EEG, return_com=True)
+
+Review components visually with ``pop_viewprops`` before removing them.
+
+DIPFIT
+======
+
+DIPFIT helpers support standalone spherical workflows. They store model fields
+under ``EEG["dipfit"]["model"]`` and keep command strings replayable:
+
+.. code-block:: python
+
+   EEG, com = pop_dipfit_settings(EEG, model="standardBESA", return_com=True)
+   EEG, com = pop_multifit(EEG, [1, 2, 3], threshold=40, return_com=True)
+
+Unavailable MRI/BEM, AFNI, LORETA, and STUDY-level source-statistics workflows
+raise explicit errors.
+
+EEG-BIDS
+========
+
+Use ``pop_load_frombids`` for one EEG recording inside a BIDS dataset and
+``bids_preproc`` for batch workflows:
+
+.. code-block:: python
+
+   EEG, report = pop_load_frombids(
+       "sub-01/eeg/sub-01_task-rest_eeg.set",
+       return_report=True,
+   )
+
+See :ref:`bids_workflow` for BIDS dataset layout and batch notes.
+
+External Extensions
+===================
+
+External EEGPrep extensions are Python packages, not MATLAB plugin folders.
+They declare an ``eegprep.extensions`` entry point and return an
+``ExtensionSpec``. The Extension Manager shows installed and curated extension
+metadata but does not install, update, remove, unzip, or execute package-manager
+commands for the user.
+
+Continue with :ref:`extensions` for package authoring and :ref:`extension_curation`
+for catalog/trust policy.

--- a/docs/source/user_guide/plugins.rst
+++ b/docs/source/user_guide/plugins.rst
@@ -26,7 +26,7 @@ Bundled Plugin Inventory
    * - FIRFilt
      - ``pop_eegfiltnew``, ``pop_firws``, ``pop_firpm``, ``pop_firma``,
        ``pop_xfirws``
-     - EEGLAB-style FIR filtering, filter-order helpers, response reports, and
+     - FIR filtering, filter-order helpers, response reports, and
        boundary-aware filtering.
    * - ICLabel
      - ``pop_iclabel``, ``pop_icflag``, ``eeg_icalabelstat``,

--- a/docs/source/user_guide/preprocessing_pipeline.rst
+++ b/docs/source/user_guide/preprocessing_pipeline.rst
@@ -4,609 +4,254 @@
 Preprocessing Pipeline
 ======================
 
-This guide provides a comprehensive overview of the eegprep preprocessing pipeline, including the order of operations, parameter tuning, and quality control.
+This page describes a practical EEGLAB-style preprocessing order in EEGPrep.
+It is not a mandatory recipe for every experiment. Adapt thresholds and review
+steps to your data, task, and lab standards.
 
-Pipeline Overview
+Recommended Order
 =================
 
-The eegprep preprocessing pipeline is designed to systematically clean and prepare raw EEG data for analysis. The pipeline removes artifacts, interpolates bad channels, resamples data, applies filtering, performs ICA decomposition, and classifies independent components.
+.. raw:: html
 
-Key Features:
+   <div class="eegprep-path">
+     <p>Load data and verify channel locations, sampling rate, events, and data
+     shape.</p>
+     <p>Select or remove channels that should not enter EEG cleaning.</p>
+     <p>Filter or clean continuous data before epoching.</p>
+     <p>Resample when lower sampling rate is appropriate for the analysis.</p>
+     <p>Run ICA on cleaned continuous or appropriate epoched data.</p>
+     <p>Classify and inspect components with ICLabel and property dashboards.</p>
+     <p>Epoch, reject, baseline correct, and save reviewed datasets.</p>
+   </div>
 
-- **Automated artifact detection and removal**: Identifies and removes noisy channels and time windows
-- **Flexible component classification**: Uses ICLabel for automatic ICA component classification
-- **Customizable parameters**: Adjust thresholds and methods for your specific needs
-- **Quality control**: Built-in checks and visualizations to assess preprocessing quality
-- **Batch processing**: Process multiple subjects efficiently with :func:`eegprep.bids_preproc`
-
-Pipeline Steps
-==============
-
-The preprocessing pipeline follows these steps in order:
-
-1. Channel Selection
-2. Artifact Removal (ASR and clean_artifacts)
-3. Channel Interpolation
-4. Resampling
-5. Filtering
-6. ICA Decomposition
-7. Component Classification (ICLabel)
-
-Step 1: Channel Selection
--------------------------
-
-Select the channels to include in preprocessing:
+Start From Sample Data
+======================
 
 .. code-block:: python
 
-    from eegprep import pop_select
+   from pathlib import Path
+   from eegprep import pop_loadset
 
-    # Select only EEG channels
-    eeg = pop_select(eeg, 'type', 'EEG')
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   print(EEG["data"].shape, EEG["srate"], len(EEG["event"]))
 
-    # Select specific channels by name
-    eeg = pop_select(eeg, 'channel', ['Cz', 'Pz', 'Oz', 'Fz'])
+Select Data and Channels
+========================
 
-    # Remove specific channels
-    eeg = pop_select(eeg, 'nochannel', ['HEOG', 'VEOG'])
-
-**When to use**: Always perform channel selection first to ensure you're working with the correct data.
-
-Step 2: Artifact Removal
-------------------------
-
-Remove noisy channels and time windows using multiple methods:
-
-Flatline Detection
-~~~~~~~~~~~~~~~~~~
-
-Remove channels with no variation (dead channels):
+Use ``pop_select`` for user-facing channel, point, time, trial, and event
+selection:
 
 .. code-block:: python
 
-    from eegprep import clean_flatlines
+   from eegprep import pop_select
 
-    eeg = clean_flatlines(
-        eeg,
-        flatline_criterion=5  # Flatline duration in seconds
-    )
+   EEG, com = pop_select(EEG, channel=[1, 2, 3, 4, 5], return_com=True)
 
-Noisy Channel Removal
-~~~~~~~~~~~~~~~~~~~~~
+GUI path: ``Edit > Select data``. Channel/component values in GUI dialogs are
+EEGLAB-facing one-based values.
 
-Remove channels with excessive noise:
+Filter
+======
 
-.. code-block:: python
-
-    from eegprep import clean_channels
-
-    eeg = clean_channels(
-        eeg,
-        ransac_criterion=0.8,  # RANSAC correlation threshold
-        max_broken_time=0.5    # Max proportion of broken time
-    )
-
-Artifact Subspace Reconstruction (ASR)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Remove bursts of high-amplitude artifacts:
+The usual FIR filtering entry point is ``pop_eegfiltnew``:
 
 .. code-block:: python
 
-    from eegprep import clean_asr
+   from eegprep import pop_eegfiltnew
 
-    eeg = clean_asr(
-        eeg,
-        asr_criterion=20,      # Standard deviation threshold
-        asr_wlen=0.5           # Window length in seconds
-    )
+   EEG, com = pop_eegfiltnew(
+       EEG,
+       locutoff=1.0,
+       hicutoff=40.0,
+       plotfreqz=False,
+       return_com=True,
+   )
+
+GUI path: ``Tools > Filter the data``. The wrapper uses bundled FIRFilt-style
+Hamming-window defaults, respects continuous-data boundary events, clears stale
+ICA activations, and returns a replayable history command.
+
+Use FIRFilt helpers for custom filter design:
+
+.. code-block:: python
+
+   from eegprep import pop_firws, pop_firwsord, pop_kaiserbeta
+
+   beta = pop_kaiserbeta(0.001)
+   order = pop_firwsord("kaiser", EEG["srate"], 2, 0.001)
+   EEG, com = pop_firws(
+       EEG,
+       fcutoff=[1, 40],
+       ftype="bandpass",
+       wtype="kaiser",
+       warg=beta,
+       forder=order,
+       return_com=True,
+   )
+
+Clean Continuous Data
+=====================
+
+Use ``pop_clean_rawdata`` when you want the EEGLAB-style GUI wrapper and
+history string:
+
+.. code-block:: python
+
+   from eegprep import pop_clean_rawdata
+
+   EEG, com = pop_clean_rawdata(
+       EEG,
+       FlatlineCriterion=5,
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4,
+       Highpass=(0.25, 0.75),
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+       return_com=True,
+   )
+
+Use ``clean_artifacts`` when you need lower-level state outputs:
+
+.. code-block:: python
+
+   from eegprep import clean_artifacts
+
+   clean_eeg, highpass_state, burst_state, removed_channels = clean_artifacts(
+       EEG,
+       FlatlineCriterion=5,
+       ChannelCriterion=0.8,
+       LineNoiseCriterion=4,
+       Highpass=(0.25, 0.75),
+       BurstCriterion=20,
+       WindowCriterion=0.25,
+   )
+
+``clean_artifacts`` returns four values. Scripts that only need the cleaned EEG
+should use the first value or call ``pop_clean_rawdata``.
+
+Riemannian ASR Notes
+====================
 
 EEGPrep supports the Riemannian ASR calibration variant through
-``clean_asr(eeg, useriemannian="calib")`` and
-``clean_artifacts(eeg, Distance="Riemannian")``. Full Riemannian ASR
+``clean_asr(EEG, useriemannian="calib")`` and
+``clean_artifacts(EEG, Distance="Riemannian")``. Full Riemannian ASR
 processing is not ported, so direct full-process requests fail clearly instead
 of silently substituting MATLAB-only behavior.
 
+Review Rejected Segments
+========================
+
 ``vis_artifacts(clean_eeg, original_eeg)`` opens an EEG browser with rejected
 sample intervals highlighted from ``clean_sample_mask``. Use
-``vis_artifacts(clean_eeg, original_eeg, show=False)`` to get rejected
-intervals, rejected fraction, removed channel labels, and the generated
-``winrej`` matrix without opening a GUI.
-
-Comprehensive Artifact Removal
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use the all-in-one :func:`eegprep.clean_artifacts` function:
+``show=False`` when scripting diagnostics:
 
 .. code-block:: python
 
-    from eegprep import clean_artifacts
+   from eegprep import vis_artifacts
 
-    eeg = clean_artifacts(
-        eeg,
-        flatline_criterion=5,
-        highpass=1,
-        lowpass=100,
-        asr_criterion=20,
-        asr_wlen=0.5,
-        remove_channels=True,
-        remove_windows=True
-    )
+   diagnostics = vis_artifacts(clean_eeg, EEG, show=False)
+   print(diagnostics["rejected_fraction"])
 
-**Parameters**:
+Resample
+========
 
-- ``flatline_criterion``: Duration (seconds) of flatline to detect (default: 5)
-- ``asr_criterion``: Standard deviation threshold for ASR (default: 20)
-- ``asr_wlen``: Window length for ASR in seconds (default: 0.5)
-- ``highpass``: High-pass filter frequency in Hz (default: 1)
-- ``lowpass``: Low-pass filter frequency in Hz (default: 100)
-
-Step 3: Channel Interpolation
-------------------------------
-
-Interpolate removed channels using spherical spline interpolation:
+Resample after early cleaning/filtering when a lower sampling rate is
+appropriate:
 
 .. code-block:: python
 
-    from eegprep import eeg_interp
+   from eegprep import pop_resample
 
-    # Interpolate removed channels
-    eeg = eeg_interp(eeg)
+   EEG, com = pop_resample(EEG, 64, return_com=True)
 
-    # Interpolate specific channels
-    eeg = eeg_interp(eeg, channels=[1, 5, 10])
+GUI path: ``Tools > Change sampling rate``. Continuous data with boundary
+events is resampled by segment. Event latencies and the time vector are updated.
 
-**When to use**: After removing noisy channels, interpolate them to maintain spatial coverage.
-
-Step 4: Resampling
-------------------
-
-Resample data to a lower sampling rate to reduce file size and computation:
-
-.. code-block:: python
-
-    from eegprep import pop_resample
-
-    # Resample to 250 Hz
-    eeg = pop_resample(eeg, 250)
-
-    # Resample to 500 Hz
-    eeg = pop_resample(eeg, 500)
-
-**Common sampling rates**:
-
-- 250 Hz: Standard for most EEG analysis
-- 500 Hz: Higher resolution for detailed analysis
-- 100 Hz: Lower resolution for quick analysis
-
-**When to use**: Resample early in the pipeline to reduce computation time for subsequent steps.
-
-Step 5: Filtering
------------------
-
-Apply frequency filtering to remove noise outside the frequency band of interest:
-
-EEGPrep includes standalone ports of the bundled FIRFilt plugin. The
-EEGLAB-style wrappers split continuous data at boundary events before
-filtering, clear stale ICA activations, and return replayable history commands.
-
-High-Pass Filtering
-~~~~~~~~~~~~~~~~~~~
-
-Remove slow drifts and DC offset:
-
-.. code-block:: python
-
-    from eegprep import pop_eegfiltnew
-
-    # High-pass filter at 1 Hz
-    eeg = pop_eegfiltnew(eeg, locutoff=1)
-
-Low-Pass Filtering
-~~~~~~~~~~~~~~~~~~
-
-Remove high-frequency noise:
-
-.. code-block:: python
-
-    # Low-pass filter at 100 Hz
-    eeg = pop_eegfiltnew(eeg, hicutoff=100)
-
-Band-Pass Filtering
-~~~~~~~~~~~~~~~~~~~
-
-Apply both high-pass and low-pass filters:
-
-.. code-block:: python
-
-    # Band-pass filter 1-100 Hz
-    eeg = pop_eegfiltnew(eeg, locutoff=1, hicutoff=100)
-
-Windowed-Sinc FIRFilt Helpers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use the bundled FIRFilt helpers when you need EEGLAB FIRFilt order estimation,
-window selection, reports, response plots, or xfir export.
-
-.. code-block:: python
-
-    from eegprep import pop_firws, pop_firwsord, pop_kaiserbeta, pop_xfirws
-
-    beta = pop_kaiserbeta(0.001)
-    order = pop_firwsord("kaiser", eeg["srate"], 2, 0.001)
-    eeg = pop_firws(
-        eeg,
-        fcutoff=[1, 40],
-        ftype="bandpass",
-        wtype="kaiser",
-        warg=beta,
-        forder=order,
-    )
-    b, a = pop_xfirws(
-        srate=eeg["srate"],
-        fcutoff=[1, 40],
-        ftype="bandpass",
-        wtype="kaiser",
-        warg=beta,
-        forder=order,
-    )
-
-**Common filter settings**:
-
-- **Resting state**: 1-100 Hz
-- **Event-related potentials (ERP)**: 0.1-30 Hz
-- **Oscillatory analysis**: 1-100 Hz
-- **High-frequency activity**: 1-200 Hz
-
-**When to use**: Apply filtering after resampling but before ICA for best results.
-
-Step 6: ICA Decomposition
--------------------------
-
-Decompose the data into independent components:
-
-Using Picard Algorithm
-~~~~~~~~~~~~~~~~~~~~~~
-
-Fast and reliable ICA decomposition:
-
-.. code-block:: python
-
-    from eegprep import eeg_picard
-
-    eeg = eeg_picard(
-        eeg,
-        ncomps=None,  # Number of components (None = number of channels)
-        max_iter=500  # Maximum iterations
-    )
-
-Using Extended Infomax ICA
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Alternative ICA algorithm:
-
-.. code-block:: python
-
-    from eegprep import eeg_picard
-
-    # Picard is recommended, but you can adjust parameters
-    eeg = eeg_picard(eeg, ncomps=eeg.nbchan)
-
-**Parameters**:
-
-- ``ncomps``: Number of components to extract (default: number of channels)
-- ``max_iter``: Maximum iterations (default: 500)
-
-**When to use**: After filtering, before component classification.
-
-Using AMICA
-~~~~~~~~~~~
-
-AMICA is supported through an external executable. EEGPrep packages do not ship
-AMICA binaries; set ``AMICA_BINARY``, put the executable on ``PATH``, or pass
-``amica_binary`` explicitly.
-
-.. code-block:: python
-
-    from eegprep import eeg_amica
-
-    eeg = eeg_amica(
-        eeg,
-        amica_binary="/path/to/amica15ub",
-        max_iter=500,
-    )
-
-Step 7: Component Classification (ICLabel)
--------------------------------------------
-
-Automatically classify ICA components using ICLabel:
-
-.. code-block:: python
-
-    from eegprep import eeg_icalabelstat, pop_iclabel, pop_viewprops
-
-    eeg = pop_iclabel(eeg, 'default')
-
-    # Access component labels and probability matrix
-    labels = eeg['etc']['ic_classification']['ICLabel']['classes']
-    probabilities = eeg['etc']['ic_classification']['ICLabel']['classifications']
-    print(labels)
-    print(probabilities)
-
-    # Review threshold-count summaries and diagnostic displays
-    stats = eeg_icalabelstat(eeg, threshold=0.9)
-    figures = pop_viewprops(eeg, typecomp=0, chanorcomp=[1, 2, 3])
-
-**Component types**:
-
-- Brain: Neural activity
-- Muscle: Muscle artifacts
-- Eye: Eye movement artifacts
-- Heart: Cardiac artifacts
-- Line Noise: 50/60 Hz noise
-- Channel Noise: Noisy channels
-- Other: Unclassified
-
-**Removing artifact components**:
-
-.. code-block:: python
-
-    from eegprep import pop_icflag, pop_subcomp
-
-    # Flag high-confidence muscle and eye components, then remove flagged ICs
-    eeg = pop_icflag(eeg)
-    eeg = pop_subcomp(eeg, [])
-
-Standalone Python EEGPrep ships the default ICLabel network. The EEGLAB
-``lite`` and ``beta`` artifacts are not bundled in the Python package; they are
-explicit MATLAB/Octave passthrough choices when that runtime provides the
-corresponding ICLabel files.
-
-Pipeline Visualization
-======================
-
-Here's a text-based flowchart of the preprocessing pipeline:
-
-.. code-block:: text
-
-    Raw EEG Data
-         |
-         v
-    Channel Selection
-         |
-         v
-    Flatline Detection
-         |
-         v
-    Noisy Channel Removal
-         |
-         v
-    Channel Interpolation
-         |
-         v
-    Resampling
-         |
-         v
-    High-Pass Filtering
-         |
-         v
-    Low-Pass Filtering
-         |
-         v
-    ICA Decomposition
-         |
-         v
-    Component Classification (ICLabel)
-         |
-         v
-    Artifact Component Removal
-         |
-         v
-    Preprocessed EEG Data
-
-Parameter Tuning
-================
-
-Key Parameters and Their Effects
----------------------------------
-
-**Flatline Criterion**
-
-- **Default**: 5 seconds
-- **Lower values**: More aggressive channel removal
-- **Higher values**: More lenient, may keep noisy channels
-- **Recommendation**: 5 seconds for most applications
-
-**ASR Criterion**
-
-- **Default**: 20 (standard deviations)
-- **Lower values**: More aggressive artifact removal
-- **Higher values**: More lenient, may keep artifacts
-- **Recommendation**: 20 for standard EEG, 15-25 for sensitive applications
-
-**High-Pass Filter**
-
-- **Default**: 1 Hz
-- **Lower values**: Preserve slow oscillations
-- **Higher values**: Remove more low-frequency noise
-- **Recommendation**: 0.5-1 Hz for most applications
-
-**Low-Pass Filter**
-
-- **Default**: 100 Hz
-- **Lower values**: Remove more high-frequency noise
-- **Higher values**: Preserve high-frequency activity
-- **Recommendation**: 100 Hz for standard EEG, 200 Hz for high-frequency analysis
-
-**Resampling Rate**
-
-- **Default**: 250 Hz
-- **Lower values**: Smaller file size, faster processing
-- **Higher values**: Better temporal resolution
-- **Recommendation**: 250 Hz for most applications
-
-Tuning Strategy
----------------
-
-1. **Start with defaults**: Use the default parameters as a baseline
-2. **Visualize results**: Plot the data before and after preprocessing
-3. **Adjust parameters**: Modify parameters based on visual inspection
-4. **Validate**: Check that preprocessing doesn't remove important signals
-5. **Document**: Record the parameters used for reproducibility
-
-Quality Control
-===============
-
-Assessing Preprocessing Quality
---------------------------------
-
-Visual Inspection
-~~~~~~~~~~~~~~~~~
-
-Plot the data before and after preprocessing:
-
-.. code-block:: python
-
-    import matplotlib.pyplot as plt
-
-    # Plot raw data
-    plt.figure(figsize=(12, 6))
-    plt.plot(eeg.data[0, :1000])
-    plt.title('Raw EEG Data')
-    plt.show()
-
-    # Plot preprocessed data
-    plt.figure(figsize=(12, 6))
-    plt.plot(eeg.data[0, :1000])
-    plt.title('Preprocessed EEG Data')
-    plt.show()
-
-Spectral Analysis
-~~~~~~~~~~~~~~~~~
-
-Compare power spectral density before and after preprocessing:
-
-.. code-block:: python
-
-    from eegprep import eeg_rpsd
-    import matplotlib.pyplot as plt
-
-    # Compute power spectral density
-    psd = eeg_rpsd(eeg)
-
-    plt.figure(figsize=(12, 6))
-    plt.semilogy(psd)
-    plt.xlabel('Frequency (Hz)')
-    plt.ylabel('Power (µV²/Hz)')
-    plt.title('Power Spectral Density')
-    plt.show()
-
-Component Inspection
-~~~~~~~~~~~~~~~~~~~~
-
-Visualize ICA components:
-
-.. code-block:: python
-
-    from eegprep import topoplot
-    import matplotlib.pyplot as plt
-
-    # Plot component topographies
-    topoplot(eeg, components=[0, 1, 2, 3])
-    plt.title('ICA Component Topographies')
-    plt.show()
-
-    # Check component classifications
-    if hasattr(eeg, 'etc') and 'ic_classification' in eeg.etc:
-        classifications = eeg.etc.ic_classification.ICLabel.classifications
-        for i, probs in enumerate(classifications):
-            print(f"Component {i}: {probs}")
-
-Data Loss Assessment
-~~~~~~~~~~~~~~~~~~~~
-
-Check how much data was removed:
-
-.. code-block:: python
-
-    # Check removed channels
-    if hasattr(eeg, 'removed_channels'):
-        print(f"Removed channels: {eeg.removed_channels}")
-
-    # Check removed windows
-    if hasattr(eeg, 'removed_windows'):
-        print(f"Removed windows: {eeg.removed_windows}")
-
-    # Calculate percentage of data retained
-    if hasattr(eeg, 'removed_windows'):
-        pct_retained = (1 - len(eeg.removed_windows) / eeg.pnts) * 100
-        print(f"Data retained: {pct_retained:.1f}%")
-
-Quality Metrics
-~~~~~~~~~~~~~~~
-
-Compute quality metrics:
-
-.. code-block:: python
-
-    # Signal-to-noise ratio
-    from eegprep import eeg_rpsd
-
-    psd = eeg_rpsd(eeg)
-    snr = psd[1:50].mean() / psd[50:100].mean()
-    print(f"SNR: {snr:.2f}")
-
-    # Autocorrelation
-    from eegprep import eeg_autocorr
-
-    acf = eeg_autocorr(eeg, maxlag=100)
-    print(f"Autocorrelation: {acf}")
-
-Common Issues and Solutions
+Re-Reference and Interpolate
 ============================
 
-Too Many Channels Removed
---------------------------
+Average reference:
 
-**Problem**: Preprocessing removes too many channels
+.. code-block:: python
 
-**Solutions**:
+   from eegprep import pop_reref
 
-1. Increase flatline criterion
-2. Increase ASR criterion
-3. Check data quality before preprocessing
-4. Verify channel locations are correct
+   EEG, com = pop_reref(EEG, [], return_com=True)
 
-Too Few Artifacts Removed
---------------------------
+Interpolate known bad channels after channel removal or rejection:
 
-**Problem**: Preprocessing doesn't remove enough artifacts
+.. code-block:: python
 
-**Solutions**:
+   from eegprep import pop_interp
 
-1. Decrease ASR criterion
-2. Decrease flatline criterion
-3. Apply additional filtering
-4. Manually inspect and remove bad components
+   EEG, com = pop_interp(EEG, [0, 4, 9], return_com=True)
 
-ICA Fails to Converge
----------------------
+Use ``Tools > Re-reference the data`` and ``Tools > Interpolate electrodes``
+from the GUI.
 
-**Problem**: ICA decomposition doesn't converge
+The programmatic ``bad_elec`` list for ``pop_interp`` uses Python zero-based
+indices when integers are supplied. GUI channel selection remains one-based and
+label-driven.
 
-**Solutions**:
+Run ICA and ICLabel
+===================
 
-1. Increase max_iter parameter
-2. Ensure data is properly filtered
-3. Check for remaining artifacts
-4. Try different ICA algorithm
+Run ICA:
 
-Next Steps
-==========
+.. code-block:: python
 
-Now that you understand the preprocessing pipeline:
+   from eegprep import pop_runica
 
-1. Read the :ref:`configuration` guide for advanced parameter tuning
-2. Explore the :ref:`bids_workflow` for batch processing
-3. Check the :ref:`advanced_topics` for custom pipelines
-4. Review the :ref:`api_reference` for detailed function documentation
+   EEG, com = pop_runica(EEG, icatype="picard", gui=False, return_com=True)
+
+Label and review components:
+
+.. code-block:: python
+
+   from eegprep import eeg_icalabelstat, pop_iclabel, pop_viewprops
+
+   EEG, com = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1, 2, 3])
+
+See :ref:`ica_rejection` before removing components.
+
+Epoch and Baseline
+==================
+
+Use ``pop_epoch`` and ``pop_rmbase`` for ERP-style workflows:
+
+.. code-block:: python
+
+   from eegprep import pop_epoch, pop_rmbase
+
+   EEG, com_epoch = pop_epoch(EEG, ["square"], [-1, 2], return_com=True)
+   EEG, com_base = pop_rmbase(EEG, [-200, 0], return_com=True)
+
+GUI paths: ``Tools > Extract epochs`` and ``Tools > Remove epoch baseline``.
+
+Save
+====
+
+Save reviewed datasets with ``pop_saveset``:
+
+.. code-block:: python
+
+   from pathlib import Path
+   from eegprep import pop_saveset
+
+   pop_saveset(EEG, Path("sample_data") / "eeglab_data_preprocessed.set")
+
+For large datasets, review :ref:`large_dataset_storage` before deciding whether to keep data
+in memory, memory-map sidecar files, or retrieve offloaded datasets.
+
+Quality Control Checklist
+=========================
+
+* Confirm ``EEG["data"].shape`` after each major transform.
+* Inspect events after filtering/resampling and before epoching.
+* Review rejected channels/windows visually before final removal.
+* Inspect ICLabel probabilities, scalp maps, spectra, and activity before
+  removing components.
+* Keep ``LASTCOM`` and ``ALLCOM`` from GUI/console runs so the workflow can be
+  replayed in scripts.

--- a/docs/source/user_guide/preprocessing_pipeline.rst
+++ b/docs/source/user_guide/preprocessing_pipeline.rst
@@ -4,7 +4,7 @@
 Preprocessing Pipeline
 ======================
 
-This page describes a practical EEGLAB-style preprocessing order in EEGPrep.
+This page describes a practical preprocessing order in EEGPrep.
 It is not a mandatory recipe for every experiment. Adapt thresholds and review
 steps to your data, task, and lab standards.
 
@@ -92,8 +92,8 @@ Use FIRFilt helpers for custom filter design:
 Clean Continuous Data
 =====================
 
-Use ``pop_clean_rawdata`` when you want the EEGLAB-style GUI wrapper and
-history string:
+Use ``pop_clean_rawdata`` when you want the interactive wrapper and history
+string:
 
 .. code-block:: python
 

--- a/docs/source/user_guide/quickstart.rst
+++ b/docs/source/user_guide/quickstart.rst
@@ -4,9 +4,9 @@
 Quick Start
 ===========
 
-This quick start uses the checked-in EEGLAB tutorial data under
-``sample_data/``. It shows the same first workflow in normal Python and in the
-GUI plus ``eegprep-console`` session.
+This quick start uses the checked-in tutorial data under ``sample_data/``. It
+shows the same first workflow in normal Python and in the shared GUI plus
+``eegprep-console`` session.
 
 Sample Data
 ===========
@@ -135,7 +135,9 @@ Where to Go Next
 ================
 
 * Read :ref:`concepts` before writing longer scripts.
+* Use :ref:`gui_console_session` to understand switching between the GUI and
+  console.
 * Use :ref:`gui_tutorials` to repeat the workflow from menus.
-* Use :ref:`interactive_console` to understand auto-store behavior.
+* Use :ref:`interactive_console` for console launch and history details.
 * Use :ref:`scripting_workflows` to turn history into reproducible scripts.
 * Use :ref:`mne_integration` for issue #22's MNE examples.

--- a/docs/source/user_guide/quickstart.rst
+++ b/docs/source/user_guide/quickstart.rst
@@ -4,354 +4,138 @@
 Quick Start
 ===========
 
-This guide will get you up and running with eegprep in just a few minutes. We'll cover the basic workflow for loading, preprocessing, and saving EEG data.
+This quick start uses the checked-in EEGLAB tutorial data under
+``sample_data/``. It shows the same first workflow in normal Python and in the
+GUI plus ``eegprep-console`` session.
 
-Basic Preprocessing (5-Minute Example)
-======================================
+Sample Data
+===========
 
-Here's a complete example that demonstrates the core eegprep workflow:
+The repository includes small tutorial datasets named after EEGLAB's
+``sample_data`` convention:
 
-.. code-block:: python
+.. list-table::
+   :header-rows: 1
 
-    import eegprep
-    from eegprep import pop_loadset, pop_saveset, clean_artifacts, iclabel
+   * - File
+     - Use
+   * - ``sample_data/eeglab_data.set``
+     - Continuous 32-channel tutorial data with events.
+   * - ``sample_data/eeglab_data_epochs_ica.set``
+     - Epoched tutorial data with ICA fields.
+   * - ``sample_data/eeglab_data_with_ica_tmp.set``
+     - Continuous tutorial data with ICA fields.
+   * - ``sample_data/eeglab_data_hdf5.set``
+     - HDF5-backed EEGLAB ``.set`` load path.
 
-    # Load EEG data
-    eeg = pop_loadset('sample_data.set')
-    print(f"Loaded EEG with {eeg.nbchan} channels and {eeg.pnts} points")
+Five-Minute Python Workflow
+===========================
 
-    # Run preprocessing
-    eeg = clean_artifacts(eeg)
-    print("Artifacts cleaned")
-
-    # Save results
-    pop_saveset(eeg, 'sample_data_preprocessed.set')
-    print("Data saved")
-
-Loading EEG Data
-================
-
-Using pop_loadset
------------------
-
-The :func:`eegprep.pop_loadset` function loads EEGLAB .set files:
+Run this from the repository root after installing EEGPrep or syncing the
+source checkout.
 
 .. code-block:: python
 
-    from eegprep import pop_loadset
+   from pathlib import Path
 
-    # Load a .set file
-    eeg = pop_loadset('sample_data/subject_01.set')
+   from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
 
-    # Access basic information
-    print(f"Channels: {eeg.nbchan}")
-    print(f"Sampling rate: {eeg.srate} Hz")
-    print(f"Duration: {eeg.pnts / eeg.srate} seconds")
-    print(f"Channel names: {eeg.chanlocs}")
+   input_file = Path("sample_data") / "eeglab_data.set"
+   output_file = Path("sample_data") / "eeglab_data_quickstart.set"
 
-**Expected Output:**
+   EEG = pop_loadset(input_file)
+   print(EEG["setname"], EEG["nbchan"], EEG["pnts"], EEG["srate"])
 
-.. code-block:: text
+   EEG, filter_com = pop_eegfiltnew(
+       EEG,
+       locutoff=1.0,
+       hicutoff=40.0,
+       plotfreqz=False,
+       return_com=True,
+   )
+   EEG, resample_com = pop_resample(EEG, 64, return_com=True)
+   pop_saveset(EEG, output_file)
 
-    Channels: 64
-    Sampling rate: 500 Hz
-    Duration: 120.0 seconds
-    Channel names: [Fp1, Fp2, F3, F4, ...]
+   print(filter_com)
+   print(resample_com)
 
-Loading from BIDS Format
--------------------------
+The important pattern is ``return_com=True``. It gives you the updated dataset
+and the history command that the GUI or console would record.
 
-For BIDS-formatted datasets, use :func:`eegprep.pop_load_frombids`:
-
-.. code-block:: python
-
-    from eegprep import pop_load_frombids
-
-    # Load from BIDS dataset
-    eeg = pop_load_frombids(
-        bids_root='sample_data/bids_dataset',
-        subject='01',
-        session='01',
-        task='rest'
-    )
-
-Running Preprocessing
-======================
-
-Basic Artifact Removal
-----------------------
-
-The :func:`eegprep.clean_artifacts` function performs comprehensive artifact removal:
-
-.. code-block:: python
-
-    from eegprep import clean_artifacts
-
-    # Run artifact removal with default settings
-    eeg = clean_artifacts(eeg)
-    print("Preprocessing complete")
-
-    # Check what was removed
-    print(f"Channels removed: {eeg.removed_channels}")
-    print(f"Windows rejected: {eeg.removed_windows}")
-
-**Expected Output:**
-
-.. code-block:: text
-
-    Preprocessing complete
-    Channels removed: []
-    Windows rejected: 12
-
-Advanced Preprocessing with Custom Parameters
-----------------------------------------------
-
-Customize the preprocessing pipeline:
-
-.. code-block:: python
-
-    from eegprep import clean_artifacts
-
-    # Custom preprocessing parameters
-    eeg = clean_artifacts(
-        eeg,
-        flatline_criterion=5,  # Flatline detection threshold
-        highpass=1,            # High-pass filter at 1 Hz
-        lowpass=100,           # Low-pass filter at 100 Hz
-        asr_criterion=20,      # ASR threshold
-        ica=True,              # Enable ICA
-        iclabel=True           # Enable ICLabel classification
-    )
-
-Step-by-Step Preprocessing
----------------------------
-
-For more control, apply preprocessing steps individually:
-
-.. code-block:: python
-
-    from eegprep import (
-        clean_flatlines,
-        clean_channels,
-        pop_resample,
-        pop_eegfiltnew,
-        eeg_picard,
-        iclabel
-    )
-
-    # 1. Remove flatline channels
-    eeg = clean_flatlines(eeg, flatline_criterion=5)
-    print(f"Channels after flatline removal: {eeg.nbchan}")
-
-    # 2. Remove noisy channels
-    eeg = clean_channels(eeg)
-    print(f"Channels after noise removal: {eeg.nbchan}")
-
-    # 3. Resample if needed
-    eeg = pop_resample(eeg, 250)  # Resample to 250 Hz
-    print(f"New sampling rate: {eeg.srate} Hz")
-
-    # 4. Filter the data
-    eeg = pop_eegfiltnew(eeg, locutoff=1, hicutoff=100)
-    print("Data filtered")
-
-    # 5. Run ICA
-    eeg = eeg_picard(eeg)
-    print(f"ICA components: {eeg.icaweights.shape[0]}")
-
-    # 6. Classify components with ICLabel
-    eeg = iclabel(eeg)
-    print("Components classified")
-
-Saving Results
-==============
-
-Using pop_saveset
------------------
-
-Save preprocessed data back to EEGLAB format:
-
-.. code-block:: python
-
-    from eegprep import pop_saveset
-
-    # Save to .set file
-    pop_saveset(eeg, 'sample_data/subject_01_preprocessed.set')
-    print("Data saved successfully")
-
-Saving with Compression
-------------------------
-
-Save with compression to reduce file size:
-
-.. code-block:: python
-
-    from eegprep import pop_saveset
-
-    # Save with compression
-    pop_saveset(
-        eeg,
-        'sample_data/subject_01_preprocessed.set',
-        savemode='onefile'  # Save as single file
-    )
-
-Saving to HDF5 Format
----------------------
-
-For large datasets, save to HDF5 format:
-
-.. code-block:: python
-
-    from eegprep import pop_saveset
-
-    # Save to HDF5
-    pop_saveset(
-        eeg,
-        'sample_data/subject_01_preprocessed.h5',
-        fmt='h5'
-    )
-
-Visualization
-=============
-
-Topographic Plots
-------------------
-
-Visualize channel locations and data:
-
-.. code-block:: python
-
-    from eegprep import topoplot
-    import matplotlib.pyplot as plt
-
-    # Plot channel locations
-    topoplot(eeg)
-    plt.title('Channel Locations')
-    plt.show()
-
-    # Plot component topographies
-    topoplot(eeg, components=[0, 1, 2, 3])
-    plt.title('ICA Component Topographies')
-    plt.show()
-
-Plotting Preprocessed Data
----------------------------
-
-Visualize the preprocessed signal:
-
-.. code-block:: python
-
-    import matplotlib.pyplot as plt
-
-    # Plot first 5 seconds of data
-    start_sample = 0
-    end_sample = int(eeg.srate * 5)  # 5 seconds
-
-    plt.figure(figsize=(12, 8))
-    for ch in range(min(10, eeg.nbchan)):  # Plot first 10 channels
-        plt.plot(eeg.data[ch, start_sample:end_sample] + ch * 100)
-    plt.xlabel('Sample')
-    plt.ylabel('Channel')
-    plt.title('Preprocessed EEG Data (First 5 seconds)')
-    plt.show()
-
-Complete Workflow Example
+GUI Plus Console Workflow
 =========================
 
-Here's a complete example combining all steps:
+Launch the shared GUI/console session:
+
+.. code-block:: bash
+
+   uv run eegprep-console --full
+
+Then:
+
+.. raw:: html
+
+   <div class="eegprep-path">
+     <p>Choose <strong>File > Load existing dataset</strong> and open
+     <code>sample_data/eeglab_data.set</code>.</p>
+     <p>In the console, inspect <code>EEG["nbchan"]</code>,
+     <code>EEG["srate"]</code>, <code>CURRENTSET</code>, and
+     <code>LASTCOM</code>.</p>
+     <p>Choose <strong>Tools > Filter the data</strong> or run
+     <code>pop_eegfiltnew(EEG, locutoff=1, hicutoff=40)</code> from the
+     console.</p>
+     <p>Choose <strong>Tools > Change sampling rate</strong> or run
+     <code>pop_resample(EEG, 64)</code>.</p>
+     <p>Choose <strong>Plot > Channel data (scroll)</strong> to inspect the
+     current dataset in EEGBrowser.</p>
+   </div>
+
+The GUI and console share the same ``EEGPrepSession``. A GUI action updates the
+console's ``EEG``, ``ALLEEG``, ``CURRENTSET``, ``LASTCOM``, and ``ALLCOM``.
+Console ``pop_*`` calls update the GUI when they use the console wrappers.
+
+Inspect the EEG Structure
+=========================
+
+EEGPrep datasets are dictionaries:
 
 .. code-block:: python
 
-    from eegprep import (
-        pop_loadset,
-        pop_saveset,
-        clean_artifacts,
-        iclabel,
-        topoplot
-    )
-    import matplotlib.pyplot as plt
+   print(EEG.keys())
+   print(EEG["data"].shape)
+   print(EEG["event"][0])
+   print([chan["labels"] for chan in EEG["chanlocs"][:5]])
 
-    # 1. Load data
-    print("Loading data...")
-    eeg = pop_loadset('raw_data.set')
-    print(f"Loaded: {eeg.nbchan} channels, {eeg.pnts} samples")
+Continuous data is usually ``(nbchan, pnts)``. Epoched data is usually
+``(nbchan, pnts, trials)``.
 
-    # 2. Preprocess
-    print("Preprocessing...")
-    eeg = clean_artifacts(
-        eeg,
-        highpass=1,
-        lowpass=100,
-        ica=True,
-        iclabel=True
-    )
-    print("Preprocessing complete")
+Load Epoched ICA Data
+=====================
 
-    # 3. Visualize
-    print("Visualizing...")
-    topoplot(eeg)
-    plt.show()
-
-    # 4. Save
-    print("Saving...")
-    pop_saveset(eeg, 'preprocessed_data.set')
-    print("Done!")
-
-Common Tasks
-============
-
-Selecting Specific Channels
-----------------------------
+Use the ICA sample when you want to review ICLabel/component workflows without
+waiting for a decomposition:
 
 .. code-block:: python
 
-    from eegprep import pop_select
+   from pathlib import Path
+   from eegprep import eeg_icalabelstat, pop_iclabel, pop_loadset, pop_viewprops
 
-    # Select only EEG channels (exclude EOG, EMG, etc.)
-    eeg = pop_select(eeg, 'type', 'EEG')
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set")
+   EEG, com = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+   figures = pop_viewprops(EEG, typecomp=0, chanorcomp=[1], plot=False)
 
-    # Select specific channels by name
-    eeg = pop_select(eeg, 'channel', ['Cz', 'Pz', 'Oz'])
+   print(com)
+   print(stats["counts"])
 
-Epoching Data
--------------
+``typecomp=0`` means component mode, matching EEGLAB's component property
+dialogs. Component numbers are user-facing one-based values.
 
-.. code-block:: python
+Where to Go Next
+================
 
-    from eegprep import pop_epoch
-
-    # Epoch data around event markers
-    eeg, indices = pop_epoch(eeg, ["stim"], [-1, 2])
-    print(f"Epochs: {eeg['trials']}")
-
-Re-referencing
----------------
-
-.. code-block:: python
-
-    from eegprep import pop_reref
-
-    # Re-reference to average
-    eeg = pop_reref(eeg, [])  # Empty list = average reference
-
-    # Re-reference to a specific channel by 0-based index
-    eeg = pop_reref(eeg, 31)  # Reference to the 32nd channel
-
-.. note::
-
-   Numeric channel indices in EEGPrep Python calls and GUI text fields are
-   0-based. For example, enter ``0`` for the first channel. EEGPrep still writes
-   generated EEGLAB-style history commands with 1-based indices so the command
-   text matches EEGLAB conventions.
-
-Next Steps
-==========
-
-Now that you understand the basics:
-
-1. Read the :ref:`preprocessing_pipeline` guide for detailed information about each preprocessing step
-2. Explore the :ref:`bids_workflow` for batch processing
-3. Check the :ref:`configuration` guide for advanced parameter tuning
-4. Review the :ref:`advanced_topics` for custom pipelines and optimization
-
-For detailed API documentation, see the :ref:`api_reference`.
+* Read :ref:`concepts` before writing longer scripts.
+* Use :ref:`gui_tutorials` to repeat the workflow from menus.
+* Use :ref:`interactive_console` to understand auto-store behavior.
+* Use :ref:`scripting_workflows` to turn history into reproducible scripts.
+* Use :ref:`mne_integration` for issue #22's MNE examples.

--- a/docs/source/user_guide/scripting_workflows.rst
+++ b/docs/source/user_guide/scripting_workflows.rst
@@ -1,0 +1,166 @@
+.. _scripting_workflows:
+
+===================
+Scripting Workflows
+===================
+
+EEGPrep scripts should look familiar to EEGLAB users but use ordinary Python
+imports, assignments, and paths. The safest pattern is explicit input, explicit
+return value, and ``return_com=True`` whenever a command should be replayable.
+
+From Menu History to Script
+===========================
+
+When you run a GUI action or a ``pop_*`` call in ``eegprep-console``, inspect
+``LASTCOM`` and ``ALLCOM``:
+
+.. code-block:: python
+
+   LASTCOM
+   ALLCOM[-5:]
+
+Move the same calls into a script with explicit assignment:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
+
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   EEG, com_filter = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False, return_com=True)
+   EEG, com_resample = pop_resample(EEG, 64, return_com=True)
+   pop_saveset(EEG, Path("sample_data") / "eeglab_data_scripted.set")
+
+   history = [com_filter, com_resample]
+
+Normal Python does not auto-store bare ``pop_*`` calls. This is intentional:
+auto-storage belongs to ``eegprep-console`` because it has a shared
+``EEGPrepSession`` to update.
+
+Batch Over Sample Data
+======================
+
+Use ``pathlib`` and keep outputs outside immutable tutorial files:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
+
+   inputs = [
+       Path("sample_data") / "eeglab_data.set",
+       Path("sample_data") / "eeglab_data_with_ica_tmp.set",
+   ]
+   output_dir = Path("sample_data") / "processed"
+   output_dir.mkdir(exist_ok=True)
+
+   all_history = {}
+   for input_file in inputs:
+       EEG = pop_loadset(input_file)
+       EEG, filter_com = pop_eegfiltnew(EEG, locutoff=1, hicutoff=40, plotfreqz=False, return_com=True)
+       EEG, resample_com = pop_resample(EEG, 64, return_com=True)
+       pop_saveset(EEG, output_dir / input_file.name)
+       all_history[input_file.name] = [filter_com, resample_com]
+
+Do not mutate ``ALLEEG`` by hand in scripts unless you are deliberately
+building a session-like workflow. Use ``EEGPrepSession`` when you need
+EEGLAB-style dataset storage.
+
+Use an EEGPrepSession
+=====================
+
+``EEGPrepSession`` is useful when a script needs the same state model as the
+GUI:
+
+.. code-block:: python
+
+   from pathlib import Path
+   from eegprep import EEGPrepSession, pop_loadset, pop_newset, pop_resample
+
+   session = EEGPrepSession()
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data.set")
+   ALLEEG, EEG, CURRENTSET, com = pop_newset(session.ALLEEG, EEG, session.CURRENTSET, setname="tutorial")
+   session.ALLEEG = ALLEEG
+   session.store_current(EEG, set_index=CURRENTSET)
+   session.add_history(com)
+
+   EEG, com = pop_resample(session.EEG, 64, return_com=True)
+   session.store_current(EEG)
+   session.add_history(com)
+
+This mirrors what ``eegprep-console`` does for you automatically.
+
+Script Component Review
+=======================
+
+Use the ICA sample to script ICLabel review:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   import numpy as np
+   from eegprep import eeg_icalabelstat, pop_icflag, pop_iclabel, pop_loadset, pop_subcomp
+
+   EEG = pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set")
+   EEG, com_label = pop_iclabel(EEG, "default", return_com=True)
+   stats = eeg_icalabelstat(EEG, threshold=0.9, verbose=False)
+
+   # Flag components with high eye or muscle probability, then remove flagged components.
+   EEG, com_flag = pop_icflag(
+       EEG,
+       threshold=np.array(
+           [
+               [0, 0],        # Brain
+               [0.8, 1.0],    # Muscle
+               [0.8, 1.0],    # Eye
+               [0, 0],        # Heart
+               [0, 0],        # Line noise
+               [0, 0],        # Channel noise
+               [0, 0],        # Other
+           ]
+       ),
+       return_com=True,
+   )
+   EEG, com_remove = pop_subcomp(EEG, [], return_com=True)
+
+The class order follows ICLabel: Brain, Muscle, Eye, Heart, Line Noise,
+Channel Noise, Other.
+
+Work With STUDY Scripts
+=======================
+
+Create a small STUDY from loaded datasets:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from eegprep import pop_loadset, pop_precomp, pop_study, std_readerp
+
+   ALLEEG = [
+       pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set"),
+       pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set"),
+   ]
+   for index, EEG in enumerate(ALLEEG, start=1):
+       EEG["subject"] = f"S{index:02d}"
+       EEG["condition"] = "tutorial"
+
+   STUDY, ALLEEG, com_study = pop_study(None, ALLEEG, name="Tutorial study", return_com=True)
+   STUDY, ALLEEG, com_precomp = pop_precomp(STUDY, ALLEEG, "channels", erp="on", return_com=True)
+   erpdata, erptimes = std_readerp(STUDY, ALLEEG, channels=[1])[:2]
+
+STUDY dataset and trial selectors return EEGLAB-facing one-based indices. Use
+Python zero-based indices only when directly slicing arrays.
+
+Guardrails
+==========
+
+* Keep tutorial and lab scripts explicit: assign returned ``EEG`` or ``STUDY``.
+* Use ``return_com=True`` for history-relevant steps.
+* Keep user-facing component, channel, and dataset selectors one-based in
+  command strings.
+* Do not rely on the vendored ``src/eegprep/eeglab`` tree at runtime.
+* Prefer packaged resources, project-relative paths, and ``pathlib.Path``.

--- a/docs/source/user_guide/scripting_workflows.rst
+++ b/docs/source/user_guide/scripting_workflows.rst
@@ -4,9 +4,9 @@
 Scripting Workflows
 ===================
 
-EEGPrep scripts should look familiar to EEGLAB users but use ordinary Python
-imports, assignments, and paths. The safest pattern is explicit input, explicit
-return value, and ``return_com=True`` whenever a command should be replayable.
+EEGPrep scripts should be ordinary Python: explicit imports, explicit
+assignments, and clear paths. Use ``return_com=True`` whenever a command should
+be replayable from session history.
 
 From Menu History to Script
 ===========================
@@ -66,7 +66,7 @@ Use ``pathlib`` and keep outputs outside immutable tutorial files:
 
 Do not mutate ``ALLEEG`` by hand in scripts unless you are deliberately
 building a session-like workflow. Use ``EEGPrepSession`` when you need
-EEGLAB-style dataset storage.
+the same dataset storage model as the GUI and console.
 
 Use an EEGPrepSession
 =====================

--- a/docs/source/user_guide/storage.rst
+++ b/docs/source/user_guide/storage.rst
@@ -5,16 +5,16 @@ Large-Dataset Storage
 =====================
 
 EEGPrep keeps normal EEG dictionaries as the public API while supporting
-EEGLAB-style large-dataset workflows through explicit Python storage handles.
+large-dataset workflows through explicit Python storage handles.
 The runtime does not depend on EEGLAB's MATLAB ``@memmapdata`` or ``@mmo``
 classes.
 
 Two-File ``.set`` / ``.fdt`` Datasets
 =====================================
 
-``pop_saveset`` saves one-file ``.set`` files by default. To write a MATLAB
-EEGLAB-style header plus float32 data sidecar, pass ``savemode="twofiles"`` or
-set ``EEG_OPTIONS["option_savetwofiles"] = 1``:
+``pop_saveset`` saves one-file ``.set`` files by default. To write a two-file
+``.set`` header plus float32 data sidecar, pass ``savemode="twofiles"`` or set
+``EEG_OPTIONS["option_savetwofiles"] = 1``:
 
 .. code-block:: python
 

--- a/docs/source/user_guide/study_workflows.rst
+++ b/docs/source/user_guide/study_workflows.rst
@@ -8,6 +8,33 @@ EEGPrep includes standalone STUDY/session surfaces for common group-level
 workflows. These APIs mirror EEGLAB's STUDY-facing names while storing cached
 measure data in EEGPrep-owned JSON-safe structures.
 
+GUI Plus Console Flow
+=====================
+
+Load two or more datasets, then use ``File > Create study > Using all loaded
+datasets``. ``eegprep-console`` will show ``STUDY`` and ``CURRENTSTUDY`` update
+immediately. Continue with ``Study > Precompute channel measures`` and
+``Study > Plot channel measures`` when the selected datasets have compatible
+metadata and shapes.
+
+The same workflow in Python can reuse the sample epoched ICA dataset:
+
+.. code-block:: python
+
+   from pathlib import Path
+   from eegprep import pop_loadset, pop_precomp, pop_study
+
+   ALLEEG = [
+       pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set"),
+       pop_loadset(Path("sample_data") / "eeglab_data_epochs_ica.set"),
+   ]
+   for index, EEG in enumerate(ALLEEG, start=1):
+       EEG["subject"] = f"S{index:02d}"
+       EEG["condition"] = "tutorial"
+
+   STUDY, ALLEEG, com = pop_study(None, ALLEEG, name="Tutorial study", return_com=True)
+   STUDY, ALLEEG, com = pop_precomp(STUDY, ALLEEG, "channels", erp="on", return_com=True)
+
 Implemented Workflows
 =====================
 

--- a/src/eegprep/functions/popfunc/eeg_amica.py
+++ b/src/eegprep/functions/popfunc/eeg_amica.py
@@ -54,7 +54,7 @@ def eeg_amica(
         source-tree development binary, EEGLAB's AMICA plugin, or PATH.
     max_threads : int
         Maximum number of threads for the binary.
-    **kwargs : dict
+    kwargs : dict
         Additional AMICA parameters passed through to the binary.
 
     Returns

--- a/src/eegprep/functions/popfunc/eeg_interp.py
+++ b/src/eegprep/functions/popfunc/eeg_interp.py
@@ -30,14 +30,11 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
     EEG : dict
         EEG data structure with 'data', 'chanlocs', 'nbchan', etc.
     bad_chans : list, array-like, or list of dicts
-        Can be one of:
-        - List of channel names (strings): e.g., ['Fp1', 'Fp2']
-        - List of channel indices (integers): e.g., [0, 1, 2]
-        - List of chanloc structures (dicts): e.g., [{'labels': 'T7', 'X': 0.8, 'Y': 0.0, 'Z': 0.6}, ...]
-          When chanloc structures are provided, the function supports three modes:
-          1. If chanlocs are identical to EEG['chanlocs'], returns data unchanged
-          2. If no overlap with existing channels, appends new channels and interpolates them
-          3. If existing channels are a subset, remaps data to new channel structure
+        Channel names, channel indices, or channel-location dictionaries.
+        When channel-location dictionaries are provided, the function can
+        return unchanged data for identical locations, append new channels when
+        no existing locations overlap, or remap data when existing channels are
+        a subset of the requested channel structure.
     method : str, optional
         Interpolation method ('spherical', 'sphericalKang', 'sphericalCRD',
         'sphericalfast', 'invdist'/'v4', or 'spacetime').
@@ -45,10 +42,10 @@ def eeg_interp(EEG, bad_chans, method='spherical', t_range=None, params=None, dt
         Time range for interpolation
     params : tuple, optional
         Method-specific parameters
-    dtype: str | dtype, optional
-        Optionally the precision in which to perform the computation;
-        * 'float32' : matches MATLAB, but limits precision (default)
-        * 'float64': operate at full precision; requires twice the memory
+    dtype : str or dtype, optional
+        Precision for the interpolation computation. Use ``"float32"`` to
+        match MATLAB-oriented workflows with lower memory use, or
+        ``"float64"`` for full precision.
 
     Returns
     -------

--- a/src/eegprep/functions/popfunc/eeg_picard.py
+++ b/src/eegprep/functions/popfunc/eeg_picard.py
@@ -20,9 +20,9 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
         If 'on' or True, normalize component signs so max(abs(activations)) is positive. Default is 'off'.
     sortcomps : str | bool, optional
         If 'on' or True, sort components by descending activation variance. Default is 'off'.
-    **kwargs : dict
-        Additional keyword arguments to be passed to the Picard algorithm.
-        For example, `{'maxiter': 500}`.
+    kwargs : dict
+        Additional keyword arguments to pass to the Picard algorithm. For
+        example, ``{"maxiter": 500}``.
 
     Returns
     -------

--- a/src/eegprep/functions/popfunc/eeg_runica.py
+++ b/src/eegprep/functions/popfunc/eeg_runica.py
@@ -17,8 +17,8 @@ def eeg_runica(EEG, posact='off', sortcomps='off', **kwargs):
         If 'on' or True, normalize component signs so max(abs(activations)) is positive. Default is 'off'.
     sortcomps : str | bool, optional
         If 'on' or True, sort components by descending activation variance. Default is 'off'.
-    **kwargs : dict
-        Additional keyword arguments to be passed to the runica algorithm.
+    kwargs : dict
+        Additional keyword arguments to pass to the runica algorithm.
 
     Returns
     -------

--- a/src/eegprep/functions/popfunc/pop_load_frombids.py
+++ b/src/eegprep/functions/popfunc/pop_load_frombids.py
@@ -59,35 +59,43 @@ def pop_load_frombids(
         Path to the EEG data file in a BIDS dataset.
     bidsmetadata : bool
         Whether to override any metadata in the EEG file with
-      metadata from BIDS.
+        metadata from BIDS.
     bidschanloc : bool
         Whether to override any channel information (incl. locations)
-      in the EEG file with channel information from BIDS.
+        in the EEG file with channel information from BIDS.
     bidsevent : bool or str
         Whether to load in and override any event data in the EEG file with
-      event data from BIDS. Can be one of the following:
-      * 'replace'/True: replace events from EEG file with those from the BIDS event file
-      * 'merge': selectively override events from EEG file with those from the BIDS event file
-      * 'append': append events from the BIDS event file to those from the EEG file;
-          WARNING: this mode can result in duplicate events; use with caution
-      * False/None: do not load events from BIDS, keep those from the EEG file
+        event data from BIDS. Can be one of the following:
+
+        * ``"replace"``/``True``: replace events from EEG file with those from
+          the BIDS event file.
+        * ``"merge"``: selectively override events from EEG file with those
+          from the BIDS event file.
+        * ``"append"``: append events from the BIDS event file to those from
+          the EEG file. This mode can result in duplicate events; use with
+          caution.
+        * ``False``/``None``: do not load events from BIDS; keep those from the
+          EEG file.
     eventtype : str or None
         Optionally the column name in the BIDS events file to use for event
-      types; if not set, will be inferred heuristically.
+        types; if not set, will be inferred heuristically.
     infer_locations : bool or str or None
         Whether to infer channel locations if necessary from the
-      channel labels (if 10-20 labeling system).
-      * True: infer locations from channel labels; override existing locations if any
-      * False: leave locations as-is, even if missing
-      * None: infer only if no channels have locations
-      * str: filename of a locations file to infer locations from; see files in
-        resources/montages directory (this can be used to disambiguate between
-        alternative montages that use the same naming system)
+        channel labels (if 10-20 labeling system).
+
+        * ``True``: infer locations from channel labels and override existing
+          locations if any.
+        * ``False``: leave locations as-is, even if missing.
+        * ``None``: infer only if no channels have locations.
+        * ``str``: filename of a locations file to infer locations from. See
+          files in ``resources/montages``; this can disambiguate alternative
+          montages that use the same naming system.
     dtype : np.dtype
         The data type to use for the EEG data.
     numeric_null : Any
         The value to use for empty numeric fields in the EEG data.
-      * the default is np.array([]) for MATLAB/pop_loadset compatibility
+
+        The default is ``np.array([])`` for MATLAB/pop_loadset compatibility.
     return_report : bool
         whether to return an import report dictionary as a second output
     verbose : bool

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -71,7 +71,7 @@ def topoplot(datavector, chan_locs, **kwargs):
         Values to plot at each channel location.
     chan_locs : list of dict
         Channel location structures with 'labels', 'theta', and 'radius' fields.
-    **kwargs : dict
+    kwargs : dict
         Additional keyword arguments for customization:
 
         - noplot : str or tuple, default 'off'

--- a/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids_preproc.py
@@ -186,8 +186,6 @@ def bids_preproc(
     root : str
         The root directory containing BIDS data or a single EEG file path.
 
-    (BIDS import stage parameters)
-
     ApplyMetadata : bool
         Whether to apply metadata from BIDS sidecar files when loading raw EEG data.
         (default True)
@@ -216,7 +214,7 @@ def bids_preproc(
     OutputDir : str
         The name of the subdirectory where cleaned files will be saved. This can start
         with the placeholder '{root}' which will be replaced with the root path of
-        the BIDS dataset. Defaults to '{root}/derivatives/eegprep' if not specified.    (overall run configuration)
+        the BIDS dataset. Defaults to '{root}/derivatives/eegprep' if not specified.
 
     SkipIfPresent : bool
         skip processing files that already have a cleaned version present.
@@ -230,16 +228,13 @@ def bids_preproc(
     ReservePerJob : str
         Optionally the resource amount and type to reserve per job, e.g. '4GB' or '2CPU';
         the run will then use as many jobs as fit within the system resources of the specified type.
-        * You can also specify how much of a margin of the total system resources should
-        be *withheld* for use by other programs on the computer, by following the amount
-        by a : and then the margin, as in '4GB:10GB' (always leave 10GB unused), '2CPU:10%'
-        (always leave 10% of the total installed RAM unused). This also works with other metrics.
-        * one may also specify a total or maximum number of jobs, as in '10total' or '10max'.
-        * Multiple criteria can be spefied in a comma-separated list of reservations, e.g.
-        '4GB:20%, 2CPU, 5max'.
-        * If neither this nor NumJobs are specified, a single job will run. Note that the
-        system will also run in serial when in debug mode and when on a platform that does
-        not cleanly support multiprocessing.
+        You can add a margin after a colon, as in '4GB:10GB' or '2CPU:10%'.
+        You can also specify a total or maximum number of jobs, such as
+        '10total' or '10max'. Multiple criteria can be provided as a
+        comma-separated list, for example '4GB:20%, 2CPU, 5max'. If neither
+        ReservePerJob nor NumJobs is specified, a single job will run. The
+        system also runs serially in debug mode and on platforms that do not
+        cleanly support multiprocessing.
         Tip: a good way to size this is to perform a serial run and to monitor how much
         peak RAM a single job takes, and then setting this to <PeakUsage>GB:<YourMargin>GB
         where YourMargin is however much you want to leave to other programs, e.g., 5GB
@@ -253,7 +248,6 @@ def bids_preproc(
         quite a lot of memory for large studies and it may be better to iterate over
         the preprocessed files in downstream analyses.
 
-    (overall processing parameters)
     OnlyChannelsWithPosition : bool
         Whether to retain only channels for which positions were recorded or could be
         inferred. If this is not set, then OnlyModalities should be set so as to retain
@@ -269,7 +263,7 @@ def bids_preproc(
     WithInterp : bool
         Whether to reinterpolate dropped channels, thus retaining the same channel
         count as the raw data.
-    WithICA (bool):
+    WithICA : bool
         Whether to apply PICARD ICA decomposition after cleaning.
     AmicaArgs : dict or None
         Additional keyword arguments for AMICA when ICAAlgorithm='amica',
@@ -277,11 +271,9 @@ def bids_preproc(
     WithICLabel : bool
         Whether to apply ICLabel classification after ICA. Normally requires
         WithICA=True.
-    CommonAverageReference (bool):
+    CommonAverageReference : bool
         Whether to transform the EEG data to a common average referencing scheme;
         recommended for cross-study processing.
-
-    (parameters for artifact removal - same as in clean_artifacts function)
 
     ChannelCriterion : float or 'off'
         Minimum channel correlation threshold for channel cleaning; channels below
@@ -336,7 +328,6 @@ def bids_preproc(
     availableRAM_GB : float or None
         Available system RAM in GB to adjust MaxMem. Default None.
 
-     (parameters for an optional epoching and baseline removal step)
     EpochEvents : str or Sequence[str] or None
         Optionally a list of event types or regular expression matching event types
         at which to time-lock epochs. If None (default), no epoching is done. If [],
@@ -349,8 +340,6 @@ def bids_preproc(
         correction. If None (default), no baseline correction is applied. The special
         value None can be used to refer to the respective end of the epoch limits,
         as in (None, 0).
-
-    (misc parameters)
 
     StageNames : Sequence[str]
         list of file name parts for the preprocessing stages, in the order of cleaning,ica,iclabel;
@@ -367,8 +356,6 @@ def bids_preproc(
     MinimizeDiskUsage : bool
         whether to minimize disk usage by not saving some intermediate files (specifically
         the PICARD output if WithICLabel=False). Default True.
-
-    (parameters retained for backwards compatibility with EEGLAB's pop_importbids call signature)
 
     bidsmetadata : bool
         alias for ApplyMetadata

--- a/src/eegprep/resources/help/pop_chansel.md
+++ b/src/eegprep/resources/help/pop_chansel.md
@@ -1,0 +1,19 @@
+# POP_CHANSEL - Select channels from a list
+
+`pop_chansel` opens an EEGLAB-style channel selector and returns selected
+one-based channel indices, a display string, and the selected channel labels.
+
+Usage:
+
+```python
+chanlist, chanliststr, labels = pop_chansel(EEG["chanlocs"], withindex="on")
+```
+
+Use `field="type"` to select from channel types instead of labels. Use
+`selectionmode="single"` when only one channel or type should be selected.
+
+The helper is used by GUI dialogs such as clean_rawdata and ICA channel/type
+selectors. Programmatic scripts can use `pop_chansel_display_values` and
+`pop_chansel_selected_string` to format channel choices without opening a GUI.
+
+See also: LISTDLG2, POP_SELECT, POP_CHANEDIT

--- a/src/eegprep/resources/help/pop_load_frombids.md
+++ b/src/eegprep/resources/help/pop_load_frombids.md
@@ -1,0 +1,24 @@
+# POP_LOAD_FROMBIDS - Load one EEG file from a BIDS dataset
+
+`pop_load_frombids` loads a supported EEG recording from a BIDS dataset and
+applies BIDS metadata, channel, and event information when available.
+
+Usage:
+
+```python
+EEG = pop_load_frombids("sub-01/eeg/sub-01_task-rest_eeg.set")
+EEG, report = pop_load_frombids(
+    "sub-01/eeg/sub-01_task-rest_eeg.set",
+    return_report=True,
+)
+```
+
+Supported data files include EEGLAB `.set`, EDF, BDF, and BrainVision `.vhdr`
+files when the required readers are installed. `bidsevent` can be `"replace"`,
+`"merge"`, `"append"`, or disabled. `infer_locations` can infer channel
+locations from known channel labels or a packaged montage resource.
+
+Use `pop_importbids` or `bids_preproc` when you need to scan or process a whole
+BIDS dataset.
+
+See also: POP_IMPORTBIDS, POP_EXPORTBIDS, BIDS_PREPROC

--- a/src/eegprep/resources/help/pop_loadset_h5.md
+++ b/src/eegprep/resources/help/pop_loadset_h5.md
@@ -1,0 +1,19 @@
+# POP_LOADSET_H5 - Load an HDF5-backed EEGLAB dataset
+
+`pop_loadset_h5` loads HDF5-backed EEGLAB `.set` files and returns an EEGPrep
+EEG dictionary.
+
+Usage:
+
+```python
+EEG = pop_loadset_h5("sample_data/eeglab_data_hdf5.set")
+```
+
+Most users should call `pop_loadset`. It automatically falls back to
+`pop_loadset_h5` when a `.set` file uses the HDF5 layout. Use this helper
+directly only when you specifically want to exercise the HDF5 loader path.
+
+The loader normalizes ICA channel indices and then runs EEGPrep's dataset
+checks before returning the dataset.
+
+See also: POP_LOADSET, POP_SAVESET


### PR DESCRIPTION
Reorganizes EEGPrep's Sphinx docs into a standalone user manual with sample_data quickstarts, shared GUI plus eegprep-console workflows, scripting tutorials, MNE integration, bundled plugin notes, migration guidance, refreshed styling, generated API pages, and missing pop_* help resources.

This update also adds contributor/skill guidance requiring future user-facing EEGPrep changes to update Sphinx docs and packaged help resources, cleans generated/API doc ownership so cold Sphinx builds are warning-free, and includes docstring-only cleanup for public APIs whose generated docs previously rendered with autodoc/docutils warnings. No EEG processing behavior changed.

Follow-up review cleanup fixed stale manual pages that still described older object-style APIs, corrected BIDS workflow examples to the implemented `pop_load_frombids`/`bids_list_eeg_files`/`bids_preproc`/`pop_exportbids` APIs, clarified plugin inventory access through `session.PLUGINLIST`, and fixed broken internal/external documentation links found by Sphinx linkcheck.

Closes #164
Closes #22
