### PR TITLE
[tests] Make the test suite able to fail (Fable 5 Phase 1)

### DIFF
--- a/tests/test_ICL_feature_extractor.py
+++ b/tests/test_ICL_feature_extractor.py
@@ -16,27 +16,9 @@ from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 
+from tests.fixtures import create_test_eeg
+
 local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
-
-
-def create_test_eeg(n_channels=32, n_samples=1000, srate=250.0, n_trials=1):
-    """Create a synthetic EEG structure for testing."""
-    data = np.random.randn(n_channels, n_samples, n_trials) * 0.5
-    if n_trials == 1:
-        data = data.squeeze(axis=2)  # Remove trial dimension for continuous data
-
-    return {
-        'data': data,
-        'srate': srate,
-        'pnts': n_samples,
-        'nbchan': n_channels,
-        'trials': n_trials,
-        'xmin': 0.0,
-        'xmax': (n_samples - 1) / srate,
-        'times': np.arange(n_samples) / srate,
-        'event': [],
-        'ref': 'unknown',
-    }
 
 
 class TestICLFeatureExtractorBasic(unittest.TestCase):
@@ -109,54 +91,46 @@ class TestICLFeatureExtractorBasic(unittest.TestCase):
 
     def test_icl_feature_extractor_basic_functionality(self):
         """Test basic ICL_feature_extractor functionality."""
-        try:
-            features = ICL_feature_extractor(self.test_eeg, flag_autocorr=False)
+        features = ICL_feature_extractor(self.test_eeg, flag_autocorr=False)
 
-            # Should return 2 features (topo and psd) when flag_autocorr=False
-            self.assertEqual(len(features), 2)
+        # Should return 2 features (topo and psd) when flag_autocorr=False
+        self.assertEqual(len(features), 2)
 
-            # Check topo features
-            topo = features[0]
-            self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
-            self.assertEqual(topo.dtype, np.float32)
-            self.assertTrue(np.all(np.abs(topo) <= 0.99))  # Should be scaled by 0.99
+        # Check topo features
+        topo = features[0]
+        self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
+        self.assertEqual(topo.dtype, np.float32)
+        self.assertTrue(np.all(np.abs(topo) <= 0.99))  # Should be scaled by 0.99
 
-            # Check psd features
-            psd = features[1]
-            self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
-            self.assertEqual(psd.dtype, np.float32)
-            self.assertTrue(np.all(np.abs(psd) <= 0.99))  # Should be scaled by 0.99
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor basic functionality not available: {e}")
+        # Check psd features
+        psd = features[1]
+        self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
+        self.assertEqual(psd.dtype, np.float32)
+        self.assertTrue(np.all(np.abs(psd) <= 0.99))  # Should be scaled by 0.99
 
     def test_icl_feature_extractor_with_autocorr(self):
         """Test ICL_feature_extractor with autocorrelation features."""
-        try:
-            features = ICL_feature_extractor(self.test_eeg, flag_autocorr=True)
+        features = ICL_feature_extractor(self.test_eeg, flag_autocorr=True)
 
-            # Should return 3 features (topo, psd, autocorr) when flag_autocorr=True
-            self.assertEqual(len(features), 3)
+        # Should return 3 features (topo, psd, autocorr) when flag_autocorr=True
+        self.assertEqual(len(features), 3)
 
-            # Check topo features
-            topo = features[0]
-            self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
-            self.assertEqual(topo.dtype, np.float32)
+        # Check topo features
+        topo = features[0]
+        self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
+        self.assertEqual(topo.dtype, np.float32)
 
-            # Check psd features
-            psd = features[1]
-            self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
-            self.assertEqual(psd.dtype, np.float32)
+        # Check psd features
+        psd = features[1]
+        self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
+        self.assertEqual(psd.dtype, np.float32)
 
-            # Check autocorr features
-            autocorr = features[2]
-            self.assertEqual(autocorr.ndim, 4)  # Should be 4D
-            self.assertEqual(autocorr.dtype, np.float32)
-            self.assertEqual(autocorr.shape[3], self.n_components)  # Last dimension should be n_components
-            self.assertTrue(np.all(np.abs(autocorr) <= 0.99))  # Should be scaled by 0.99
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor with autocorr not available: {e}")
+        # Check autocorr features
+        autocorr = features[2]
+        self.assertEqual(autocorr.ndim, 4)  # Should be 4D
+        self.assertEqual(autocorr.dtype, np.float32)
+        self.assertEqual(autocorr.shape[3], self.n_components)  # Last dimension should be n_components
+        self.assertTrue(np.all(np.abs(autocorr) <= 0.99))  # Should be scaled by 0.99
 
 
 class TestICLFeatureExtractorDataTypes(unittest.TestCase):
@@ -201,32 +175,24 @@ class TestICLFeatureExtractorDataTypes(unittest.TestCase):
         EEG = self.base_eeg.copy()
         EEG['icaact'] = EEG['icaact'].astype(np.float32)
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
 
-            # Should work and return float32 features
-            self.assertEqual(len(features), 2)
-            for feature in features:
-                self.assertEqual(feature.dtype, np.float32)
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor float32 test not available: {e}")
+        # Should work and return float32 features
+        self.assertEqual(len(features), 2)
+        for feature in features:
+            self.assertEqual(feature.dtype, np.float32)
 
     def test_icl_feature_extractor_float64_data(self):
         """Test ICL_feature_extractor with float64 input data."""
         EEG = self.base_eeg.copy()
         EEG['icaact'] = EEG['icaact'].astype(np.float64)
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
 
-            # Should work and return float32 features (converted internally)
-            self.assertEqual(len(features), 2)
-            for feature in features:
-                self.assertEqual(feature.dtype, np.float32)
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor float64 test not available: {e}")
+        # Should work and return float32 features (converted internally)
+        self.assertEqual(len(features), 2)
+        for feature in features:
+            self.assertEqual(feature.dtype, np.float32)
 
 
 class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
@@ -268,21 +234,17 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
 
     def test_icl_feature_extractor_small_eeg_data(self):
         """Test ICL_feature_extractor with small EEG data."""
-        try:
-            features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
+        features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
 
-            # Should work with small data
-            self.assertEqual(len(features), 2)
+        # Should work with small data
+        self.assertEqual(len(features), 2)
 
-            # Check feature dimensions
-            topo = features[0]
-            self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
+        # Check feature dimensions
+        topo = features[0]
+        self.assertEqual(topo.shape, (32, 32, 1, self.n_components))
 
-            psd = features[1]
-            self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor small EEG test not available: {e}")
+        psd = features[1]
+        self.assertEqual(psd.shape, (1, 100, 1, self.n_components))
 
     def test_icl_feature_extractor_single_component(self):
         """Test ICL_feature_extractor with single ICA component."""
@@ -291,21 +253,17 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         EEG['icaweights'] = EEG['icaweights'][:1, :]  # Keep only first component
         EEG['icaact'] = EEG['icaact'][:1, :, :]  # Keep only first component
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
 
-            # Should work with single component
-            self.assertEqual(len(features), 2)
+        # Should work with single component
+        self.assertEqual(len(features), 2)
 
-            # Check feature dimensions
-            topo = features[0]
-            self.assertEqual(topo.shape, (32, 32, 1, 1))  # 1 component
+        # Check feature dimensions
+        topo = features[0]
+        self.assertEqual(topo.shape, (32, 32, 1, 1))  # 1 component
 
-            psd = features[1]
-            self.assertEqual(psd.shape, (1, 100, 1, 1))  # 1 component
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor single component test not available: {e}")
+        psd = features[1]
+        self.assertEqual(psd.shape, (1, 100, 1, 1))  # 1 component
 
     def test_icl_feature_extractor_many_components(self):
         """Test ICL_feature_extractor with many ICA components."""
@@ -317,21 +275,17 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         EEG['icaweights'] = np.linalg.pinv(EEG['icawinv'])
         EEG['icaact'] = np.random.randn(n_many_components, self.n_samples, 1) * 0.5
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
 
-            # Should work with many components
-            self.assertEqual(len(features), 2)
+        # Should work with many components
+        self.assertEqual(len(features), 2)
 
-            # Check feature dimensions
-            topo = features[0]
-            self.assertEqual(topo.shape, (32, 32, 1, n_many_components))
+        # Check feature dimensions
+        topo = features[0]
+        self.assertEqual(topo.shape, (32, 32, 1, n_many_components))
 
-            psd = features[1]
-            self.assertEqual(psd.shape, (1, 100, 1, n_many_components))
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor many components test not available: {e}")
+        psd = features[1]
+        self.assertEqual(psd.shape, (1, 100, 1, n_many_components))
 
     def test_icl_feature_extractor_very_short_data(self):
         """Test ICL_feature_extractor with short data (minimum for 100 freq bins)."""
@@ -344,21 +298,17 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         EEG['pnts'] = short_samples
         EEG['xmax'] = short_samples / self.srate
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
 
-            # Should work with very short data
-            self.assertEqual(len(features), 2)
+        # Should work with very short data
+        self.assertEqual(len(features), 2)
 
-            # Features should still have expected shapes
-            topo = features[0]
-            self.assertEqual(topo.shape[0:3], (32, 32, 1))
+        # Features should still have expected shapes
+        topo = features[0]
+        self.assertEqual(topo.shape[0:3], (32, 32, 1))
 
-            psd = features[1]
-            self.assertEqual(psd.shape[0:3], (1, 100, 1))
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor very short data test not available: {e}")
+        psd = features[1]
+        self.assertEqual(psd.shape[0:3], (1, 100, 1))
 
     def test_icl_feature_extractor_autocorr_path_selection(self):
         """Test ICL_feature_extractor autocorr path selection based on data length."""
@@ -371,11 +321,8 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         short_eeg['xmax'] = 3.0
         short_eeg['times'] = np.arange(short_pnts) / self.srate
 
-        try:
-            features = ICL_feature_extractor(short_eeg, flag_autocorr=True)
-            self.assertEqual(len(features), 3)  # Should include autocorr
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor short data autocorr test not available: {e}")
+        features = ICL_feature_extractor(short_eeg, flag_autocorr=True)
+        self.assertEqual(len(features), 3)  # Should include autocorr
 
         # Test long data (> 5 seconds) - should use eeg_autocorr_welch
         long_eeg = self.base_eeg.copy()
@@ -386,11 +333,8 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         long_eeg['xmax'] = 6.0
         long_eeg['times'] = np.arange(long_pnts) / self.srate
 
-        try:
-            features = ICL_feature_extractor(long_eeg, flag_autocorr=True)
-            self.assertEqual(len(features), 3)  # Should include autocorr
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor long data autocorr test not available: {e}")
+        features = ICL_feature_extractor(long_eeg, flag_autocorr=True)
+        self.assertEqual(len(features), 3)  # Should include autocorr
 
     def test_icl_feature_extractor_multi_trial_data(self):
         """Test ICL_feature_extractor with multi-trial data."""
@@ -402,18 +346,14 @@ class TestICLFeatureExtractorEdgeCases(unittest.TestCase):
         EEG['icaact'] = np.random.randn(self.n_components, self.n_samples, n_trials) * 0.5
         EEG['data'] = np.random.randn(self.n_channels, self.n_samples, n_trials) * 0.5
 
-        try:
-            features = ICL_feature_extractor(EEG, flag_autocorr=True)
+        features = ICL_feature_extractor(EEG, flag_autocorr=True)
 
-            # Should work with multi-trial data and use eeg_autocorr_fftw
-            self.assertEqual(len(features), 3)
+        # Should work with multi-trial data and use eeg_autocorr_fftw
+        self.assertEqual(len(features), 3)
 
-            # Check that features have correct component dimension
-            for feature in features:
-                self.assertEqual(feature.shape[3], self.n_components)
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor multi-trial test not available: {e}")
+        # Check that features have correct component dimension
+        for feature in features:
+            self.assertEqual(feature.shape[3], self.n_components)
 
 
 class TestICLFeatureExtractorValidation(unittest.TestCase):
@@ -455,49 +395,37 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
 
     def test_icl_feature_extractor_no_inf_nan_in_features(self):
         """Test ICL_feature_extractor produces no inf/nan values in features."""
-        try:
-            features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
+        features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
 
-            # Check that no features contain inf or nan
-            for i, feature in enumerate(features):
-                self.assertTrue(np.all(np.isfinite(feature)), f"Feature {i} contains inf or nan values")
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor inf/nan test not available: {e}")
+        # Check that no features contain inf or nan
+        for i, feature in enumerate(features):
+            self.assertTrue(np.all(np.isfinite(feature)), f"Feature {i} contains inf or nan values")
 
     def test_icl_feature_extractor_deterministic_seed(self):
         """Test ICL_feature_extractor produces consistent results with same seed."""
-        try:
-            # Set seed and extract features
-            np.random.seed(123)
-            features1 = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
+        # Set seed and extract features
+        np.random.seed(123)
+        features1 = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
 
-            # Reset seed and extract features again
-            np.random.seed(123)
-            features2 = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
+        # Reset seed and extract features again
+        np.random.seed(123)
+        features2 = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
 
-            # Results should be identical (at least for the deterministic parts)
-            # Note: Some randomness may come from internal functions, so we check structure
-            self.assertEqual(len(features1), len(features2))
-            for i in range(len(features1)):
-                self.assertEqual(features1[i].shape, features2[i].shape)
-                self.assertEqual(features1[i].dtype, features2[i].dtype)
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor deterministic test not available: {e}")
+        # Results should be identical (at least for the deterministic parts)
+        # Note: Some randomness may come from internal functions, so we check structure
+        self.assertEqual(len(features1), len(features2))
+        for i in range(len(features1)):
+            self.assertEqual(features1[i].shape, features2[i].shape)
+            self.assertEqual(features1[i].dtype, features2[i].dtype)
 
     def test_icl_feature_extractor_ref_not_average(self):
         """Test ICL_feature_extractor with reference not set to average."""
         EEG = self.base_eeg.copy()
         EEG['ref'] = 'Cz'  # Not average reference
 
-        try:
-            # Should still work (function re-references internally)
-            features = ICL_feature_extractor(EEG, flag_autocorr=False)
-            self.assertEqual(len(features), 2)
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor non-average ref test not available: {e}")
+        # Should still work (function re-references internally)
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        self.assertEqual(len(features), 2)
 
     def test_icl_feature_extractor_mismatched_icachansind(self):
         """Test ICL_feature_extractor with mismatched icachansind."""
@@ -514,33 +442,23 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
         except (ValueError, IndexError):
             # Expected behavior for mismatched indices
             pass
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor mismatched icachansind test not available: {e}")
 
     def test_icl_feature_extractor_feature_scaling(self):
         """Test ICL_feature_extractor feature scaling (should be scaled by 0.99)."""
-        try:
-            features = ICL_feature_extractor(self.base_eeg, flag_autocorr=True)
+        features = ICL_feature_extractor(self.base_eeg, flag_autocorr=True)
 
-            # All features should be scaled by 0.99 (max absolute value <= 0.99)
-            for i, feature in enumerate(features):
-                max_abs_val = np.max(np.abs(feature))
-                self.assertLessEqual(max_abs_val, 0.99 + 1e-6, f"Feature {i} not properly scaled by 0.99")
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor scaling test not available: {e}")
+        # All features should be scaled by 0.99 (max absolute value <= 0.99)
+        for i, feature in enumerate(features):
+            max_abs_val = np.max(np.abs(feature))
+            self.assertLessEqual(max_abs_val, 0.99 + 1e-6, f"Feature {i} not properly scaled by 0.99")
 
     def test_icl_feature_extractor_psd_length_extrapolation(self):
         """Test ICL_feature_extractor PSD length handling (should be 100 frequencies)."""
-        try:
-            features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
+        features = ICL_feature_extractor(self.base_eeg, flag_autocorr=False)
 
-            # PSD should always have 100 frequency bins (extrapolated if needed)
-            psd = features[1]
-            self.assertEqual(psd.shape[1], 100, "PSD should have exactly 100 frequency bins")
-
-        except Exception as e:
-            self.skipTest(f"ICL_feature_extractor PSD extrapolation test not available: {e}")
+        # PSD should always have 100 frequency bins (extrapolated if needed)
+        psd = features[1]
+        self.assertEqual(psd.shape[1], 100, "PSD should have exactly 100 frequency bins")
 
 
 class TestICLFeatureExtractorParity(unittest.TestCase):

--- a/tests/test_clean_artifacts.py
+++ b/tests/test_clean_artifacts.py
@@ -14,62 +14,12 @@ sys.path.insert(0, 'src')
 from eegprep.plugins.clean_rawdata.clean_artifacts import clean_artifacts
 from eegprep.utils.testing import DebuggableTestCase
 
+from tests.fixtures import create_test_eeg as _create_test_eeg
+
 
 def create_test_eeg():
-    """Create a complete test EEG structure with all required fields.
-
-    Note: clean_artifacts expects continuous (2D) data, not epoched (3D) data.
-    """
-    n_pnts = 10000  # 20 seconds at 500 Hz
-    return {
-        'data': np.random.randn(32, n_pnts),  # 2D continuous data
-        'srate': 500.0,
-        'nbchan': 32,
-        'pnts': n_pnts,
-        'trials': 1,
-        'xmin': 0.0,
-        'xmax': n_pnts / 500.0,
-        'times': np.linspace(0, n_pnts / 500.0, n_pnts),
-        'icaact': [],
-        'icawinv': [],
-        'icasphere': [],
-        'icaweights': [],
-        'icachansind': [],
-        'chanlocs': [
-            {
-                'labels': f'EEG{i:03d}',
-                'type': 'EEG',
-                'theta': np.random.uniform(-90, 90),
-                'radius': np.random.uniform(0, 1),
-                'X': np.random.uniform(-1, 1),
-                'Y': np.random.uniform(-1, 1),
-                'Z': np.random.uniform(-1, 1),
-                'sph_theta': np.random.uniform(-180, 180),
-                'sph_phi': np.random.uniform(-90, 90),
-                'sph_radius': np.random.uniform(0, 1),
-                'urchan': i + 1,
-                'ref': '',
-            }
-            for i in range(32)
-        ],
-        'urchanlocs': [],
-        'chaninfo': {'removedchans': []},
-        'ref': 'common',
-        'history': '',
-        'saved': 'yes',
-        'etc': {},
-        'event': [],
-        'epoch': [],
-        'setname': 'test_dataset',
-        'filename': 'test.set',
-        'filepath': '/tmp',
-        'specdata': [],
-        'specicaact': [],
-        'reject': [],
-        'stats': [],
-        'dipfit': [],
-        'roi': [],
-    }
+    """Continuous (2D) EEG fixture sized for clean_artifacts (20 s at 500 Hz)."""
+    return _create_test_eeg(n_channels=32, n_samples=10000, srate=500.0, n_trials=1)
 
 
 class TestCleanArtifactsBasic(DebuggableTestCase):
@@ -81,49 +31,41 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
 
     def test_clean_artifacts_basic_functionality(self):
         """Test basic clean_artifacts functionality with default parameters."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(self.test_eeg)
+        EEG, HP, BUR, removed_channels = clean_artifacts(self.test_eeg)
 
-            # Check that all return values are present
-            self.assertIsInstance(EEG, dict)
-            self.assertIsInstance(HP, dict)
-            self.assertIsInstance(BUR, dict)
-            self.assertIsInstance(removed_channels, np.ndarray)
+        # Check that all return values are present
+        self.assertIsInstance(EEG, dict)
+        self.assertIsInstance(HP, dict)
+        self.assertIsInstance(BUR, dict)
+        self.assertIsInstance(removed_channels, np.ndarray)
 
-            # Check that EEG structure is preserved
-            self.assertIn('data', EEG)
-            self.assertIn('srate', EEG)
-            self.assertIn('nbchan', EEG)
-            self.assertIn('pnts', EEG)
+        # Check that EEG structure is preserved
+        self.assertIn('data', EEG)
+        self.assertIn('srate', EEG)
+        self.assertIn('nbchan', EEG)
+        self.assertIn('pnts', EEG)
 
-            # Check that data dimensions are reasonable
-            self.assertEqual(EEG['srate'], self.test_eeg['srate'])
-            self.assertGreaterEqual(EEG['nbchan'], 1)  # At least one channel should remain
-            self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts basic functionality not available: {e}")
+        # Check that data dimensions are reasonable
+        self.assertEqual(EEG['srate'], self.test_eeg['srate'])
+        self.assertGreaterEqual(EEG['nbchan'], 1)  # At least one channel should remain
+        self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
 
     def test_clean_artifacts_all_off(self):
         """Test clean_artifacts with all criteria disabled."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # With all criteria off, data should be unchanged
-            self.assertEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-            self.assertEqual(EEG['pnts'], self.test_eeg['pnts'])
-            np.testing.assert_array_equal(EEG['data'], self.test_eeg['data'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts all off not available: {e}")
+        # With all criteria off, data should be unchanged
+        self.assertEqual(EEG['nbchan'], self.test_eeg['nbchan'])
+        self.assertEqual(EEG['pnts'], self.test_eeg['pnts'])
+        np.testing.assert_array_equal(EEG['data'], self.test_eeg['data'])
 
     def test_clean_artifacts_invalid_highpass_string(self):
         """Test clean_artifacts with invalid highpass string parameter."""
@@ -157,91 +99,79 @@ class TestCleanArtifactsBasic(DebuggableTestCase):
 
     def test_clean_artifacts_valid_highpass_list(self):
         """Test clean_artifacts with valid highpass list (should work like tuple)."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Highpass=[0.25, 0.75],  # List instead of tuple
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                FlatlineCriterion='off',
-            )
-            # Should work - list is acceptable
-            self.assertIsInstance(EEG, dict)
-        except Exception as e:
-            self.skipTest(f"clean_artifacts valid highpass list not available: {e}")
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Highpass=[0.25, 0.75],  # List instead of tuple
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            FlatlineCriterion='off',
+        )
+        # Should work - list is acceptable
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_mutually_exclusive_channels(self):
         """Test clean_artifacts with mutually exclusive channel parameters."""
         with self.assertRaises(ValueError) as cm:
-            clean_artifacts(self.test_eeg, Channels=['EEG001', 'EEG002'], Channels_ignore=['EEG003'])
+            clean_artifacts(self.test_eeg, Channels=['Ch1', 'Ch2'], Channels_ignore=['Ch3'])
         self.assertIn('mutually exclusive', str(cm.exception))
 
     def test_clean_artifacts_mutually_exclusive_channels_both_empty(self):
         """Test clean_artifacts with both channel parameters empty (should work)."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Channels=[],  # Empty list
-                Channels_ignore=[],  # Empty list
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            # Should work - empty lists are not mutually exclusive
-            self.assertIsInstance(EEG, dict)
-        except Exception as e:
-            self.skipTest(f"clean_artifacts empty channel lists not available: {e}")
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Channels=[],  # Empty list
+            Channels_ignore=[],  # Empty list
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        # Should work - empty lists are not mutually exclusive
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_mutually_exclusive_channels_none_and_list(self):
         """Test clean_artifacts with None and non-empty list (should work)."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Channels=None,  # None
-                Channels_ignore=['EEG001'],  # Non-empty list
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            # Should work - None and list is not mutually exclusive
-            self.assertIsInstance(EEG, dict)
-        except Exception as e:
-            self.skipTest(f"clean_artifacts None and channel list not available: {e}")
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Channels=None,  # None
+            Channels_ignore=['Ch1'],  # Non-empty list
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        # Should work - None and list is not mutually exclusive
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_mutually_exclusive_channels_both_none(self):
         """Test clean_artifacts with both channel parameters as None (should work)."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Channels=None,  # None
-                Channels_ignore=None,  # None
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            # Should work - both None is not mutually exclusive
-            self.assertIsInstance(EEG, dict)
-        except Exception as e:
-            self.skipTest(f"clean_artifacts both None not available: {e}")
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Channels=None,  # None
+            Channels_ignore=None,  # None
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        # Should work - both None is not mutually exclusive
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_mutually_exclusive_channels_overlapping(self):
         """Test clean_artifacts with overlapping channel lists (error expected)."""
         with self.assertRaises(ValueError) as cm:
             clean_artifacts(
                 self.test_eeg,
-                Channels=['EEG001', 'EEG002', 'EEG003'],
-                Channels_ignore=['EEG002', 'EEG004'],  # EEG002 overlaps
+                Channels=['Ch1', 'Ch2', 'Ch3'],
+                Channels_ignore=['Ch2', 'Ch4'],  # Ch2 overlaps
             )
         self.assertIn('mutually exclusive', str(cm.exception))
 
@@ -255,53 +185,45 @@ class TestCleanArtifactsFlatline(DebuggableTestCase):
 
     def test_clean_artifacts_flatline_removal(self):
         """Test flatline channel removal."""
-        try:
-            # Create some flatline channels
-            eeg_with_flatlines = self.test_eeg.copy()
-            eeg_with_flatlines['data'] = self.test_eeg['data'].copy()
-            eeg_with_flatlines['data'][5, :] = 0.0  # Flatline channel (2D data)
-            eeg_with_flatlines['data'][10, :] = 1.0  # Another flatline channel
-            original_nbchan = eeg_with_flatlines['nbchan']
+        # Create some flatline channels
+        eeg_with_flatlines = self.test_eeg.copy()
+        eeg_with_flatlines['data'] = self.test_eeg['data'].copy()
+        eeg_with_flatlines['data'][5, :] = 0.0  # Flatline channel (2D data)
+        eeg_with_flatlines['data'][10, :] = 1.0  # Another flatline channel
+        original_nbchan = eeg_with_flatlines['nbchan']
 
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                eeg_with_flatlines,
-                FlatlineCriterion=1.0,  # Short flatline duration
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            eeg_with_flatlines,
+            FlatlineCriterion=1.0,  # Short flatline duration
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+        )
 
-            # Should have removed some channels
-            self.assertLess(EEG['nbchan'], original_nbchan)
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts flatline removal not available: {e}")
+        # Should have removed some channels
+        self.assertLess(EEG['nbchan'], original_nbchan)
 
     def test_clean_artifacts_flatline_off(self):
         """Test flatline removal disabled."""
-        try:
-            # Create some flatline channels
-            eeg_with_flatlines = self.test_eeg.copy()
-            eeg_with_flatlines['data'] = self.test_eeg['data'].copy()
-            eeg_with_flatlines['data'][5, :] = 0.0  # Flatline channel (2D data)
+        # Create some flatline channels
+        eeg_with_flatlines = self.test_eeg.copy()
+        eeg_with_flatlines['data'] = self.test_eeg['data'].copy()
+        eeg_with_flatlines['data'][5, :] = 0.0  # Flatline channel (2D data)
 
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                eeg_with_flatlines,
-                FlatlineCriterion='off',
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            eeg_with_flatlines,
+            FlatlineCriterion='off',
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+        )
 
-            # Should not have removed any channels
-            self.assertEqual(EEG['nbchan'], eeg_with_flatlines['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts flatline off not available: {e}")
+        # Should not have removed any channels
+        self.assertEqual(EEG['nbchan'], eeg_with_flatlines['nbchan'])
 
 
 class TestCleanArtifactsHighpass(DebuggableTestCase):
@@ -313,47 +235,39 @@ class TestCleanArtifactsHighpass(DebuggableTestCase):
 
     def test_clean_artifacts_highpass_filtering(self):
         """Test highpass filtering."""
-        try:
-            original_data = self.test_eeg['data'].copy()  # Save before call
+        original_data = self.test_eeg['data'].copy()  # Save before call
 
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Highpass=(0.5, 1.0),
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Highpass=(0.5, 1.0),
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            FlatlineCriterion='off',
+        )
 
-            # HP should contain the highpass filtered data
-            self.assertIsInstance(HP, dict)
-            self.assertIn('data', HP)
+        # HP should contain the highpass filtered data
+        self.assertIsInstance(HP, dict)
+        self.assertIn('data', HP)
 
-            # Data should be different after filtering
-            self.assertFalse(np.array_equal(HP['data'], original_data))
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts highpass filtering not available: {e}")
+        # Data should be different after filtering
+        self.assertFalse(np.array_equal(HP['data'], original_data))
 
     def test_clean_artifacts_highpass_off(self):
         """Test highpass filtering disabled."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Highpass='off',
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Highpass='off',
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            FlatlineCriterion='off',
+        )
 
-            # Data should be unchanged
-            np.testing.assert_array_equal(HP['data'], self.test_eeg['data'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts highpass off not available: {e}")
+        # Data should be unchanged
+        np.testing.assert_array_equal(HP['data'], self.test_eeg['data'])
 
 
 class TestCleanArtifactsChannelCleaning(DebuggableTestCase):
@@ -365,60 +279,48 @@ class TestCleanArtifactsChannelCleaning(DebuggableTestCase):
 
     def test_clean_artifacts_channel_criterion(self):
         """Test channel correlation criterion."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion=0.9,  # High threshold
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion=0.9,  # High threshold
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have removed some channels with high threshold
-            self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts channel criterion not available: {e}")
+        # Should have removed some channels with high threshold
+        self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
 
     def test_clean_artifacts_line_noise_criterion(self):
         """Test line noise criterion."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion=2.0,  # Low threshold
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion=2.0,  # Low threshold
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have removed some channels with low threshold
-            self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts line noise criterion not available: {e}")
+        # Should have removed some channels with low threshold
+        self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
 
     def test_clean_artifacts_both_channel_criteria(self):
         """Test both channel and line noise criteria."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion=0.8,
-                LineNoiseCriterion=4.0,
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion=0.8,
+            LineNoiseCriterion=4.0,
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have removed some channels
-            self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts both channel criteria not available: {e}")
+        # Should have removed some channels
+        self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
 
 
 class TestCleanArtifactsBurstCleaning(DebuggableTestCase):
@@ -430,62 +332,50 @@ class TestCleanArtifactsBurstCleaning(DebuggableTestCase):
 
     def test_clean_artifacts_burst_criterion(self):
         """Test burst criterion."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion=5.0,
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion=5.0,
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # BUR should contain the burst repaired data
-            self.assertIsInstance(BUR, dict)
-            self.assertIn('data', BUR)
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts burst criterion not available: {e}")
+        # BUR should contain the burst repaired data
+        self.assertIsInstance(BUR, dict)
+        self.assertIn('data', BUR)
 
     def test_clean_artifacts_burst_rejection(self):
         """Test burst rejection mode."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion=5.0,
-                BurstRejection='on',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion=5.0,
+            BurstRejection='on',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have removed some samples
-            self.assertLessEqual(EEG['pnts'], self.test_eeg['pnts'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts burst rejection not available: {e}")
+        # Should have removed some samples
+        self.assertLessEqual(EEG['pnts'], self.test_eeg['pnts'])
 
     def test_clean_artifacts_burst_off(self):
         """Test burst cleaning disabled."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Data should be unchanged
-            np.testing.assert_array_equal(BUR['data'], self.test_eeg['data'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts burst off not available: {e}")
+        # Data should be unchanged
+        np.testing.assert_array_equal(BUR['data'], self.test_eeg['data'])
 
 
 class TestCleanArtifactsWindowCleaning(DebuggableTestCase):
@@ -497,41 +387,33 @@ class TestCleanArtifactsWindowCleaning(DebuggableTestCase):
 
     def test_clean_artifacts_window_criterion(self):
         """Test window criterion."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion=0.5,  # Allow 50% bad channels per window
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion=0.5,  # Allow 50% bad channels per window
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have removed some samples
-            self.assertLessEqual(EEG['pnts'], self.test_eeg['pnts'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts window criterion not available: {e}")
+        # Should have removed some samples
+        self.assertLessEqual(EEG['pnts'], self.test_eeg['pnts'])
 
     def test_clean_artifacts_window_off(self):
         """Test window cleaning disabled."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Data should be unchanged
-            self.assertEqual(EEG['pnts'], self.test_eeg['pnts'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts window off not available: {e}")
+        # Data should be unchanged
+        self.assertEqual(EEG['pnts'], self.test_eeg['pnts'])
 
 
 class TestCleanArtifactsChannelSelection(DebuggableTestCase):
@@ -543,48 +425,40 @@ class TestCleanArtifactsChannelSelection(DebuggableTestCase):
 
     def test_clean_artifacts_channels_include(self):
         """Test channel inclusion."""
-        try:
-            channels_to_include = ['EEG001', 'EEG002', 'EEG003']
+        channels_to_include = ['Ch1', 'Ch2', 'Ch3']
 
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Channels=channels_to_include,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Channels=channels_to_include,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have only the specified channels
-            self.assertEqual(EEG['nbchan'], len(channels_to_include))
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts channels include not available: {e}")
+        # Should have only the specified channels
+        self.assertEqual(EEG['nbchan'], len(channels_to_include))
 
     def test_clean_artifacts_channels_ignore(self):
         """Test channel exclusion."""
-        try:
-            channels_to_ignore = ['EEG001', 'EEG002']
-            original_nbchan = self.test_eeg['nbchan']  # Save before call
+        channels_to_ignore = ['Ch1', 'Ch2']
+        original_nbchan = self.test_eeg['nbchan']  # Save before call
 
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Channels_ignore=channels_to_ignore,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Channels_ignore=channels_to_ignore,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should have fewer channels
-            self.assertEqual(EEG['nbchan'], original_nbchan - len(channels_to_ignore))
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts channels ignore not available: {e}")
+        # Should have fewer channels
+        self.assertEqual(EEG['nbchan'], original_nbchan - len(channels_to_ignore))
 
 
 class TestCleanArtifactsParameterValidation(DebuggableTestCase):
@@ -597,187 +471,166 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
     def test_clean_artifacts_invalid_channel_criterion_type(self):
         """Test clean_artifacts with invalid ChannelCriterion type."""
         # Should accept numeric values and 'off'
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion=0.8,
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts channel criterion validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion=0.8,
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
     def test_clean_artifacts_invalid_line_noise_criterion_type(self):
         """Test clean_artifacts with invalid LineNoiseCriterion type."""
         # Should accept numeric values and 'off'
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion=4.0,
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts line noise criterion validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion=4.0,
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
     def test_clean_artifacts_invalid_burst_criterion_type(self):
         """Test clean_artifacts with invalid BurstCriterion type."""
         # Should accept numeric values and 'off'
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion=5.0,
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts burst criterion validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion=5.0,
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
     def test_clean_artifacts_invalid_window_criterion_type(self):
         """Test clean_artifacts with invalid WindowCriterion type."""
         # Should accept numeric values and 'off'
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion=0.25,
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts window criterion validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion=0.25,
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
     def test_clean_artifacts_invalid_flatline_criterion_type(self):
         """Test clean_artifacts with invalid FlatlineCriterion type."""
         # Should accept numeric values and 'off'
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion=5.0,
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts flatline criterion validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion=5.0,
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
     def test_clean_artifacts_invalid_burst_rejection_type(self):
         """Test clean_artifacts with invalid BurstRejection type."""
         # Should accept 'on' and 'off' strings
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-                BurstRejection='on',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-                BurstRejection='off',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts burst rejection validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+            BurstRejection='on',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+            BurstRejection='off',
+        )
 
     def test_clean_artifacts_documented_distance_metrics_with_asr_disabled(self):
         """Test clean_artifacts accepts documented Distance spellings when ASR is disabled."""
-        try:
-            # Valid cases
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-                Distance='euclidian',
-            )
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-                Distance='riemannian',
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts distance metric validation not available: {e}")
+        # Valid cases
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+            Distance='euclidian',
+        )
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+            Distance='riemannian',
+        )
 
     def test_clean_artifacts_rejects_unknown_distance_metric(self):
         """Test clean_artifacts rejects unknown Distance spellings before cleaning."""
@@ -813,33 +666,27 @@ class TestCleanArtifactsParameterValidation(DebuggableTestCase):
 
     def test_clean_artifacts_zero_values(self):
         """Test clean_artifacts with zero parameter values."""
-        try:
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion=0.0,  # Zero correlation threshold
-                LineNoiseCriterion=0.0,
-                BurstCriterion='off',
-                WindowCriterion=0.0,
-                Highpass='off',
-                FlatlineCriterion=0.0,
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts zero values not available: {e}")
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion=0.0,  # Zero correlation threshold
+            LineNoiseCriterion=0.0,
+            BurstCriterion='off',
+            WindowCriterion=0.0,
+            Highpass='off',
+            FlatlineCriterion=0.0,
+        )
 
     def test_clean_artifacts_extreme_values(self):
         """Test clean_artifacts with extreme parameter values."""
-        try:
-            clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion=1.0,  # Perfect correlation required
-                LineNoiseCriterion=100.0,
-                BurstCriterion='off',
-                WindowCriterion=1.0,
-                Highpass='off',
-                FlatlineCriterion=1000.0,
-            )
-        except Exception as e:
-            self.skipTest(f"clean_artifacts extreme values not available: {e}")
+        clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion=1.0,  # Perfect correlation required
+            LineNoiseCriterion=100.0,
+            BurstCriterion='off',
+            WindowCriterion=1.0,
+            Highpass='off',
+            FlatlineCriterion=1000.0,
+        )
 
 
 class TestCleanArtifactsParameters(DebuggableTestCase):
@@ -851,63 +698,51 @@ class TestCleanArtifactsParameters(DebuggableTestCase):
 
     def test_clean_artifacts_available_ram(self):
         """Test available RAM parameter."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                availableRAM_GB=2.0,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            availableRAM_GB=2.0,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should complete without error
-            self.assertIsInstance(EEG, dict)
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts available RAM not available: {e}")
+        # Should complete without error
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_distance_metric(self):
         """Test distance metric parameter."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                Distance='euclidian',
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            Distance='euclidian',
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should complete without error
-            self.assertIsInstance(EEG, dict)
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts distance metric not available: {e}")
+        # Should complete without error
+        self.assertIsInstance(EEG, dict)
 
     def test_clean_artifacts_max_mem(self):
         """Test max memory parameter."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                MaxMem=128,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            MaxMem=128,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Should complete without error
-            self.assertIsInstance(EEG, dict)
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts max memory not available: {e}")
+        # Should complete without error
+        self.assertIsInstance(EEG, dict)
 
 
 class TestCleanArtifactsIntegration(DebuggableTestCase):
@@ -919,73 +754,65 @@ class TestCleanArtifactsIntegration(DebuggableTestCase):
 
     def test_clean_artifacts_full_pipeline(self):
         """Test the full clean_artifacts pipeline."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                FlatlineCriterion=5.0,
-                Highpass=(0.25, 0.75),
-                ChannelCriterion=0.8,
-                LineNoiseCriterion=4.0,
-                BurstCriterion=5.0,
-                WindowCriterion=0.25,
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            FlatlineCriterion=5.0,
+            Highpass=(0.25, 0.75),
+            ChannelCriterion=0.8,
+            LineNoiseCriterion=4.0,
+            BurstCriterion=5.0,
+            WindowCriterion=0.25,
+        )
 
-            # Check all return values
-            self.assertIsInstance(EEG, dict)
-            self.assertIsInstance(HP, dict)
-            self.assertIsInstance(BUR, dict)
-            self.assertIsInstance(removed_channels, np.ndarray)
+        # Check all return values
+        self.assertIsInstance(EEG, dict)
+        self.assertIsInstance(HP, dict)
+        self.assertIsInstance(BUR, dict)
+        self.assertIsInstance(removed_channels, np.ndarray)
 
-            # Check data integrity
-            self.assertIn('data', EEG)
-            self.assertIn('srate', EEG)
-            self.assertIn('nbchan', EEG)
-            self.assertIn('pnts', EEG)
+        # Check data integrity
+        self.assertIn('data', EEG)
+        self.assertIn('srate', EEG)
+        self.assertIn('nbchan', EEG)
+        self.assertIn('pnts', EEG)
 
-            # Check that some processing occurred
-            self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts full pipeline not available: {e}")
+        # Check that some processing occurred
+        self.assertLessEqual(EEG['nbchan'], self.test_eeg['nbchan'])
 
     def test_clean_artifacts_return_values(self):
         """Test that all return values have correct structure."""
-        try:
-            EEG, HP, BUR, removed_channels = clean_artifacts(
-                self.test_eeg,
-                ChannelCriterion='off',
-                LineNoiseCriterion='off',
-                BurstCriterion='off',
-                WindowCriterion='off',
-                Highpass='off',
-                FlatlineCriterion='off',
-            )
+        EEG, HP, BUR, removed_channels = clean_artifacts(
+            self.test_eeg,
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
 
-            # Check EEG structure
-            self.assertIn('data', EEG)
-            self.assertIn('srate', EEG)
-            self.assertIn('nbchan', EEG)
-            self.assertIn('pnts', EEG)
-            self.assertIn('etc', EEG)
+        # Check EEG structure
+        self.assertIn('data', EEG)
+        self.assertIn('srate', EEG)
+        self.assertIn('nbchan', EEG)
+        self.assertIn('pnts', EEG)
+        self.assertIn('etc', EEG)
 
-            # Check HP structure (should be same as EEG when no highpass)
-            self.assertIn('data', HP)
-            self.assertIn('srate', HP)
-            self.assertIn('nbchan', HP)
-            self.assertIn('pnts', HP)
+        # Check HP structure (should be same as EEG when no highpass)
+        self.assertIn('data', HP)
+        self.assertIn('srate', HP)
+        self.assertIn('nbchan', HP)
+        self.assertIn('pnts', HP)
 
-            # Check BUR structure (should be same as EEG when no burst cleaning)
-            self.assertIn('data', BUR)
-            self.assertIn('srate', BUR)
-            self.assertIn('nbchan', BUR)
-            self.assertIn('pnts', BUR)
+        # Check BUR structure (should be same as EEG when no burst cleaning)
+        self.assertIn('data', BUR)
+        self.assertIn('srate', BUR)
+        self.assertIn('nbchan', BUR)
+        self.assertIn('pnts', BUR)
 
-            # Check removed_channels array
-            self.assertEqual(len(removed_channels), self.test_eeg['nbchan'])
-            self.assertTrue(np.issubdtype(removed_channels.dtype, np.bool_))
-
-        except Exception as e:
-            self.skipTest(f"clean_artifacts return values not available: {e}")
+        # Check removed_channels array
+        self.assertEqual(len(removed_channels), self.test_eeg['nbchan'])
+        self.assertTrue(np.issubdtype(removed_channels.dtype, np.bool_))
 
 
 if __name__ == '__main__':

--- a/tests/test_clean_drifts.py
+++ b/tests/test_clean_drifts.py
@@ -14,56 +14,12 @@ sys.path.insert(0, 'src')
 from eegprep.plugins.clean_rawdata.clean_drifts import clean_drifts
 from eegprep.utils.testing import DebuggableTestCase
 
+from tests.fixtures import create_test_eeg as _create_test_eeg
+
 
 def create_test_eeg():
-    """Create a complete test EEG structure with all required fields.
-
-    Note: clean_drifts expects continuous (2D) data, not epoched (3D) data.
-    """
-    n_pnts = 10000  # 20 seconds at 500 Hz
-    return {
-        'data': np.random.randn(32, n_pnts),  # 2D continuous data
-        'srate': 500.0,
-        'nbchan': 32,
-        'pnts': n_pnts,
-        'trials': 1,
-        'xmin': 0.0,
-        'xmax': n_pnts / 500.0,
-        'times': np.linspace(0, n_pnts / 500.0, n_pnts),
-        'icaact': [],
-        'icawinv': [],
-        'icasphere': [],
-        'icaweights': [],
-        'icachansind': [],
-        'chanlocs': [
-            {
-                'labels': f'EEG{i:03d}',
-                'type': 'EEG',
-                'theta': np.random.uniform(-90, 90),
-                'radius': np.random.uniform(0, 1),
-                'X': np.random.uniform(-1, 1),
-                'Y': np.random.uniform(-1, 1),
-                'Z': np.random.uniform(-1, 1),
-                'sph_theta': np.random.uniform(-180, 180),
-                'sph_phi': np.random.uniform(-90, 90),
-                'sph_radius': np.random.uniform(0, 1),
-                'urchan': i + 1,
-                'ref': '',
-            }
-            for i in range(32)
-        ],
-        'urchanlocs': [],
-        'chaninfo': {'removedchans': []},
-        'ref': 'common',
-        'history': '',
-        'saved': 'yes',
-        'etc': {},
-        'event': [],
-        'epoch': [],
-        'setname': 'test_dataset',
-        'filename': 'test.set',
-        'filepath': '/tmp',
-    }
+    """Continuous (2D) EEG fixture sized for clean_drifts (20 s at 500 Hz)."""
+    return _create_test_eeg(n_channels=32, n_samples=10000, srate=500.0, n_trials=1)
 
 
 class TestCleanDriftsBasic(DebuggableTestCase):
@@ -75,90 +31,66 @@ class TestCleanDriftsBasic(DebuggableTestCase):
 
     def test_clean_drifts_basic_functionality(self):
         """Test basic clean_drifts functionality with default parameters."""
-        try:
-            result = clean_drifts(self.test_eeg.copy())
+        result = clean_drifts(self.test_eeg.copy())
 
-            # Check that EEG structure is preserved
-            self.assertIn('data', result)
-            self.assertIn('srate', result)
-            self.assertIn('nbchan', result)
-            self.assertIn('pnts', result)
-            self.assertIn('etc', result)
+        # Check that EEG structure is preserved
+        self.assertIn('data', result)
+        self.assertIn('srate', result)
+        self.assertIn('nbchan', result)
+        self.assertIn('pnts', result)
+        self.assertIn('etc', result)
 
-            # Check that data dimensions are preserved
-            self.assertEqual(result['srate'], self.test_eeg['srate'])
-            self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
-            self.assertEqual(result['pnts'], self.test_eeg['pnts'])
-            self.assertEqual(result['trials'], self.test_eeg['trials'])
+        # Check that data dimensions are preserved
+        self.assertEqual(result['srate'], self.test_eeg['srate'])
+        self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
+        self.assertEqual(result['pnts'], self.test_eeg['pnts'])
+        self.assertEqual(result['trials'], self.test_eeg['trials'])
 
-            # Check that data type is float64
-            self.assertEqual(result['data'].dtype, np.float64)
+        # Check that data type is float64
+        self.assertEqual(result['data'].dtype, np.float64)
 
-            # Check that filter kernel is stored
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts basic functionality not available: {e}")
+        # Check that filter kernel is stored
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_default_parameters(self):
         """Test clean_drifts with default parameters."""
-        try:
-            result = clean_drifts(self.test_eeg.copy())
+        result = clean_drifts(self.test_eeg.copy())
 
-            # Should work with default parameters
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts default parameters not available: {e}")
+        # Should work with default parameters
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_custom_transition(self):
         """Test clean_drifts with custom transition band."""
-        try:
-            result = clean_drifts(self.test_eeg.copy(), transition=(1.0, 2.0))
+        result = clean_drifts(self.test_eeg.copy(), transition=(1.0, 2.0))
 
-            # Should work with custom transition band
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts custom transition not available: {e}")
+        # Should work with custom transition band
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_custom_attenuation(self):
         """Test clean_drifts with custom attenuation."""
-        try:
-            result = clean_drifts(self.test_eeg.copy(), attenuation=60.0)
+        result = clean_drifts(self.test_eeg.copy(), attenuation=60.0)
 
-            # Should work with custom attenuation
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts custom attenuation not available: {e}")
+        # Should work with custom attenuation
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_fir_method(self):
         """Test clean_drifts with FIR method."""
-        try:
-            result = clean_drifts(self.test_eeg.copy(), method='fir')
+        result = clean_drifts(self.test_eeg.copy(), method='fir')
 
-            # Should work with FIR method
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts FIR method not available: {e}")
+        # Should work with FIR method
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_fft_method(self):
         """Test clean_drifts with FFT method."""
-        try:
-            result = clean_drifts(self.test_eeg.copy(), method='fft')
+        result = clean_drifts(self.test_eeg.copy(), method='fft')
 
-            # Should work with FFT method
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts FFT method not available: {e}")
+        # Should work with FFT method
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
 
 class TestCleanDriftsEdgeCases(DebuggableTestCase):
@@ -170,87 +102,67 @@ class TestCleanDriftsEdgeCases(DebuggableTestCase):
 
     def test_clean_drifts_single_channel(self):
         """Test clean_drifts with single channel data."""
-        try:
-            # Create single channel data (2D continuous)
-            single_channel_eeg = self.test_eeg.copy()
-            single_channel_eeg['data'] = np.random.randn(1, 10000)
-            single_channel_eeg['nbchan'] = 1
-            single_channel_eeg['chanlocs'] = [single_channel_eeg['chanlocs'][0]]
+        # Create single channel data (2D continuous)
+        single_channel_eeg = self.test_eeg.copy()
+        single_channel_eeg['data'] = np.random.randn(1, 10000)
+        single_channel_eeg['nbchan'] = 1
+        single_channel_eeg['chanlocs'] = [single_channel_eeg['chanlocs'][0]]
 
-            result = clean_drifts(single_channel_eeg)
+        result = clean_drifts(single_channel_eeg)
 
-            # Should work with single channel
-            self.assertEqual(result['nbchan'], 1)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts single channel not available: {e}")
+        # Should work with single channel
+        self.assertEqual(result['nbchan'], 1)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_single_trial(self):
         """Test clean_drifts with continuous (single trial) data."""
-        try:
-            # Create continuous data (2D - single trial is the normal case)
-            single_trial_eeg = self.test_eeg.copy()
-            single_trial_eeg['data'] = np.random.randn(32, 10000)
-            single_trial_eeg['trials'] = 1
+        # Create continuous data (2D - single trial is the normal case)
+        single_trial_eeg = self.test_eeg.copy()
+        single_trial_eeg['data'] = np.random.randn(32, 10000)
+        single_trial_eeg['trials'] = 1
 
-            result = clean_drifts(single_trial_eeg)
+        result = clean_drifts(single_trial_eeg)
 
-            # Should work with single trial
-            self.assertEqual(result['trials'], 1)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts single trial not available: {e}")
+        # Should work with single trial
+        self.assertEqual(result['trials'], 1)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_continuous_data(self):
         """Test clean_drifts with continuous (2D) data."""
-        try:
-            # Create continuous data (2D)
-            continuous_eeg = self.test_eeg.copy()
-            continuous_eeg['data'] = np.random.randn(32, 1000)
-            continuous_eeg['trials'] = 1
+        # Create continuous data (2D)
+        continuous_eeg = self.test_eeg.copy()
+        continuous_eeg['data'] = np.random.randn(32, 1000)
+        continuous_eeg['trials'] = 1
 
-            result = clean_drifts(continuous_eeg)
+        result = clean_drifts(continuous_eeg)
 
-            # Should work with continuous data
-            self.assertIn('data', result)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts continuous data not available: {e}")
+        # Should work with continuous data
+        self.assertIn('data', result)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_float32_data(self):
         """Test clean_drifts with float32 data."""
-        try:
-            # Create float32 data
-            float32_eeg = self.test_eeg.copy()
-            float32_eeg['data'] = np.random.randn(32, 10000).astype(np.float32)
+        # Create float32 data
+        float32_eeg = self.test_eeg.copy()
+        float32_eeg['data'] = np.random.randn(32, 10000).astype(np.float32)
 
-            result = clean_drifts(float32_eeg)
+        result = clean_drifts(float32_eeg)
 
-            # Should convert to float64
-            self.assertEqual(result['data'].dtype, np.float64)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts float32 data not available: {e}")
+        # Should convert to float64
+        self.assertEqual(result['data'].dtype, np.float64)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_float64_data(self):
         """Test clean_drifts with float64 data."""
-        try:
-            # Create float64 data
-            float64_eeg = self.test_eeg.copy()
-            float64_eeg['data'] = np.random.randn(32, 10000).astype(np.float64)
+        # Create float64 data
+        float64_eeg = self.test_eeg.copy()
+        float64_eeg['data'] = np.random.randn(32, 10000).astype(np.float64)
 
-            result = clean_drifts(float64_eeg)
+        result = clean_drifts(float64_eeg)
 
-            # Should remain float64
-            self.assertEqual(result['data'].dtype, np.float64)
-            self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts float64 data not available: {e}")
+        # Should remain float64
+        self.assertEqual(result['data'].dtype, np.float64)
+        self.assertIn('clean_drifts_kernel', result['etc'])
 
 
 class TestCleanDriftsParameters(DebuggableTestCase):
@@ -262,45 +174,33 @@ class TestCleanDriftsParameters(DebuggableTestCase):
 
     def test_clean_drifts_different_transition_bands(self):
         """Test clean_drifts with different transition bands."""
-        try:
-            # Test different transition bands
-            transitions = [(0.1, 0.5), (0.5, 1.0), (1.0, 2.0), (2.0, 5.0)]
+        # Test different transition bands
+        transitions = [(0.1, 0.5), (0.5, 1.0), (1.0, 2.0), (2.0, 5.0)]
 
-            for transition in transitions:
-                result = clean_drifts(self.test_eeg.copy(), transition=transition)
-                self.assertIn('data', result)
-                self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts different transition bands not available: {e}")
+        for transition in transitions:
+            result = clean_drifts(self.test_eeg.copy(), transition=transition)
+            self.assertIn('data', result)
+            self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_different_attenuations(self):
         """Test clean_drifts with different attenuation values."""
-        try:
-            # Test different attenuation values
-            attenuations = [40.0, 60.0, 80.0, 100.0]
+        # Test different attenuation values
+        attenuations = [40.0, 60.0, 80.0, 100.0]
 
-            for attenuation in attenuations:
-                result = clean_drifts(self.test_eeg.copy(), attenuation=attenuation)
-                self.assertIn('data', result)
-                self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts different attenuations not available: {e}")
+        for attenuation in attenuations:
+            result = clean_drifts(self.test_eeg.copy(), attenuation=attenuation)
+            self.assertIn('data', result)
+            self.assertIn('clean_drifts_kernel', result['etc'])
 
     def test_clean_drifts_both_methods(self):
         """Test clean_drifts with both FIR and FFT methods."""
-        try:
-            # Test both methods
-            methods = ['fir', 'fft']
+        # Test both methods
+        methods = ['fir', 'fft']
 
-            for method in methods:
-                result = clean_drifts(self.test_eeg.copy(), method=method)
-                self.assertIn('data', result)
-                self.assertIn('clean_drifts_kernel', result['etc'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts both methods not available: {e}")
+        for method in methods:
+            result = clean_drifts(self.test_eeg.copy(), method=method)
+            self.assertIn('data', result)
+            self.assertIn('clean_drifts_kernel', result['etc'])
 
 
 class TestCleanDriftsIntegration(DebuggableTestCase):
@@ -312,56 +212,44 @@ class TestCleanDriftsIntegration(DebuggableTestCase):
 
     def test_clean_drifts_preserves_structure(self):
         """Test that clean_drifts preserves EEG structure."""
-        try:
-            result = clean_drifts(self.test_eeg.copy())
+        result = clean_drifts(self.test_eeg.copy())
 
-            # Check that all essential fields are preserved
-            essential_fields = ['data', 'srate', 'nbchan', 'pnts', 'trials', 'xmin', 'xmax', 'times', 'chanlocs']
-            for field in essential_fields:
-                self.assertIn(field, result)
+        # Check that all essential fields are preserved
+        essential_fields = ['data', 'srate', 'nbchan', 'pnts', 'trials', 'xmin', 'xmax', 'times', 'chanlocs']
+        for field in essential_fields:
+            self.assertIn(field, result)
 
-            # Check that data integrity is maintained
-            self.assertEqual(result['srate'], self.test_eeg['srate'])
-            self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
-            self.assertEqual(result['pnts'], self.test_eeg['pnts'])
-            self.assertEqual(result['trials'], self.test_eeg['trials'])
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts preserves structure not available: {e}")
+        # Check that data integrity is maintained
+        self.assertEqual(result['srate'], self.test_eeg['srate'])
+        self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
+        self.assertEqual(result['pnts'], self.test_eeg['pnts'])
+        self.assertEqual(result['trials'], self.test_eeg['trials'])
 
     def test_clean_drifts_data_modification(self):
         """Test that clean_drifts actually modifies the data."""
-        try:
-            original_data = self.test_eeg['data'].copy()
-            result = clean_drifts(self.test_eeg.copy())
+        original_data = self.test_eeg['data'].copy()
+        result = clean_drifts(self.test_eeg.copy())
 
-            # Data should be modified (filtered)
-            self.assertFalse(np.array_equal(original_data, result['data']))
+        # Data should be modified (filtered)
+        self.assertFalse(np.array_equal(original_data, result['data']))
 
-            # But shape should be preserved
-            self.assertEqual(original_data.shape, result['data'].shape)
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts data modification not available: {e}")
+        # But shape should be preserved
+        self.assertEqual(original_data.shape, result['data'].shape)
 
     def test_clean_drifts_kernel_properties(self):
         """Test properties of the filter kernel."""
-        try:
-            result = clean_drifts(self.test_eeg.copy())
+        result = clean_drifts(self.test_eeg.copy())
 
-            kernel = result['etc']['clean_drifts_kernel']
+        kernel = result['etc']['clean_drifts_kernel']
 
-            # Kernel should be a numpy array
-            self.assertIsInstance(kernel, np.ndarray)
+        # Kernel should be a numpy array
+        self.assertIsInstance(kernel, np.ndarray)
 
-            # Kernel should not be empty
-            self.assertGreater(len(kernel), 0)
+        # Kernel should not be empty
+        self.assertGreater(len(kernel), 0)
 
-            # Kernel should be 1D
-            self.assertEqual(kernel.ndim, 1)
-
-        except Exception as e:
-            self.skipTest(f"clean_drifts kernel properties not available: {e}")
+        # Kernel should be 1D
+        self.assertEqual(kernel.ndim, 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_clean_flatlines.py
+++ b/tests/test_clean_flatlines.py
@@ -14,52 +14,12 @@ sys.path.insert(0, 'src')
 from eegprep.plugins.clean_rawdata.clean_flatlines import clean_flatlines
 from eegprep.utils.testing import DebuggableTestCase
 
+from tests.fixtures import create_test_eeg as _create_test_eeg
+
 
 def create_test_eeg():
-    """Create a complete test EEG structure with all required fields."""
-    return {
-        'data': np.random.randn(32, 1000, 10),
-        'srate': 500.0,
-        'nbchan': 32,
-        'pnts': 1000,
-        'trials': 10,
-        'xmin': -1.0,
-        'xmax': 1.0,
-        'times': np.linspace(-1.0, 1.0, 1000),
-        'icaact': [],
-        'icawinv': [],
-        'icasphere': [],
-        'icaweights': [],
-        'icachansind': [],
-        'chanlocs': [
-            {
-                'labels': f'EEG{i:03d}',
-                'type': 'EEG',
-                'theta': np.random.uniform(-90, 90),
-                'radius': np.random.uniform(0, 1),
-                'X': np.random.uniform(-1, 1),
-                'Y': np.random.uniform(-1, 1),
-                'Z': np.random.uniform(-1, 1),
-                'sph_theta': np.random.uniform(-180, 180),
-                'sph_phi': np.random.uniform(-90, 90),
-                'sph_radius': np.random.uniform(0, 1),
-                'urchan': i + 1,
-                'ref': '',
-            }
-            for i in range(32)
-        ],
-        'urchanlocs': [],
-        'chaninfo': [],
-        'ref': 'common',
-        'history': '',
-        'saved': 'yes',
-        'etc': {},
-        'event': [],
-        'epoch': [],
-        'setname': 'test_dataset',
-        'filename': 'test.set',
-        'filepath': '/tmp',
-    }
+    """Epoched EEG fixture sized for clean_flatlines (32 ch, 1000 pnts, 10 trials)."""
+    return _create_test_eeg(n_channels=32, n_samples=1000, srate=500.0, n_trials=10)
 
 
 class TestCleanFlatlinesBasic(DebuggableTestCase):

--- a/tests/test_eeg_autocorr_fftw.py
+++ b/tests/test_eeg_autocorr_fftw.py
@@ -311,9 +311,12 @@ class TestEegAutocorrFftw(DebuggableTestCase):
         # Both should have same shape
         self.assertEqual(result_fftw.shape, result_regular.shape)
 
-        # Results should be similar (but not necessarily identical due to different FFT implementations)
-        # Check that they're in the same ballpark
-        self.assertTrue(np.allclose(result_fftw, result_regular, rtol=0.1, atol=0.1))
+        # Both compute the same autocorrelation; the only divergence is that
+        # eeg_autocorr casts its FFT to single precision (complex64) for MATLAB
+        # parity while eeg_autocorr_fftw stays double precision. Observed max
+        # relative difference is ~3e-5, so a float-realistic tolerance still
+        # catches any several-percent port regression.
+        self.assertTrue(np.allclose(result_fftw, result_regular, rtol=1e-4, atol=1e-7))
 
     def test_axis_handling_in_fft(self):
         """Test that FFT operations handle axes correctly."""

--- a/tests/test_eeg_mne2eeg.py
+++ b/tests/test_eeg_mne2eeg.py
@@ -71,27 +71,23 @@ class TestEEGMNE2EEG(unittest.TestCase):
         # Create Raw object
         raw = mne.io.RawArray(data, info)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict (EEGLAB format)
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict (EEGLAB format)
+        self.assertIsInstance(result, dict)
 
-            # Check basic fields
-            self.assertIn('data', result)
-            self.assertIn('srate', result)
-            self.assertIn('nbchan', result)
-            self.assertIn('pnts', result)
-            self.assertIn('trials', result)
+        # Check basic fields
+        self.assertIn('data', result)
+        self.assertIn('srate', result)
+        self.assertIn('nbchan', result)
+        self.assertIn('pnts', result)
+        self.assertIn('trials', result)
 
-            # Check data dimensions
-            self.assertEqual(result['nbchan'], n_channels)
-            self.assertEqual(result['pnts'], n_times)
-            self.assertEqual(result['trials'], 1)
-            self.assertEqual(result['srate'], sfreq)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg raw conversion not available: {e}")
+        # Check data dimensions
+        self.assertEqual(result['nbchan'], n_channels)
+        self.assertEqual(result['pnts'], n_times)
+        self.assertEqual(result['trials'], 1)
+        self.assertEqual(result['srate'], sfreq)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_cleans_temporary_bridge_files(self):
@@ -133,27 +129,23 @@ class TestEEGMNE2EEG(unittest.TestCase):
         # Create Epochs object
         epochs = mne.EpochsArray(data, info, events, tmin=0, event_id=event_id)
 
-        try:
-            result = eeg_mne2eeg(epochs)
+        result = eeg_mne2eeg(epochs)
 
-            # Check that result is a dict (EEGLAB format)
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict (EEGLAB format)
+        self.assertIsInstance(result, dict)
 
-            # Check basic fields
-            self.assertIn('data', result)
-            self.assertIn('srate', result)
-            self.assertIn('nbchan', result)
-            self.assertIn('pnts', result)
-            self.assertIn('trials', result)
+        # Check basic fields
+        self.assertIn('data', result)
+        self.assertIn('srate', result)
+        self.assertIn('nbchan', result)
+        self.assertIn('pnts', result)
+        self.assertIn('trials', result)
 
-            # Check data dimensions
-            self.assertEqual(result['nbchan'], n_channels)
-            self.assertEqual(result['pnts'], n_times)
-            self.assertEqual(result['trials'], n_epochs)
-            self.assertEqual(result['srate'], sfreq)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg epochs conversion not available: {e}")
+        # Check data dimensions
+        self.assertEqual(result['nbchan'], n_channels)
+        self.assertEqual(result['pnts'], n_times)
+        self.assertEqual(result['trials'], n_epochs)
+        self.assertEqual(result['srate'], sfreq)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_with_annotations(self):
@@ -174,28 +166,24 @@ class TestEEGMNE2EEG(unittest.TestCase):
         )
         raw.set_annotations(annotations)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check that events were converted
-            self.assertIn('event', result)
-            self.assertIsInstance(result['event'], list)
+        # Check that events were converted
+        self.assertIn('event', result)
+        self.assertIsInstance(result['event'], list)
 
-            # Check event count
-            self.assertEqual(len(result['event']), 3)
+        # Check event count
+        self.assertEqual(len(result['event']), 3)
 
-            # Check event structure
-            for event in result['event']:
-                self.assertIn('latency', event)
-                self.assertIn('type', event)
-                self.assertIsInstance(event['latency'], int)
-                self.assertIsInstance(event['type'], str)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg with annotations not available: {e}")
+        # Check event structure
+        for event in result['event']:
+            self.assertIn('latency', event)
+            self.assertIn('type', event)
+            self.assertIsInstance(event['latency'], int)
+            self.assertIsInstance(event['type'], str)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_with_events(self):
@@ -224,27 +212,23 @@ class TestEEGMNE2EEG(unittest.TestCase):
 
         epochs = mne.EpochsArray(data, info, events, tmin=0, event_id=event_id)
 
-        try:
-            result = eeg_mne2eeg(epochs)
+        result = eeg_mne2eeg(epochs)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check that events were converted
-            self.assertIn('event', result)
-            self.assertIsInstance(result['event'], list)
+        # Check that events were converted
+        self.assertIn('event', result)
+        self.assertIsInstance(result['event'], list)
 
-            # Check event count
-            self.assertEqual(len(result['event']), 5)
+        # Check event count
+        self.assertEqual(len(result['event']), 5)
 
-            # Check event types
-            event_types = [event['type'] for event in result['event']]
-            self.assertIn('stimulus', event_types)
-            self.assertIn('response', event_types)
-            self.assertIn('feedback', event_types)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg with events not available: {e}")
+        # Check event types
+        event_types = [event['type'] for event in result['event']]
+        self.assertIn('stimulus', event_types)
+        self.assertIn('response', event_types)
+        self.assertIn('feedback', event_types)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_single_channel(self):
@@ -259,19 +243,15 @@ class TestEEGMNE2EEG(unittest.TestCase):
         data = np.random.randn(n_channels, n_times)
         raw = mne.io.RawArray(data, info)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check data dimensions
-            self.assertEqual(result['nbchan'], 1)
-            self.assertEqual(result['pnts'], 500)
-            self.assertEqual(result['trials'], 1)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg single channel not available: {e}")
+        # Check data dimensions
+        self.assertEqual(result['nbchan'], 1)
+        self.assertEqual(result['pnts'], 500)
+        self.assertEqual(result['trials'], 1)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_short_data(self):
@@ -286,19 +266,15 @@ class TestEEGMNE2EEG(unittest.TestCase):
         data = np.random.randn(n_channels, n_times)
         raw = mne.io.RawArray(data, info)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check data dimensions
-            self.assertEqual(result['nbchan'], 8)
-            self.assertEqual(result['pnts'], 10)
-            self.assertEqual(result['trials'], 1)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg short data not available: {e}")
+        # Check data dimensions
+        self.assertEqual(result['nbchan'], 8)
+        self.assertEqual(result['pnts'], 10)
+        self.assertEqual(result['trials'], 1)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_float32_data(self):
@@ -313,17 +289,13 @@ class TestEEGMNE2EEG(unittest.TestCase):
         data = np.random.randn(n_channels, n_times).astype(np.float32)
         raw = mne.io.RawArray(data, info)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check data type
-            self.assertEqual(result['data'].dtype, np.float32)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg float32 data not available: {e}")
+        # Check data type
+        self.assertEqual(result['data'].dtype, np.float32)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_large_dataset(self):
@@ -338,20 +310,16 @@ class TestEEGMNE2EEG(unittest.TestCase):
         data = np.random.randn(n_channels, n_times)
         raw = mne.io.RawArray(data, info)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check data dimensions
-            self.assertEqual(result['nbchan'], 64)
-            self.assertEqual(result['pnts'], 5000)
-            self.assertEqual(result['trials'], 1)
-            self.assertEqual(result['srate'], 1000.0)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg large dataset not available: {e}")
+        # Check data dimensions
+        self.assertEqual(result['nbchan'], 64)
+        self.assertEqual(result['pnts'], 5000)
+        self.assertEqual(result['trials'], 1)
+        self.assertEqual(result['srate'], 1000.0)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_empty_annotations(self):
@@ -370,18 +338,14 @@ class TestEEGMNE2EEG(unittest.TestCase):
         empty_annotations = mne.Annotations([], [], [])
         raw.set_annotations(empty_annotations)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check that events field exists but is empty
-            self.assertIn('event', result)
-            self.assertEqual(len(result['event']), 0)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg empty annotations not available: {e}")
+        # Check that events field exists but is empty
+        self.assertIn('event', result)
+        self.assertEqual(len(result['event']), 0)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_no_events(self):
@@ -401,24 +365,20 @@ class TestEEGMNE2EEG(unittest.TestCase):
 
         epochs = mne.EpochsArray(data, info, events, tmin=0)
 
-        try:
-            result = eeg_mne2eeg(epochs)
+        result = eeg_mne2eeg(epochs)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check that events were converted with string types
-            self.assertIn('event', result)
-            self.assertIsInstance(result['event'], list)
-            self.assertEqual(len(result['event']), 3)
+        # Check that events were converted with string types
+        self.assertIn('event', result)
+        self.assertIsInstance(result['event'], list)
+        self.assertEqual(len(result['event']), 3)
 
-            # Check that event types are strings
-            for event in result['event']:
-                self.assertIsInstance(event['type'], str)
-                self.assertEqual(event['type'], '999')
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg no events not available: {e}")
+        # Check that event types are strings
+        for event in result['event']:
+            self.assertIsInstance(event['type'], str)
+            self.assertEqual(event['type'], '999')
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_eeg_mne2eeg_integration_workflow(self):
@@ -441,29 +401,25 @@ class TestEEGMNE2EEG(unittest.TestCase):
         )
         raw.set_annotations(annotations)
 
-        try:
-            result = eeg_mne2eeg(raw)
+        result = eeg_mne2eeg(raw)
 
-            # Check that result is a dict
-            self.assertIsInstance(result, dict)
+        # Check that result is a dict
+        self.assertIsInstance(result, dict)
 
-            # Check basic properties
-            self.assertEqual(result['nbchan'], 32)
-            self.assertEqual(result['pnts'], 2000)
-            self.assertEqual(result['trials'], 1)
-            self.assertEqual(result['srate'], 500.0)
+        # Check basic properties
+        self.assertEqual(result['nbchan'], 32)
+        self.assertEqual(result['pnts'], 2000)
+        self.assertEqual(result['trials'], 1)
+        self.assertEqual(result['srate'], 500.0)
 
-            # Check events
-            self.assertIn('event', result)
-            self.assertEqual(len(result['event']), 5)
+        # Check events
+        self.assertIn('event', result)
+        self.assertEqual(len(result['event']), 5)
 
-            # Check event types
-            event_types = [event['type'] for event in result['event']]
-            self.assertIn('stimulus', event_types)
-            self.assertIn('response', event_types)
-
-        except Exception as e:
-            self.skipTest(f"eeg_mne2eeg integration workflow not available: {e}")
+        # Check event types
+        event_types = [event['type'] for event in result['event']]
+        self.assertIn('stimulus', event_types)
+        self.assertIn('response', event_types)
 
 
 class TestMNEEventsToEEGLABEvents(unittest.TestCase):
@@ -485,27 +441,23 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
 
         raw = MockRaw(annotations, 500.0)
 
-        try:
-            result = _mne_events_to_eeglab_events(raw)
+        result = _mne_events_to_eeglab_events(raw)
 
-            # Check result structure
-            self.assertIsInstance(result, list)
-            self.assertEqual(len(result), 3)
+        # Check result structure
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
 
-            # Check event structure
-            for event in result:
-                self.assertIn('latency', event)
-                self.assertIn('type', event)
-                self.assertIsInstance(event['latency'], int)
-                self.assertIsInstance(event['type'], str)
+        # Check event structure
+        for event in result:
+            self.assertIn('latency', event)
+            self.assertIn('type', event)
+            self.assertIsInstance(event['latency'], int)
+            self.assertIsInstance(event['type'], str)
 
-            # Check latency values (1-based indexing)
-            latencies = [event['latency'] for event in result]
-            expected_latencies = [int(0.1 * 500) + 1, int(0.5 * 500) + 1, int(1.0 * 500) + 1]
-            self.assertEqual(latencies, expected_latencies)
-
-        except Exception as e:
-            self.skipTest(f"_mne_events_to_eeglab_events annotations not available: {e}")
+        # Check latency values (1-based indexing)
+        latencies = [event['latency'] for event in result]
+        expected_latencies = [int(0.1 * 500) + 1, int(0.5 * 500) + 1, int(1.0 * 500) + 1]
+        self.assertEqual(latencies, expected_latencies)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_mne_events_to_eeglab_events_events_array(self):
@@ -529,32 +481,28 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
         event_id = {'stimulus': 1, 'response': 2}
         epochs = MockEpochs(events, event_id, 500.0)
 
-        try:
-            result = _mne_events_to_eeglab_events(epochs)
+        result = _mne_events_to_eeglab_events(epochs)
 
-            # Check result structure
-            self.assertIsInstance(result, list)
-            self.assertEqual(len(result), 3)
+        # Check result structure
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
 
-            # Check event structure
-            for event in result:
-                self.assertIn('latency', event)
-                self.assertIn('type', event)
-                self.assertIsInstance(event['latency'], int)
-                self.assertIsInstance(event['type'], str)
+        # Check event structure
+        for event in result:
+            self.assertIn('latency', event)
+            self.assertIn('type', event)
+            self.assertIsInstance(event['latency'], int)
+            self.assertIsInstance(event['type'], str)
 
-            # Check latency values (1-based indexing)
-            latencies = [event['latency'] for event in result]
-            expected_latencies = [1, 101, 201]
-            self.assertEqual(latencies, expected_latencies)
+        # Check latency values (1-based indexing)
+        latencies = [event['latency'] for event in result]
+        expected_latencies = [1, 101, 201]
+        self.assertEqual(latencies, expected_latencies)
 
-            # Check event types
-            event_types = [event['type'] for event in result]
-            expected_types = ['stimulus', 'response', 'stimulus']
-            self.assertEqual(event_types, expected_types)
-
-        except Exception as e:
-            self.skipTest(f"_mne_events_to_eeglab_events events array not available: {e}")
+        # Check event types
+        event_types = [event['type'] for event in result]
+        expected_types = ['stimulus', 'response', 'stimulus']
+        self.assertEqual(event_types, expected_types)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_mne_events_to_eeglab_events_no_event_id(self):
@@ -575,20 +523,16 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
 
         epochs = MockEpochs(events, 500.0)
 
-        try:
-            result = _mne_events_to_eeglab_events(epochs)
+        result = _mne_events_to_eeglab_events(epochs)
 
-            # Check result structure
-            self.assertIsInstance(result, list)
-            self.assertEqual(len(result), 2)
+        # Check result structure
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
 
-            # Check event types (should be string representations of numbers)
-            event_types = [event['type'] for event in result]
-            expected_types = ['1', '2']
-            self.assertEqual(event_types, expected_types)
-
-        except Exception as e:
-            self.skipTest(f"_mne_events_to_eeglab_events no event_id not available: {e}")
+        # Check event types (should be string representations of numbers)
+        event_types = [event['type'] for event in result]
+        expected_types = ['1', '2']
+        self.assertEqual(event_types, expected_types)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_mne_events_to_eeglab_events_empty_annotations(self):
@@ -603,15 +547,11 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
 
         raw = MockRaw(annotations, 500.0)
 
-        try:
-            result = _mne_events_to_eeglab_events(raw)
+        result = _mne_events_to_eeglab_events(raw)
 
-            # Check result structure
-            self.assertIsInstance(result, list)
-            self.assertEqual(len(result), 0)
-
-        except Exception as e:
-            self.skipTest(f"_mne_events_to_eeglab_events empty annotations not available: {e}")
+        # Check result structure
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
 
     @unittest.skipUnless(MNE_AVAILABLE, "MNE not available")
     def test_mne_events_to_eeglab_events_no_events(self):
@@ -626,15 +566,11 @@ class TestMNEEventsToEEGLABEvents(unittest.TestCase):
 
         epochs = MockEpochs(events, 500.0)
 
-        try:
-            result = _mne_events_to_eeglab_events(epochs)
+        result = _mne_events_to_eeglab_events(epochs)
 
-            # Check result structure
-            self.assertIsInstance(result, list)
-            self.assertEqual(len(result), 0)
-
-        except Exception as e:
-            self.skipTest(f"_mne_events_to_eeglab_events no events not available: {e}")
+        # Check result structure
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_eeg_picard.py
+++ b/tests/test_eeg_picard.py
@@ -1,9 +1,12 @@
 import os
 import unittest
 import numpy as np
+import pytest
 from eegprep import pop_loadset, eeg_picard, pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.utils.testing import DebuggableTestCase, matlab_function_exists
+
+from tests.fixtures import create_test_eeg as _create_test_eeg
 
 
 def compare_ica_components(weights1, weights2, rtol=0.01, atol=0.05):
@@ -66,50 +69,8 @@ local_url = os.path.join(os.path.dirname(__file__), '../sample_data/')
 
 
 def create_test_eeg():
-    """Create a complete test EEG structure with all required fields."""
-    return {
-        'data': np.random.randn(32, 1000, 10),
-        'srate': 500.0,
-        'nbchan': 32,
-        'pnts': 1000,
-        'trials': 10,
-        'xmin': -1.0,
-        'xmax': 1.0,
-        'times': np.linspace(-1.0, 1.0, 1000),
-        'icaact': [],
-        'icawinv': [],
-        'icasphere': [],
-        'icaweights': [],
-        'icachansind': [],
-        'chanlocs': [
-            {
-                'labels': f'EEG{i:03d}',
-                'type': 'EEG',
-                'theta': np.random.uniform(-90, 90),
-                'radius': np.random.uniform(0, 1),
-                'X': np.random.uniform(-1, 1),
-                'Y': np.random.uniform(-1, 1),
-                'Z': np.random.uniform(-1, 1),
-                'sph_theta': np.random.uniform(-180, 180),
-                'sph_phi': np.random.uniform(-90, 90),
-                'sph_radius': np.random.uniform(0, 1),
-                'urchan': i + 1,
-                'ref': '',
-            }
-            for i in range(32)
-        ],
-        'urchanlocs': [],
-        'chaninfo': [],
-        'ref': 'common',
-        'history': '',
-        'saved': 'yes',
-        'etc': {},
-        'event': [],
-        'epoch': [],
-        'setname': 'test_dataset',
-        'filename': 'test.set',
-        'filepath': '/tmp',
-    }
+    """Epoched EEG fixture sized for eeg_picard (32 ch, 1000 pnts, 10 trials)."""
+    return _create_test_eeg(n_channels=32, n_samples=1000, srate=500.0, n_trials=10)
 
 
 class TestEegPicardSimple(DebuggableTestCase):
@@ -121,206 +82,165 @@ class TestEegPicardSimple(DebuggableTestCase):
 
     def test_eeg_picard_basic_functionality(self):
         """Test basic eeg_picard functionality with default parameters."""
-        try:
-            result = eeg_picard(self.test_eeg.copy())
+        result = eeg_picard(self.test_eeg.copy())
 
-            # Check that all ICA fields are present
-            self.assertIn('icaweights', result)
-            self.assertIn('icasphere', result)
-            self.assertIn('icawinv', result)
-            self.assertIn('icaact', result)
-            self.assertIn('icachansind', result)
+        # Check that all ICA fields are present
+        self.assertIn('icaweights', result)
+        self.assertIn('icasphere', result)
+        self.assertIn('icawinv', result)
+        self.assertIn('icaact', result)
+        self.assertIn('icachansind', result)
 
-            # Check data types
-            self.assertIsInstance(result['icaweights'], np.ndarray)
-            self.assertIsInstance(result['icasphere'], np.ndarray)
-            self.assertIsInstance(result['icawinv'], np.ndarray)
-            self.assertIsInstance(result['icaact'], np.ndarray)
-            self.assertIsInstance(result['icachansind'], np.ndarray)
+        # Check data types
+        self.assertIsInstance(result['icaweights'], np.ndarray)
+        self.assertIsInstance(result['icasphere'], np.ndarray)
+        self.assertIsInstance(result['icawinv'], np.ndarray)
+        self.assertIsInstance(result['icaact'], np.ndarray)
+        self.assertIsInstance(result['icachansind'], np.ndarray)
 
-            # Check shapes
-            n_chans = self.test_eeg['nbchan']
-            n_pnts = self.test_eeg['pnts']
-            n_trials = self.test_eeg['trials']
+        # Check shapes
+        n_chans = self.test_eeg['nbchan']
+        n_pnts = self.test_eeg['pnts']
+        n_trials = self.test_eeg['trials']
 
-            self.assertEqual(result['icaweights'].shape, (n_chans, n_chans))
-            self.assertEqual(result['icasphere'].shape, (n_chans, n_chans))
-            self.assertEqual(result['icawinv'].shape, (n_chans, n_chans))
-            self.assertEqual(result['icaact'].shape, (n_chans, n_pnts, n_trials))
-            self.assertEqual(len(result['icachansind']), n_chans)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard basic functionality not available: {e}")
+        self.assertEqual(result['icaweights'].shape, (n_chans, n_chans))
+        self.assertEqual(result['icasphere'].shape, (n_chans, n_chans))
+        self.assertEqual(result['icawinv'].shape, (n_chans, n_chans))
+        self.assertEqual(result['icaact'].shape, (n_chans, n_pnts, n_trials))
+        self.assertEqual(len(result['icachansind']), n_chans)
 
     def test_eeg_picard_with_custom_parameters(self):
         """Test eeg_picard with custom parameters."""
-        try:
-            result = eeg_picard(
-                self.test_eeg.copy(),
-                max_iter=10,  # picard uses max_iter, not maxiter
-                verbose=False,
-                random_state=42,
-            )
+        result = eeg_picard(
+            self.test_eeg.copy(),
+            max_iter=10,  # picard uses max_iter, not maxiter
+            verbose=False,
+            random_state=42,
+        )
 
-            # Check that all ICA fields are present
-            self.assertIn('icaweights', result)
-            self.assertIn('icasphere', result)
-            self.assertIn('icawinv', result)
-            self.assertIn('icaact', result)
-            self.assertIn('icachansind', result)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard with custom parameters not available: {e}")
+        # Check that all ICA fields are present
+        self.assertIn('icaweights', result)
+        self.assertIn('icasphere', result)
+        self.assertIn('icawinv', result)
+        self.assertIn('icaact', result)
+        self.assertIn('icachansind', result)
 
     def test_eeg_picard_data_integrity(self):
         """Test that eeg_picard preserves data integrity."""
-        try:
-            original_eeg = self.test_eeg.copy()
-            result = eeg_picard(original_eeg.copy())
+        original_eeg = self.test_eeg.copy()
+        result = eeg_picard(original_eeg.copy())
 
-            # Check that original EEG is not modified
-            self.assertEqual(original_eeg['nbchan'], self.test_eeg['nbchan'])
-            self.assertEqual(original_eeg['pnts'], self.test_eeg['pnts'])
-            self.assertEqual(original_eeg['trials'], self.test_eeg['trials'])
+        # Check that original EEG is not modified
+        self.assertEqual(original_eeg['nbchan'], self.test_eeg['nbchan'])
+        self.assertEqual(original_eeg['pnts'], self.test_eeg['pnts'])
+        self.assertEqual(original_eeg['trials'], self.test_eeg['trials'])
 
-            # Check that result has same basic structure
-            self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
-            self.assertEqual(result['pnts'], self.test_eeg['pnts'])
-            self.assertEqual(result['trials'], self.test_eeg['trials'])
-            self.assertEqual(result['srate'], self.test_eeg['srate'])
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard data integrity not available: {e}")
+        # Check that result has same basic structure
+        self.assertEqual(result['nbchan'], self.test_eeg['nbchan'])
+        self.assertEqual(result['pnts'], self.test_eeg['pnts'])
+        self.assertEqual(result['trials'], self.test_eeg['trials'])
+        self.assertEqual(result['srate'], self.test_eeg['srate'])
 
     def test_eeg_picard_ica_structure(self):
         """Test that eeg_picard creates proper ICA structure."""
-        try:
-            result = eeg_picard(self.test_eeg.copy())
+        result = eeg_picard(self.test_eeg.copy())
 
-            # Check icasphere is identity matrix
-            n_chans = self.test_eeg['nbchan']
-            expected_icasphere = np.eye(n_chans)
-            np.testing.assert_array_equal(result['icasphere'], expected_icasphere)
+        # Check icasphere is identity matrix
+        n_chans = self.test_eeg['nbchan']
+        expected_icasphere = np.eye(n_chans)
+        np.testing.assert_array_equal(result['icasphere'], expected_icasphere)
 
-            # Check icachansind contains all channel indices
-            expected_icachansind = np.arange(n_chans)
-            np.testing.assert_array_equal(result['icachansind'], expected_icachansind)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard ICA structure not available: {e}")
+        # Check icachansind contains all channel indices
+        expected_icachansind = np.arange(n_chans)
+        np.testing.assert_array_equal(result['icachansind'], expected_icachansind)
 
     def test_eeg_picard_matrix_properties(self):
         """Test mathematical properties of ICA matrices."""
-        try:
-            result = eeg_picard(self.test_eeg.copy())
+        result = eeg_picard(self.test_eeg.copy())
 
-            n_chans = self.test_eeg['nbchan']
+        n_chans = self.test_eeg['nbchan']
 
-            # Check that icaweights and icawinv are proper matrices
-            self.assertEqual(result['icaweights'].shape, (n_chans, n_chans))
-            self.assertEqual(result['icawinv'].shape, (n_chans, n_chans))
+        # Check that icaweights and icawinv are proper matrices
+        self.assertEqual(result['icaweights'].shape, (n_chans, n_chans))
+        self.assertEqual(result['icawinv'].shape, (n_chans, n_chans))
 
-            # Check that matrices are not all zeros
-            self.assertFalse(np.allclose(result['icaweights'], 0))
-            self.assertFalse(np.allclose(result['icawinv'], 0))
+        # Check that matrices are not all zeros
+        self.assertFalse(np.allclose(result['icaweights'], 0))
+        self.assertFalse(np.allclose(result['icawinv'], 0))
 
-            # Check that matrices are not all NaN
-            self.assertFalse(np.any(np.isnan(result['icaweights'])))
-            self.assertFalse(np.any(np.isnan(result['icawinv'])))
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard matrix properties not available: {e}")
+        # Check that matrices are not all NaN
+        self.assertFalse(np.any(np.isnan(result['icaweights'])))
+        self.assertFalse(np.any(np.isnan(result['icawinv'])))
 
     def test_eeg_picard_ica_activations(self):
         """Test that ICA activations have correct shape and properties."""
-        try:
-            result = eeg_picard(self.test_eeg.copy())
+        result = eeg_picard(self.test_eeg.copy())
 
-            n_chans = self.test_eeg['nbchan']
-            n_pnts = self.test_eeg['pnts']
-            n_trials = self.test_eeg['trials']
+        n_chans = self.test_eeg['nbchan']
+        n_pnts = self.test_eeg['pnts']
+        n_trials = self.test_eeg['trials']
 
-            # Check shape
-            self.assertEqual(result['icaact'].shape, (n_chans, n_pnts, n_trials))
+        # Check shape
+        self.assertEqual(result['icaact'].shape, (n_chans, n_pnts, n_trials))
 
-            # Check that activations are not all zeros
-            self.assertFalse(np.allclose(result['icaact'], 0))
+        # Check that activations are not all zeros
+        self.assertFalse(np.allclose(result['icaact'], 0))
 
-            # Check that activations are not all NaN
-            self.assertFalse(np.any(np.isnan(result['icaact'])))
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard ICA activations not available: {e}")
+        # Check that activations are not all NaN
+        self.assertFalse(np.any(np.isnan(result['icaact'])))
 
     def test_eeg_picard_deterministic(self):
         """Test that eeg_picard produces deterministic results with fixed random state."""
-        try:
-            # Run twice with same random state
-            result1 = eeg_picard(self.test_eeg.copy(), random_state=42)
-            result2 = eeg_picard(self.test_eeg.copy(), random_state=42)
+        # Run twice with same random state
+        result1 = eeg_picard(self.test_eeg.copy(), random_state=42)
+        result2 = eeg_picard(self.test_eeg.copy(), random_state=42)
 
-            # Results should be identical
-            np.testing.assert_array_equal(result1['icaweights'], result2['icaweights'])
-            np.testing.assert_array_equal(result1['icawinv'], result2['icawinv'])
-            np.testing.assert_array_equal(result1['icaact'], result2['icaact'])
+        # Results should be identical
+        np.testing.assert_array_equal(result1['icaweights'], result2['icaweights'])
+        np.testing.assert_array_equal(result1['icawinv'], result2['icawinv'])
+        np.testing.assert_array_equal(result1['icaact'], result2['icaact'])
 
-        except Exception as e:
-            self.skipTest(f"eeg_picard deterministic test not available: {e}")
-
+    @pytest.mark.xfail(reason="exposes product bug tracked in Fable 5 epic #193 (Phase 2/3)", strict=False)
     def test_eeg_picard_different_random_states(self):
         """Test that eeg_picard produces different results with different random states."""
-        try:
-            # Run with different random states
-            result1 = eeg_picard(self.test_eeg.copy(), random_state=42)
-            result2 = eeg_picard(self.test_eeg.copy(), random_state=123)
+        # Run with different random states
+        result1 = eeg_picard(self.test_eeg.copy(), random_state=42)
+        result2 = eeg_picard(self.test_eeg.copy(), random_state=123)
 
-            # Results should be different (not identical)
-            self.assertFalse(np.array_equal(result1['icaweights'], result2['icaweights']))
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard different random states test not available: {e}")
+        # eeg_picard converges to the same unmixing matrix regardless of the
+        # random_state seed, so this assertion currently fails: the random_state
+        # parameter has no observable effect on the result.
+        self.assertFalse(np.array_equal(result1['icaweights'], result2['icaweights']))
 
     def test_eeg_picard_verbose_parameter(self):
         """Test eeg_picard with verbose parameter."""
-        try:
-            # Test with verbose=True (should not raise error)
-            result1 = eeg_picard(self.test_eeg.copy(), verbose=True)
-            self.assertIn('icaweights', result1)
+        # Test with verbose=True (should not raise error)
+        result1 = eeg_picard(self.test_eeg.copy(), verbose=True)
+        self.assertIn('icaweights', result1)
 
-            # Test with verbose=False (should not raise error)
-            result2 = eeg_picard(self.test_eeg.copy(), verbose=False)
-            self.assertIn('icaweights', result2)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard verbose parameter test not available: {e}")
+        # Test with verbose=False (should not raise error)
+        result2 = eeg_picard(self.test_eeg.copy(), verbose=False)
+        self.assertIn('icaweights', result2)
 
     def test_eeg_picard_maxiter_parameter(self):
         """Test eeg_picard with maxiter parameter."""
-        try:
-            # Test with different maxiter values
-            result1 = eeg_picard(self.test_eeg.copy(), max_iter=5)
-            result2 = eeg_picard(self.test_eeg.copy(), max_iter=10)
+        # Test with different maxiter values
+        result1 = eeg_picard(self.test_eeg.copy(), max_iter=5)
+        result2 = eeg_picard(self.test_eeg.copy(), max_iter=10)
 
-            # Both should produce valid results
-            self.assertIn('icaweights', result1)
-            self.assertIn('icaweights', result2)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard maxiter parameter test not available: {e}")
+        # Both should produce valid results
+        self.assertIn('icaweights', result1)
+        self.assertIn('icaweights', result2)
 
     def test_eeg_picard_ortho_parameter(self):
         """Test eeg_picard with ortho parameter."""
-        try:
-            # Test with ortho=True
-            result1 = eeg_picard(self.test_eeg.copy(), ortho=True)
-            self.assertIn('icaweights', result1)
+        # Test with ortho=True
+        result1 = eeg_picard(self.test_eeg.copy(), ortho=True)
+        self.assertIn('icaweights', result1)
 
-            # Test with ortho=False
-            result2 = eeg_picard(self.test_eeg.copy(), ortho=False)
-            self.assertIn('icaweights', result2)
-
-        except Exception as e:
-            self.skipTest(f"eeg_picard ortho parameter test not available: {e}")
+        # Test with ortho=False
+        result2 = eeg_picard(self.test_eeg.copy(), ortho=False)
+        self.assertIn('icaweights', result2)
 
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")

--- a/tests/test_study_clustering.py
+++ b/tests/test_study_clustering.py
@@ -150,11 +150,21 @@ def test_deterministic_clustering_helpers_return_stable_shapes():
     centroids = std_centroid(data[:4], optimal_labels)
     outlier_rows = std_findoutlierclust(data, [1, 1, 1, 1, 1], threshold=1.0)
 
+    # The two tight pairs must each share a label and the pairs must differ,
+    # so a regression that swaps or misindexes cluster assignments is caught.
     assert set(optimal_labels.tolist()) == {1, 2}
+    assert optimal_labels[0] == optimal_labels[1]
+    assert optimal_labels[2] == optimal_labels[3]
+    assert optimal_labels[0] != optimal_labels[2]
     assert optimal_centers.shape == (2, 2)
     assert optimal_sumd.shape == (2,)
     assert optimal_distances.shape == (4, 2)
+
+    # The far row [20, 20] (row index 4) must land alone in its own cluster,
+    # distinct from the four tight rows.
     assert robust_labels.shape == (5,)
+    assert robust_labels[4] not in set(robust_labels[:4].tolist())
+    assert int(np.sum(robust_labels == robust_labels[4])) == 1
     assert robust_centers.shape[1] == 2
     assert robust_sumd.ndim == 1
     assert robust_distances.shape[0] == 5
@@ -163,6 +173,7 @@ def test_deterministic_clustering_helpers_return_stable_shapes():
     assert ap_centers.shape[1] == 2
     assert ap_sumd.ndim == 1
     assert centroids.shape == (2, 2)
+    # std_findoutlierclust must flag the far row (1-based index 5) as the outlier.
     assert outlier_rows.tolist() == [5]
 
 

--- a/tests/test_utils_asr.py
+++ b/tests/test_utils_asr.py
@@ -336,30 +336,39 @@ class TestAsrProcess(unittest.TestCase):
 
             self.assertIn('Not enough memory', str(cm.exception))
 
-    def test_eigendecomposition_failure_handling(self):
-        """Test handling of eigendecomposition failures."""
-        # Create problematic covariance that might cause eigendecomposition to fail
-        with patch('numpy.linalg.eigh') as mock_eigh:
-            mock_eigh.side_effect = np.linalg.LinAlgError("Eigendecomposition failed")
+    def test_rank_deficient_covariance_produces_sane_output(self):
+        """Process genuinely rank-deficient data (singular covariance).
 
-            with self.assertLogs('eegprep.plugins.clean_rawdata.asr_process', level='WARNING') as log:
-                cleaned_data, new_state = asr_process(self.test_data, self.srate, self.state)
+        Duplicate and zeroed channels make the per-window covariance singular,
+        exercising the eigendecomposition and pseudo-inverse paths with a real
+        degenerate input rather than monkeypatching numpy to raise. The cleaned
+        output must stay finite and keep its shape.
+        """
+        degenerate = self.test_data.copy()
+        degenerate[3, :] = degenerate[0, :]  # duplicate channel -> singular covariance
+        degenerate[5, :] = 0.0  # flat channel -> singular covariance
 
-            # Should log warning and use fallback
-            self.assertTrue(any('Eigendecomposition failed' in msg for msg in log.output))
-            self.assertEqual(cleaned_data.shape, self.test_data.shape)
+        cleaned_data, new_state = asr_process(degenerate, self.srate, self.state)
 
-    def test_reconstruction_matrix_failure(self):
-        """Test handling of reconstruction matrix calculation failures."""
-        with patch('numpy.linalg.pinv') as mock_pinv:
-            mock_pinv.side_effect = np.linalg.LinAlgError("Singular matrix")
+        self.assertEqual(cleaned_data.shape, degenerate.shape)
+        self.assertTrue(np.all(np.isfinite(cleaned_data)))
 
-            with self.assertLogs('eegprep.plugins.clean_rawdata.asr_process', level='WARNING') as log:
-                cleaned_data, new_state = asr_process(self.test_data, self.srate, self.state)
+    def test_extreme_artifact_amplitudes_produce_sane_output(self):
+        """Process data with extreme-amplitude artifacts.
 
-            # Should log warning and use identity matrix fallback
-            self.assertTrue(any('Failed to calculate inverse' in msg for msg in log.output))
-            self.assertEqual(cleaned_data.shape, self.test_data.shape)
+        Huge transient amplitudes drive the reconstruction matrix toward
+        ill-conditioning, exercising the same numeric path. The cleaned output
+        must remain finite, keep its shape, and attenuate the injected spike.
+        """
+        extreme = self.test_data.copy()
+        spike_peak = float(np.max(np.abs(extreme))) * 1e4
+        extreme[2, 100:150] += spike_peak
+
+        cleaned_data, new_state = asr_process(extreme, self.srate, self.state)
+
+        self.assertEqual(cleaned_data.shape, extreme.shape)
+        self.assertTrue(np.all(np.isfinite(cleaned_data)))
+        self.assertLess(float(np.max(np.abs(cleaned_data))), spike_peak)
 
     def test_state_persistence_across_calls(self):
         """Test that state is properly maintained across multiple processing calls."""
@@ -394,17 +403,6 @@ class TestAsrProcess(unittest.TestCase):
         # Should complete without errors despite small data
         self.assertEqual(cleaned_data.shape, small_data.shape)
         self.assertTrue(np.all(np.isfinite(cleaned_data)))
-
-    def test_component_selection_error_handling(self):
-        """Test error handling in component selection logic."""
-        # Mock numpy.sum to raise an error during threshold calculation
-        with patch('numpy.sum', side_effect=Exception("Threshold error")):
-            with self.assertLogs('eegprep.plugins.clean_rawdata.asr_process', level='ERROR') as log:
-                cleaned_data, new_state = asr_process(self.test_data, self.srate, self.state)
-
-            # Should log error and use fallback (keep all components)
-            self.assertTrue(any('Error in component selection' in msg for msg in log.output))
-            self.assertEqual(cleaned_data.shape, self.test_data.shape)
 
 
 class TestAsrIntegration(unittest.TestCase):

--- a/tests/test_utils_ransac.py
+++ b/tests/test_utils_ransac.py
@@ -3,6 +3,7 @@ import numpy as np
 from unittest.mock import patch, MagicMock
 
 from eegprep.plugins.clean_rawdata.private.ransac import rand_sample, calc_projector
+from eegprep.plugins.clean_rawdata.private.sphericalSplineInterpolate import sphericalSplineInterpolate
 
 
 class TestRandSample(unittest.TestCase):
@@ -327,6 +328,44 @@ class TestCalcProjector(unittest.TestCase):
 
             self.assertEqual(result.shape, (self.n_channels, self.n_channels * 3))
             self.assertEqual(mock_interp.call_count, 3)
+
+    def test_real_interpolation_channel_mapping_and_assembly(self):
+        """Validate calc_projector against the real spherical-spline kernel.
+
+        The mock-based tests above only check output shape and call counts, so a
+        bug that permutes channel indices or mishandles the per-subset transpose
+        would pass. This test runs the real interpolation on a small montage and
+        independently reproduces each subset's reconstruction matrix, catching
+        such assembly bugs.
+        """
+        num_samples = 4
+        subset_size = self.n_channels - 2
+
+        # Reproduce the exact subsets calc_projector samples (k from num_samples-1..0).
+        subset_stream = np.random.RandomState(7)
+        subsets = {k: rand_sample(self.n_channels, subset_size, subset_stream) for k in range(num_samples - 1, -1, -1)}
+
+        projector = calc_projector(self.locs, num_samples, subset_size, stream=np.random.RandomState(7))
+
+        # Output must be a finite, real-valued bag of reconstruction matrices.
+        self.assertEqual(projector.shape, (self.n_channels, self.n_channels * num_samples))
+        self.assertTrue(np.isrealobj(projector))
+        self.assertTrue(np.all(np.isfinite(projector)))
+
+        blocks = projector.reshape(self.n_channels, num_samples, self.n_channels)
+        for k, sample in subsets.items():
+            block = blocks[:, k, :]
+
+            # Only the rows of the sampled source channels carry weight; the two
+            # unsampled channels must stay all-zero. A channel-index permutation
+            # would shift the zero rows away from the unsampled channels.
+            nonzero_rows = np.flatnonzero(np.any(block != 0, axis=1))
+            np.testing.assert_array_equal(np.sort(nonzero_rows), np.sort(sample))
+
+            # The non-zero rows must equal the real spherical-spline weights for
+            # this subset, transposed exactly as calc_projector assembles them.
+            expected_w = sphericalSplineInterpolate(self.locs[sample, :].T, self.locs.T)[0]
+            np.testing.assert_allclose(block[sample, :], np.real(expected_w).T, rtol=1e-10, atol=1e-12)
 
 
 class TestRansacIntegration(unittest.TestCase):


### PR DESCRIPTION
Remove assertion-swallowing try/except-skipTest wrappers so core clean_rawdata, ICLabel, MNE, ASR and clustering tests assert real behavior instead of skipping on failure; genuine optional-dependency skips stay as explicit skipUnless guards. Also deduplicate create_test_eeg onto the shared fixture, tighten the autocorr cross-check tolerance, add a real unmocked calc_projector test, and replace ASR error-injection log-string tests with degenerate-input checks. One picard random-seed test now xfails honestly, tracked for Phase 2/3.

Fixes #194