### PR TITLE
[Quality] Fix session sync and MNE conversion invariants

### DIFF
--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -352,19 +352,18 @@ class EEGPrepConsoleWorkspace:
         history_command = self._history_command_for_source(source, targets)
         changed = False
 
-        if "ALLEEG" in targets:
+        if "ALLEEG" in targets or "CURRENTSET" in targets:
             alleeg = self.namespace.get("ALLEEG", [])
             if not isinstance(alleeg, list):
                 raise ValueError("ALLEEG must be a list of EEG datasets")
-            self.session.ALLEEG = alleeg
-            changed = True
-
-        if "CURRENTSET" in targets:
-            current = _normalize_currentset(self.namespace.get("CURRENTSET"))
-            if current:
-                self.session.retrieve(current if len(current) > 1 else current[0])
-            else:
-                self.session.CURRENTSET = []
+            current = (
+                _normalize_currentset(self.namespace.get("CURRENTSET"))
+                if "CURRENTSET" in targets
+                else self.session.CURRENTSET
+            )
+            self.session.apply_workspace_state(
+                alleeg=alleeg, currentset=current, command="", append_dataset_history=False
+            )
             changed = True
 
         if self._namespace_eeg_changed(targets):
@@ -380,16 +379,16 @@ class EEGPrepConsoleWorkspace:
                 changed = True
 
         if "STUDY" in targets:
-            self.session.STUDY = self.namespace.get("STUDY")
-            if "CURRENTSTUDY" not in targets:
-                self.session.CURRENTSTUDY = 1 if self.session.STUDY else 0
+            study_kwargs: dict[str, Any] = {"study": self.namespace.get("STUDY"), "command": ""}
+            if "CURRENTSTUDY" in targets:
+                study_kwargs["currentstudy"] = self.namespace.get("CURRENTSTUDY")
+            self.session.apply_workspace_state(**study_kwargs)
             changed = True
-        if "CURRENTSTUDY" in targets:
-            self.session.CURRENTSTUDY = int(self.namespace.get("CURRENTSTUDY") or 0)
+        elif "CURRENTSTUDY" in targets:
+            self.session.apply_workspace_state(currentstudy=self.namespace.get("CURRENTSTUDY"), command="")
             changed = True
 
         if changed:
-            self.session.notify_changed()
             if history_command and history_command != self.session.LASTCOM:
                 self.session.add_history(history_command)
         self.pull_from_session()
@@ -401,12 +400,13 @@ class EEGPrepConsoleWorkspace:
         dataset_state = _extract_pop_dataset_state(result)
         if dataset_state is not None:
             alleeg, eeg, currentset, command = dataset_state
-            self.session.ALLEEG = alleeg
-            self.session.EEG = eeg
-            self.session.CURRENTSET = _normalize_currentset(currentset)
-            if command:
-                self.session.add_history(command, notify=False)
-            self.session.notify_changed()
+            self.session.apply_workspace_state(
+                alleeg=alleeg,
+                eeg=eeg,
+                currentset=currentset,
+                command=command,
+                append_dataset_history=False,
+            )
             self._pop_updated_session = True
             self.pull_from_session()
             self._refresh()

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -903,14 +903,23 @@ class MenuActionDispatcher:
             "EEG": self.session.EEG,
             "ALLEEG": self.session.ALLEEG,
             "CURRENTSET": self.session.current_set_value(),
+            "ALLCOM": list(self.session.ALLCOM),
+            "LASTCOM": self.session.LASTCOM,
             "STUDY": self.session.STUDY,
+            "CURRENTSTUDY": self.session.CURRENTSTUDY,
         }
         command = pop_runscript(filename, namespace)
-        self.session.EEG = namespace.get("EEG", self.session.EEG)
-        self.session.ALLEEG = namespace.get("ALLEEG", self.session.ALLEEG)
-        self.session.CURRENTSET = _currentset_list(namespace.get("CURRENTSET", self.session.current_set_value()))
-        self.session.STUDY = namespace.get("STUDY", self.session.STUDY)
-        self._add_history_from_gui(command)
+        self.session.echo_command(command)
+        self.session.apply_workspace_state(
+            eeg=namespace.get("EEG", self.session.EEG),
+            alleeg=namespace.get("ALLEEG", self.session.ALLEEG),
+            currentset=namespace.get("CURRENTSET", self.session.current_set_value()),
+            allcom=namespace.get("ALLCOM", self.session.ALLCOM),
+            lastcom=namespace.get("LASTCOM", self.session.LASTCOM),
+            study=namespace.get("STUDY", self.session.STUDY),
+            currentstudy=namespace.get("CURRENTSTUDY", self.session.CURRENTSTUDY),
+            command=command,
+        )
         self._refresh()
 
     def _bids_tool_action(self, action: str, parent: Any | None) -> None:
@@ -942,8 +951,8 @@ class MenuActionDispatcher:
 
         updated, command = getattr(bids_tools, action)(target, **metadata)
         if self.session.CURRENTSTUDY == 1 and self.session.STUDY:
-            self.session.STUDY = updated
-            self._add_history_from_gui(command)
+            self.session.echo_command(command)
+            self.session.set_study(updated, command=command)
         else:
             self._store_current_from_gui(updated, command=command)
         self._refresh()
@@ -1045,11 +1054,8 @@ class MenuActionDispatcher:
         dataset_state = _extension_dataset_state(result)
         if dataset_state is not None:
             alleeg, eeg_out, currentset, command = dataset_state
-            self.session.ALLEEG = alleeg
-            self.session.EEG = eeg_out
-            self.session.CURRENTSET = _currentset_list(currentset)
-            self._add_history_from_gui(command)
-            self.session.notify_changed()
+            self.session.echo_command(command)
+            self.session.apply_workspace_state(alleeg=alleeg, eeg=eeg_out, currentset=currentset, command=command)
             self._refresh()
             return
         eeg_out, command = _extension_eeg_and_command(result)
@@ -1360,11 +1366,8 @@ class MenuActionDispatcher:
         alleeg, eeg_out, current_set, command = pop_copyset(self.session.ALLEEG, set_in, gui=True, return_com=True)
         if not command:
             return
-        self.session.ALLEEG = alleeg
-        self.session.EEG = eeg_out
-        self.session.CURRENTSET = _currentset_list(current_set)
-        self._add_history_from_gui(command)
-        self.session.notify_changed()
+        self.session.echo_command(command)
+        self.session.apply_workspace_state(alleeg=alleeg, eeg=eeg_out, currentset=current_set, command=command)
         self._refresh()
 
     def _merge_datasets(self, parent: Any | None) -> None:
@@ -1540,8 +1543,8 @@ class MenuActionDispatcher:
         study, command, _figure = pop_chanplot(self.session.STUDY, self.session.ALLEEG, gui=True, return_com=True)
         if not command:
             return
-        self.session.STUDY = study
-        self._add_history_from_gui(command)
+        self.session.echo_command(command)
+        self.session.set_study(study, command=command)
         self._refresh()
 
     def _store_current_from_gui(self, eeg: Any, **kwargs: Any) -> Any:
@@ -1577,11 +1580,7 @@ class MenuActionDispatcher:
         self.session.echo_command(command)
         self.session.add_history(command, notify=False)
         self.session.echo_command(newset_command)
-        self.session.ALLEEG = alleeg
-        self.session.EEG = current
-        self.session.CURRENTSET = _currentset_list(current_set)
-        self.session.add_history(newset_command, notify=False)
-        self.session.notify_changed()
+        self.session.apply_workspace_state(alleeg=alleeg, eeg=current, currentset=current_set, command=newset_command)
 
     def _add_history_from_gui(self, command: str | None) -> None:
         self.session.echo_command(command)
@@ -1592,7 +1591,7 @@ class MenuActionDispatcher:
         self.session.retrieve(index)
         command = f"[ALLEEG EEG CURRENTSET] = pop_newset(ALLEEG, EEG, CURRENTSET, 'retrieve', {index});"
         if was_study:
-            self.session.CURRENTSTUDY = 0
+            self.session.apply_workspace_state(currentstudy=0)
             command = f"CURRENTSTUDY = 0;{command}"
         self._add_history_from_gui(command)
         self._refresh()

--- a/src/eegprep/functions/guifunc/session.py
+++ b/src/eegprep/functions/guifunc/session.py
@@ -18,6 +18,9 @@ from eegprep.functions.adminfunc.storage import offload_storedisk_datasets
 from eegprep.functions.popfunc.eeg_emptyset import eeg_emptyset
 
 
+_UNSET = object()
+
+
 def has_eeg_data(eeg: Any) -> bool:
     """Return whether an EEG-like object contains non-empty data."""
     if not isinstance(eeg, dict):
@@ -223,6 +226,62 @@ class EEGPrepSession:
         self.notify_changed()
         return eeg
 
+    def apply_workspace_state(
+        self,
+        *,
+        eeg: Any = _UNSET,
+        alleeg: Any = _UNSET,
+        currentset: Any = _UNSET,
+        allcom: Any = _UNSET,
+        lastcom: Any = _UNSET,
+        study: Any = _UNSET,
+        currentstudy: Any = _UNSET,
+        command: str = "",
+        append_dataset_history: bool = False,
+    ) -> None:
+        """Apply a GUI/console workspace update as one session transaction."""
+        dataset_changed = eeg is not _UNSET or alleeg is not _UNSET or currentset is not _UNSET
+        if dataset_changed:
+            resolved_alleeg = self.ALLEEG if alleeg is _UNSET else alleeg
+            if not isinstance(resolved_alleeg, list):
+                raise ValueError("ALLEEG must be a list of EEG datasets")
+            resolved_currentset = (
+                list(self.CURRENTSET)
+                if currentset is _UNSET
+                else normalize_dataset_indices(currentset, allow_empty=True)
+            )
+            if resolved_currentset and max(resolved_currentset) > len(resolved_alleeg):
+                raise ValueError("CURRENTSET contains indices outside ALLEEG")
+            resolved_eeg = self._resolve_workspace_eeg(eeg, resolved_alleeg, resolved_currentset)
+            self.ALLEEG = resolved_alleeg
+            self.EEG = resolved_eeg
+            self.CURRENTSET = resolved_currentset
+            self._mirror_current_eeg_into_alleeg()
+            if append_dataset_history:
+                self._append_current_dataset_history(command)
+            offload_storedisk_datasets(self.ALLEEG, set(self.CURRENTSET))
+
+        if allcom is not _UNSET:
+            if not isinstance(allcom, list):
+                raise ValueError("ALLCOM must be a list of command strings")
+            self.ALLCOM = [str(item) for item in allcom if str(item).strip()]
+            self.LASTCOM = self.ALLCOM[-1] if self.ALLCOM else ""
+        if lastcom is not _UNSET:
+            last_command = str(lastcom or "").strip()
+            if last_command and (not self.ALLCOM or self.ALLCOM[-1] != last_command):
+                self.ALLCOM.append(last_command)
+            self.LASTCOM = last_command
+
+        if study is not _UNSET:
+            self.STUDY = study
+            if currentstudy is _UNSET:
+                self.CURRENTSTUDY = 1 if study else 0
+        if currentstudy is not _UNSET:
+            self.CURRENTSTUDY = int(currentstudy or 0)
+
+        self.add_history(command, notify=False)
+        self.notify_changed()
+
     def delete_current(self) -> None:
         """Delete the current dataset selection from memory."""
         if not self.CURRENTSET:
@@ -270,6 +329,29 @@ class EEGPrepSession:
             offload_storedisk_datasets(self.ALLEEG, set(self.CURRENTSET))
         self.add_history(command, notify=False)
         self.notify_changed()
+
+    def _resolve_workspace_eeg(
+        self,
+        eeg: Any,
+        alleeg: list[dict[str, Any]],
+        currentset: list[int],
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        if eeg is not _UNSET:
+            return eeg
+        if not currentset:
+            return eeg_emptyset()
+        selected = [alleeg[index - 1] for index in currentset]
+        return selected if len(selected) > 1 else selected[0]
+
+    def _mirror_current_eeg_into_alleeg(self) -> None:
+        if not self.CURRENTSET:
+            return
+        current = self.EEG if isinstance(self.EEG, list) else [self.EEG]
+        if len(current) != len(self.CURRENTSET):
+            raise ValueError("EEG selection length must match CURRENTSET")
+        for index, eeg in zip(self.CURRENTSET, current):
+            if 1 <= index <= len(self.ALLEEG):
+                self.ALLEEG[index - 1] = eeg
 
     def select_study(self, *, command: str = "CURRENTSTUDY = 1") -> None:
         """Select the current STUDY set in the shared workspace."""

--- a/src/eegprep/functions/miscfunc/eeg_eeg2mne.py
+++ b/src/eegprep/functions/miscfunc/eeg_eeg2mne.py
@@ -1,13 +1,13 @@
 """EEG to MNE conversion functions."""
 
-from ..popfunc.pop_loadset import pop_loadset
-import mne
+from pathlib import Path
 import tempfile
-import os
+
+import mne
+
 from ..popfunc.pop_saveset import pop_saveset  # in development
 
 
-# write a funtion that converts a MNE raw object to an EEGLAB set file
 def eeg_eeg2mne(EEG):
     """Convert EEG data structure to MNE Raw object.
 
@@ -21,34 +21,10 @@ def eeg_eeg2mne(EEG):
     raw : mne.io.Raw
         MNE Raw object
     """
-    # Generate a temporary file name
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file_path = temp_file.name
+    with tempfile.TemporaryDirectory(prefix="eegprep-eeg2mne-") as temp_dir:
+        set_path = Path(temp_dir) / "bridge.set"
+        pop_saveset(EEG, str(set_path))
 
-    base, _ = os.path.splitext(temp_file_path)
-    new_temp_file_path = base + ".set"
-
-    # save the raw file as a new EEGLAB .set file using MNE EEGLAB writer
-    pop_saveset(EEG, new_temp_file_path)
-
-    # load the EEGLAB set file
-    if EEG['trials'] > 1:
-        raw = mne.io.read_epochs_eeglab(new_temp_file_path)
-    else:
-        raw = mne.io.read_raw_eeglab(new_temp_file_path, preload=True)
-
-    return raw
-
-
-def test_eeg_eeg2mne():
-    """Test the eeg_eeg2mne function."""
-    eeglab_file_path = './eeglab_data_with_ica_tmp.set'
-    eeglab_file_path = '/System/Volumes/Data/data/matlab/eeglab/sample_data/eeglab_data_epochs_ica.set'
-    EEG = pop_loadset(eeglab_file_path)
-    raw = eeg_eeg2mne(EEG)
-
-    # print the keys of the EEG dictionary
-    print(raw.info)
-
-
-# test_eeg_eeg2mne()
+        if EEG['trials'] > 1:
+            return mne.io.read_epochs_eeglab(str(set_path))
+        return mne.io.read_raw_eeglab(str(set_path), preload=True)

--- a/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
+++ b/src/eegprep/functions/miscfunc/eeg_mne2eeg.py
@@ -1,11 +1,12 @@
 """MNE to EEG conversion functions."""
 
-from ..popfunc.pop_loadset import pop_loadset
-import mne
+from pathlib import Path
 import tempfile
-import os
+
+import mne
 from mne.export import export_raw, export_epochs
-import numpy as np
+
+from ..popfunc.pop_loadset import pop_loadset
 
 
 def _mne_events_to_eeglab_events(raw_or_epochs):
@@ -38,7 +39,6 @@ def _mne_events_to_eeglab_events(raw_or_epochs):
     return events
 
 
-# write a funtion that converts a MNE raw object to an EEGLAB set file
 def eeg_mne2eeg(raw):
     """Convert MNE Raw object to EEG data structure.
 
@@ -54,49 +54,16 @@ def eeg_mne2eeg(raw):
     """
     raw_or_epochs = raw
 
-    # Generate a temporary file name
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        temp_file_path = temp_file.name
-
-    base, _ = os.path.splitext(temp_file_path)
-    new_temp_file_path = base + ".set"
-
-    # save the raw/epochs file as a new EEGLAB .set file using MNE EEGLAB writer
-    if isinstance(raw_or_epochs, mne.BaseEpochs):
-        export_epochs(new_temp_file_path, raw_or_epochs, fmt='eeglab')
-    else:
-        export_raw(new_temp_file_path, raw_or_epochs, fmt='eeglab')
-
-    # load the EEGLAB set file
-    EEG = pop_loadset(new_temp_file_path)
+    with tempfile.TemporaryDirectory(prefix="eegprep-mne2eeg-") as temp_dir:
+        set_path = Path(temp_dir) / "bridge.set"
+        if isinstance(raw_or_epochs, mne.BaseEpochs):
+            export_epochs(str(set_path), raw_or_epochs, fmt='eeglab')
+        else:
+            export_raw(str(set_path), raw_or_epochs, fmt='eeglab')
+        EEG = pop_loadset(str(set_path))
 
     # Inject events/annotations from MNE object into EEGLAB structure
     eeglab_events = _mne_events_to_eeglab_events(raw_or_epochs)
     if eeglab_events:
         EEG['event'] = eeglab_events
-
     return EEG
-
-
-def test_eeg_mne2eeg():
-    """Test the eeg_mne2eeg function."""
-    eeglab_file_path = './eeglab_data_with_ica_tmp.set'
-    eeglab_file_path = '/System/Volumes/Data/data/matlab/eeglab/sample_data/eeglab_data_epochs_ica.set'
-    EEG = pop_loadset(eeglab_file_path)
-
-    # create MNE info structure
-    info = mne.create_info(ch_names=[x['labels'] for x in EEG['chanlocs']], sfreq=EEG['srate'], ch_types='eeg')
-    if EEG['trials'] > 1:
-        events = np.array([[i, 0, 1] for i in range(EEG['trials'])])  # NOT CORRECT CONVERTION JUST FOR TESTING
-        event_id = dict(dummy=1)
-        raw = mne.EpochsArray(EEG['data'].transpose(2, 0, 1), info, events, tmin=0, event_id=event_id)
-    else:
-        raw = mne.io.RawArray(EEG['data'], info)
-
-    EEG2 = eeg_mne2eeg(raw)
-
-    # print the keys of the EEG dictionary
-    print(EEG2.keys())
-
-
-# test_eeg_mne2eeg()

--- a/src/eegprep/functions/miscfunc/eeg_mne2eeg_epochs.py
+++ b/src/eegprep/functions/miscfunc/eeg_mne2eeg_epochs.py
@@ -1,17 +1,15 @@
 """MNE epochs to EEGLAB dataset conversion utilities."""
 
-# Example to export MNE epochs to EEGLAB dataset
-# Events are not handled correctly in this example but it works
-
-import mne
-from mne.preprocessing import ICA
+import logging
 import math
 
 import numpy as np
-from scipy.io import savemat
+
+from eegprep.functions.miscfunc.misc import finite_matmul, finite_pinv
+
+logger = logging.getLogger(__name__)
 
 
-# Load example data
 def eeg_mne2eeg_epochs(epochs, ica):
     """Convert MNE epochs with ICA to EEGLAB dataset format.
 
@@ -27,29 +25,27 @@ def eeg_mne2eeg_epochs(epochs, ica):
     dict
         EEGLAB-compatible dataset dictionary.
     """
-    # export to EEGLAB dataset
-    data = epochs.get_data()  # Get the data from the epochs
-    n_epochs, n_channels, n_times = data.shape
-    ica_weights = ica.get_components()  # ICA weights (n_components x n_channels)
-
-    # create identity matrix of size n_channels x n_channels
-    ica_sphere = np.eye(n_channels)  # ICA sphere (n_channels x n_channels)
-
-    # Compute the mixing matrix (inverse weights)
-    ica_inverse_weights = np.linalg.pinv(ica_weights)  # Shape: (n_channels, n_components)
+    mne_data = epochs.get_data(copy=True)
+    n_epochs, n_channels, n_times = mne_data.shape
+    data = np.transpose(mne_data, (1, 2, 0))
 
     ica_channels = ica.info['ch_names']
     raw_channels = epochs.info['ch_names']  # Assuming you have the raw object
     ica_channel_indices = [raw_channels.index(ch) for ch in ica_channels]
     ica_channel_indices = np.array(ica_channel_indices)
 
-    ica_act = ica.get_sources(epochs).get_data(copy=True).transpose(1, 2, 0)  # Get the ICA activations
+    ica_weights, ica_sphere, ica_inverse_weights, ica_act = _mne_ica_to_eeglab_fields(
+        ica,
+        data[ica_channel_indices],
+        n_times,
+        n_epochs,
+    )
 
-    print('Reference conversion may not be accurate...')
     if 'custom_ref_applied' in epochs.info and epochs.info['custom_ref_applied']:
         ref = 'common'  # Custom reference was applied
     else:
         ref = 'average'  # Default to average reference
+    logger.info("MNE reference metadata converted to EEGPrep ref=%s.", ref)
 
     eeglab_dict = {
         'setname': '',
@@ -70,8 +66,8 @@ def eeg_mne2eeg_epochs(epochs, ica):
         'data': data,
         'icaact': ica_act,
         'icawinv': ica_inverse_weights,
-        'icasphere': ica_weights,
-        'icaweights': ica_sphere,
+        'icasphere': ica_sphere,
+        'icaweights': ica_weights,
         'icachansind': ica_channel_indices,
         'chanlocs': np.array([]),
         'urchanlocs': np.array([]),
@@ -111,21 +107,27 @@ def eeg_mne2eeg_epochs(epochs, ica):
     Y_all = []
     Z_all = []
     for ch in ch_locs:
-        if 'loc' in ch and ch['loc'] is not None:
-            X_all.append(ch['loc'][1] * 1000)
-            Y_all.append(-ch['loc'][0] * 1000)
-            Z_all.append(ch['loc'][2] * 1000)
-            hypotxy = math.hypot(X_all[-1], Y_all[-1])
-            sph_radius_all.append(math.hypot(hypotxy, Z_all[-1]))
+        loc = ch.get('loc') if isinstance(ch, dict) else None
+        if loc is None or len(loc) < 3:
+            x = y = z = 0.0
+        else:
+            x = float(loc[1]) * 1000
+            y = -float(loc[0]) * 1000
+            z = float(loc[2]) * 1000
+        X_all.append(x)
+        Y_all.append(y)
+        Z_all.append(z)
+        hypotxy = math.hypot(x, y)
+        sph_radius_all.append(math.hypot(hypotxy, z))
 
-            az = math.atan2(Y_all[-1], X_all[-1]) / math.pi * 180
-            horiz = math.atan2(Z_all[-1], hypotxy) / math.pi * 180
+        az = math.atan2(y, x) / math.pi * 180
+        horiz = math.atan2(z, hypotxy) / math.pi * 180
 
-            sph_theta_all.append(az)
-            sph_phi_all.append(horiz)
+        sph_theta_all.append(az)
+        sph_phi_all.append(horiz)
 
-            theta_all.append(-az)  # warning inverse notation compared to MATLAB to match
-            radius_all.append(0.5 - horiz / 180)  # warning inverse notation compared to MATLAB to match
+        theta_all.append(-az)  # warning inverse notation compared to MATLAB to match
+        radius_all.append(0.5 - horiz / 180)  # warning inverse notation compared to MATLAB to match
 
     d_list = [
         {
@@ -166,43 +168,31 @@ def eeg_mne2eeg_epochs(epochs, ica):
     d_list = np.array(d_list)
     eeglab_dict['chanlocs'] = d_list
 
-    # # Step 4: Save the EEGLAB dataset as a .mat file
     return eeglab_dict
 
-    # print("EEGLAB dataset saved successfully!")
+
+def _mne_ica_to_eeglab_fields(ica, data, n_times, n_epochs):
+    n_components = int(ica.n_components_)
+    n_ica_channels = data.shape[0]
+    prewhitener = _prewhitener_matrix(ica, n_ica_channels)
+    pca_unmixing = finite_matmul(np.asarray(ica.unmixing_matrix_), np.asarray(ica.pca_components_)[:n_components])
+    unmixing = finite_matmul(pca_unmixing, prewhitener)
+    sphere = np.eye(n_ica_channels)
+    inverse_weights = finite_pinv(unmixing)
+    activations_2d = finite_matmul(unmixing, data.reshape(n_ica_channels, -1, order="F"))
+    activations = activations_2d.reshape(n_components, n_times, n_epochs, order="F")
+    return unmixing, sphere, inverse_weights, activations
 
 
-def test_eeg_mne2eeg_epochs():
-    """Test the eeg_mne2eeg_epochs function with sample MNE data."""
-    sample_data_folder = mne.datasets.sample.data_path()
-    sample_data_raw_file = sample_data_folder / "MEG" / "sample" / "sample_audvis_filt-0-40_raw.fif"
-
-    raw = mne.io.read_raw_fif(sample_data_raw_file)
-
-    # extract data epochs
-    events = mne.find_events(raw, stim_channel="STI 014")
-    event_dict = {
-        "auditory/left": 1,
-        "auditory/right": 2,
-        "visual/left": 3,
-        "visual/right": 4,
-        "smiley": 5,
-        "buttonpress": 32,
-    }
-    epochs = mne.Epochs(
-        raw,
-        events,
-        event_id=event_dict,
-        tmin=-0.2,
-        tmax=0.5,
-        preload=True,
-    )
-
-    ica = ICA(n_components=15, random_state=97, max_iter=800)
-    ica.fit(raw)
-
-    EEG = eeg_mne2eeg_epochs(epochs, ica)
-    savemat('output_file.mat', EEG)  # use pop_saveset
-
-
-# test_eeg_mne2eeg_epochs()
+def _prewhitener_matrix(ica, n_channels):
+    prewhitener = np.asarray(ica.pre_whitener_)
+    if ica.noise_cov is not None:
+        if prewhitener.shape != (n_channels, n_channels):
+            raise ValueError("MNE ICA pre-whitener has incompatible shape")
+        return prewhitener
+    values = prewhitener.reshape(-1)
+    if values.size == 1:
+        return np.eye(n_channels) / float(values[0])
+    if values.size != n_channels:
+        raise ValueError("MNE ICA pre-whitener has incompatible shape")
+    return np.diag(1.0 / values)

--- a/src/eegprep/functions/sigprocfunc/epoch.py
+++ b/src/eegprep/functions/sigprocfunc/epoch.py
@@ -4,9 +4,13 @@ This module provides functions for extracting epochs from continuous EEG data ti
 locked to specified events.
 """
 
+import logging
+
 import numpy as np
 
 from ..miscfunc.misc import round_mat
+
+logger = logging.getLogger(__name__)
 
 
 def epoch(data, events, lim, **kwargs):
@@ -51,7 +55,8 @@ def epoch(data, events, lim, **kwargs):
     reallim[1] = int(round_mat(lim[1] * g['srate'] - 1))  # minus 1 sample
 
     # --- epoching ---
-    print('Epoching...')
+    if g['verbose'] == 'on':
+        logger.info('Epoching...')
 
     newdatalength = int(reallim[1] - reallim[0] + 1)
 
@@ -116,12 +121,12 @@ def epoch(data, events, lim, **kwargs):
                     indexes[index] = 1
                 else:
                     if g['verbose'] == 'on':
-                        print(f'Warning: event {index + 1} out of value limits')
+                        logger.warning('event %s out of value limits', index + 1)
             else:
                 indexes[index] = 1
         else:
             if g['verbose'] == 'on':
-                print(f'Warning: event {index + 1} out of data boundary')
+                logger.warning('event %s out of data boundary', index + 1)
 
         # Re-reference events
         if g['allevents'] is not None and g['allevents'].size > 0:

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -809,6 +809,26 @@ def test_bare_legacy_pop_averef_alias_updates_session_history():
     workspace.close()
 
 
+def test_console_dataset_state_result_updates_session_once_without_duplicate_history():
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg("one"), new=True)
+    session.store_current(_demo_eeg("two"), new=True)
+    refresh = mock.Mock()
+    workspace = EEGPrepConsoleWorkspace(session, refresh=refresh, exports={})
+    first = dict(session.ALLEEG[0], setname="one edited")
+    second = dict(session.ALLEEG[1], setname="two edited")
+    command = "[ALLEEG EEG CURRENTSET] = pop_newset(ALLEEG, EEG, CURRENTSET, retrieve=[2, 1]);"
+
+    result = workspace.accept_pop_result(([first, second], [second, first], [2, 1], command), (), {})
+
+    assert list(result)[3] == command
+    assert session.CURRENTSET == [2, 1]
+    assert [item["setname"] for item in session.EEG] == ["two edited", "one edited"]
+    assert [item["setname"] for item in session.ALLEEG] == ["one edited", "two edited"]
+    assert session.ALLCOM == [command]
+    refresh.assert_called_once()
+
+
 def test_pop_call_without_history_command_records_raw_console_source():
     session = EEGPrepSession()
     session.store_current(_demo_eeg(), new=True)

--- a/tests/test_eeg_eeg2mne.py
+++ b/tests/test_eeg_eeg2mne.py
@@ -9,6 +9,7 @@ import os
 import numpy as np
 import tempfile
 import shutil
+from unittest import mock
 
 from eegprep.functions.miscfunc.eeg_eeg2mne import eeg_eeg2mne
 
@@ -25,9 +26,6 @@ try:
     from .fixtures import create_test_eeg
 except (ImportError, ValueError):
     from fixtures import create_test_eeg
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
 
 
 class TestEEGEEG2MNE(unittest.TestCase):
@@ -59,6 +57,22 @@ class TestEEGEEG2MNE(unittest.TestCase):
         # Check that data dimensions match
         self.assertEqual(result.info['nchan'], continuous_eeg['nbchan'])
         self.assertEqual(result.n_times, continuous_eeg['pnts'])
+
+    @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
+    def test_eeg_eeg2mne_cleans_temporary_bridge_files(self):
+        continuous_eeg = self.test_eeg.copy()
+        continuous_eeg['data'] = np.random.randn(32, 1000)
+        continuous_eeg['trials'] = 1
+        real_tempdir = tempfile.TemporaryDirectory
+
+        def tempdir_factory(*args, **kwargs):
+            kwargs["dir"] = self.temp_dir
+            return real_tempdir(*args, **kwargs)
+
+        with mock.patch("eegprep.functions.miscfunc.eeg_eeg2mne.tempfile.TemporaryDirectory", tempdir_factory):
+            eeg_eeg2mne(continuous_eeg)
+
+        self.assertEqual(os.listdir(self.temp_dir), [])
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_eeg2mne_epoched_data(self):

--- a/tests/test_eeg_mne2eeg.py
+++ b/tests/test_eeg_mne2eeg.py
@@ -10,6 +10,7 @@ import numpy as np
 import tempfile
 import os
 import shutil
+from unittest import mock
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
@@ -91,6 +92,21 @@ class TestEEGMNE2EEG(unittest.TestCase):
 
         except Exception as e:
             self.skipTest(f"eeg_mne2eeg raw conversion not available: {e}")
+
+    @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
+    def test_eeg_mne2eeg_cleans_temporary_bridge_files(self):
+        info = mne.create_info(["EEG001", "EEG002"], 100.0, ch_types='eeg')
+        raw = mne.io.RawArray(np.random.randn(2, 100), info)
+        real_tempdir = tempfile.TemporaryDirectory
+
+        def tempdir_factory(*args, **kwargs):
+            kwargs["dir"] = self.temp_dir
+            return real_tempdir(*args, **kwargs)
+
+        with mock.patch("eegprep.functions.miscfunc.eeg_mne2eeg.tempfile.TemporaryDirectory", tempdir_factory):
+            eeg_mne2eeg(raw)
+
+        self.assertEqual(os.listdir(self.temp_dir), [])
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_epochs_object(self):

--- a/tests/test_eeg_mne2eeg_epochs.py
+++ b/tests/test_eeg_mne2eeg_epochs.py
@@ -4,6 +4,8 @@ Test suite for eeg_mne2eeg_epochs.py - MNE Epochs to EEGLAB conversion.
 This module tests the eeg_mne2eeg_epochs function that converts MNE Epochs with ICA to EEGLAB datasets.
 """
 
+import contextlib
+import io
 import unittest
 import os
 import numpy as np
@@ -11,6 +13,7 @@ import tempfile
 import shutil
 
 from eegprep.functions.miscfunc.eeg_mne2eeg_epochs import eeg_mne2eeg_epochs
+from eegprep.functions.miscfunc.misc import finite_matmul, finite_pinv
 
 try:
     import mne
@@ -24,9 +27,6 @@ try:
     from .fixtures import create_test_eeg
 except (ImportError, ValueError):
     from fixtures import create_test_eeg
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
 
 
 class TestEEGMNE2EEGEpochs(unittest.TestCase):
@@ -86,6 +86,28 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
             self.skipTest(f"eeg_mne2eeg_epochs basic functionality not available: {e}")
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
+    def test_eeg_mne2eeg_epochs_uses_channel_major_data_without_stdout(self):
+        n_channels = 4
+        n_times = 20
+        n_epochs = 3
+        sfreq = 100.0
+        ch_names = [f'EEG{i:03d}' for i in range(n_channels)]
+        info = mne.create_info(ch_names, sfreq, ch_types='eeg')
+        data = np.arange(n_epochs * n_channels * n_times, dtype=float).reshape(n_epochs, n_channels, n_times)
+        events = np.array([[i, 0, 1] for i in range(n_epochs)])
+        epochs = mne.EpochsArray(data, info, events, tmin=0, event_id={'event': 1}, verbose=False)
+        ica = ICA(n_components=2, random_state=42, max_iter=20)
+        ica.fit(epochs, verbose=False)
+
+        stream = io.StringIO()
+        with contextlib.redirect_stdout(stream):
+            result = eeg_mne2eeg_epochs(epochs, ica)
+
+        self.assertEqual(stream.getvalue(), "")
+        self.assertEqual(result['data'].shape, (n_channels, n_times, n_epochs))
+        np.testing.assert_allclose(result['data'], np.transpose(data, (1, 2, 0)))
+
+    @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_epochs_ica_fields(self):
         """Test ICA fields in the converted EEGLAB dataset."""
         # Create MNE Epochs object
@@ -106,25 +128,23 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
         ica = ICA(n_components=8, random_state=42)
         ica.fit(epochs)
 
-        try:
-            result = eeg_mne2eeg_epochs(epochs, ica)
+        result = eeg_mne2eeg_epochs(epochs, ica)
 
-            # Check ICA fields
-            self.assertIn('icaact', result)
-            self.assertIn('icawinv', result)
-            self.assertIn('icasphere', result)
-            self.assertIn('icaweights', result)
-            self.assertIn('icachansind', result)
-
-            # Check ICA field shapes
-            self.assertEqual(result['icaact'].shape, (8, n_times, n_epochs))  # n_components x n_times x n_epochs
-            self.assertEqual(result['icawinv'].shape, (8, n_channels))  # n_components x n_channels
-            self.assertEqual(result['icasphere'].shape, (n_channels, 8))  # n_channels x n_components
-            self.assertEqual(result['icaweights'].shape, (n_channels, n_channels))  # identity matrix
-            self.assertEqual(len(result['icachansind']), n_channels)  # channel indices
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg_epochs ICA fields not available: {e}")
+        self.assertIn('icaact', result)
+        self.assertIn('icawinv', result)
+        self.assertIn('icasphere', result)
+        self.assertIn('icaweights', result)
+        self.assertIn('icachansind', result)
+        self.assertEqual(result['icaact'].shape, (8, n_times, n_epochs))
+        self.assertEqual(result['icawinv'].shape, (n_channels, 8))
+        self.assertEqual(result['icasphere'].shape, (n_channels, n_channels))
+        self.assertEqual(result['icaweights'].shape, (8, n_channels))
+        self.assertEqual(len(result['icachansind']), n_channels)
+        unmixing = finite_matmul(result['icaweights'], result['icasphere'])
+        data_2d = result['data'][result['icachansind']].reshape(n_channels, -1, order="F")
+        icaact_2d = result['icaact'].reshape(8, -1, order="F")
+        np.testing.assert_allclose(finite_matmul(unmixing, data_2d), icaact_2d, rtol=1e-10, atol=1e-10)
+        np.testing.assert_allclose(finite_pinv(unmixing), result['icawinv'], rtol=1e-10, atol=1e-10)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_epochs_channel_locations(self):
@@ -252,9 +272,8 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
         try:
             result = eeg_mne2eeg_epochs(epochs, ica)
 
-            # Check data dimensions (data is in MNE format: n_epochs x n_channels x n_times)
             self.assertEqual(result['trials'], 1)
-            self.assertEqual(result['data'].shape, (n_epochs, n_channels, n_times))
+            self.assertEqual(result['data'].shape, (n_channels, n_times, n_epochs))
             self.assertEqual(result['icaact'].shape, (8, n_times, n_epochs))
 
         except Exception as e:
@@ -286,8 +305,8 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
             result = eeg_mne2eeg_epochs(epochs, ica)
 
             # Check data dimensions
-            self.assertEqual(result['nbchan'], 1)
-            self.assertEqual(result['data'].shape, (1, n_times, n_epochs))
+            self.assertEqual(result['nbchan'], n_channels)
+            self.assertEqual(result['data'].shape, (n_channels, n_times, n_epochs))
             self.assertEqual(result['icaact'].shape, (2, n_times, n_epochs))
 
         except Exception as e:
@@ -317,10 +336,9 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
         try:
             result = eeg_mne2eeg_epochs(epochs, ica)
 
-            # Check data dimensions (data is in MNE format: n_epochs x n_channels x n_times)
             self.assertEqual(result['pnts'], 10)
             self.assertEqual(result['trials'], 3)
-            self.assertEqual(result['data'].shape, (n_epochs, n_channels, n_times))
+            self.assertEqual(result['data'].shape, (n_channels, n_times, n_epochs))
 
         except Exception as e:
             self.skipTest(f"eeg_mne2eeg_epochs short data not available: {e}")
@@ -484,9 +502,9 @@ class TestEEGMNE2EEGEpochs(unittest.TestCase):
 
             # Check ICA properties
             self.assertEqual(result['icaact'].shape, (15, 200, 20))
-            self.assertEqual(result['icawinv'].shape, (15, 32))
-            self.assertEqual(result['icasphere'].shape, (32, 15))
-            self.assertEqual(result['icaweights'].shape, (32, 32))
+            self.assertEqual(result['icawinv'].shape, (32, 15))
+            self.assertEqual(result['icasphere'].shape, (32, 32))
+            self.assertEqual(result['icaweights'].shape, (15, 32))
             self.assertEqual(len(result['icachansind']), 32)
 
             # Check channel locations

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -1329,7 +1329,14 @@ class MenuActionDispatcherTests(unittest.TestCase):
         qt_widgets = _fake_qt_widgets(open_file="/tmp/script.py")
 
         def fake_runscript(_filename, namespace):
+            self.assertIn("ALLCOM", namespace)
+            self.assertIn("LASTCOM", namespace)
+            self.assertIn("CURRENTSTUDY", namespace)
             namespace["CURRENTSET"] = 2
+            namespace["ALLCOM"].append("EEG = script_command(EEG);")
+            namespace["LASTCOM"] = "EEG = script_command(EEG);"
+            namespace["STUDY"] = {"name": "script study"}
+            namespace["CURRENTSTUDY"] = 1
             return "LASTCOM = pop_runscript('/tmp/script.py');"
 
         with (
@@ -1339,7 +1346,13 @@ class MenuActionDispatcherTests(unittest.TestCase):
             dispatcher.dispatch("pop_runscript")
 
         self.assertEqual(session.CURRENTSET, [2])
-        self.assertEqual(session.ALLCOM[-1], "LASTCOM = pop_runscript('/tmp/script.py');")
+        self.assertEqual(session.STUDY["name"], "script study")
+        self.assertEqual(session.CURRENTSTUDY, 1)
+        self.assertEqual(
+            session.ALLCOM,
+            ["EEG = script_command(EEG);", "LASTCOM = pop_runscript('/tmp/script.py');"],
+        )
+        self.assertEqual(session.LASTCOM, "LASTCOM = pop_runscript('/tmp/script.py');")
 
 
 class QtMainWindowTests(unittest.TestCase):

--- a/tests/test_pop_epoch.py
+++ b/tests/test_pop_epoch.py
@@ -6,6 +6,8 @@ CONCLUSION: The Python implementation achieves perfect numerical parity with
 MATLAB EEGLAB's pop_epoch function across all tested scenarios.
 """
 
+import contextlib
+import io
 import os
 import numpy as np
 import unittest
@@ -389,6 +391,27 @@ class TestPopEpochParity(unittest.TestCase):
 class TestPopEpochEdgeCases(unittest.TestCase):
     def setUp(self):
         np.random.seed(42)
+
+    def test_pop_epoch_does_not_print_to_stdout(self):
+        EEG = {
+            'data': np.random.randn(2, 500).astype(np.float32),
+            'srate': 100.0,
+            'nbchan': 2,
+            'pnts': 500,
+            'trials': 1,
+            'xmin': 0.0,
+            'xmax': 4.99,
+            'setname': 'stdout_test',
+            'event': [{'type': 'stim', 'latency': 250}],
+            'epoch': [],
+            'saved': 'no',
+        }
+        stream = io.StringIO()
+
+        with contextlib.redirect_stdout(stream):
+            pop_epoch(EEG, 'stim', [-0.1, 0.1])
+
+        self.assertEqual(stream.getvalue(), "")
 
     def test_boundary_events_near_edges(self):
         """Test epoching when events are near data boundaries"""


### PR DESCRIPTION
Centralizes GUI and console workspace state updates through EEGPrepSession, and fixes MNE conversion paths to preserve channel-major data, valid ICA fields, scoped temp files, and clean stdout. Adds regression tests for run-script sync, dataset-state results, epoch logging, and MNE invariants. This is stacked on PR #177.

Fixes #178
Fixes #179
Fixes #180
Fixes #181
Fixes #182
Fixes #183