### PR TITLE
[core] Stop mutating caller EEG and fix ICA sign-flip invariant (Fable 5 Phase 2)

### DIFF
--- a/src/eegprep/functions/popfunc/_file_io.py
+++ b/src/eegprep/functions/popfunc/_file_io.py
@@ -120,7 +120,10 @@ def eeg_from_data(
         else:
             raise ValueError("nbchan does not match imported data")
     if not nbchan and array.ndim == 2 and array.shape[0] > array.shape[1]:
-        array = array.T
+        raise ValueError(
+            "Cannot determine channel-major orientation for a 2-D array with more "
+            "rows than columns; pass nbchan to specify the number of channels."
+        )
     if pnts and array.ndim == 2:
         pnts = int(pnts)
         if pnts > 0 and array.shape[1] % pnts == 0:

--- a/src/eegprep/functions/popfunc/eeg_amica.py
+++ b/src/eegprep/functions/popfunc/eeg_amica.py
@@ -1,7 +1,9 @@
 """Perform ICA decomposition using the AMICA (Adaptive Mixture ICA) algorithm."""
 
+import copy
+
 import numpy as np
-from ..miscfunc.pinv import pinv
+from ._ica_utils import flatten_ica_data, reshape_ica_activations
 from ..sigprocfunc.runamica import runamica
 
 
@@ -62,9 +64,10 @@ def eeg_amica(
     dict
         The updated EEG structure with ICA fields.
     """
+    EEG = copy.deepcopy(EEG)
+
     # Extract data and reshape from 3D to 2D
-    data = EEG['data'].astype('float64')
-    data = data.reshape(data.shape[0], -1)
+    data = flatten_ica_data(EEG['data'].astype('float64'))
 
     # Run AMICA
     weights, sphere, mods = runamica(
@@ -88,7 +91,7 @@ def eeg_amica(
     # Compute ICA activations
     EEG['icaact'] = (EEG['icaweights'] @ EEG['icasphere']) @ data
     # Reshape icaact back to 3D
-    EEG['icaact'] = EEG['icaact'].reshape(EEG['icaact'].shape[0], EEG['pnts'], EEG['trials'])
+    EEG['icaact'] = reshape_ica_activations(EEG['icaact'], EEG['pnts'], EEG['trials'])
     EEG['icachansind'] = np.arange(EEG['nbchan'])
 
     # Store full multi-model results
@@ -99,7 +102,7 @@ def eeg_amica(
     # Optionally sort components by mean descending activation variance
     if sortcomps in ('on', True):
         # Flatten icaact to 2D for variance computation
-        icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
+        icaact_2d = flatten_ica_data(EEG['icaact'])
         # Compute variance metric: sum(icawinv^2) .* sum(icaact^2)
         variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
         # Sort indices in descending order
@@ -112,23 +115,21 @@ def eeg_amica(
     # Optionally normalize components using the same rule as runica()
     if posact in ('on', True):
         # Flatten icaact to 2D for finding max abs values
-        icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
+        icaact_2d = flatten_ica_data(EEG['icaact'])
         # Find indices of max absolute values for each component
         ix = np.argmax(np.abs(icaact_2d), axis=1)
-        had_flips = False
         ncomps = EEG['icaact'].shape[0]
 
         for r in range(ncomps):
             if np.sign(icaact_2d[r, ix[r]]) < 0:
-                # Flip the activations
+                # A sign flip commutes through the factorization, so negate the
+                # matching row of icaweights and column of icawinv directly. This
+                # preserves the invariants icawinv == pinv(icaweights @ icasphere)
+                # and icaact == icaweights @ icasphere @ data, leaving icasphere
+                # untouched.
                 EEG['icaact'][r, :, :] = -EEG['icaact'][r, :, :]
-                # Flip the corresponding column of the mixing matrix
                 EEG['icawinv'][:, r] = -EEG['icawinv'][:, r]
-                had_flips = True
-
-        if had_flips:
-            # Recompute unmixing matrix
-            EEG['icaweights'] = pinv(EEG['icawinv'])
+                EEG['icaweights'][r, :] = -EEG['icaweights'][r, :]
 
     return EEG
 
@@ -160,13 +161,15 @@ def load_amica_model(EEG, mods, model_num=0):
     if model_num < 0 or model_num >= num_models:
         raise ValueError(f"model_num={model_num} out of range for {num_models} models")
 
+    EEG = copy.deepcopy(EEG)
+
     EEG['icaweights'] = mods['W'][:, :, model_num]
     EEG['icasphere'] = mods['S'][:num_pcs, :]
     EEG['icawinv'] = mods['A'][:, :, model_num]
 
     # Recompute activations
-    data = EEG['data'].astype('float64').reshape(EEG['data'].shape[0], -1)
+    data = flatten_ica_data(EEG['data'].astype('float64'))
     EEG['icaact'] = (EEG['icaweights'] @ EEG['icasphere']) @ data
-    EEG['icaact'] = EEG['icaact'].reshape(EEG['icaact'].shape[0], EEG['pnts'], EEG['trials'])
+    EEG['icaact'] = reshape_ica_activations(EEG['icaact'], EEG['pnts'], EEG['trials'])
 
     return EEG

--- a/src/eegprep/functions/popfunc/eeg_picard.py
+++ b/src/eegprep/functions/popfunc/eeg_picard.py
@@ -1,7 +1,10 @@
 """Module for performing ICA decomposition using the Picard algorithm."""
 
+import copy
+
 from picard import picard
 import numpy as np
+from ._ica_utils import flatten_ica_data, reshape_ica_activations
 from ..miscfunc.pinv import pinv
 
 
@@ -29,12 +32,14 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
     dict
         The updated EEG structure with ICA fields.
     """
+    EEG = copy.deepcopy(EEG)
+
     if engine is None:
         # Assuming EEG['data'] contains the EEG data as a numpy array of shape (channels, timepoints)
         data = EEG['data'].astype('float64')
 
         # reshape from 3D to 2D
-        data = data.reshape(data.shape[0], -1)
+        data = flatten_ica_data(data)
 
         # Parameters to match MATLAB picard defaults for reproducible parity
         # Using identity w_init ensures deterministic results matching MATLAB
@@ -63,7 +68,7 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
         EEG['icaact'] = sources
 
         # reshape EEG['icaact'] back to 3D as EEG['data']
-        EEG['icaact'] = EEG['icaact'].reshape(EEG['icaact'].shape[0], EEG['pnts'], EEG['trials'])
+        EEG['icaact'] = reshape_ica_activations(EEG['icaact'], EEG['pnts'], EEG['trials'])
         EEG['icachansind'] = np.arange(EEG['nbchan'])
 
     else:
@@ -75,7 +80,7 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
     # optionally sort components by mean descending activation variance
     if sortcomps in ('on', True):
         # Flatten icaact to 2D for variance computation
-        icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
+        icaact_2d = flatten_ica_data(EEG['icaact'])
         # Compute variance metric: sum(icawinv^2) .* sum(icaact^2)
         variance_metric = np.sum(EEG['icawinv'] ** 2, axis=0) * np.sum(icaact_2d**2, axis=1)
         # Sort indices in descending order
@@ -88,22 +93,20 @@ def eeg_picard(EEG, engine=None, posact='off', sortcomps='off', **kwargs):
     # optionally normalize components using the same rule as runica()
     if posact in ('on', True):
         # Flatten icaact to 2D for finding max abs values
-        icaact_2d = EEG['icaact'].reshape(EEG['icaact'].shape[0], -1)
+        icaact_2d = flatten_ica_data(EEG['icaact'])
         # Find indices of max absolute values for each component
         ix = np.argmax(np.abs(icaact_2d), axis=1)
-        had_flips = False
         ncomps = EEG['icaact'].shape[0]
 
         for r in range(ncomps):
             if np.sign(icaact_2d[r, ix[r]]) < 0:
-                # Flip the activations
+                # A sign flip commutes through the factorization, so negate the
+                # matching row of icaweights and column of icawinv directly. This
+                # preserves the invariants icawinv == pinv(icaweights @ icasphere)
+                # and icaact == icaweights @ icasphere @ data, leaving icasphere
+                # untouched.
                 EEG['icaact'][r, :, :] = -EEG['icaact'][r, :, :]
-                # Flip the corresponding column of the mixing matrix
                 EEG['icawinv'][:, r] = -EEG['icawinv'][:, r]
-                had_flips = True
-
-        if had_flips:
-            # Recompute unmixing matrix
-            EEG['icaweights'] = pinv(EEG['icawinv'])
+                EEG['icaweights'][r, :] = -EEG['icaweights'][r, :]
 
     return EEG

--- a/src/eegprep/functions/popfunc/eeg_runica.py
+++ b/src/eegprep/functions/popfunc/eeg_runica.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 from ._ica_utils import flatten_ica_data, reshape_ica_activations
 from ..miscfunc.misc import finite_matmul, finite_pinv
@@ -25,6 +27,8 @@ def eeg_runica(EEG, posact='off', sortcomps='off', **kwargs):
     dict
         The updated EEG structure with ICA fields.
     """
+    EEG = copy.deepcopy(EEG)
+
     # Extract data and reshape from 3D to 2D
     data = flatten_ica_data(EEG['data'].astype('float64'))
 
@@ -68,19 +72,17 @@ def eeg_runica(EEG, posact='off', sortcomps='off', **kwargs):
         icaact_2d = flatten_ica_data(EEG['icaact'])
         # Find indices of max absolute values for each component
         ix = np.argmax(np.abs(icaact_2d), axis=1)
-        had_flips = False
         ncomps = EEG['icaact'].shape[0]
 
         for r in range(ncomps):
             if np.sign(icaact_2d[r, ix[r]]) < 0:
-                # Flip the activations
+                # A sign flip commutes through the factorization, so negate the
+                # matching row of icaweights and column of icawinv directly. This
+                # preserves the invariants icawinv == pinv(icaweights @ icasphere)
+                # and icaact == icaweights @ icasphere @ data, leaving icasphere
+                # untouched.
                 EEG['icaact'][r, :, :] = -EEG['icaact'][r, :, :]
-                # Flip the corresponding column of the mixing matrix
                 EEG['icawinv'][:, r] = -EEG['icawinv'][:, r]
-                had_flips = True
-
-        if had_flips:
-            # Recompute unmixing matrix
-            EEG['icaweights'] = finite_pinv(EEG['icawinv'], solver=pinv)
+                EEG['icaweights'][r, :] = -EEG['icaweights'][r, :]
 
     return EEG

--- a/src/eegprep/functions/popfunc/pop_headplot.py
+++ b/src/eegprep/functions/popfunc/pop_headplot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import math
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,7 @@ def pop_headplot(
     if EEG is None:
         return ([], "") if return_com else []
 
+    EEG = copy.deepcopy(EEG)
     typeplot = int(typeplot)
     if typeplot not in {0, 1}:
         raise ValueError("typeplot must be 1 for ERP maps or 0 for component maps")

--- a/src/eegprep/functions/popfunc/pop_saveset.py
+++ b/src/eegprep/functions/popfunc/pop_saveset.py
@@ -1,5 +1,6 @@
 """EEG data saving and loading utilities."""
 
+import copy
 import os
 from pathlib import Path
 
@@ -86,6 +87,21 @@ def _matlab_empty_if_missing(EEG, key):
     """Return an EEGLAB empty array for optional fields missing from EEG."""
     value = EEG.get(key, default_empty)
     return default_empty if value is None else value
+
+
+def _matlab_empty_or_copy(EEG, key):
+    """Like ``_matlab_empty_if_missing`` but deep-copies struct-array fields.
+
+    Saving applies in-place 1-based offsets and latency coercion to the
+    MATLAB-facing structures; copying first keeps the caller's chanlocs/event
+    dicts (0-based urchan/urevent, untouched latencies) intact.  ``chanlocs``
+    and ``event`` can be Python lists or NumPy object arrays of dicts, so both
+    are deep-copied.
+    """
+    value = _matlab_empty_if_missing(EEG, key)
+    if isinstance(value, list) or (isinstance(value, np.ndarray) and value.dtype == object):
+        return copy.deepcopy(value)
+    return value
 
 
 def _matlab_empty_struct_if_missing(EEG, key):
@@ -377,11 +393,11 @@ def pop_saveset(EEG, file_name=None, *args, **kwargs):
         'icasphere': _matlab_empty_if_missing(EEG, 'icasphere'),
         'icaweights': _matlab_empty_if_missing(EEG, 'icaweights'),
         'icachansind': _matlab_empty_if_missing(EEG, 'icachansind').copy(),
-        'chanlocs': _matlab_empty_if_missing(EEG, 'chanlocs'),
+        'chanlocs': _matlab_empty_or_copy(EEG, 'chanlocs'),
         'urchanlocs': _matlab_empty_if_missing(EEG, 'urchanlocs'),
         'chaninfo': _serialize_chaninfo(EEG.get('chaninfo', {})),
         'ref': EEG.get('ref', 'common'),
-        'event': _matlab_empty_if_missing(EEG, 'event'),
+        'event': _matlab_empty_or_copy(EEG, 'event'),
         'urevent': _matlab_empty_if_missing(EEG, 'urevent'),
         'eventdescription': _matlab_empty_if_missing(EEG, 'eventdescription'),
         'epoch': _matlab_empty_if_missing(EEG, 'epoch'),
@@ -434,7 +450,7 @@ def pop_saveset(EEG, file_name=None, *args, **kwargs):
                 'urchan': c['urchan'] if not isinstance(c.get('urchan', matlab_null), np.ndarray) else None,
                 'ref': c['ref'] if not isinstance(c.get('ref', matlab_null), np.ndarray) else None,
             }
-            for c in EEG['chanlocs']
+            for c in eeglab_dict['chanlocs']
         ]
 
         # build a list of fields to selectively filter out if all entries are None

--- a/src/eegprep/functions/popfunc/pop_select.py
+++ b/src/eegprep/functions/popfunc/pop_select.py
@@ -59,6 +59,7 @@ def _pop_select_apply(EEG, **kwargs):
     -------
     EEG_out, com
     """
+    EEG = copy.deepcopy(EEG)
     # shallow options with MATLAB-compatible aliases
     g = {
         'time': kwargs.get('time', []),  # seconds; can be Nx2 for continuous
@@ -368,12 +369,11 @@ def _pop_select_apply(EEG, **kwargs):
                 newevents = []
                 for ev in EEG['event']:
                     if 'epoch' in ev and 'latency' in ev:
-                        e = copy.deepcopy(ev)
                         # within-epoch latency shift by (a-1) samples
-                        e['latency'] = e['latency'] - (a - 1)
+                        ev['latency'] = ev['latency'] - (a - 1)
                         # keep only events that remain inside the cropped window
-                        if 1 <= e['latency'] <= pnts * len(g['trial']):
-                            newevents.append(e)
+                        if 1 <= ev['latency'] <= pnts * len(g['trial']):
+                            newevents.append(ev)
                 EEG['event'] = newevents
 
             # erase epoch-level event fields

--- a/src/eegprep/functions/sigprocfunc/runica.py
+++ b/src/eegprep/functions/sigprocfunc/runica.py
@@ -222,8 +222,10 @@ def runica(data, **kwargs):
     # 1. DATA VALIDATION AND INITIALIZATION
     # =========================================================================
 
-    # Ensure data is float64 for numerical consistency with MATLAB
-    data = np.asarray(data, dtype=np.float64)
+    # Ensure data is float64 for numerical consistency with MATLAB.
+    # Copy at entry so the in-place channel-mean subtraction below never
+    # mutates the caller's array, regardless of input dtype.
+    data = np.array(data, dtype=np.float64, copy=True)
 
     chans, frames = data.shape
     urchans = chans  # remember original data channels

--- a/src/eegprep/plugins/EEG_BIDS/coords.py
+++ b/src/eegprep/plugins/EEG_BIDS/coords.py
@@ -17,14 +17,13 @@ __all__ = [
 def coords_to_mm(coords: np.ndarray, unit: str) -> np.ndarray:
     """Convert the given coordinates array from the specified unit to millimeters."""
     if unit in ('mm', 'millimeters'):
-        pass
+        return np.array(coords, copy=True)
     elif unit in ('cm', 'centimeters'):
-        coords *= 10.0
+        return coords * 10.0
     elif unit in ('m', 'meters'):
-        coords *= 1000.0
+        return coords * 1000.0
     else:
         raise ValueError(f"Unsupported coordinate unit: {unit}. Supported units are 'mm', 'cm', 'm'.")
-    return coords
 
 
 def coords_RAS_to_ALS(coords: np.ndarray) -> np.ndarray:

--- a/src/eegprep/plugins/ICLabel/eeg_rpsd.py
+++ b/src/eegprep/plugins/ICLabel/eeg_rpsd.py
@@ -53,9 +53,9 @@ def eeg_rpsd(EEG, nfreqs=None, pct_data=100):
         .transpose()
     )
 
-    np.random.seed(0)  # rng('default') in MATLAB
+    rng = np.random.RandomState(0)  # rng('default') in MATLAB; local RNG avoids mutating global state
     n_seg = index.shape[1] * EEG['trials']
-    subset = np.random.permutation(n_seg)[: int(n_seg * pct_data / 100)]
+    subset = rng.permutation(n_seg)[: int(n_seg * pct_data / 100)]
 
     # calculate windowed spectrums
     psdmed = np.zeros((ncomp, nfreqs))

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -241,9 +241,8 @@ def clean_artifacts(
     BUR = EEG  # default in case ASR is skipped
     if BurstCriterion not in (None, 'off'):
         logger.info('Applying ASR burst repair...')
-        # Save original data before clean_asr modifies EEG in place.
-        # MATLAB passes structs by value so the caller's EEG retains the
-        # original data, but Python dicts are passed by reference.
+        # Snapshot the pre-repair data to compare against the ASR-repaired
+        # result; clean_asr returns a fresh dataset (BUR) and leaves EEG intact.
         original_data = EEG['data'].copy() if BurstRejection else None
         useriemannian = _DISTANCE_MODES[distance]
         BUR = clean_asr(
@@ -257,8 +256,8 @@ def clean_artifacts(
         )
 
         if BurstRejection:
-            # Determine unchanged samples: compare original (pre-ASR) with repaired.
-            # Use original_data saved before clean_asr modified EEG['data'] in place.
+            # Determine unchanged samples: compare the pre-repair snapshot with
+            # the ASR-repaired data returned in BUR.
             sample_mask = np.sum(np.abs(original_data - BUR['data']), axis=0) < 1e-8
             del original_data
             # Convert retained samples to inclusive zero-based intervals.
@@ -272,8 +271,7 @@ def clean_artifacts(
                     sample_mask[s : e + 1] = False
                 retain_intervals = retain_intervals[~small]
 
-            # Reject bad periods from the ASR-repaired dataset (BUR), preserving
-            # the prior behaviour where clean_asr updated the data in place.
+            # Reject bad periods from the ASR-repaired dataset (BUR).
             EEG = BUR
             rejected_intervals = mask_to_intervals(sample_mask, value=False)
             if rejected_intervals.size:

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -1,5 +1,6 @@
 """EEG artifact cleaning functions."""
 
+import copy
 import logging
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
@@ -196,8 +197,10 @@ def clean_artifacts(
             raise ValueError('Highpass must be a (low, high) tuple or None/"off".')
         logger.info('Applying high‑pass filter...')
         EEG = clean_drifts(EEG, tuple(Highpass))
-    # Keep a copy after HP for optional return
-    HP = EEG.copy()
+    # Keep a point-in-time snapshot after HP for optional return. Deep-copy so
+    # later stages that mutate EEG['etc'] (channel/sample masks) do not bleed
+    # into the returned high-pass dataset.
+    HP = copy.deepcopy(EEG)
 
     # ------------------------------------------------------------------
     #            3) Channel cleaning (noisy / disconnected)
@@ -269,6 +272,9 @@ def clean_artifacts(
                     sample_mask[s : e + 1] = False
                 retain_intervals = retain_intervals[~small]
 
+            # Reject bad periods from the ASR-repaired dataset (BUR), preserving
+            # the prior behaviour where clean_asr updated the data in place.
+            EEG = BUR
             rejected_intervals = mask_to_intervals(sample_mask, value=False)
             if rejected_intervals.size:
                 EEG = eeg_eegrej(EEG, rejected_intervals)

--- a/src/eegprep/plugins/clean_rawdata/clean_asr.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_asr.py
@@ -80,7 +80,9 @@ def clean_asr(
         raise ValueError("EEG dictionary must contain 'data', 'srate', and 'nbchan'.")
     useriemannian = _normalise_useriemannian(useriemannian)
 
-    data = np.asarray(EEG['data'], dtype=np.float64)
+    # Operate on a copy so the caller's data array (and dict) are never mutated;
+    # asr_calibrate zeroes non-finite samples in place on whatever array it receives.
+    data = np.array(EEG['data'], dtype=np.float64, copy=True)
     srate = float(EEG['srate'])
     nbchan = int(EEG['nbchan'])
     C, S = data.shape
@@ -200,6 +202,7 @@ def clean_asr(
     # --- Finalize ---
     # shift signal content back (to compensate for processing delay)
     outdata = outdata[:, :S]
+    EEG = deepcopy(EEG)
     EEG['data'] = outdata
     logger.info('ASR cleaning finished.')
 

--- a/src/eegprep/plugins/clean_rawdata/clean_windows.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_windows.py
@@ -5,6 +5,7 @@ from continuous EEG data.
 """
 
 import logging
+from copy import deepcopy
 from typing import Any, Dict, Sequence, Tuple, Union
 
 import numpy as np
@@ -79,9 +80,11 @@ def clean_windows(
     # ------------------------------------------------------------------
     #                           Input handling
     # ------------------------------------------------------------------
+    # Operate on a deep copy so the caller's dataset is never mutated.
+    EEG = deepcopy(EEG)
     input_data = np.asarray(EEG['data'])
     output_dtype = input_data.dtype if np.issubdtype(input_data.dtype, np.floating) else np.dtype(np.float64)
-    EEG['data'] = input_data.astype(np.float64, copy=False)
+    EEG['data'] = input_data.astype(np.float64, copy=True)
     C, S = EEG['data'].shape
     Fs = EEG['srate']
 

--- a/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
+++ b/src/eegprep/plugins/clean_rawdata/pop_clean_rawdata.py
@@ -69,11 +69,13 @@ def pop_clean_rawdata(
         return (output, command) if return_com else output
     if int(EEG.get("trials", 1) or 1) > 1 or np.asarray(EEG.get("data")).ndim == 3:
         raise ValueError("Input data must be continuous. This data seems epoched.")
-    original_eeg = copy.deepcopy(EEG) if show_vis_artifacts else None
-    clean_eeg, _hp, _bur, _removed_channels = clean_artifacts(EEG, **options)
+    # Deep-copy so a failure (or any partial cleaning stage) leaves the caller's
+    # input dataset untouched and a successful run returns a distinct object.
+    working_eeg = copy.deepcopy(EEG)
+    clean_eeg, _hp, _bur, _removed_channels = clean_artifacts(working_eeg, **options)
     command = _history_command(options)
-    if show_vis_artifacts and original_eeg is not None:
-        vis_artifacts(clean_eeg, original_eeg)
+    if show_vis_artifacts:
+        vis_artifacts(clean_eeg, EEG)
     logger.info("Done.")
     return (clean_eeg, command) if return_com else clean_eeg
 

--- a/tests/test_ICL_feature_extractor.py
+++ b/tests/test_ICL_feature_extractor.py
@@ -12,6 +12,7 @@ import tempfile
 import scipy.io
 
 from eegprep.plugins.ICLabel.ICL_feature_extractor import ICL_feature_extractor
+from eegprep.plugins.ICLabel.eeg_rpsd import eeg_rpsd
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_saveset import pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
@@ -541,6 +542,45 @@ class TestICLFeatureExtractorValidation(unittest.TestCase):
 
         except Exception as e:
             self.skipTest(f"ICL_feature_extractor PSD extrapolation test not available: {e}")
+
+
+class TestEegRpsdGlobalRng(unittest.TestCase):
+    """Regression tests that eeg_rpsd never mutates the global numpy RNG."""
+
+    def setUp(self):
+        np.random.seed(42)
+        n_channels = 16
+        n_components = 4
+        n_samples = 500
+        srate = 250.0
+        eeg = create_test_eeg(n_channels=n_channels, n_samples=n_samples, srate=srate, n_trials=1)
+        eeg['icawinv'] = np.random.randn(n_channels, n_components) * 0.5
+        eeg['icaweights'] = np.linalg.pinv(eeg['icawinv'])
+        eeg['icasphere'] = np.eye(n_channels)
+        eeg['icaact'] = np.random.randn(n_components, n_samples, 1) * 0.5
+        eeg['icachansind'] = np.arange(n_channels)
+        self.eeg = eeg
+
+    def test_does_not_mutate_global_rng(self):
+        """eeg_rpsd must use a local RNG, leaving np.random's global state intact."""
+        np.random.seed(123)
+        before = np.random.get_state()
+        eeg_rpsd(self.eeg)
+        after = np.random.get_state()
+
+        self.assertEqual(before[0], after[0])
+        self.assertTrue(np.array_equal(before[1], after[1]))
+        self.assertEqual(before[2:], after[2:])
+
+    def test_output_is_deterministic(self):
+        """eeg_rpsd must return identical output regardless of global RNG state."""
+        np.random.seed(1)
+        psd_a = eeg_rpsd(self.eeg)
+        np.random.seed(999)
+        np.random.rand(37)  # perturb the global RNG between calls
+        psd_b = eeg_rpsd(self.eeg)
+
+        self.assertTrue(np.array_equal(psd_a, psd_b))
 
 
 class TestICLFeatureExtractorParity(unittest.TestCase):

--- a/tests/test_bids_preproc.py
+++ b/tests/test_bids_preproc.py
@@ -9,12 +9,10 @@ import unittest
 
 import numpy as np
 
+from eegprep.plugins.EEG_BIDS.coords import coords_to_mm
 from eegprep.utils.testing import DebuggableTestCase
 
 logger = logging.getLogger(__name__)
-
-if os.getenv('EEGPREP_SKIP_MATLAB') == '1':
-    raise unittest.SkipTest("MATLAB not available")
 
 curhost = socket.gethostname()
 
@@ -233,3 +231,24 @@ class TestBidsPreproc(DebuggableTestCase):
                 EpochBaseline=[None, 0],
                 MinimizeDiskUsage=False,
             )
+
+
+class TestCoordsToMm(unittest.TestCase):
+    """Regression tests that coords_to_mm never mutates the caller's array."""
+
+    def test_does_not_mutate_input(self):
+        for unit, factor in (('mm', 1.0), ('cm', 10.0), ('m', 1000.0)):
+            with self.subTest(unit=unit):
+                coords = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+                original = coords.copy()
+
+                out = coords_to_mm(coords, unit)
+
+                # Caller's array is unchanged and the result is a distinct array.
+                self.assertTrue(np.array_equal(original, coords))
+                self.assertIsNot(out, coords)
+                np.testing.assert_array_equal(out, original * factor)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_clean_artifacts.py
+++ b/tests/test_clean_artifacts.py
@@ -12,6 +12,7 @@ import numpy as np
 # Add src to path for imports
 sys.path.insert(0, 'src')
 from eegprep.plugins.clean_rawdata.clean_artifacts import clean_artifacts
+from eegprep.plugins.clean_rawdata.pop_clean_rawdata import pop_clean_rawdata
 from eegprep.utils.testing import DebuggableTestCase
 
 
@@ -986,6 +987,63 @@ class TestCleanArtifactsIntegration(DebuggableTestCase):
 
         except Exception as e:
             self.skipTest(f"clean_artifacts return values not available: {e}")
+
+
+class TestCleanArtifactsHpSnapshot(DebuggableTestCase):
+    """Regression test for the high-pass snapshot point-in-time contract."""
+
+    def setUp(self):
+        np.random.seed(11)
+        self.test_eeg = create_test_eeg()
+
+    def test_hp_snapshot_is_point_in_time(self):
+        """HP must not carry the sample mask written by the later window stage."""
+        EEG, HP, _BUR, _removed = clean_artifacts(
+            self.test_eeg,
+            Highpass='off',
+            ChannelCriterion=0.8,
+            LineNoiseCriterion=4.0,
+            BurstCriterion='off',
+            WindowCriterion=0.25,
+        )
+
+        # The window stage populates clean_sample_mask on the final EEG dataset...
+        self.assertIn('clean_sample_mask', EEG['etc'])
+        # ...but the high-pass snapshot predates that stage, so it must not share
+        # the same etc object or carry the later mask.
+        self.assertIsNot(HP['etc'], EEG['etc'])
+        self.assertNotIn('clean_sample_mask', HP['etc'])
+
+
+class TestPopCleanRawdataNoMutation(DebuggableTestCase):
+    """Regression test that pop_clean_rawdata never mutates the caller's EEG."""
+
+    def setUp(self):
+        np.random.seed(13)
+        self.test_eeg = create_test_eeg()
+
+    def test_does_not_mutate_input(self):
+        """The wrapper must deep-copy so the caller's dataset is untouched."""
+        EEG_in = self.test_eeg
+        original_data = EEG_in['data'].copy()
+        original_nbchan = EEG_in['nbchan']
+
+        cleaned = pop_clean_rawdata(
+            EEG_in,
+            gui=False,
+            ChannelCriterion=0.8,
+            LineNoiseCriterion=4.0,
+            BurstCriterion='off',
+            WindowCriterion=0.25,
+        )
+
+        # Caller's data, channel count, and etc are all unchanged.
+        self.assertTrue(np.array_equal(original_data, EEG_in['data']))
+        self.assertEqual(EEG_in['nbchan'], original_nbchan)
+        self.assertNotIn('clean_channel_mask', EEG_in.get('etc', {}))
+        self.assertNotIn('clean_sample_mask', EEG_in.get('etc', {}))
+        # The returned dataset is a distinct object.
+        self.assertIsNot(cleaned, EEG_in)
 
 
 if __name__ == '__main__':

--- a/tests/test_clean_windows.py
+++ b/tests/test_clean_windows.py
@@ -488,6 +488,25 @@ class TestCleanWindows(unittest.TestCase):
         # Check that sample_mask is boolean
         self.assertEqual(sample_mask.dtype, bool)
 
+    def test_does_not_mutate_input(self):
+        """clean_windows must not mutate the caller's EEG dict or data array."""
+        EEG_in = self.EEG_artifacts
+        original_data = EEG_in['data'].copy()
+        original_dtype = EEG_in['data'].dtype
+        original_keys = set(EEG_in.keys())
+
+        EEG_out, _ = clean_windows(EEG_in)
+
+        # Caller's data array is unchanged in value, dtype, and shape.
+        self.assertTrue(np.array_equal(original_data, EEG_in['data']))
+        self.assertEqual(EEG_in['data'].dtype, original_dtype)
+        # No new keys (e.g. 'etc') were injected into the caller's dict.
+        self.assertEqual(set(EEG_in.keys()), original_keys)
+        self.assertNotIn('etc', EEG_in)
+        # Output is a distinct object from the input.
+        self.assertIsNot(EEG_out, EEG_in)
+        self.assertIsNot(EEG_out['data'], EEG_in['data'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_eeg_amica.py
+++ b/tests/test_eeg_amica.py
@@ -13,9 +13,12 @@ Tests cover:
 """
 
 import unittest
+from unittest import mock
 
 import numpy as np
 
+from eegprep.functions.miscfunc.pinv import pinv
+from eegprep.functions.popfunc import eeg_amica as eeg_amica_module
 from eegprep.functions.popfunc.eeg_amica import eeg_amica, load_amica_model
 from eegprep.functions.sigprocfunc.runamica import is_amica_available
 
@@ -295,6 +298,134 @@ class TestLoadAmicaModel(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             load_amica_model(result, mods, model_num=-1)
+
+
+def _eeglab_flattened(data):
+    """Concatenate trials in EEGLAB column-major epoch order."""
+    return np.concatenate([data[:, :, trial] for trial in range(data.shape[2])], axis=1)
+
+
+def _epoched_eeg():
+    data = np.zeros((2, 3, 2), dtype=np.float64)
+    data[0, :, 0] = [1.0, -2.0, 3.0]
+    data[0, :, 1] = [4.0, -5.0, 6.0]
+    data[1, :, 0] = [-7.0, 8.0, -9.0]
+    data[1, :, 1] = [10.0, -11.0, 12.0]
+    return {
+        'data': data,
+        'nbchan': 2,
+        'pnts': 3,
+        'trials': 2,
+        'srate': 100,
+        'chanlocs': [],
+        'icaweights': np.eye(2),
+        'icasphere': np.eye(2),
+        'etc': {},
+    }
+
+
+def _continuous_eeg():
+    data = np.array([[1.0, -2.0, 3.0, -4.0], [-5.0, 6.0, -7.0, 8.0]])
+    return {
+        'data': data,
+        'nbchan': 2,
+        'pnts': 4,
+        'trials': 1,
+        'srate': 100,
+        'chanlocs': [],
+        'icaweights': np.eye(2),
+        'icasphere': np.eye(2),
+        'etc': {},
+    }
+
+
+# A weights/sphere pair with a non-identity sphere so that the posact sign-flip
+# step exercises the icaweights @ icasphere @ data == icaact invariant.
+_AMICA_WEIGHTS = np.array([[2.0, 1.0], [-1.0, 3.0]])
+_AMICA_SPHERE = np.array([[1.5, 0.5], [0.0, 2.0]])
+
+
+def _fake_runamica_factory(captured):
+    winv = pinv(_AMICA_WEIGHTS @ _AMICA_SPHERE)
+
+    def fake_runamica(data, **_kwargs):
+        captured['data'] = np.asarray(data).copy()
+        mods = {
+            'num_pcs': 2,
+            'num_models': 1,
+            'W': _AMICA_WEIGHTS.copy()[:, :, None],
+            'S': _AMICA_SPHERE.copy(),
+            'A': winv.copy()[:, :, None],
+        }
+        return _AMICA_WEIGHTS.copy(), _AMICA_SPHERE.copy(), mods
+
+    return fake_runamica
+
+
+class TestEegAmicaRegressions(unittest.TestCase):
+    """Regression tests that do not require the AMICA binary (runamica mocked)."""
+
+    def test_eeg_amica_flattens_epoched_data_like_eeglab(self):
+        eeg = _epoched_eeg()
+        captured = {}
+        with mock.patch.object(eeg_amica_module, 'runamica', _fake_runamica_factory(captured)):
+            out = eeg_amica(eeg)
+
+        # AMICA must receive data flattened in EEGLAB column-major epoch order.
+        np.testing.assert_array_equal(captured['data'], _eeglab_flattened(eeg['data']))
+
+        # icaact must reshape back to channel x point x trial via the same order,
+        # so it equals icaweights @ icasphere @ data reshaped per-trial.
+        expected_2d = (out['icaweights'] @ out['icasphere']) @ _eeglab_flattened(eeg['data'])
+        expected_3d = expected_2d.reshape(expected_2d.shape[0], out['pnts'], out['trials'], order='F')
+        np.testing.assert_allclose(out['icaact'], expected_3d)
+
+    def test_eeg_amica_does_not_mutate_caller(self):
+        eeg = _continuous_eeg()
+        data_before = eeg['data'].copy()
+        weights_before = eeg['icaweights'].copy()
+        captured = {}
+        with mock.patch.object(eeg_amica_module, 'runamica', _fake_runamica_factory(captured)):
+            eeg_amica(eeg, posact=True)
+
+        self.assertTrue(np.array_equal(eeg['data'], data_before))
+        self.assertTrue(np.array_equal(eeg['icaweights'], weights_before))
+        self.assertEqual(eeg['etc'], {})
+
+    def test_eeg_amica_posact_preserves_ica_invariants(self):
+        eeg = _continuous_eeg()
+        captured = {}
+        with mock.patch.object(eeg_amica_module, 'runamica', _fake_runamica_factory(captured)):
+            out = eeg_amica(eeg, posact=True)
+
+        data2d = out['data'].reshape(out['nbchan'], -1, order='F')
+        icaact2d = out['icaact'].reshape(out['icaact'].shape[0], -1, order='F')
+
+        # A posact flip must have occurred (non-identity sphere makes this the
+        # case that previously folded the sphere into icaweights).
+        self.assertFalse(np.array_equal(out['icaweights'], _AMICA_WEIGHTS))
+        # Core EEGLAB ICA invariants must hold after sign normalization.
+        np.testing.assert_allclose(out['icaweights'] @ out['icasphere'] @ data2d[out['icachansind']], icaact2d)
+        np.testing.assert_allclose(out['icawinv'], pinv(out['icaweights'] @ out['icasphere']))
+        # icasphere must be untouched by the sign-flip step.
+        np.testing.assert_array_equal(out['icasphere'], _AMICA_SPHERE)
+        ix = np.argmax(np.abs(icaact2d), axis=1)
+        self.assertTrue(np.all(icaact2d[np.arange(icaact2d.shape[0]), ix] >= 0))
+
+    def test_load_amica_model_does_not_mutate_caller(self):
+        eeg = _continuous_eeg()
+        captured = {}
+        with mock.patch.object(eeg_amica_module, 'runamica', _fake_runamica_factory(captured)):
+            decomposed = eeg_amica(eeg)
+
+        mods = decomposed['etc']['amica']
+        icaact_before = decomposed['icaact'].copy()
+        reloaded = load_amica_model(decomposed, mods, model_num=0)
+
+        # Reloading model 0 must reproduce the same activations and leave the
+        # source EEG structure untouched.
+        np.testing.assert_allclose(reloaded['icaact'], icaact_before)
+        self.assertTrue(np.array_equal(decomposed['icaact'], icaact_before))
 
 
 if __name__ == '__main__':

--- a/tests/test_eeg_picard.py
+++ b/tests/test_eeg_picard.py
@@ -196,13 +196,16 @@ class TestEegPicardSimple(DebuggableTestCase):
     def test_eeg_picard_does_not_mutate_caller(self):
         """eeg_picard must not mutate the caller's data or ICA fields."""
         data_before = self.test_eeg['data'].copy()
-        weights_before = list(self.test_eeg['icaweights'])
+        # A pre-ICA input has no icaweights yet; "does not mutate" means the
+        # caller's fields stay the exact objects they were (the result is a copy).
+        weights_before = self.test_eeg.get('icaweights')
+        chansind_before = self.test_eeg.get('icachansind')
 
         eeg_picard(self.test_eeg, posact=True, max_iter=10, random_state=1, verbose=False)
 
         self.assertTrue(np.array_equal(self.test_eeg['data'], data_before))
-        self.assertEqual(list(self.test_eeg['icaweights']), weights_before)
-        self.assertEqual(list(self.test_eeg['icachansind']), [])
+        self.assertIs(self.test_eeg.get('icaweights'), weights_before)
+        self.assertIs(self.test_eeg.get('icachansind'), chansind_before)
 
     def test_eeg_picard_posact_preserves_unmixing_invariant(self):
         """After posact sign flips, icawinv must stay pinv(icaweights @ icasphere)."""

--- a/tests/test_eeg_picard.py
+++ b/tests/test_eeg_picard.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 from eegprep import pop_loadset, eeg_picard, pop_saveset
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+from eegprep.functions.miscfunc.pinv import pinv
 from eegprep.utils.testing import DebuggableTestCase, matlab_function_exists
 
 
@@ -191,6 +192,30 @@ class TestEegPicardSimple(DebuggableTestCase):
 
         except Exception as e:
             self.skipTest(f"eeg_picard data integrity not available: {e}")
+
+    def test_eeg_picard_does_not_mutate_caller(self):
+        """eeg_picard must not mutate the caller's data or ICA fields."""
+        data_before = self.test_eeg['data'].copy()
+        weights_before = list(self.test_eeg['icaweights'])
+
+        eeg_picard(self.test_eeg, posact=True, max_iter=10, random_state=1, verbose=False)
+
+        self.assertTrue(np.array_equal(self.test_eeg['data'], data_before))
+        self.assertEqual(list(self.test_eeg['icaweights']), weights_before)
+        self.assertEqual(list(self.test_eeg['icachansind']), [])
+
+    def test_eeg_picard_posact_preserves_unmixing_invariant(self):
+        """After posact sign flips, icawinv must stay pinv(icaweights @ icasphere)."""
+        result = eeg_picard(self.test_eeg, posact=True, max_iter=10, random_state=1, verbose=False)
+
+        icaact_2d = result['icaact'].reshape(result['icaact'].shape[0], -1, order='F')
+        ix = np.argmax(np.abs(icaact_2d), axis=1)
+        # Every component's max-abs activation must be positive after posact.
+        self.assertTrue(np.all(icaact_2d[np.arange(icaact_2d.shape[0]), ix] >= 0))
+        # icasphere is left untouched by the sign-flip step.
+        np.testing.assert_array_equal(result['icasphere'], np.eye(self.test_eeg['nbchan']))
+        # icawinv stays consistent with the (sign-flipped) unmixing matrix.
+        np.testing.assert_allclose(result['icawinv'], pinv(result['icaweights'] @ result['icasphere']))
 
     def test_eeg_picard_ica_structure(self):
         """Test that eeg_picard creates proper ICA structure."""

--- a/tests/test_eeg_runica.py
+++ b/tests/test_eeg_runica.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from eegprep.functions.miscfunc.pinv import pinv
 from eegprep.functions.popfunc.eeg_runica import eeg_runica
 from eegprep.functions.popfunc.pop_runica import pop_runica
 
@@ -41,6 +42,73 @@ def test_eeg_runica_flattens_and_reshapes_epoched_data_like_eeglab(monkeypatch):
     np.testing.assert_array_equal(captured["data"], _eeglab_flattened(eeg["data"]))
     np.testing.assert_array_equal(out["icaact"], eeg["data"])
     np.testing.assert_array_equal(out["icachansind"], np.array([0, 1]))
+
+
+def _nonidentity_decomposition():
+    """Weights and a non-identity sphere that make activations sign-flippable."""
+    weights = np.array([[2.0, 1.0], [-1.0, 3.0]])
+    sphere = np.array([[1.5, 0.5], [0.0, 2.0]])
+    return weights, sphere
+
+
+def _continuous_eeg():
+    data = np.array([[1.0, -2.0, 3.0, -4.0], [-5.0, 6.0, -7.0, 8.0]])
+    return {
+        "data": data,
+        "nbchan": 2,
+        "pnts": 4,
+        "trials": 1,
+        "srate": 100,
+        "chanlocs": [],
+        "icaweights": np.eye(2),
+        "icasphere": np.eye(2),
+    }
+
+
+def test_eeg_runica_does_not_mutate_caller(monkeypatch):
+    eeg = _continuous_eeg()
+    data_before = eeg["data"].copy()
+    weights_before = eeg["icaweights"].copy()
+    sphere_before = eeg["icasphere"].copy()
+
+    weights, sphere = _nonidentity_decomposition()
+
+    def fake_runica(data, **_kwargs):
+        return weights.copy(), sphere.copy(), np.zeros(2), np.zeros((2, 1)), np.ones((2, 1)), []
+
+    monkeypatch.setattr("eegprep.functions.popfunc.eeg_runica.runica", fake_runica)
+
+    eeg_runica(eeg, posact=True)
+
+    assert np.array_equal(eeg["data"], data_before)
+    assert np.array_equal(eeg["icaweights"], weights_before)
+    assert np.array_equal(eeg["icasphere"], sphere_before)
+
+
+def test_eeg_runica_posact_preserves_ica_invariants(monkeypatch):
+    eeg = _continuous_eeg()
+    weights, sphere = _nonidentity_decomposition()
+    weights_unflipped = weights.copy()
+
+    def fake_runica(data, **_kwargs):
+        return weights.copy(), sphere.copy(), np.zeros(2), np.zeros((2, 1)), np.ones((2, 1)), []
+
+    monkeypatch.setattr("eegprep.functions.popfunc.eeg_runica.runica", fake_runica)
+
+    out = eeg_runica(eeg, posact=True)
+
+    data2d = out["data"].reshape(out["nbchan"], -1, order="F")
+    icaact2d = out["icaact"].reshape(out["icaact"].shape[0], -1, order="F")
+
+    # A posact flip must have occurred for this decomposition (otherwise the
+    # test would not exercise the invariant-preserving branch).
+    assert not np.array_equal(out["icaweights"], weights_unflipped)
+    # Core EEGLAB ICA invariants must hold after sign normalization.
+    np.testing.assert_allclose(out["icaweights"] @ out["icasphere"] @ data2d[out["icachansind"]], icaact2d)
+    np.testing.assert_allclose(out["icawinv"], pinv(out["icaweights"] @ out["icasphere"]))
+    # Every component's max-abs activation must be positive.
+    ix = np.argmax(np.abs(icaact2d), axis=1)
+    assert np.all(icaact2d[np.arange(icaact2d.shape[0]), ix] >= 0)
 
 
 def test_pop_runica_concatenates_epoched_datasets_in_eeglab_order(monkeypatch):

--- a/tests/test_file_menu_pop_functions.py
+++ b/tests/test_file_menu_pop_functions.py
@@ -47,6 +47,21 @@ def _matlab_string(value):
     return "'" + str(value).replace("'", "''") + "'"
 
 
+def test_eeg_from_data_raises_on_ambiguous_tall_array():
+    # A tall channel-major array (more channels than samples) must not be
+    # silently transposed; orientation has to be stated via nbchan.
+    with pytest.raises(ValueError, match="orientation"):
+        eeg_from_data(np.zeros((256, 100)), srate=100)
+
+
+def test_eeg_from_data_loads_tall_channel_major_with_nbchan():
+    eeg = eeg_from_data(np.arange(256 * 100, dtype=float).reshape(256, 100), srate=100, nbchan=256)
+
+    assert eeg["nbchan"] == 256
+    assert eeg["pnts"] == 100
+    assert eeg["data"].shape == (256, 100)
+
+
 def test_pop_importdata_imports_ascii_data(tmp_path):
     data_file = tmp_path / "data.tsv"
     np.savetxt(data_file, np.array([[1, 2, 3], [4, 5, 6]]), delimiter="\t")

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -21,7 +21,12 @@ from eegprep.functions.guifunc.spec import controls_by_tag
 from eegprep.functions.popfunc.pop_comperp import pop_comperp, pop_comperp_dialog_spec
 from eegprep.functions.popfunc.pop_envtopo import pop_envtopo
 from eegprep.functions.popfunc.pop_erpimage import pop_erpimage, pop_erpimage_dialog_spec
-from eegprep.functions.popfunc.pop_headplot import pop_headplot, pop_headplot_dialog_spec, _shared_maplimits
+from eegprep.functions.popfunc.pop_headplot import (
+    pop_headplot,
+    pop_headplot_dialog_spec,
+    _current_spline_file,
+    _shared_maplimits,
+)
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_epoch import pop_epoch
 from eegprep.functions.popfunc._plot_utils import component_activations
@@ -103,10 +108,28 @@ def test_pop_headplot_plots_sample_latency_map_with_spline_setup(sample_eeg, tmp
     assert len(figures) == 1
     assert figures[0].axes[0].name == "3d"
     assert splinefile.exists()
-    assert eeg["splinefile"] == str(splinefile)
+    assert _current_spline_file(eeg, 1) != str(splinefile)  # plot must not mutate the caller's EEG
     assert "setup={" in command
     _assert_python_command(command)
     plt.close(figures[0])
+
+
+def test_pop_headplot_does_not_mutate_caller_eeg(sample_eeg, tmp_path):
+    eeg = deepcopy(sample_eeg)
+    before = deepcopy(eeg)
+    setup = {
+        "splinefile": str(tmp_path / "nomutate.spl"),
+        "transform": [0, -10, 0, -0.1, 0, -1.6, 1100, 1100, 1100],
+    }
+
+    figures = pop_headplot(eeg, typeplot=1, items=[0], setup=setup)
+
+    assert set(eeg.keys()) == set(before.keys())  # no new spline/mesh keys added
+    assert np.array_equal(np.asarray(eeg["splinefile"]), np.asarray(before["splinefile"]))
+    assert "headplotmeshfile" not in eeg
+    assert np.array_equal(np.asarray(eeg["data"]), np.asarray(before["data"]))
+    for fig in figures:
+        plt.close(fig)
 
 
 def test_pop_headplot_single_map_has_eeglab_like_title_and_surface(sample_eeg, tmp_path):
@@ -303,7 +326,7 @@ def test_pop_headplot_component_path_creates_ica_spline(ica_epoch, tmp_path):
     )
 
     assert len(figures) == 1
-    assert eeg["icasplinefile"] == str(splinefile)
+    assert _current_spline_file(eeg, 0) != str(splinefile)  # plot must not mutate the caller's EEG
     assert "IC 2" in figures[0].axes[1].get_title()
     _assert_python_command(command)
     plt.close(figures[0])
@@ -383,7 +406,8 @@ def test_pop_headplot_gui_setup_result_is_replayable(sample_eeg, tmp_path):
     figures, command = pop_headplot(eeg, typeplot=1, gui=True, renderer=renderer, return_com=True)
 
     assert renderer.spec.title == "ERP head plot(s) -- pop_headplot()"
-    assert Path(eeg["splinefile"]).exists()
+    assert (tmp_path / "gui.spl").exists()
+    assert _current_spline_file(eeg, 1) == ""  # plot must not mutate the caller's EEG
     assert "setup={" in command
     assert "electrodes='off'" in command
     _assert_python_command(command)

--- a/tests/test_pop_saveset.py
+++ b/tests/test_pop_saveset.py
@@ -1,5 +1,9 @@
 import os
+import tempfile
 import unittest
+
+import numpy as np
+
 from eegprep import pop_loadset, pop_saveset  # Explicitly import pop_resample
 
 
@@ -38,6 +42,31 @@ class TestPopSaveset(unittest.TestCase):
         pop_saveset(
             self.EEG, os.path.join(local_url, 'eeglab_data_tmp.set')
         )  # see MATLAB code to compare the results at the end of the file
+
+    def test_saveset_does_not_mutate_caller_indices(self):
+        EEG = pop_loadset(os.path.join(local_url, 'eeglab_data_with_ica_tmp.set'))
+
+        chanlocs = EEG['chanlocs']
+        events = EEG['event']
+        urchan_before = [int(c['urchan']) for c in chanlocs if 'urchan' in c]
+        urevent_before = [int(ev['urevent']) for ev in events if 'urevent' in ev]
+        latency_before = [float(ev['latency']) for ev in events if 'latency' in ev]
+        self.assertTrue(urchan_before, "Dataset must have urchan values to exercise the regression")
+        self.assertTrue(urevent_before, "Dataset must have urevent values to exercise the regression")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, 'roundtrip.set')
+            pop_saveset(EEG, out)
+            # A second save must not double-increment the caller's in-memory indices.
+            pop_saveset(EEG, out)
+
+        urchan_after = [int(c['urchan']) for c in EEG['chanlocs'] if 'urchan' in c]
+        urevent_after = [int(ev['urevent']) for ev in EEG['event'] if 'urevent' in ev]
+        latency_after = [float(ev['latency']) for ev in EEG['event'] if 'latency' in ev]
+
+        self.assertEqual(urchan_after, urchan_before)  # still 0-based in memory
+        self.assertEqual(urevent_after, urevent_before)
+        np.testing.assert_array_equal(latency_after, latency_before)
         # """Test basic resampling functionality with different engines"""
         # # Apply resampling with different engines
         # EEG_python = pop_resample(self.EEG.copy(), self.new_freq, engine='scipy')

--- a/tests/test_pop_select.py
+++ b/tests/test_pop_select.py
@@ -202,6 +202,30 @@ class TestPopSelectFunctional(unittest.TestCase):
 
             self.assertEqual(np.asarray(EEG_out.get('epoch')).size, 0)
 
+    def test_caller_eeg_is_not_mutated(self):
+        EEG = copy.deepcopy(self.EEG)
+        original_data = EEG['data'].copy()
+        original_nbchan = int(EEG['nbchan'])
+        events = EEG.get('event')
+        original_event_count = 0 if events is None else len(events)
+        original_first_latency = (
+            float(events[0]['latency']) if original_event_count and 'latency' in events[0] else None
+        )
+
+        labels = _chan_labels(EEG)
+        self.assertGreaterEqual(len(labels), 2, "Dataset must have at least 2 channels")
+        EEG_out = pop_select(EEG, channel=labels[:2])
+
+        # The returned dataset reflects the selection ...
+        self.assertEqual(EEG_out['nbchan'], 2)
+        # ... while the caller's EEG is left completely untouched.
+        self.assertTrue(np.array_equal(original_data, EEG['data']))
+        self.assertEqual(int(EEG['nbchan']), original_nbchan)
+        events_after = EEG.get('event')
+        self.assertEqual(0 if events_after is None else len(events_after), original_event_count)
+        if original_first_latency is not None:
+            self.assertEqual(float(events_after[0]['latency']), original_first_latency)
+
 
 class TestPopSelectEdgeCases(unittest.TestCase):
     """Test edge cases and error conditions in pop_select."""

--- a/tests/test_runica.py
+++ b/tests/test_runica.py
@@ -48,6 +48,17 @@ class TestRunicaFunctionality(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(bias)))
         self.assertTrue(np.all(np.isfinite(signs)))
 
+    def test_runica_does_not_mutate_input_array(self):
+        """runica must not modify the caller's data array (mean subtraction)."""
+        np.random.seed(42)
+        data = np.random.randn(8, 500).astype(np.float64)
+        original = data.copy()
+
+        runica(data, maxsteps=5, verbose=False, rndreset='off')
+
+        # The float64 input array passed by the caller must be untouched.
+        self.assertTrue(np.array_equal(data, original))
+
     def test_extended_ica(self):
         """Test extended-ICA mode."""
         np.random.seed(42)

--- a/tests/test_utils_asr.py
+++ b/tests/test_utils_asr.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from eegprep.plugins.clean_rawdata.asr_calibrate import asr_calibrate
 from eegprep.plugins.clean_rawdata.asr_process import asr_process
+from eegprep.plugins.clean_rawdata.clean_asr import clean_asr
 
 
 class TestAsrCalibrate(unittest.TestCase):
@@ -658,6 +659,44 @@ class TestAsrEdgeCases(unittest.TestCase):
                 # Test processing with memory limits
                 cleaned_data, _ = asr_process(data[:, :1000], srate, state, max_mem=max_mem)
                 self.assertEqual(cleaned_data.shape, (n_channels, 1000))
+
+
+class TestCleanAsrNoMutation(unittest.TestCase):
+    """Regression tests that clean_asr never mutates the caller's EEG."""
+
+    def setUp(self):
+        np.random.seed(7)
+        n_channels = 8
+        n_samples = 2500
+        srate = 250.0
+        data = np.random.randn(n_channels, n_samples) * 0.5
+        for i in range(n_channels):
+            for j in range(1, n_samples):
+                data[i, j] += 0.8 * data[i, j - 1]
+        # Inject a non-finite sample to exercise the in-place NaN-zeroing path
+        # that asr_calibrate applies to whatever array it receives.
+        data[0, 100] = np.nan
+        self.EEG = {
+            'data': data,
+            'srate': srate,
+            'nbchan': n_channels,
+            'pnts': n_samples,
+            'etc': {},
+        }
+
+    def test_does_not_mutate_input_data(self):
+        """clean_asr must leave the caller's EEG['data'] (incl. NaNs) unchanged."""
+        EEG_in = self.EEG
+        original_data = EEG_in['data'].copy()
+
+        EEG_out = clean_asr(EEG_in, ref_maxbadchannels='off')
+
+        # The caller's data is byte-for-byte unchanged, including the NaN that
+        # asr_calibrate would otherwise have zeroed in place.
+        self.assertTrue(np.array_equal(original_data, EEG_in['data'], equal_nan=True))
+        # Output is a distinct object with distinct data.
+        self.assertIsNot(EEG_out, EEG_in)
+        self.assertIsNot(EEG_out['data'], EEG_in['data'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make side-effect-free functions actually side-effect-free by copying at entry across pop_saveset, pop_select, pop_headplot, eeg_runica/eeg_amica/eeg_picard, runica, clean_asr, clean_windows, clean_artifacts, pop_clean_rawdata, eeg_rpsd and the BIDS coords helpers, so operations a researcher believes are read-only no longer corrupt the in-memory dataset. The ICA posact sign-flip now negates the icaweights row directly instead of recomputing via pinv(icawinv), preserving the icaweights/icasphere factorization; eeg_amica and eeg_picard flatten epoched data in Fortran order to match eeg_runica. eeg_from_data raises instead of silently transposing ambiguous 2-D input. Adds input-unchanged and ICA-invariant regression tests.

Fixes #195