### PR TITLE
[Parity] Close final standalone evidence

### DIFF
--- a/.notes/eeglab-final-epic-closeout.md
+++ b/.notes/eeglab-final-epic-closeout.md
@@ -1,0 +1,180 @@
+# EEGPrep Final Standalone Epic Closeout Evidence
+
+Date: 2026-06-07
+Phase issue: #165
+Epic issue: #157
+Branch: `phase/165-final-integration-release-hardening`
+Base: `origin/feature/eeglab-full-standalone-completion`
+Final epic PR target after this phase: `origin/develop`
+
+Phase 8 closes the phase stack on the epic branch. It prepares evidence for the
+future epic PR to `develop`, but does not open that final PR.
+
+## Phase Issues and PRs
+
+| Phase | Issue | PR | Scope | Result |
+| --- | --- | --- | --- | --- |
+| 1 | #158 | #166 | Final standalone audit matrix, validator, runtime contract, docs architecture | Merged |
+| 2 | #159 | #171 | clean_rawdata and FIRFilt bundled-plugin completion | Merged |
+| 3 | #160 | #169 | DIPFIT and source-localization standalone parity | Merged |
+| 4 | #161 | #170 | STUDY PAC, LIMO-compatible design, and advanced statistics boundaries | Merged |
+| 5 | #162 | #168 | Large-dataset `.fdt`, memmap, and `storedisk` semantics | Merged |
+| 6 | #163 | #167 | ICLabel, viewprops, and component diagnostic parity | Merged |
+| 7 | #164 | #172 | Standalone Sphinx manual, tutorials, API pages, and help resources | Merged |
+| 8 | #165 | This branch | Integration, QA, release hardening, and evidence | In review |
+
+## Feature Summary
+
+The merged epic branch now covers the remaining standalone EEGLAB parity areas
+identified after the core parity PR:
+
+- A machine-readable final parity matrix and validator for bundled plugins,
+  object/storage semantics, optional-toolbox boundaries, and documentation.
+- clean_rawdata standard ASR, calibration-time Riemannian ASR support, explicit
+  full-Riemannian limitation, artifact diagnostics, and FIRFilt helper/dialog
+  parity.
+- DIPFIT standalone spherical settings, grid search, nonlinear fitting,
+  multifit, leadfield, dipplot, coordinate transforms, and explicit source
+  backend limits.
+- STUDY PAC compute/cache/read/plot workflows, LIMO-compatible design-matrix
+  export, neighbor/interpolation helpers, and explicit source-statistics
+  boundaries.
+- Python-native large-dataset save/load, `.fdt` sidecars, memory maps,
+  `storedisk` offload/retrieve behavior, and GUI/console session synchronization.
+- ICLabel default-network runtime behavior, label statistics, viewprops-style
+  diagnostics, and explicit alternate-network boundaries.
+- EEGPrep-owned Sphinx user manual, migration notes, GUI plus console tutorials,
+  BIDS workflow docs, bundled plugin docs, generated API pages, and packaged
+  help resources.
+
+## Matrix Closeout
+
+`docs/parity/eeglab_final_parity_matrix.json` now validates against the full
+final-epic reference surface:
+
+- 31 grouped rows cover 180 final-epic EEGLAB reference paths.
+- Status counts: 21 `implemented`, 3 `consolidated`, 2 `optional_dependency`,
+  2 `partial`, 2 `stale_skip`, and 1 `matlab_runtime_skip`.
+- There are no remaining `port` or `docs_gap` rows.
+- The two `partial` rows are intentional backend boundaries, not forgotten work:
+  DIPFIT MRI/BEM/LORETA/FieldTrip source workflows and STUDY-level
+  FieldTrip/source-statistics workflows.
+
+Phase 8 reclassified the six Phase 7 documentation rows from `docs_gap` to
+`implemented` after verifying that the completed Sphinx manual covers console
+history migration, event/indexing tutorials, STUDY workflows, source/DIPFIT
+boundaries, time-frequency/visual workflow notes, and BIDS tutorials.
+
+## Phase 8 Findings Fixed
+
+- The final matrix still had six Phase 7 documentation rows marked `docs_gap`
+  after PR #172 merged. Phase 8 reclassified those rows to `implemented` and
+  added regression coverage that no final closeout row remains `port` or
+  `docs_gap`.
+- The MATLAB-enabled parity run exposed an inconsistent synthetic HDF5 fixture:
+  `xmin=-1`, `pnts=1000`, `srate=500`, and `xmax=1.0`. EEGLAB/EEGPrep timing
+  semantics make the final point `0.998`, so Phase 8 corrected the fixture and
+  assertion in `tests/test_pop_loadset_h5.py`.
+- OC autoreview found that the time-frequency/movie documentation row needed
+  explicit user-guide coverage. Phase 8 added supported time-frequency and ERP
+  image wrapper guidance to `docs/source/user_guide/preprocessing_pipeline.rst`
+  and the EEG movie boundary to `docs/source/user_guide/visual_parity.rst`.
+- The first MATLAB parity attempt found a truncated ignored
+  `sample_data/EmotionValence.set` download. Phase 8 refreshed that local
+  fixture to the S3-reported 203,941,008 bytes before rerunning the suite.
+
+## Runtime Independence
+
+Runtime package code must not read, import from, or shell out to
+`src/eegprep/eeglab`. The vendored tree remains a development and parity-test
+oracle only.
+
+Phase 8 verified this with `tests/test_runtime_eeglab_independence.py` and a
+source scan for direct `src/eegprep/eeglab`, `eegprep.eeglab`, importlib
+resource, or package-root path-join dependencies. Development validators and
+visual parity tools may read the vendored reference tree.
+
+## Public API, Help, Package Data, and Menu Inventory
+
+Phase 8 kept the public API/menu/help/package evidence in tested surfaces:
+
+- `tests/test_package_exports.py` covers lazy public exports.
+- `tests/test_public_api_examples.py` covers documented API examples and
+  package-data declarations.
+- `tests/test_guifunc_pophelp_chansel.py` covers packaged Markdown help
+  resources, `pophelp`, and implemented menu help targets.
+- `tests/test_menu_placeholder_inventory.py` covers menu placeholder metadata.
+- `tests/test_gui_main_window.py` covers main-window menu/help/session wiring.
+
+## Visual Parity Attachment Inventory
+
+Visual artifacts are attached to phase PR comments rather than committed:
+
+- PR #167, ICLabel/viewprops: `iclabel_pop_prop_extended_dashboard`,
+  `pop_icflag_dialog`, `pop_iclabel_dialog`, and `pop_viewprops_dialog`
+  side-by-side images.
+- PR #169, DIPFIT: `pop_dipfit_settings`, `pop_dipfit_gridsearch`,
+  `pop_dipfit_nonlinear`, `pop_dipplot`, `pop_multifit`, `pop_leadfield`,
+  `pop_dipfit_loreta`, and `pop_dipfit_headmodel` evidence.
+- PR #171, FIRFilt: `pop_kaiserbeta_dialog`, `pop_firwsord_dialog`,
+  `pop_firpmord_dialog`, `pop_xfirws_dialog`, and refreshed
+  `pop_firpmord_dialog_review_fix` evidence.
+- PRs #166, #168, #170, and #172 did not add new GUI dialog layouts requiring
+  fresh visual attachments.
+
+## GUI Agent Mixed Workflow QA
+
+Computer Use inspected the live `eegprep-gui --window-menu-bar` window and
+confirmed the visible startup state: File and Help enabled, dataset-dependent
+Edit/Tools/Plot/Study/Datasets menus disabled, and the EEGLAB-style startup
+instructions visible. Computer Use click actions against the Python-hosted
+Qt app were rejected by the tool as inactive immediately after state capture,
+so Phase 8 continued the requested flow QA with Qt-driven actions against the
+real main window.
+
+The mixed workflow QA script exercised startup menus, Help menu opening,
+packaged `pophelp` dispatch, dataset storage and GUI refresh, GUI dataset
+retrieve followed by console namespace inspection, and a bare console
+`pop_reref(EEG, [])` call followed by GUI refresh.
+
+## Accepted Non-Goals
+
+These are explicit final-epic boundaries rather than Phase 8 omissions:
+
+- Full Manopt-backed Riemannian ASR processing remains an optional dependency
+  decision; standard ASR and calibration-time Riemannian behavior are supported.
+- DIPFIT MRI-derived BEM headmodel creation, AFNI atlas clipping, LORETA source
+  analysis, and FieldTrip source-statistics workflows remain explicit backend
+  limits.
+- Full LIMO model fitting, result computation, and browsing remain external
+  backend workflows; EEGPrep owns design-matrix preparation.
+- ICLabel `lite` and `beta` network artifacts remain explicit MATLAB/Octave
+  engine paths until EEGPrep packages tested standalone assets.
+- MATLAB object overloads, developer tests, command-window shims, and third-party
+  plugin ecosystems remain consolidated, skipped, or extension-owned rather than
+  one-for-one runtime ports.
+
+## Verification Log
+
+Phase 8 verification is run from this branch. Results are updated before the
+phase PR is opened.
+
+| Command | Result |
+| --- | --- |
+| `uv sync --group dev --extra gui --extra console --extra docs --extra torch` | Passed |
+| `uv pip install /Applications/MATLAB_R2026a.app/extern/engines/python` | Passed: installed local `matlabengine==26.1` for MATLAB parity verification |
+| `uv run --no-sync python -m tools.eeglab_final_parity_matrix --json` | Passed: `ok: true`, 31 rows, 180 expected paths |
+| `uv run --no-sync pytest tests/test_eeglab_final_parity_matrix.py tests/test_pop_loadset_h5.py::TestPopLoadsetH5::test_basic_h5_loading --tb=short` | Passed: 13 passed |
+| `uv run --no-sync pytest tests/test_runtime_eeglab_independence.py tests/test_guifunc_pophelp_chansel.py tests/test_public_api_examples.py tests/test_package_exports.py tests/test_menu_placeholder_inventory.py` | Passed: 37 passed |
+| `uv run --no-sync pytest tests/test_gui_main_window.py` | Passed: 69 passed |
+| `uv run --no-sync pytest tests/test_console_workspace.py` | Passed: 86 passed |
+| `uv run --no-sync ruff check .` | Passed |
+| `uv run --no-sync ruff format --check .` | Passed |
+| `uv run --no-sync ty check` | Passed |
+| `uv run --no-sync sphinx-build -b html docs/source docs/_build/html` | Passed |
+| `uv run --no-sync pytest tests/test_visual_parity.py` | Passed: 26 passed |
+| `EEGPREP_SKIP_MATLAB=1 uv run --no-sync pytest -m "not slow" --tb=short` | Passed: 1873 passed, 209 skipped, 12 deselected |
+| `uv run --no-sync pytest -m "matlab or octave" --tb=short` | Passed: 342 passed, 21 skipped, 1818 deselected |
+| GUI Agent mixed workflow QA script | Passed: startup/menu/help, GUI retrieve to console sync, console bare `pop_reref` to GUI refresh |
+| `.agents/skills/oc-autoreview-adapted/scripts/autoreview --mode local --codex-bin /tmp/codex-fast-autoreview` | Passed clean after fixing accepted docs findings |
+| `./pre-commit.py --fix` | Passed on the staged Phase 8 files |

--- a/docs/parity/eeglab_final_parity_matrix.json
+++ b/docs/parity/eeglab_final_parity_matrix.json
@@ -974,10 +974,10 @@
         "docs/source/user_guide/interactive_console.rst",
         "docs/source/user_guide/eeglab_migration.rst"
       ],
-      "status": "docs_gap",
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "EEGLAB users need an explicit guide from MATLAB command history to EEGPrep console history, LASTCOM, ALLCOM, and replayable Python commands.",
+      "rationale": "Phase 7 added the EEGPrep-owned console and migration guides that map EEGLAB command-history habits to eegprep-console, LASTCOM, ALLCOM, GUI session updates, and replayable Python commands.",
       "user_facing_surface": [
         "eegprep-console",
         "history replay"
@@ -986,7 +986,7 @@
         "docs/source/user_guide/interactive_console.rst",
         "docs/source/user_guide/eeglab_migration.rst"
       ],
-      "test_notes": "Phase 7 should add docs build coverage and examples that match actual console behavior."
+      "test_notes": "Covered by the Sphinx docs build, interactive-console examples, GUI/console session docs, and Phase 8 closeout review of shared-session smoke coverage."
     },
     {
       "row_id": "docs-event-processing-tutorials",
@@ -996,11 +996,14 @@
         "tutorial_scripts/event_processing_single_dataset.m",
         "tutorial_scripts/event_processing_study.m"
       ],
-      "eegprep_equivalent": null,
-      "status": "docs_gap",
+      "eegprep_equivalent": [
+        "docs/source/user_guide/concepts.rst",
+        "docs/source/user_guide/eeglab_migration.rst"
+      ],
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "Event latency, urevent, epoch, and STUDY event handling need tutorial coverage with explicit MATLAB/Python indexing boundaries.",
+      "rationale": "Phase 7 added concepts and migration coverage for event latency, urevent, epoch, STUDY event handling, and explicit MATLAB-facing versus Python-indexing boundaries.",
       "user_facing_surface": [
         "events",
         "epochs",
@@ -1010,7 +1013,7 @@
         "docs/source/user_guide/concepts.rst",
         "docs/source/user_guide/eeglab_migration.rst"
       ],
-      "test_notes": "Phase 7 should keep examples aligned with tested pop_adjustevents, epoching, and STUDY behavior."
+      "test_notes": "Covered by the Sphinx docs build and by existing pop_adjustevents, epoching, STUDY trialinfo, and migration-guide examples referenced from the manual."
     },
     {
       "row_id": "docs-study-tutorials",
@@ -1025,10 +1028,10 @@
       "eegprep_equivalent": [
         "docs/source/user_guide/study_workflows.rst"
       ],
-      "status": "docs_gap",
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "Current STUDY docs describe implemented surfaces, but Phase 7 needs EEGLAB-style task tutorials that include GUI, console, scripting, cache, and limitations.",
+      "rationale": "Phase 7 expanded STUDY documentation into task-oriented GUI, console, scripting, cache, ERP, PAC, clustering, and limitation guidance based on completed Phase 4 behavior.",
       "user_facing_surface": [
         "STUDY",
         "group workflows",
@@ -1037,7 +1040,7 @@
       "docs_targets": [
         "docs/source/user_guide/study_workflows.rst"
       ],
-      "test_notes": "Phase 7 should build examples around completed Phase 4 behavior and avoid documenting intentions as implemented features."
+      "test_notes": "Covered by the Sphinx docs build, STUDY workflow examples, and existing STUDY cache/design/PAC tests that anchor the documented behavior."
     },
     {
       "row_id": "docs-source-reconstruction-tutorials",
@@ -1048,11 +1051,14 @@
         "tutorial_scripts/source_reconstruction_custom_mri.m",
         "tutorial_scripts/source_reconstruction_eeg.mlx"
       ],
-      "eegprep_equivalent": null,
-      "status": "docs_gap",
+      "eegprep_equivalent": [
+        "docs/source/user_guide/study_workflows.rst",
+        "docs/source/user_guide/plugins.rst"
+      ],
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "DIPFIT and source reconstruction docs must be written after Phase 3 defines what is implemented, optional, or explicitly unavailable.",
+      "rationale": "Phase 7 documented the implemented dataset-level DIPFIT spherical workflows and the explicit MRI/BEM, AFNI atlas clipping, LORETA, FieldTrip, and STUDY source-statistics backend boundaries defined by Phase 3.",
       "user_facing_surface": [
         "DIPFIT",
         "source reconstruction"
@@ -1061,7 +1067,7 @@
         "docs/source/user_guide/study_workflows.rst",
         "docs/source/user_guide/plugins.rst"
       ],
-      "test_notes": "Phase 7 should describe actual Phase 3 behavior and optional backend setup, with clear limitation callouts."
+      "test_notes": "Covered by the Sphinx docs build, DIPFIT workflow docs, plugins guide, and existing DIPFIT implementation and limitation-path tests."
     },
     {
       "row_id": "docs-time-frequency-and-movie-tutorials",
@@ -1071,11 +1077,14 @@
         "tutorial_scripts/make_eeg_movie.m",
         "tutorial_scripts/time_freq_all_elec.mlx"
       ],
-      "eegprep_equivalent": null,
-      "status": "docs_gap",
+      "eegprep_equivalent": [
+        "docs/source/user_guide/preprocessing_pipeline.rst",
+        "docs/source/user_guide/visual_parity.rst"
+      ],
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "Time-frequency docs should reflect completed core parity plus explicit limitations around movie/visual workflows that are not standalone EEGPrep features yet.",
+      "rationale": "Phase 7 documented the supported preprocessing and time-frequency-adjacent workflow surfaces while keeping EEG movie and visual parity capture behavior as explicit tooling or future-work boundaries.",
       "user_facing_surface": [
         "time-frequency analysis",
         "visualization tutorials"
@@ -1084,7 +1093,7 @@
         "docs/source/user_guide/preprocessing_pipeline.rst",
         "docs/source/user_guide/visual_parity.rst"
       ],
-      "test_notes": "Phase 7 should base runnable examples on tested EEGPrep functions and classify non-ported visual workflows clearly."
+      "test_notes": "Covered by the Sphinx docs build, preprocessing tutorial examples, visual parity tooling docs, and existing time-frequency/core parity test coverage."
     },
     {
       "row_id": "docs-bids-face-experiment-tutorial",
@@ -1096,10 +1105,10 @@
       "eegprep_equivalent": [
         "docs/source/user_guide/bids_workflow.rst"
       ],
-      "status": "docs_gap",
+      "status": "implemented",
       "responsible_phase": "phase_7",
       "phase_issue": "#164 EEGLAB-style Sphinx documentation and tutorials",
-      "rationale": "BIDS documentation should include an EEGLAB-style end-to-end tutorial that is accurate to EEGPrep's standalone BIDS import/export and preprocessing behavior.",
+      "rationale": "Phase 7 added a standalone BIDS workflow tutorial covering EEGLAB .set/.fdt export, BIDS file listing, sidecar-aware loading, batch preprocessing, derivative loading, and GUI/console menu flow.",
       "user_facing_surface": [
         "BIDS workflow",
         "batch preprocessing"
@@ -1108,7 +1117,7 @@
         "docs/source/user_guide/bids_workflow.rst",
         "docs/source/examples/index.rst"
       ],
-      "test_notes": "Phase 7 should keep the tutorial runnable against EEGPrep sample or synthetic data and covered by docs build checks."
+      "test_notes": "Covered by the Sphinx docs build, BIDS workflow examples, and existing BIDS import/export/preprocessing tests."
     }
   ]
 }

--- a/docs/source/user_guide/preprocessing_pipeline.rst
+++ b/docs/source/user_guide/preprocessing_pipeline.rst
@@ -216,6 +216,36 @@ Label and review components:
 
 See :ref:`ica_rejection` before removing components.
 
+Time-Frequency and ERP Images
+=============================
+
+After epoching or component review, use EEGPrep's standalone time-frequency
+wrappers for the common EEGLAB plotting workflows:
+
+.. code-block:: python
+
+   from eegprep import pop_newcrossf, pop_newtimef, pop_spectopo
+
+   ersp, com_timef = pop_newtimef(EEG, typeproc=1, num=1, return_com=True)
+   cross, com_crossf = pop_newcrossf(EEG, typeproc=1, num1=1, num2=2, return_com=True)
+   spectra, com_spectopo = pop_spectopo(EEG, 1, timerange=[], return_com=True)
+
+Legacy ``pop_timef`` and ``pop_crossf`` calls route through the standalone
+``pop_newtimef`` and ``pop_newcrossf`` implementations. ERP-image workflows use
+``pop_erpimage`` for channel or component images:
+
+.. code-block:: python
+
+   from eegprep import pop_erpimage
+
+   image, com = pop_erpimage(EEG, typeplot=1, index=1, return_com=True)
+
+GUI paths live under the ``Plot`` menu when a dataset is loaded. EEGPrep
+returns replayable Python history commands for these wrappers. Some MATLAB-only
+``pop_erpimage`` event-alignment and advanced renormalization options are not
+standalone EEGPrep features; those requests raise explicit errors instead of
+silently substituting a different analysis.
+
 Epoch and Baseline
 ==================
 

--- a/docs/source/user_guide/visual_parity.rst
+++ b/docs/source/user_guide/visual_parity.rst
@@ -17,6 +17,18 @@ Headless MATLAB batch sessions can run structural checks, but they cannot
 capture EEGLAB UI controls with ``getframe`` unless figure windows are actually
 displayed.
 
+EEG Movies and Visual Workflow Boundaries
+=========================================
+
+EEGLAB's tutorial movie scripts, such as ``make_eeg_movie.m``, are treated as
+visual workflow references for this epic rather than standalone EEGPrep runtime
+features. EEGPrep owns static plots, ERP images, time-frequency wrappers, GUI
+dialog rendering, and the visual parity capture tooling described here. It does
+not currently ship an EEGLAB-compatible EEG movie generator or a persistent
+movie-authoring UI. Use the plotting wrappers documented in
+:ref:`preprocessing_pipeline` for analysis figures, and use this page's capture
+tools for reviewable GUI evidence.
+
 Install the optional EEGPREP GUI dependencies before capturing Python dialogs:
 
 .. code-block:: bash

--- a/tests/test_eeglab_final_parity_matrix.py
+++ b/tests/test_eeglab_final_parity_matrix.py
@@ -35,7 +35,24 @@ def test_final_matrix_uses_complete_status_taxonomy() -> None:
 
     assert tuple(payload["metadata"]["status_taxonomy"]) == VALID_STATUSES
     assert statuses <= set(VALID_STATUSES)
-    assert {"optional_dependency", "docs_gap"} <= statuses
+    assert "optional_dependency" in statuses
+
+
+def test_final_closeout_has_no_unimplemented_or_documentation_gap_rows() -> None:
+    payload = load_matrix(MATRIX_PATH)
+    remaining = [(row["row_id"], row["status"]) for row in payload["rows"] if row["status"] in {"port", "docs_gap"}]
+
+    assert remaining == []
+
+
+def test_final_partial_rows_are_explicit_backend_boundaries() -> None:
+    payload = load_matrix(MATRIX_PATH)
+    partial_rows = [row for row in payload["rows"] if row["status"] == "partial"]
+
+    assert partial_rows
+    for row in partial_rows:
+        explanation = f"{row['rationale']} {row['test_notes']}".lower()
+        assert "limitation" in explanation or "boundary" in explanation
 
 
 def test_final_matrix_discovers_final_epic_paths_without_third_party_bloat() -> None:

--- a/tests/test_pop_loadset_h5.py
+++ b/tests/test_pop_loadset_h5.py
@@ -50,7 +50,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
             eeg_group.create_dataset('nbchan', data=np.array([[32]]))
             eeg_group.create_dataset('trials', data=np.array([[10]]))
             eeg_group.create_dataset('xmin', data=np.array([[-1.0]]))
-            eeg_group.create_dataset('xmax', data=np.array([[1.0]]))
+            eeg_group.create_dataset('xmax', data=np.array([[0.998]]))
 
             # Create string fields (as byte strings)
             eeg_group.create_dataset('setname', data=np.array([b'test_dataset'], dtype='S'))
@@ -64,7 +64,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
                 # Create sample data (channels x timepoints x trials)
                 data = np.random.randn(32, 1000, 10).astype(np.float32)
                 eeg_group.create_dataset('data', data=data)
-                eeg_group.create_dataset('times', data=np.linspace(-1, 1, 1000))
+                eeg_group.create_dataset('times', data=np.linspace(-1, 0.998, 1000))
                 eeg_group.create_dataset('icaweights', data=np.random.randn(32, 32))
                 eeg_group.create_dataset('icasphere', data=np.eye(32))
                 eeg_group.create_dataset('icawinv', data=np.random.randn(32, 32))
@@ -150,7 +150,7 @@ class TestPopLoadsetH5(DebuggableTestCase):
         self.assertEqual(EEG['nbchan'], 32)
         self.assertEqual(EEG['trials'], 10)
         self.assertEqual(EEG['xmin'], -1.0)
-        self.assertEqual(EEG['xmax'], 1.0)
+        self.assertEqual(EEG['xmax'], 0.998)
 
         # Check string fields
         self.assertEqual(EEG['setname'], 'test_dataset')


### PR DESCRIPTION
Close the final standalone parity phase by reclassifying completed documentation matrix rows, adding closeout evidence notes, documenting time-frequency and movie workflow boundaries, and tightening tests for closeout status and HDF5 timing semantics.

Closes #165