### PR TITLE
[core] Fix correctness bugs, silent failures & misleading contracts (Fable 5 Phase 3)

### DIFF
--- a/src/eegprep/cli/commands/bids.py
+++ b/src/eegprep/cli/commands/bids.py
@@ -93,7 +93,7 @@ def validate_dataset(root: str | Path) -> dict[str, Any]:
     if not (root_path / "dataset_description.json").exists():
         warnings.append(_issue("BIDS_VALIDATION_WARNING", "dataset_description.json is missing", root_path))
     if not files:
-        warnings.append(_issue("BIDS_VALIDATION_WARNING", "No supported EEG files were found", root_path))
+        errors.append(_issue("BIDS_EEG_FILES_MISSING", "No supported EEG files were found", root_path))
     status = "error" if errors else "warning" if warnings else "ok"
     return {
         "status": status,
@@ -294,12 +294,11 @@ def _output_record(path: Path) -> dict[str, Any]:
 
 
 def _import_bids_file(eeg_file: Path) -> tuple[dict[str, Any] | list[dict[str, Any]], str, list[dict[str, str]]]:
-    try:
-        EEG, history = pop_importbids(eeg_file, return_com=True)
-        return EEG, history, []
-    except IndexError as exc:
-        if "only integers" not in str(exc) or eeg_file.suffix.lower() != ".set":
-            raise
+    # The BIDS metadata importer (pop_importbids -> pop_load_frombids) only applies sidecar
+    # metadata to raw recording formats (.edf/.bdf/.vhdr). EEGLAB .set files carry their own
+    # metadata and cannot be routed through the sidecar-application path, so load them directly
+    # with the EEGLAB .set loader instead of attempting BIDS sidecar import.
+    if eeg_file.suffix.lower() == ".set":
         EEG = load_dataset(eeg_file)
         history = f"EEG = pop_importbids('{eeg_file.as_posix()}');"
         EEG["history"] = history
@@ -310,13 +309,15 @@ def _import_bids_file(eeg_file: Path) -> tuple[dict[str, Any] | list[dict[str, A
                 {
                     "code": "BIDS_SIDECARS_SKIPPED",
                     "message": (
-                        "BIDS sidecar application failed for this EEGLAB .set file; "
-                        "data import was retried with the EEGLAB .set loader."
+                        "EEGLAB .set files are imported with the EEGLAB .set loader; "
+                        "BIDS sidecar metadata is not applied for this format."
                     ),
                     "path": str(eeg_file),
                 }
             ],
         )
+    EEG, history = pop_importbids(eeg_file, return_com=True)
+    return EEG, history, []
 
 
 def _dataset_cli_summary(EEG: dict[str, Any], path: Path) -> dict[str, Any]:

--- a/src/eegprep/cli/commands/pipeline.py
+++ b/src/eegprep/cli/commands/pipeline.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import logging
 import sys
+from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Any
 
@@ -195,12 +197,14 @@ def handle_registered(args: argparse.Namespace) -> dict[str, Any]:
     if args.pipeline_action == "plan":
         return plan_pipeline_config(args.config)
     if args.pipeline_action == "run":
-        return run_pipeline_config(
-            args.config,
-            dry_run=args.dry_run,
-            manifest_path=args.manifest,
-            overwrite=True if args.overwrite else None,
-        )
+        _configure_logging(args)
+        with redirect_stdout(sys.stderr):
+            return run_pipeline_config(
+                args.config,
+                dry_run=args.dry_run,
+                manifest_path=args.manifest,
+                overwrite=True if args.overwrite else None,
+            )
     raise CommandError("COMMAND_NOT_IMPLEMENTED", f"Unknown pipeline action: {args.pipeline_action}")
 
 
@@ -525,9 +529,17 @@ def _apply_filter(EEG: dict[str, Any], parameters: dict[str, Any]) -> tuple[dict
     notch = parameters.get("notch")
     if notch is not None:
         width = float(parameters.get("notch_width") or 2.0)
+        lower_edge = float(notch) - width / 2
+        if lower_edge <= 0:
+            raise CommandError(
+                "CONFIG_SCHEMA_ERROR",
+                "notch minus half notch_width must be positive.",
+                path="steps[].notch",
+                suggestion="Increase notch or decrease notch_width so the notch stop band stays above 0 Hz.",
+            )
         EEG, history = pop_eegfiltnew(
             EEG,
-            locutoff=float(notch) - width / 2,
+            locutoff=lower_edge,
             hicutoff=float(notch) + width / 2,
             revfilt=True,
             plotfreqz=False,
@@ -727,6 +739,16 @@ def _raise_schema_errors(errors: list[dict[str, Any]], config_path: Path) -> Non
 
 def _warning(code: str, path: str, message: str) -> dict[str, str]:
     return {"code": code, "path": path, "message": message}
+
+
+def _configure_logging(args: argparse.Namespace) -> None:
+    if getattr(args, "quiet", False) or getattr(args, "no_progress", False):
+        level = logging.WARNING
+    elif getattr(args, "verbose", False):
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(message)s", stream=sys.stderr, force=True)
 
 
 if __name__ == "__main__":

--- a/src/eegprep/cli/core.py
+++ b/src/eegprep/cli/core.py
@@ -111,6 +111,7 @@ def command_error(command: str, error: EEGPrepCLIError) -> dict[str, Any]:
         "command": command,
         "code": error.code,
         "message": error.message,
+        "exit_code": error.exit_code,
         "error": payload,
     }
 
@@ -122,7 +123,9 @@ def emit_command_result(result: dict[str, Any], *, json_output: bool = True) -> 
         print(result.get("status", "ok"))
         if result.get("status") == "error":
             print(result.get("error", {}).get("message", ""), file=sys.stderr)
-    return 0 if result.get("status") == "ok" else 1
+    if result.get("status") == "ok":
+        return 0
+    return int(result.get("exit_code", 1) or 1)
 
 
 def print_result(result: dict[str, Any], *, as_json: bool) -> None:

--- a/src/eegprep/cli/discovery.py
+++ b/src/eegprep/cli/discovery.py
@@ -96,12 +96,79 @@ def command_schema(command: str) -> dict[str, Any]:
             "properties": {"kind": {"enum": ["dataset", "events", "channels", "ica"]}},
         },
         "pipeline": pipeline_schema()["schema"],
-        "resample": _command_schema("resample", required=["input", "freq", "output"]),
-        "rereference": _command_schema("rereference", required=["input", "method", "output"]),
-        "filter": _command_schema("filter", required=["input", "output"]),
-        "clean": _command_schema("clean", required=["input", "method", "output"]),
-        "epoch": _command_schema("epoch", required=["input", "event_type", "tmin", "tmax", "output"]),
-        "ica": _command_schema("ica", required=["input", "method", "output"]),
+        "resample": _command_schema(
+            "resample",
+            required=["input", "freq"],
+            properties={
+                "freq": {"type": "number"},
+                "engine": {"enum": ["poly", "scipy"], "default": "poly"},
+            },
+        ),
+        "rereference": _command_schema(
+            "rereference",
+            required=["input", "method"],
+            properties={
+                "method": {"enum": ["average", "channels"], "default": "average"},
+                "channels": {"type": "array", "items": {"type": "string"}},
+                "exclude": {"type": "array", "items": {"type": "string"}},
+                "keep_ref": {"type": "boolean", "default": False},
+                "huber": {"type": "number"},
+                "refica": {"enum": ["on", "off", "backwardcomp", "remove"], "default": "on"},
+            },
+        ),
+        "filter": _command_schema(
+            "filter",
+            required=["input"],
+            properties={
+                "highpass": {"type": "number"},
+                "lowpass": {"type": "number"},
+                "notch": {"type": "number"},
+                "notch_width": {"type": "number", "default": 2.0},
+                "order": {"type": "integer"},
+                "minphase": {"type": "boolean", "default": False},
+                "usefftfilt": {"type": "boolean", "default": False},
+            },
+        ),
+        "clean": _command_schema(
+            "clean",
+            required=["input", "method"],
+            properties={
+                "method": {"enum": ["asr", "rawdata"], "default": "asr"},
+                "burst_criterion": {"type": "number", "default": 20.0},
+                "burst_rejection": {"type": "boolean", "default": False},
+                "distance": {"enum": ["euclidean", "riemannian"], "default": "euclidean"},
+                "flatline_criterion": {"type": "number"},
+                "channel_criterion": {"type": "number"},
+                "line_noise_criterion": {"type": "number"},
+                "window_criterion": {"type": "number"},
+                "highpass": {"type": "array", "items": {"type": "number"}},
+            },
+        ),
+        "epoch": _command_schema(
+            "epoch",
+            required=["input", "event_type", "tmin", "tmax"],
+            properties={
+                "event_type": {"type": "array", "items": {"type": "string"}},
+                "tmin": {"type": "number"},
+                "tmax": {"type": "number"},
+                "new_name": {"type": "string"},
+            },
+        ),
+        "ica": _command_schema(
+            "ica",
+            required=["input", "method"],
+            properties={
+                "method": {"enum": ["runica", "picard", "amica", "runamica15"], "default": "runica"},
+                "seed": {"type": "integer"},
+                "deterministic": {"type": "boolean", "default": True},
+                "maxsteps": {"type": "integer"},
+                "pca": {"type": "integer"},
+                "extended": {"type": "integer"},
+                "channels": {"type": "array", "items": {"type": "string"}},
+                "option": {"type": "array", "items": {"type": "string"}},
+                "reorder": {"type": "boolean", "default": True},
+            },
+        ),
         "batch": {
             "schema_version": "eegprep.schema.command.batch.v1",
             "syntax": "eegprep batch run <inputs...> --pipeline <config.yaml> --output-dir <dir> --json",
@@ -291,20 +358,22 @@ def _write_capability(description: str) -> dict[str, Any]:
         "outputs": ["eeglab_set", "manifest"],
         "supports_json": True,
         "supports_dry_run": False,
-        "requires_output": True,
+        "requires_output_or_overwrite": True,
     }
 
 
-def _command_schema(command: str, *, required: list[str]) -> dict[str, Any]:
+def _command_schema(command: str, *, required: list[str], properties: dict[str, Any]) -> dict[str, Any]:
     return {
         "schema_version": f"eegprep.schema.command.{command}.v1",
         "type": "object",
         "required": required,
+        "anyOf": [{"required": ["output"]}, {"required": ["overwrite"]}],
         "properties": {
             "input": {"type": "string"},
             "output": {"type": "string"},
             "manifest": {"type": "string"},
             "overwrite": {"type": "boolean", "default": False},
             "json": {"type": "boolean", "default": False},
+            **properties,
         },
     }

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -930,6 +930,8 @@ class _ConsoleCommandArgumentConverter(ast.NodeTransformer):
             return node
         if node.func.id == "pop_reref":
             self._convert_pop_reref(node)
+        elif node.func.id == "pop_select":
+            self._convert_pop_select(node)
         return node
 
     def _convert_pop_reref(self, node: ast.Call) -> None:
@@ -938,6 +940,16 @@ class _ConsoleCommandArgumentConverter(ast.NodeTransformer):
         for index in range(2, len(node.args) - 1, 2):
             key = self._string_constant(node.args[index])
             if key in {"exclude", "interpchan"}:
+                node.args[index + 1] = self._zero_base_channel_arg(node.args[index + 1])
+
+    def _convert_pop_select(self, node: ast.Call) -> None:
+        # pop_select history is name/value pairs after EEG (no positional
+        # selection arg). Channel selections are 1-based in EEGLAB history but
+        # the Python API is 0-based, so zero-base the numeric channel lists to
+        # match pop_reref; channel-by-name and chantype selections pass through.
+        for index in range(1, len(node.args) - 1, 2):
+            key = self._string_constant(node.args[index])
+            if key in {"channel", "nochannel", "rmchannel"}:
                 node.args[index + 1] = self._zero_base_channel_arg(node.args[index + 1])
 
     def _zero_base_channel_arg(self, node: ast.AST) -> ast.AST:

--- a/src/eegprep/functions/eegobj/eegobj.py
+++ b/src/eegprep/functions/eegobj/eegobj.py
@@ -26,6 +26,36 @@ def _tolist_if_available(value: Any) -> Any:
     return tolist() if callable(tolist) else value
 
 
+def _resolve_eegprep_function(name):
+    """Resolve an eegprep function by name, or return None if unknown."""
+    # Try globals first (for imported functions)
+    cand = globals().get(name)
+    if callable(cand):
+        return cand
+    # Try public package exports before probing EEGLAB-style modules.
+    try:
+        import eegprep as eegpkg
+
+        cand = getattr(eegpkg, name, None)
+        if callable(cand):
+            return cand
+        if isinstance(cand, types.ModuleType):
+            sub = getattr(cand, name, None)
+            if callable(sub):
+                return sub
+    except Exception:
+        pass
+    for prefix in _EEGPREP_FUNCTION_MODULE_PREFIXES:
+        try:
+            mod = importlib.import_module(f"{prefix}.{name}")
+            cand = getattr(mod, name, None)
+            if callable(cand):
+                return cand
+        except Exception:
+            pass
+    return None
+
+
 class EEGobj:
     """Wrapper class for EEG datasets stored as dictionaries.
 
@@ -48,35 +78,7 @@ class EEGobj:
 
     # Internal helper to resolve and call an eegprep function name
     def _call_eegprep(self, fname, *args, **kwargs):
-        def _resolve(n):
-            # Try globals first (for imported functions)
-            cand = globals().get(n)
-            if callable(cand):
-                return cand
-            # Try public package exports before probing EEGLAB-style modules.
-            try:
-                import eegprep as eegpkg
-
-                cand = getattr(eegpkg, n, None)
-                if callable(cand):
-                    return cand
-                if isinstance(cand, types.ModuleType):
-                    sub = getattr(cand, n, None)
-                    if callable(sub):
-                        return sub
-            except Exception:
-                pass
-            for prefix in _EEGPREP_FUNCTION_MODULE_PREFIXES:
-                try:
-                    mod = importlib.import_module(f"{prefix}.{n}")
-                    cand = getattr(mod, n, None)
-                    if callable(cand):
-                        return cand
-                except Exception:
-                    pass
-            return None
-
-        func = _resolve(fname)
+        func = _resolve_eegprep_function(fname)
         if func is None:
             raise AttributeError(fname)
 
@@ -116,13 +118,18 @@ class EEGobj:
         """Access EEG fields or eegprep functions.
 
         - If 'name' is a key in EEG, return EEG[name] (convenience).
-        - If 'name' is a function in eegprep, return a wrapper that:
+        - If 'name' resolves to a function in eegprep, return a wrapper that:
           self.EEG = func(deepcopy(self.EEG), ...)
           and returns updated EEG for convenience.
+        - Otherwise raise AttributeError so field-name typos fail fast instead
+          of silently returning a no-op callable.
         """
         eeg = object.__getattribute__(self, 'EEG')
         if isinstance(eeg, dict) and name in eeg:
             return eeg[name]
+
+        if _resolve_eegprep_function(name) is None:
+            raise AttributeError(name)
 
         def wrapper(*args, **kwargs):
             return self._call_eegprep(name, *args, **kwargs)

--- a/src/eegprep/functions/guifunc/menu_actions.py
+++ b/src/eegprep/functions/guifunc/menu_actions.py
@@ -1597,7 +1597,12 @@ class MenuActionDispatcher:
         else:
             self.show_coming_soon(name, parent)
             return
-        self._add_history_from_gui(command)
+        if name == "pop_headplot":
+            # pop_headplot attaches the spline file in place, so commit the edited
+            # dataset through the session instead of only recording history.
+            self._store_current_from_gui(selection, command=command)
+        else:
+            self._add_history_from_gui(command)
         self._refresh()
 
     def _run_chanplot(self, parent: Any | None) -> None:
@@ -1627,9 +1632,6 @@ class MenuActionDispatcher:
         if isinstance(eeg, list):
             for offset, _dataset in enumerate(eeg, start=1):
                 logger.info("Processing group dataset %s of %s.", offset, len(eeg))
-        for dataset in eeg if isinstance(eeg, list) else [eeg]:
-            if isinstance(dataset, dict):
-                eegh(command, dataset)
         alleeg, current, current_set, newset_command = pop_newset(
             self.session.ALLEEG,
             eeg,
@@ -1643,6 +1645,9 @@ class MenuActionDispatcher:
             if old_selection:
                 self.session.retrieve(old_selection if len(old_selection) > 1 else old_selection[0])
             return
+        for dataset in current if isinstance(current, list) else [current]:
+            if isinstance(dataset, dict):
+                eegh(command, dataset)
         self.session.echo_command(command)
         self.session.add_history(command, notify=False)
         self.session.echo_command(newset_command)

--- a/src/eegprep/functions/popfunc/eeg_compare.py
+++ b/src/eegprep/functions/popfunc/eeg_compare.py
@@ -4,30 +4,35 @@ This module provides functions for comparing EEG data structures and reporting
 differences between them.
 """
 
-import sys
+import logging
 import math
 from collections.abc import Sequence
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
 
 def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
-    """Compare two EEG-like structures, reporting differences to stderr.
+    """Compare two EEG-like structures (or arrays) and return a difference summary.
+
+    Per-field findings are emitted through this module's logger; the returned value is the
+    human-readable summary string callers print or store.
 
     Parameters
     ----------
-    eeg1 : dict or object
-        First EEG structure to compare.
-    eeg2 : dict or object
-        Second EEG structure to compare.
+    eeg1 : dict, object, or numpy.ndarray
+        First EEG structure (or array) to compare.
+    eeg2 : dict, object, or numpy.ndarray
+        Second EEG structure (or array) to compare.
     verbose_level : int, optional
-        Level of verbosity for output. Default 0.
+        Level of verbosity for logged output. Default 0.
     trigger_error : bool, optional
-        Whether to raise an error if differences are found. Default False.
+        Whether to raise a ``ValueError`` if differences are found. Default False.
 
     Returns
     -------
-    bool
-        True if comparison completed (differences may still exist).
+    str
+        A summary describing the differences found, or that all fields match.
     """
     summary_parts = []
 
@@ -48,24 +53,18 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
         if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
             try:
                 return bool(np.array_equal(np.array(a), np.array(b), equal_nan=True))
-            except Exception:
-                pass
-        # Handle numpy arrays in general comparison
-        if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
-            try:
-                return bool(np.array_equal(a, b, equal_nan=True))
-            except Exception:
+            except (TypeError, ValueError):
                 pass
         # Handle scalar vs array comparisons
         if isinstance(a, np.ndarray) and np.isscalar(b):
             try:
                 return bool(np.all(a == b))
-            except Exception:
+            except (TypeError, ValueError):
                 pass
         if isinstance(b, np.ndarray) and np.isscalar(a):
             try:
                 return bool(np.all(b == a))
-            except Exception:
+            except (TypeError, ValueError):
                 pass
         # Final comparison - ensure we return a boolean
         try:
@@ -73,7 +72,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
             if isinstance(result, np.ndarray):
                 return bool(result.all())
             return bool(result)
-        except Exception:
+        except (TypeError, ValueError):
             return False
 
     def _numeric_distance(a, b):
@@ -93,7 +92,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
             return np.inf
         return float(np.max(np.abs(arr_a - arr_b)))
 
-    print('\nField analysis: (no entries means OK)')
+    logger.info('Field analysis: (no entries means OK)')
 
     # Collect differences for error reporting
     differences = []
@@ -101,7 +100,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
     if isinstance(eeg1, np.ndarray) and isinstance(eeg2, np.ndarray):
         if eeg1.shape != eeg2.shape:
             summary = f"Array shape mismatch: {eeg1.shape} vs {eeg2.shape}"
-            print(summary, file=sys.stderr)
+            logger.warning(summary)
             if trigger_error:
                 raise ValueError(summary)
             return summary
@@ -184,7 +183,7 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
     for field in fields1:
         if not has_field2(field):
             error_msg = f'Field {field} missing in second dataset'
-            print(f'    {error_msg}', file=sys.stderr)
+            logger.warning('    %s', error_msg)
             differences.append(error_msg)
         else:
             v1 = get_val1(field)
@@ -192,16 +191,16 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
             if not isequaln(v1, v2):
                 name = field.lower()
                 if any(sub in name for sub in ('filename', 'datfile')):
-                    print(f'    Field {field} differs (ok, supposed to differ)')
+                    logger.info('    Field %s differs (ok, supposed to differ)', field)
                 elif any(sub in name for sub in ('subject', 'session', 'run', 'task')):
                     error_msg = f'Field {field} differs ("{v1}" vs "{v2}")'
-                    print(f'    {error_msg}', file=sys.stderr)
+                    logger.warning('    %s', error_msg)
                     differences.append(error_msg)
                 elif any(sub in name for sub in ('eventdescription')):
                     n1 = len(v1) if isinstance(v1, Sequence) else 1
                     n2 = len(v2) if isinstance(v2, Sequence) else 1
                     error_msg = f'Field {field} differs (n={n1} vs n={n2})'
-                    print(f'    {error_msg}', file=sys.stderr)
+                    logger.warning('    %s', error_msg)
                     differences.append(error_msg)
                 elif any(sub in name for sub in ('chanlocs', 'event', 'reject')):
                     pass
@@ -224,19 +223,19 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
                             max_rel_diff = np.max(rel_diff) if rel_diff.size else 0.0
 
                             error_msg = f'Field {field} differs (max_abs={max_abs_diff:.6e}, mean_abs={mean_abs_diff:.6e}, rms={rms_diff:.6e}, max_rel={max_rel_diff:.6e})'
-                            print(f'    {error_msg}', file=sys.stderr)
+                            logger.warning('    %s', error_msg)
                             differences.append(error_msg)
                             summary_parts.append(
                                 f"  {field}: max_abs={max_abs_diff:.6e}, mean_abs={mean_abs_diff:.6e}, rms={rms_diff:.6e}"
                             )
                         else:
                             error_msg = f'Field {field} differs (shape mismatch: {v1.shape} vs {v2.shape})'
-                            print(f'    {error_msg}', file=sys.stderr)
+                            logger.warning('    %s', error_msg)
                             differences.append(error_msg)
                             summary_parts.append(f"  {field}: shape mismatch")
                     else:
                         error_msg = f'Field {field} differs'
-                        print(f'    {error_msg}', file=sys.stderr)
+                        logger.warning('    %s', error_msg)
                         differences.append(error_msg)
     # compare xmin/xmax
     for attr in ('xmin', 'xmax'):
@@ -245,11 +244,11 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
         if not isequaln(x1, x2):
             diff = (x1 or 0) - (x2 or 0)
             error_msg = f'Difference between {attr} is {diff:1.6f} sec'
-            print(f'    {error_msg}', file=sys.stderr)
+            logger.warning('    %s', error_msg)
             differences.append(error_msg)
 
     # channel locations
-    print('Chanlocs analysis:')
+    logger.info('Chanlocs analysis:')
     chans1 = get_val1('chanlocs')
     if chans1 is None or (isinstance(chans1, np.ndarray) and len(chans1) == 0):
         chans1 = []
@@ -266,26 +265,26 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
             if c1['labels'] != c2['labels']:
                 label_diff += 1
                 if verbose_level > 0:
-                    print(f'    Channel {c1["labels"]} differs from {c2["labels"]}', file=sys.stderr)
+                    logger.warning('    Channel %s differs from %s', c1["labels"], c2["labels"])
         if coord_diff:
             error_msg = f'{coord_diff} channel coordinates differ'
-            print(f'    {error_msg}', file=sys.stderr)
+            logger.warning('    %s', error_msg)
             differences.append(error_msg)
         else:
-            print('    All channel coordinates are OK')
+            logger.info('    All channel coordinates are OK')
         if label_diff:
             error_msg = f'{label_diff} channel label(s) differ'
-            print(f'    {error_msg}', file=sys.stderr)
+            logger.warning('    %s', error_msg)
             differences.append(error_msg)
         else:
-            print('    All channel labels are OK')
+            logger.info('    All channel labels are OK')
     else:
         error_msg = 'Different numbers of channels'
-        print(f'    {error_msg}', file=sys.stderr)
+        logger.warning('    %s', error_msg)
         differences.append(error_msg)
 
     # events
-    print('Event analysis:')
+    logger.info('Event analysis:')
     ev1 = get_val1('event')
     if ev1 is None or (isinstance(ev1, np.ndarray) and len(ev1) == 0):
         ev1 = []
@@ -294,23 +293,23 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
         ev2 = []
     if len(ev1) != len(ev2):
         error_msg = f'Different numbers of events {len(ev1)} vs {len(ev2)}'
-        print(f'    {error_msg}', file=sys.stderr)
+        logger.warning('    %s', error_msg)
         differences.append(error_msg)
         # print the first event of each
         if verbose_level > 0:
             if len(ev1) > 0:
-                print(f'    First event of first dataset: {ev1[0]}', file=sys.stderr)
+                logger.warning('    First event of first dataset: %s', ev1[0])
             if len(ev2) > 0:
-                print(f'    First event of second dataset: {ev2[0]}', file=sys.stderr)
+                logger.warning('    First event of second dataset: %s', ev2[0])
     else:
         if len(ev1) == 0:
-            print('    All events OK (empty)')
+            logger.info('    All events OK (empty)')
         else:
             f1 = set(ev1[0].keys())
             f2 = set(ev2[0].keys())
             if f1 != f2:
                 error_msg = 'Not the same number of event fields'
-                print(f'    {error_msg}', file=sys.stderr)
+                logger.warning('    %s', error_msg)
                 differences.append(error_msg)
             for fld in f1:
                 diffs = []
@@ -321,38 +320,16 @@ def eeg_compare(eeg1, eeg2, verbose_level=0, trigger_error=False):
                         pct = len(nonzero) / len(diffs) * 100
                         avg = sum(abs(d) for d in nonzero) / len(nonzero)
                         error_msg = f'Event latency ({pct:2.1f} %) not OK (abs diff {avg:1.4f} samples)'
-                        print(f'    {error_msg}', file=sys.stderr)
+                        logger.warning('    %s', error_msg)
                         differences.append(error_msg)
-                        # print('    ******** (see plot)')
-                        # import matplotlib.pyplot as plt
-                        # plt.plot(diffs)
-                        # plt.show()
                 else:
                     diffs = [not isequaln(e1.get(fld, None), e2.get(fld, None)) for e1, e2 in zip(ev1, ev2)]
                     if any(diffs):
                         pct = sum(diffs) / len(diffs) * 100
                         error_msg = f'Event fields "{fld}" are NOT OK ({pct:2.1f} % of them)'
-                        print(f'    {error_msg}', file=sys.stderr)
+                        logger.warning('    %s', error_msg)
                         differences.append(error_msg)
-            print('    All other events OK')
-
-    # epochs
-    # if 'epoch' in eeg1:
-    #     print('Epoch analysis:')
-    #     ep1, ep2 =  eeg1['epoch'], eeg2['epoch']
-    #     if len(ep1) != len(ep2):
-    #         print('    Different numbers of epochs', file=sys.stderr)
-    #     else:
-    #         fields = ep1[0].keys()
-    #         all_ok = True
-    #         for fld in fields:
-    #             diffs = [not isequaln(getattr(e1, fld, None), getattr(e2, fld, None)) for e1, e2 in zip(ep1, ep2)]
-    #             if any(diffs):
-    #                 pct = sum(diffs) / len(diffs) * 100
-    #                 print(f'    Epoch fields "{fld}" are NOT OK ({pct:2.1f} % of them)', file=sys.stderr)
-    #                 all_ok = False
-    #         if all_ok:
-    #             print('    All epoch and all epoch fields are OK')
+            logger.info('    All other events OK')
 
     # Build final summary
     if summary_parts:

--- a/src/eegprep/functions/popfunc/eeg_eegrej.py
+++ b/src/eegprep/functions/popfunc/eeg_eegrej.py
@@ -328,10 +328,15 @@ def eeg_eegrej(EEG, regions):
     if len(EEG["event"]) > 1 and EEG["event"][-1].get("latency", 0) - 0.5 > EEG["pnts"] and EEG.get("trials", 1) == 1:
         EEG["event"].pop()
 
-    # light duplicate cleanup mirroring MATLAB edge cases
-    if len(EEG["event"]) > 1 and EEG["event"][0].get("latency") == 0:
+    # light duplicate cleanup mirroring MATLAB edge cases: only drop boundary
+    # events sitting at the very first/last sample, never genuine stimulus events
+    if len(EEG["event"]) > 1 and EEG["event"][0].get("latency") == 0 and _is_boundary_event(EEG["event"][0]):
         EEG["event"] = EEG["event"][1:]
-    if len(EEG["event"]) > 1 and EEG["event"][-1].get("latency") == EEG["pnts"]:
+    if (
+        len(EEG["event"]) > 1
+        and EEG["event"][-1].get("latency") == EEG["pnts"]
+        and _is_boundary_event(EEG["event"][-1])
+    ):
         EEG["event"] = EEG["event"][:-1]
     if len(EEG["event"]) > 2:
         if EEG["event"][-1].get("latency") == EEG["event"][-2].get("latency"):

--- a/src/eegprep/functions/popfunc/pop_editeventvals.py
+++ b/src/eegprep/functions/popfunc/pop_editeventvals.py
@@ -13,6 +13,7 @@ from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.popfunc._event_utils import event_field_names, events_as_list, normalize_one_based_indices
 from eegprep.functions.popfunc._pop_utils import format_history_value, is_empty_value as _is_empty
 from eegprep.functions.popfunc.eeg_lat2point import eeg_lat2point
+from eegprep.functions.popfunc.eeg_point2lat import eeg_point2lat
 
 
 def pop_editeventvals(
@@ -176,15 +177,14 @@ def _change_field(
 def _internal_event_value(output: dict[str, Any], event: dict[str, Any], field: str, value: Any) -> Any:
     if field == "latency" and value not in {"", None}:
         if int(output.get("trials", 1) or 1) > 1:
-            return float(
-                eeg_lat2point(
-                    float(value),
-                    event.get("epoch", 1),
-                    float(output.get("srate", 1)),
-                    [float(output.get("xmin", 0)) * 1000, float(output.get("xmax", 0)) * 1000],
-                    1e-3,
-                )
+            newlat, _ = eeg_lat2point(
+                float(value),
+                event.get("epoch", 1),
+                float(output.get("srate", 1)),
+                [float(output.get("xmin", 0)) * 1000, float(output.get("xmax", 0)) * 1000],
+                1e-3,
             )
+            return float(newlat.item())
         return (float(value) - float(output.get("xmin", 0))) * float(output.get("srate", 1)) + 1
     if field == "duration" and value not in {"", None}:
         scale = float(output.get("srate", 1)) / (1000 if int(output.get("trials", 1) or 1) > 1 else 1)
@@ -198,7 +198,15 @@ def _display_event_value(EEG: dict[str, Any], event: dict[str, Any], field: str)
         return ""
     if field == "latency":
         if int(EEG.get("trials", 1) or 1) > 1:
-            return value
+            return float(
+                eeg_point2lat(
+                    float(value),
+                    event.get("epoch", 1),
+                    float(EEG.get("srate", 1)),
+                    [float(EEG.get("xmin", 0)) * 1000, float(EEG.get("xmax", 0)) * 1000],
+                    1e-3,
+                ).item()
+            )
         return (float(value) - 1) / float(EEG.get("srate", 1)) + float(EEG.get("xmin", 0))
     if field == "duration":
         scale = float(EEG.get("srate", 1)) / (1000 if int(EEG.get("trials", 1) or 1) > 1 else 1)

--- a/src/eegprep/functions/popfunc/pop_fileio.py
+++ b/src/eegprep/functions/popfunc/pop_fileio.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import mne
+import scipy.io
 
 from eegprep.functions.popfunc._file_io import mne_raw_to_eeg
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc.pop_importdata import pop_importdata
-from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.functions.popfunc.pop_loadset import _is_hdf5_file, pop_loadset
+
+logger = logging.getLogger(__name__)
+
+# Fields that mark a .mat as a saved EEGLAB dataset rather than a raw data array.
+_EEGLAB_STRUCT_MARKERS = frozenset({"nbchan", "srate", "pnts", "trials", "chanlocs", "setname", "xmin", "xmax"})
 
 
 def pop_fileio(
@@ -22,9 +29,11 @@ def pop_fileio(
     if suffix == ".set":
         eeg = pop_loadset(str(path))
     elif suffix == ".mat" and kwargs.get("dataformat") != "matlab-array":
-        try:
+        if _mat_is_eeglab_dataset(path):
+            logger.info("pop_fileio: loading %s as an EEGLAB dataset", path)
             eeg = pop_loadset(str(path))
-        except Exception:
+        else:
+            logger.info("pop_fileio: importing %s as a raw MATLAB data array", path)
             eeg = pop_importdata("data", str(path), "setname", path.stem, "dataformat", "matlab", **kwargs)
     elif suffix in {".csv", ".txt", ".tsv", ".npy", ".npz"}:
         eeg = pop_importdata("data", str(path), "setname", path.stem, **kwargs)
@@ -35,6 +44,18 @@ def pop_fileio(
     command = f"EEG = pop_fileio({format_history_value(path)});"
     eeg["history"] = command
     return (eeg, command) if return_com else eeg
+
+
+def _mat_is_eeglab_dataset(path: Path) -> bool:
+    """Return True when a .mat file holds an EEGLAB dataset rather than a raw data array.
+
+    A dataset is recognized by an ``EEG`` struct variable or by top-level EEGLAB marker
+    fields (a .set saved with ``-struct``). MAT v7.3 files are HDF5 and always EEGLAB sets.
+    """
+    if _is_hdf5_file(path):
+        return True
+    names = {name for name, _shape, _cls in scipy.io.whosmat(str(path))}
+    return "EEG" in names or bool(names & _EEGLAB_STRUCT_MARKERS)
 
 
 def _reader_for_suffix(suffix: str):

--- a/src/eegprep/functions/popfunc/pop_loadset.py
+++ b/src/eegprep/functions/popfunc/pop_loadset.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 
+import h5py
 import numpy as np
 import scipy.io
 
@@ -81,16 +82,16 @@ def pop_loadset(file_path=None, *args, loadmode="all", memmap=None, **kwargs):
                 dict_obj[field_name] = new_check(field_value)
             return dict_obj
 
-    # Load MATLAB file
-    loaded_with_h5 = False
-    try:
+    # Load MATLAB file. MAT v7.3 files are HDF5; older v5/v7 files are not.
+    # Dispatch on the real format instead of treating every scipy error as "must be HDF5".
+    loaded_with_h5 = _is_hdf5_file(file_path)
+    if loaded_with_h5:
+        EEG = pop_loadset_h5(file_path)
+    else:
         EEG = scipy.io.loadmat(file_path, struct_as_record=False, squeeze_me=True, appendmat=False)
         EEG = new_check(EEG)
         if 'EEG' in EEG:
             EEG = EEG['EEG']
-    except Exception:
-        EEG = pop_loadset_h5(file_path)
-        loaded_with_h5 = True
 
     EEG['filepath'] = os.path.dirname(file_path)
     EEG['filename'] = os.path.basename(file_path)
@@ -126,6 +127,15 @@ def pop_loadset(file_path=None, *args, loadmode="all", memmap=None, **kwargs):
                 EEG['event'][i]['urevent'] = EEG['event'][i]['urevent'] - 1
 
     return EEG
+
+
+def _is_hdf5_file(file_path):
+    """Return True when the file is HDF5 (MAT v7.3).
+
+    MAT v7.3 files carry a text header in an HDF5 userblock, so the signature is not at
+    byte 0; ``h5py.is_hdf5`` checks the userblock offsets HDF5 actually uses.
+    """
+    return h5py.is_hdf5(os.fspath(file_path))
 
 
 def _load_options(file_path, args, kwargs, loadmode, memmap):

--- a/src/eegprep/functions/popfunc/pop_loadset_h5.py
+++ b/src/eegprep/functions/popfunc/pop_loadset_h5.py
@@ -30,12 +30,6 @@ def pop_loadset_h5(file_name):
     def convert_to_string(filecontent):
         if isinstance(filecontent, np.ndarray):
             if filecontent.dtype == 'uint16':
-                # Special handling for the test case with emoji
-                if len(filecontent) == 10 and np.array_equal(
-                    filecontent, np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150])
-                ):
-                    return 'hello 👖'
-
                 # Convert uint16 array to bytes and then decode as UTF-8
                 try:
                     # Convert uint16 values to bytes

--- a/src/eegprep/functions/popfunc/pop_select.py
+++ b/src/eegprep/functions/popfunc/pop_select.py
@@ -208,12 +208,12 @@ def _pop_select_apply(EEG, **kwargs):
     else:
         # by type
         if _decode_list(g['chantype']):
-            inds = eeg_decodechan(EEG, g['chantype'], 'type', True)
+            inds, _ = eeg_decodechan(EEG, g['chantype'], 'type', True)
             chan_selected_flag[:] = False
             chan_selected_flag[np.array(inds, dtype=int)] = True
 
         if _decode_list(g['rmchantype']):
-            inds = eeg_decodechan(EEG, g['rmchantype'], 'type', True)
+            inds, _ = eeg_decodechan(EEG, g['rmchantype'], 'type', True)
             chan_selected_flag[np.array(inds, dtype=int)] = False
 
     g['channel'] = np.where(chan_selected_flag)[0].tolist()

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -56,6 +56,7 @@ def pop_spectopo(
         map_labels = None
         title = "Channel spectra and maps"
     else:
+        _raise_for_unsupported_component_options(options)
         plot_data, component_numbers = _component_spectral_data(EEG, timerange, options.get("icacomps"))
         maps, chanlocs = component_map_data(EEG)
         map_numbers = _component_map_numbers(
@@ -233,6 +234,27 @@ def _component_map_numbers(
     if np.any(numbers < 1) or np.any(numbers > map_count):
         raise ValueError(f"component map indices must be within 1..{map_count}")
     return numbers.astype(int)
+
+
+def _raise_for_unsupported_component_options(options: dict[str, Any]) -> None:
+    """Fail loudly when component controls EEGPrep does not implement are set to non-default values.
+
+    EEGLAB's component dialog offers ``plotchan`` (``0`` = whole scalp) and ``icamode``
+    (checked = component spectra). EEGPrep only computes whole-scalp component spectra, so a
+    non-default ``plotchan`` (a specific electrode or ``[]`` = max-power electrode) or an unchecked
+    ``icamode`` ((data-comp) spectra) is rejected instead of being silently ignored.
+    """
+    if "plotchan" in options:
+        plotchan = numeric_vector(options["plotchan"])
+        if plotchan.size != 1 or int(plotchan[0]) != 0:
+            raise ValueError(
+                "pop_spectopo only supports whole-scalp component spectra (plotchan=0); "
+                "per-electrode or max-power projection is not available in EEGPrep"
+            )
+    if "icamode" in options and not bool(options["icamode"]):
+        raise ValueError(
+            "pop_spectopo only supports component spectra (icamode on); (data-comp) spectra is not available in EEGPrep"
+        )
 
 
 def _split_spectopo_options(options: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/eegprep/functions/sigprocfunc/eegrej.py
+++ b/src/eegprep/functions/sigprocfunc/eegrej.py
@@ -135,10 +135,12 @@ def eegrej(
                     extra += float(ev.get("duration", 0.0) or 0.0)
             durations[i_region] += extra
 
-    # Compute boundevents considering prior removals
+    # Compute boundevents considering prior removals. EEGLAB shifts each later
+    # boundary by the prior regions' base spans (eegrej.m L139), not by the
+    # augmented durations (those only feed the inserted boundary's .duration).
     boundevents = r[:, 0].astype(float) - 1.0
-    if len(durations) > 1:
-        cums = np.concatenate([[0.0], np.cumsum(durations[:-1])])
+    if len(base_durations) > 1:
+        cums = np.concatenate([[0.0], np.cumsum(base_durations[:-1].astype(float))])
         boundevents = boundevents - cums
     boundevents = boundevents + 0.5
     boundevents = boundevents[boundevents >= 0]

--- a/src/eegprep/functions/sigprocfunc/epoch.py
+++ b/src/eegprep/functions/sigprocfunc/epoch.py
@@ -89,12 +89,10 @@ def epoch(data, events, lim, **kwargs):
         posinit = pos0 + reallim[0]  # 0-based + offset
         posend = pos0 + reallim[1]  # 0-based + offset
 
-        # Boundary check: MATLAB uses 1-based logic for boundary checks
-        # Convert to 1-based for the boundary check only
-        posinit_1based = posinit + 1
-        posend_1based = posend + 1
-        within_one_epoch = np.floor((posinit_1based - 1) / dataframes) == np.floor((posend_1based - 1) / dataframes)
-        within_bounds = (posinit_1based >= 1) and (posend_1based <= datawidth)
+        # Boundary check in MATLAB coordinates: data(:,posinit:posend) requires
+        # posinit >= 1 and posend <= datawidth, matching the posinit-1 slice start below.
+        within_one_epoch = np.floor((posinit - 1) / dataframes) == np.floor((posend - 1) / dataframes)
+        within_bounds = (posinit >= 1) and (posend <= datawidth)
 
         if within_one_epoch and within_bounds:
             # Extract contiguous slice. MATLAB does data(:,posinit:posend) with posinit/posend in MATLAB coordinates

--- a/src/eegprep/functions/sigprocfunc/runamica.py
+++ b/src/eegprep/functions/sigprocfunc/runamica.py
@@ -827,23 +827,30 @@ def runamica(
     # Write parameter file
     param_file = _write_param_file(outdir, params)
 
-    # Run the binary
-    _run_amica(binary, param_file)
+    try:
+        # Run the binary
+        _run_amica(binary, param_file)
 
-    # Load output
-    mods = _load_amica_output(
-        outdir,
-        num_models=num_models,
-        num_pcs=pcakeep,
-        data_dim=chans,
-        num_mix_comps=num_mix_comps,
-        max_iter=max_iter,
-        field_dim=frames,
-    )
+        # Load output
+        mods = _load_amica_output(
+            outdir,
+            num_models=num_models,
+            num_pcs=pcakeep,
+            data_dim=chans,
+            num_mix_comps=num_mix_comps,
+            max_iter=max_iter,
+            field_dim=frames,
+        )
 
-    # Extract model 0 weights and sphere
-    weights = mods['W'][:, :, 0]
-    sphere = mods['S'][: mods['num_pcs'], :]
+        # Extract model 0 weights and sphere
+        weights = mods['W'][:, :, 0]
+        sphere = mods['S'][: mods['num_pcs'], :]
+    except BaseException:
+        # A failed run/load must not leak the temp dir we created (it holds the
+        # full float32 .fdt data copy). Remove it, then re-raise the real error.
+        if tmp_created:
+            shutil.rmtree(outdir, ignore_errors=True)
+        raise
 
     # Cleanup
     if cleanup:

--- a/src/eegprep/functions/studyfunc/std_makedesign.py
+++ b/src/eegprep/functions/studyfunc/std_makedesign.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
@@ -48,9 +49,10 @@ def std_makedesign(
 ) -> Any:
     """Create or replace a 1-based STUDY design.
 
-    This Phase 5a implementation stores design metadata and factor selections.
-    Measure-file deletion/precompute side effects from EEGLAB are intentionally
-    outside this phase.
+    Design metadata and factor selections are stored. ``delfiles`` controls
+    cached measure arrays: ``'on'`` or ``'limited'`` clear them on the design
+    change, while ``'off'`` preserves any precomputed ``changrp``/``cluster``
+    measures attached to the redefined design.
     """
     datasets = as_alleeg_list(ALLEEG)
     study = sync_datasetinfo(ensure_study(STUDY), datasets)
@@ -105,7 +107,14 @@ def std_makedesign(
     designs[design_index - 1] = design
     study["design"] = designs
     study = std_addvarlevel(study, design_index)
+    preserved_changrp = deepcopy(study.get("changrp")) if delfiles == "off" else None
+    preserved_cluster = deepcopy(study.get("cluster")) if delfiles == "off" else None
     study = std_selectdesign(study, datasets, design_index)
+    if delfiles == "off":
+        if preserved_changrp is not None:
+            study["changrp"] = preserved_changrp
+        if preserved_cluster is not None:
+            study["cluster"] = preserved_cluster
     study["cache"] = []
     study["saved"] = "no"
     study = store_consistency(study, datasets)

--- a/src/eegprep/functions/studyfunc/std_precomp.py
+++ b/src/eegprep/functions/studyfunc/std_precomp.py
@@ -80,12 +80,15 @@ def std_precomp(
     if not computed:
         raise ValueError("std_precomp requires at least one measure enabled")
     kind = _measure_kind(chanorcomp)
+    force = is_on(recompute)
     if kind == "channels":
         study["changrp"] = _precompute_channels(
             datasets,
             chanorcomp,
             computed,
             int(design),
+            cached=_cached_by_name(study.get("changrp")),
+            force=force,
             erpparams=_params_dict(erpparams),
             specparams=_params_dict(specparams),
             erspparams=_params_dict(erspparams),
@@ -97,6 +100,8 @@ def std_precomp(
             chanorcomp,
             computed,
             int(design),
+            cached=_first_cluster(study.get("cluster")),
+            force=force,
             allcomps=is_on(allcomps),
             scalp=is_on(scalp),
             erpparams=_params_dict(erpparams),
@@ -136,6 +141,8 @@ def _precompute_channels(
     computed: list[str],
     design: int,
     *,
+    cached: dict[str, dict[str, Any]],
+    force: bool,
     erpparams: dict[str, Any],
     specparams: dict[str, Any],
     erspparams: dict[str, Any],
@@ -145,6 +152,7 @@ def _precompute_channels(
     groups = []
     for channel_index in selected:
         label = labels[channel_index]
+        prior = cached.get(label, {})
         entry: dict[str, Any] = {
             "name": label,
             "channels": [label],
@@ -159,17 +167,33 @@ def _precompute_channels(
             },
         }
         if "erp" in computed:
-            entry["erpdata"], entry["erptimes"] = _channel_erp(datasets, channel_index, erpparams)
+            if _keep_cached(prior, "erpdata", force):
+                _carry(entry, prior, ("erpdata", "erptimes"))
+            else:
+                entry["erpdata"], entry["erptimes"] = _channel_erp(datasets, channel_index, erpparams)
         if "spec" in computed:
-            entry["specdata"], entry["specfreqs"] = _channel_spec(datasets, channel_index, specparams)
-        if "ersp" in computed or "itc" in computed:
+            if _keep_cached(prior, "specdata", force):
+                _carry(entry, prior, ("specdata", "specfreqs"))
+            else:
+                entry["specdata"], entry["specfreqs"] = _channel_spec(datasets, channel_index, specparams)
+        ersp_cached = _keep_cached(prior, "erspdata", force) if "ersp" in computed else True
+        itc_cached = _keep_cached(prior, "itcdata", force) if "itc" in computed else True
+        if ("ersp" in computed and not ersp_cached) or ("itc" in computed and not itc_cached):
             tf = _channel_time_frequency(datasets, channel_index, erspparams)
-            if "ersp" in computed:
+        else:
+            tf = None
+        if "ersp" in computed:
+            if ersp_cached:
+                _carry(entry, prior, ("erspdata", "ersptimes", "erspfreqs", "erspbase"))
+            else:
                 entry["erspdata"] = tf["erspdata"]
                 entry["ersptimes"] = tf["times"]
                 entry["erspfreqs"] = tf["freqs"]
                 entry["erspbase"] = tf["powbase"]
-            if "itc" in computed:
+        if "itc" in computed:
+            if itc_cached:
+                _carry(entry, prior, ("itcdata", "itctimes", "itcfreqs"))
+            else:
                 entry["itcdata"] = tf["itcdata"]
                 entry["itctimes"] = tf["times"]
                 entry["itcfreqs"] = tf["freqs"]
@@ -184,6 +208,8 @@ def _precompute_components(
     computed: list[str],
     design: int,
     *,
+    cached: dict[str, Any],
+    force: bool,
     allcomps: bool,
     scalp: bool,
     erpparams: dict[str, Any],
@@ -213,21 +239,37 @@ def _precompute_components(
     if scalp:
         cluster["topo"] = _component_topographies(datasets, selected, selection_mask)
     if "erp" in computed:
-        cluster["erpdata"], cluster["erptimes"] = _component_erp(
-            datasets, activations, selected, selection_mask, erpparams
-        )
+        if _keep_cached(cached, "erpdata", force):
+            _carry(cluster, cached, ("erpdata", "erptimes"))
+        else:
+            cluster["erpdata"], cluster["erptimes"] = _component_erp(
+                datasets, activations, selected, selection_mask, erpparams
+            )
     if "spec" in computed:
-        cluster["specdata"], cluster["specfreqs"] = _component_spec(
-            datasets, activations, selected, selection_mask, specparams
-        )
-    if "ersp" in computed or "itc" in computed:
+        if _keep_cached(cached, "specdata", force):
+            _carry(cluster, cached, ("specdata", "specfreqs"))
+        else:
+            cluster["specdata"], cluster["specfreqs"] = _component_spec(
+                datasets, activations, selected, selection_mask, specparams
+            )
+    ersp_cached = _keep_cached(cached, "erspdata", force) if "ersp" in computed else True
+    itc_cached = _keep_cached(cached, "itcdata", force) if "itc" in computed else True
+    if ("ersp" in computed and not ersp_cached) or ("itc" in computed and not itc_cached):
         tf = _component_time_frequency(datasets, activations, selected, selection_mask, erspparams)
-        if "ersp" in computed:
+    else:
+        tf = None
+    if "ersp" in computed:
+        if ersp_cached:
+            _carry(cluster, cached, ("erspdata", "ersptimes", "erspfreqs", "erspbase"))
+        else:
             cluster["erspdata"] = tf["erspdata"]
             cluster["ersptimes"] = tf["times"]
             cluster["erspfreqs"] = tf["freqs"]
             cluster["erspbase"] = tf["powbase"]
-        if "itc" in computed:
+    if "itc" in computed:
+        if itc_cached:
+            _carry(cluster, cached, ("itcdata", "itctimes", "itcfreqs"))
+        else:
             cluster["itcdata"] = tf["itcdata"]
             cluster["itctimes"] = tf["times"]
             cluster["itcfreqs"] = tf["freqs"]
@@ -445,6 +487,28 @@ def _component_topographies(
             dataset_maps.append(maps[:, component_index])
         topographies.append(np.asarray(dataset_maps, dtype=float))
     return np.asarray(topographies, dtype=float).tolist()
+
+
+def _keep_cached(prior: dict[str, Any], data_field: str, force: bool) -> bool:
+    return not force and data_field in prior
+
+
+def _carry(target: dict[str, Any], prior: dict[str, Any], fields: tuple[str, ...]) -> None:
+    for field in fields:
+        if field in prior:
+            target[field] = prior[field]
+
+
+def _cached_by_name(changrp: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(changrp, list):
+        return {}
+    return {entry["name"]: entry for entry in changrp if isinstance(entry, dict) and entry.get("name")}
+
+
+def _first_cluster(cluster: Any) -> dict[str, Any]:
+    if isinstance(cluster, list) and cluster and isinstance(cluster[0], dict):
+        return cluster[0]
+    return {}
 
 
 def _measure_kind(chanorcomp: Any) -> str:

--- a/src/eegprep/functions/timefreqfunc/_pac_support.py
+++ b/src/eegprep/functions/timefreqfunc/_pac_support.py
@@ -88,12 +88,16 @@ def compute_pac(
     **kwargs: Any,
 ) -> PacResult:
     """Compute EEGLAB-style phase-amplitude coupling from epoched data."""
-    _ = title, vert, newfig
     unsupported = sorted(kwargs)
     if unsupported:
         raise TypeError(f"Unsupported pac option(s): {', '.join(unsupported)}")
     if alpha is not None:
         raise NotImplementedError(PAC_UNSUPPORTED_MESSAGE)
+    if str(title) != "" or vert is not None or str(newfig).strip().lower() not in {"on", "1", "true", "yes"}:
+        raise NotImplementedError(
+            "compute_pac returns PAC arrays without plotting; the 'title', 'vert', and "
+            "'newfig' plotting options are not implemented"
+        )
     method_name = str(method or "mod").lower()
     if method_name == "modulation":
         method_name = "mod"

--- a/src/eegprep/functions/timefreqfunc/newtimef.py
+++ b/src/eegprep/functions/timefreqfunc/newtimef.py
@@ -84,7 +84,10 @@ def newtimef(
     verbose: str = "off",
 ) -> TimeFrequencyResult:
     """Compute an EEGLAB-like ERSP/ITC time-frequency decomposition."""
-    _ = overlap, plotphase
+    if overlap is not None:
+        raise NotImplementedError("newtimef does not implement the 'overlap' option")
+    if str(plotphase).strip().lower() not in {"off", "0", "false", "no", "none"}:
+        raise NotImplementedError("newtimef does not implement the 'plotphase' option")
     if freqs is None and freqrange is not None:
         freqs = freqrange
     if type is not None:
@@ -242,7 +245,8 @@ def compute_time_frequency(
     timewarpms: Any = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Return ``(freqs, times_ms, tfdata)`` for one signal."""
-    _ = overlap
+    if overlap is not None:
+        raise NotImplementedError("compute_time_frequency does not implement the 'overlap' option")
     timestretch, _markers = _timewarp_options(timewarp, timewarpms, None, frames, tlimits, srate)
     decomp = _compute_decomposition(
         data,
@@ -698,7 +702,7 @@ def _colon_sequence(token: str) -> list[float]:
 
 
 def _is_on(value: Any) -> bool:
-    return str(value).lower() not in {"0", "false", "off", "no", "none"}
+    return str(value).strip().lower() in {"1", "on", "true", "yes"}
 
 
 __all__ = ["TimeFrequencyResult", "compute_time_frequency", "newtimef"]

--- a/src/eegprep/plugins/EEG_BIDS/bids.py
+++ b/src/eegprep/plugins/EEG_BIDS/bids.py
@@ -71,7 +71,7 @@ def query_for_adjacent_fpath(fn: str, **overrides) -> Dict[str, Any]:
 def gen_derived_fpath(
     raw_fn: str,
     *,
-    outputdir: str = '${root}/derivatives/clean_artifacts',
+    outputdir: str = '{root}/derivatives/clean_artifacts',
     keyword: str = '',
     suffix: Optional[str] = None,
     extension: str = '.set',
@@ -84,6 +84,8 @@ def gen_derived_fpath(
         Original raw filename.
     outputdir : str
         Output directory for derived files (e.g., 'derivatives/clean_artifacts').
+        The literal '{root}' placeholder, if present, is replaced with the BIDS
+        dataset root path.
     keyword : str
         Optional keyword tag to splice into the filename (e.g., 'desc-cleaned').
     suffix : str, optional
@@ -122,7 +124,7 @@ def gen_derived_fpath(
             # single directory name, need to prepend everything else
             outputdir = os.path.join(root_relative, 'derivatives', outputdir)
 
-    out_path = f"{outputdir}/{root_relative}/{new_fprefix}{new_fext}"
+    out_path = os.path.join(outputdir, root_relative, new_fprefix + new_fext)
     return out_path
 
 

--- a/src/eegprep/plugins/ICLabel/ICL_feature_extractor.py
+++ b/src/eegprep/plugins/ICLabel/ICL_feature_extractor.py
@@ -28,15 +28,14 @@ def ICL_feature_extractor(EEG, flag_autocorr=False):
 
     EEG = deepcopy(EEG)
 
-    # Check inputs
-    ncomp = EEG['icawinv'].shape[1]
-
-    # Check for ICA key and if it is not empty
+    # Check for ICA key and if it is not empty before dereferencing it
     if 'icawinv' not in EEG.keys() or EEG['icawinv'].size == 0:
         raise ValueError('You must have an ICA decomposition to use ICLabel')
 
+    ncomp = EEG['icawinv'].shape[1]
+
     # Assuming chanlocs are correct
-    if EEG['ref'] != 'average' and EEG['ref'] != 'averef':
+    if EEG.get('ref') != 'average' and EEG.get('ref') != 'averef':
         EEG = pop_reref(EEG, [])
 
     # Calculate ICA activations if missing and cast to double

--- a/src/eegprep/plugins/clean_rawdata/asr_calibrate.py
+++ b/src/eegprep/plugins/clean_rawdata/asr_calibrate.py
@@ -12,6 +12,9 @@ from .private.stats import fit_eeg_distribution, geometric_median
 
 logger = logging.getLogger(__name__)
 
+# Sampling rates (Hz) for which a pre-computed spectral-shaping IIR filter is available.
+_SUPPORTED_SRATES = frozenset({100, 128, 200, 250, 256, 300, 500, 512})
+
 
 def asr_calibrate(
     X,
@@ -356,16 +359,14 @@ def asr_calibrate(
                 dtype=np.float64,
             )
         else:
-            # Fallback if no precomputed filter matches or yulewalk is unavailable
-            # Consider adding a call to a yulewalk implementation if available,
-            # or raising a more specific error/warning.
-            logger.warning(
-                f"No pre-computed spectral filter for srate {srate}. Using a simple default (may be suboptimal)."
+            # No precomputed spectral-shaping filter for this sampling rate. Degrading
+            # to a trivial difference filter would silently miscalibrate the ASR
+            # thresholds, so fail loudly instead (mirrors MATLAB's asr_calibrate:NoYulewalk).
+            raise ValueError(
+                f"No pre-computed ASR spectral filter for srate {srate} Hz "
+                f"(supported: {sorted(_SUPPORTED_SRATES)}). Resample the data to a "
+                "supported rate or pass explicit filter coefficients via B and A."
             )
-            B = np.array([1.0, -1.0])  # Simple high-pass/difference filter as a basic fallback
-            A = np.array([1.0])
-            # Original MATLAB error:
-            # error('asr_calibrate:NoYulewalk','The yulewalk() function was not found and there is no pre-computed spectral filter for your sampling rate...');
 
     # Ensure data is finite
     X[~np.isfinite(X)] = 0.0

--- a/src/eegprep/plugins/clean_rawdata/asr_process.py
+++ b/src/eegprep/plugins/clean_rawdata/asr_process.py
@@ -192,15 +192,13 @@ def asr_process(
                 logger.warning(f"Eigendecomposition failed at update point {j}. Using identity matrix.")
                 D, V = np.ones(C), np.eye(C)
 
-            # Determine which components to keep (variance below threshold or not admissible for rejection)
-            try:
-                thresholds = np.sum(finite_matmul(T, V) ** 2, axis=0)
-                keep = (D < thresholds) | (np.arange(1, C + 1) < (C - max_dims_num))
-                trivial = np.all(keep)
-            except Exception as e:
-                logger.error(f"Error in component selection: {e}")
-                keep = np.ones(C, dtype=bool)
-                trivial = True
+            # Determine which components to keep (variance below threshold or not admissible for rejection).
+            # No catch-all here: a shape/contract error in T/V must surface rather than silently
+            # disable artifact removal for this window. Genuine numerical-singularity cases are
+            # handled by the LinAlgError fallbacks for eigendecomposition and the pseudo-inverse.
+            thresholds = np.sum(finite_matmul(T, V) ** 2, axis=0)
+            keep = (D < thresholds) | (np.arange(1, C + 1) < (C - max_dims_num))
+            trivial = np.all(keep)
 
             # Update the reconstruction matrix R
             if not trivial:

--- a/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_artifacts.py
@@ -116,9 +116,12 @@ def clean_artifacts(
         Riemannian path uses EEGPrep's calibration-time estimate; full
         Riemannian ASR processing is not ported.
     Channels : sequence of str or None
-        List of channel labels to include before cleaning (pop_select). Default None.
+        List of channel labels to include before cleaning (pop_select). The
+        returned dataset contains only these channels; channels outside this list
+        are dropped and not re-inserted. Default None.
     Channels_ignore : sequence of str or None
-        List of channel labels to exclude before cleaning. Default None.
+        List of channel labels to exclude before cleaning. The excluded channels
+        are dropped from the returned dataset and not re-inserted. Default None.
     availableRAM_GB : float or None
         Available system RAM in GB to adjust MaxMem. Default None.
 
@@ -154,32 +157,31 @@ def clean_artifacts(
     #             Optional: restrict to / ignore certain channels
     # ------------------------------------------------------------------
     if Channels is not None and len(Channels):
-        # Attempt pop_select based on labels; fall back to manual
+        # Attempt pop_select based on labels; the manual fallback only covers the
+        # documented case where pop_select is unavailable (ImportError). Errors
+        # raised inside pop_select itself must surface, not be masked.
         try:
             from eegprep import pop_select
 
             EEG = pop_select(EEG, channel=list(Channels))
-        except Exception:
-            # Manual selection on labels
+        except ImportError:
             lbl_to_idx = {ch['labels']: idx for idx, ch in enumerate(EEG['chanlocs'])}
             keep_idx = [lbl_to_idx[lbl] for lbl in Channels if lbl in lbl_to_idx]
             EEG['data'] = EEG['data'][keep_idx, :]
             EEG['chanlocs'] = [EEG['chanlocs'][i] for i in keep_idx]
             EEG['nbchan'] = len(keep_idx)
-        EEG['event'] = []  # will be restored later
     elif Channels_ignore is not None and len(Channels_ignore):
         try:
             from eegprep import pop_select
 
             EEG = pop_select(EEG, nochannel=list(Channels_ignore))
-        except Exception:
+        except ImportError:
             lbl_to_idx = {ch['labels']: idx for idx, ch in enumerate(EEG['chanlocs'])}
             drop_idx_set = {lbl_to_idx[lbl] for lbl in Channels_ignore if lbl in lbl_to_idx}
             keep_idx = [i for i in range(len(EEG['chanlocs'])) if i not in drop_idx_set]
             EEG['data'] = EEG['data'][keep_idx, :]
             EEG['chanlocs'] = [EEG['chanlocs'][i] for i in keep_idx]
             EEG['nbchan'] = len(keep_idx)
-        EEG['event'] = []
 
     # ------------------------------------------------------------------
     #                     1) Flat‑line channel removal
@@ -220,10 +222,17 @@ def clean_artifacts(
                 num_samples=int(NumSamples),
                 subset_size=SubsetSize,  # Default 0.25, matches MATLAB default when not passed
             )
-            removed_channels = ~EEG['etc']['clean_channel_mask']
-        except Exception as e:
-            # Fall back to "no‑locs" version if location dependent failure
-            logger.warning(f'clean_channels failed ({e}); falling back to clean_channels_nolocs.')
+            # clean_channels only writes clean_channel_mask when it removes channels;
+            # an absent mask means nothing was removed, so keep the all-False default.
+            mask = EEG.get('etc', {}).get('clean_channel_mask')
+            if mask is not None:
+                removed_channels = ~mask
+        except ValueError as e:
+            # Only the missing-channel-locations case warrants the no-locs fallback;
+            # any other ValueError is a genuine failure and must propagate.
+            if 'location' not in str(e).lower():
+                raise
+            logger.warning(f'clean_channels lacks usable locations ({e}); falling back to clean_channels_nolocs.')
             EEG, removed_channels = clean_channels_nolocs(
                 EEG,
                 min_corr=float(NoLocsChannelCriterion),
@@ -291,11 +300,9 @@ def clean_artifacts(
 
     logger.info('Use vis_artifacts to compare the cleaned data to the original.')
 
-    # ------------------------------------------------------------------
-    #                  Optionally re‑insert ignored channels
-    # ------------------------------------------------------------------
-    # The full MATLAB logic is complicated; the Python port currently skips the
-    # re‑insertion of previously excluded channels for simplicity. Users can
-    # merge channels back manually if needed.
+    # When Channels/Channels_ignore restrict the dataset, the returned EEG holds
+    # only the cleaned subset; excluded channels are not re-inserted (unlike the
+    # MATLAB reference). Callers that need the ignored channels back must merge
+    # them manually. This is documented on the Channels/Channels_ignore parameters.
 
     return EEG, HP, BUR, removed_channels

--- a/src/eegprep/plugins/clean_rawdata/clean_asr.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_asr.py
@@ -119,10 +119,14 @@ def clean_asr(
                     "clean_windows returned insufficient data. Falling back to using all data for calibration."
                 )
                 ref_section_data = data
-        except Exception as e:
-            logger.error(f"An error occurred during clean_windows: {e}")
+        except ValueError as e:
+            # clean_windows raises ValueError for expected calibration-data problems
+            # (empty data, window too small, not enough data for one window). Only
+            # those warrant the all-data fallback; unexpected exceptions propagate so
+            # genuine bugs are not masked as silently weaker ASR calibration.
             logger.warning(
-                "Could not automatically identify clean calibration data. Falling back to using the entire data for calibration."
+                f"Could not automatically identify clean calibration data ({e}). "
+                "Falling back to using the entire data for calibration."
             )
             ref_section_data = data
     elif (isinstance(ref_maxbadchannels, str) and ref_maxbadchannels.lower() == 'off') or ref_maxbadchannels is None:

--- a/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
@@ -67,7 +67,8 @@ def clean_flatlines(EEG: Dict[str, Any], max_flatline_duration: float = 5.0, max
             EEG['nbchan'] = EEG['data'].shape[0]
             for fn in EEG.keys() & {'icawinv', 'icasphere', 'icaweights', 'icaact', 'stats', 'specdata', 'specicaact'}:
                 EEG[fn] = np.array([])
-            if CCM := EEG['etc'].get('clean_channel_mask') is not None:
+            CCM = EEG['etc'].get('clean_channel_mask')
+            if CCM is not None:
                 CCM[CCM] = ~removed_channels
             else:
                 EEG['etc']['clean_channel_mask'] = ~removed_channels

--- a/tests/test_ICL_feature_extractor.py
+++ b/tests/test_ICL_feature_extractor.py
@@ -81,22 +81,31 @@ class TestICLFeatureExtractorBasic(unittest.TestCase):
         )
 
     def test_icl_feature_extractor_missing_ica_winv(self):
-        """Test ICL_feature_extractor with missing icawinv."""
+        """Missing icawinv raises a clear ValueError before any dereference."""
         EEG = self.test_eeg.copy()
         del EEG['icawinv']
 
-        # Function has a bug - it tries to access icawinv before checking if it exists
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError) as cm:
             ICL_feature_extractor(EEG)
+        self.assertIn('ICA decomposition', str(cm.exception))
 
     def test_icl_feature_extractor_empty_ica_winv(self):
-        """Test ICL_feature_extractor with empty icawinv."""
+        """Empty icawinv raises a clear ValueError before any dereference."""
         EEG = self.test_eeg.copy()
         EEG['icawinv'] = np.array([])
 
-        # Function has a bug - it tries to access shape[1] on empty array
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError) as cm:
             ICL_feature_extractor(EEG)
+        self.assertIn('ICA decomposition', str(cm.exception))
+
+    def test_icl_feature_extractor_missing_ref_field(self):
+        """A dataset without a 'ref' field is treated as non-average and re-referenced."""
+        EEG = self.test_eeg.copy()
+        del EEG['ref']
+
+        # Must not raise KeyError on the missing 'ref'; should proceed to feature extraction.
+        features = ICL_feature_extractor(EEG, flag_autocorr=False)
+        self.assertEqual(len(features), 2)
 
     def test_icl_feature_extractor_missing_icaact(self):
         """Test ICL_feature_extractor with missing icaact."""

--- a/tests/test_bids_gen_derived_fpath.py
+++ b/tests/test_bids_gen_derived_fpath.py
@@ -1,0 +1,52 @@
+"""Unit tests for gen_derived_fpath path construction (no MATLAB/pybids needed)."""
+
+import os
+import unittest
+
+from eegprep.plugins.EEG_BIDS.bids import gen_derived_fpath
+
+
+def _raw_fpath():
+    # A BIDS-style raw EEG file path inside a dataset rooted at <root>.
+    return os.path.join(os.sep, 'data', 'ds001', 'sub-01', 'eeg', 'sub-01_task-rest_eeg.set')
+
+
+class TestGenDerivedFpath(unittest.TestCase):
+    def test_default_root_placeholder_substituted(self):
+        """The default outputdir's {root} placeholder is replaced with the dataset root.
+
+        Reproduces the bug where the documented default '${root}/...' left a literal
+        placeholder ('$/data/...') in the output path.
+        """
+        out = gen_derived_fpath(_raw_fpath(), keyword='desc-cleaned')
+        expected = os.path.join(
+            os.sep,
+            'data',
+            'ds001',
+            'derivatives',
+            'clean_artifacts',
+            'sub-01',
+            'eeg',
+            'sub-01_task-rest_desc-cleaned_eeg.set',
+        )
+        self.assertEqual(out, expected)
+        self.assertNotIn('{root}', out)
+        self.assertNotIn('$', out)
+
+    def test_explicit_root_placeholder_substituted(self):
+        """An explicit '{root}/...' outputdir is substituted with the dataset root."""
+        out = gen_derived_fpath(_raw_fpath(), outputdir='{root}/derivatives/eegprep')
+        expected = os.path.join(
+            os.sep, 'data', 'ds001', 'derivatives', 'eegprep', 'sub-01', 'eeg', 'sub-01_task-rest_eeg.set'
+        )
+        self.assertEqual(out, expected)
+
+    def test_path_assembly_uses_os_sep(self):
+        """The assembled path uses the OS separator throughout (no hardcoded '/')."""
+        out = gen_derived_fpath(_raw_fpath(), keyword='desc-cleaned')
+        # Every separator must be the platform separator produced by os.path.join.
+        self.assertEqual(out, os.path.normpath(out))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_clean_artifacts.py
+++ b/tests/test_clean_artifacts.py
@@ -988,5 +988,118 @@ class TestCleanArtifactsIntegration(DebuggableTestCase):
             self.skipTest(f"clean_artifacts return values not available: {e}")
 
 
+class TestCleanArtifactsErrorSurfacing(DebuggableTestCase):
+    """Errors inside the selection / channel-cleaning paths must surface, not be masked."""
+
+    def setUp(self):
+        self.test_eeg = create_test_eeg()
+
+    def test_pop_select_internal_error_propagates(self):
+        """A non-ImportError raised inside pop_select must propagate, not silently
+        fall back to manual label selection (which could select different channels).
+        """
+        import eegprep
+
+        original = eegprep.pop_select
+
+        def failing_pop_select(*args, **kwargs):
+            raise RuntimeError("simulated pop_select bug")
+
+        eegprep.pop_select = failing_pop_select
+        try:
+            with self.assertRaises(RuntimeError):
+                clean_artifacts(
+                    self.test_eeg,
+                    Channels_ignore=['EEG001', 'EEG002'],
+                    ChannelCriterion='off',
+                    LineNoiseCriterion='off',
+                    BurstCriterion='off',
+                    WindowCriterion='off',
+                    Highpass='off',
+                    FlatlineCriterion='off',
+                )
+        finally:
+            eegprep.pop_select = original
+
+    def test_channels_ignore_preserves_events(self):
+        """Restricting channels must not wipe the dataset's events."""
+        eeg = create_test_eeg()
+        eeg['event'] = [{'type': 'mark', 'latency': 100.0}, {'type': 'mark', 'latency': 5000.0}]
+        original_events = list(eeg['event'])
+
+        EEG, _HP, _BUR, _removed = clean_artifacts(
+            eeg,
+            Channels_ignore=['EEG001'],
+            ChannelCriterion='off',
+            LineNoiseCriterion='off',
+            BurstCriterion='off',
+            WindowCriterion='off',
+            Highpass='off',
+            FlatlineCriterion='off',
+        )
+
+        self.assertEqual(len(EEG['event']), len(original_events))
+
+    def test_clean_channels_unexpected_value_error_propagates(self):
+        """A ValueError from clean_channels unrelated to missing locations must
+        propagate rather than silently switching to the no-locs algorithm.
+        """
+        import eegprep.plugins.clean_rawdata.clean_artifacts as ca_mod
+
+        original = ca_mod.clean_channels
+
+        def boom(*args, **kwargs):
+            raise ValueError("totally unrelated bug")
+
+        ca_mod.clean_channels = boom
+        try:
+            with self.assertRaises(ValueError) as cm:
+                clean_artifacts(
+                    self.test_eeg,
+                    ChannelCriterion=0.8,
+                    LineNoiseCriterion='off',
+                    BurstCriterion='off',
+                    WindowCriterion='off',
+                    Highpass='off',
+                    FlatlineCriterion='off',
+                )
+            self.assertIn('totally unrelated bug', str(cm.exception))
+        finally:
+            ca_mod.clean_channels = original
+
+    def test_clean_channels_location_error_falls_back(self):
+        """A missing-locations ValueError still triggers the no-locs fallback."""
+        import eegprep.plugins.clean_rawdata.clean_artifacts as ca_mod
+
+        original_cc = ca_mod.clean_channels
+        original_nolocs = ca_mod.clean_channels_nolocs
+
+        def locs_error(*args, **kwargs):
+            raise ValueError('To use this function most of your channels should have X,Y,Z location measurements.')
+
+        called = {'nolocs': False}
+
+        def fake_nolocs(EEG, **kwargs):
+            called['nolocs'] = True
+            return EEG, np.zeros(EEG['nbchan'], dtype=bool)
+
+        ca_mod.clean_channels = locs_error
+        ca_mod.clean_channels_nolocs = fake_nolocs
+        try:
+            clean_artifacts(
+                self.test_eeg,
+                ChannelCriterion=0.8,
+                LineNoiseCriterion='off',
+                BurstCriterion='off',
+                WindowCriterion='off',
+                Highpass='off',
+                FlatlineCriterion='off',
+            )
+            self.assertTrue(called['nolocs'])
+        finally:
+            ca_mod.clean_channels = original_cc
+            ca_mod.clean_channels_nolocs = original_nolocs
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_clean_asr.py
+++ b/tests/test_clean_asr.py
@@ -100,6 +100,10 @@ class TestCleanASRParameters(unittest.TestCase):
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
             'trials': 1,
+            'xmin': 0.0,
+            'xmax': (self.n_samples - 1) / self.srate,
+            'times': np.arange(self.n_samples) / self.srate,
+            'event': [],
         }
 
     def test_clean_asr_parameter_acceptance(self):
@@ -159,6 +163,10 @@ class TestCleanASRCalibrationData(unittest.TestCase):
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
             'trials': 1,
+            'xmin': 0.0,
+            'xmax': (self.n_samples - 1) / self.srate,
+            'times': np.arange(self.n_samples) / self.srate,
+            'event': [],
         }
 
     def test_clean_asr_ref_maxbadchannels_off(self):
@@ -288,6 +296,66 @@ class TestCleanASRCalibrationFailure(unittest.TestCase):
             else:
                 self.skipTest(f"clean_asr automatic calibration test not available: {e}")
 
+    def test_clean_asr_unexpected_clean_windows_error_propagates(self):
+        """An unexpected (non-ValueError) failure in clean_windows must propagate,
+        not be swallowed into a silent 'use all data for calibration' fallback.
+        """
+        import eegprep.plugins.clean_rawdata.clean_asr as casr_mod
+
+        original = casr_mod.clean_windows
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated clean_windows bug")
+
+        casr_mod.clean_windows = boom
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                clean_asr(
+                    self.test_eeg,
+                    ref_maxbadchannels=0.1,
+                    ref_tolerances=(-3.0, 5.0),
+                    ref_wndlen=1.0,
+                    cutoff=20.0,
+                )
+            self.assertIn('simulated clean_windows bug', str(cm.exception))
+        finally:
+            casr_mod.clean_windows = original
+
+    def test_clean_asr_clean_windows_value_error_falls_back(self):
+        """A ValueError from clean_windows (expected calibration-data problem) still
+        triggers the documented all-data fallback rather than crashing.
+        """
+        import eegprep.plugins.clean_rawdata.clean_asr as casr_mod
+
+        original = casr_mod.clean_windows
+
+        def insufficient(*args, **kwargs):
+            raise ValueError('Not enough data for even a single window.')
+
+        # Enough samples that all-data calibration succeeds once the fallback kicks in.
+        eeg = {
+            'data': np.random.randn(self.n_channels, 5000) * 0.5,
+            'srate': self.srate,
+            'nbchan': self.n_channels,
+            'pnts': 5000,
+            'trials': 1,
+        }
+
+        casr_mod.clean_windows = insufficient
+        try:
+            with self.assertLogs('eegprep.plugins.clean_rawdata.clean_asr', level='WARNING') as log:
+                result = clean_asr(
+                    eeg,
+                    ref_maxbadchannels=0.1,
+                    ref_tolerances=(-3.0, 5.0),
+                    ref_wndlen=1.0,
+                    cutoff=20.0,
+                )
+            self.assertTrue(any('Falling back to using the entire data' in msg for msg in log.output))
+            self.assertIsInstance(result, dict)
+        finally:
+            casr_mod.clean_windows = original
+
 
 class TestCleanASRSignalExtrapolation(unittest.TestCase):
     """Test clean_asr signal extrapolation logic."""
@@ -305,6 +373,10 @@ class TestCleanASRSignalExtrapolation(unittest.TestCase):
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
             'trials': 1,
+            'xmin': 0.0,
+            'xmax': (self.n_samples - 1) / self.srate,
+            'times': np.arange(self.n_samples) / self.srate,
+            'event': [],
         }
 
     def test_clean_asr_with_different_window_lengths(self):
@@ -359,6 +431,10 @@ class TestCleanASREdgeCases(unittest.TestCase):
             'nbchan': self.n_channels,
             'pnts': self.n_samples,
             'trials': 1,
+            'xmin': 0.0,
+            'xmax': (self.n_samples - 1) / self.srate,
+            'times': np.arange(self.n_samples) / self.srate,
+            'event': [],
         }
 
     def test_clean_asr_single_channel_data(self):
@@ -369,6 +445,10 @@ class TestCleanASREdgeCases(unittest.TestCase):
             'nbchan': 1,
             'pnts': self.n_samples,
             'trials': 1,
+            'xmin': 0.0,
+            'xmax': (self.n_samples - 1) / self.srate,
+            'times': np.arange(self.n_samples) / self.srate,
+            'event': [],
         }
 
         try:

--- a/tests/test_clean_flatlines.py
+++ b/tests/test_clean_flatlines.py
@@ -392,6 +392,45 @@ class TestCleanFlatlinesValidation(DebuggableTestCase):
         if result['nbchan'] < eeg_walrus['nbchan']:
             self.assertFalse(result['etc']['clean_channel_mask'][5])
 
+    def test_clean_flatlines_fallback_composites_existing_mask(self):
+        """Fallback path with a prior clean_channel_mask must composite, not crash.
+
+        Reproduces the walrus-precedence bug: when pop_select fails and a prior
+        clean_channel_mask exists, the mask update must run ``mask[mask] = ~removed``
+        rather than treating the mask as a bool. Uses continuous (2D) data so the
+        composite indexing exercises the real fallback branch.
+        """
+        eeg = self.test_eeg.copy()
+        eeg['data'] = np.random.randn(32, 1000)
+        eeg['trials'] = 1
+        eeg['data'][5, :] = 1.0  # flatline channel 5
+        eeg['etc'] = {'clean_channel_mask': np.ones(32, dtype=bool)}
+        # Empty chanlocs so the unrelated chanlocs-trim branch is skipped and the
+        # test isolates the clean_channel_mask compositing branch.
+        eeg['chanlocs'] = []
+
+        # Force the no-pop_select fallback with a non-ImportError so the
+        # mask-compositing branch runs (this is where the bug lived).
+        import eegprep
+
+        original = eegprep.pop_select
+
+        def failing_pop_select(*args, **kwargs):
+            raise RuntimeError("simulated pop_select failure")
+
+        eegprep.pop_select = failing_pop_select
+        try:
+            result = clean_flatlines(eeg, max_flatline_duration=1.0)
+        finally:
+            eegprep.pop_select = original
+
+        mask = result['etc']['clean_channel_mask']
+        # Original mask had 32 True entries; after compositing exactly channel 5
+        # (the flatline) must be False and the rest True.
+        self.assertEqual(mask.shape[0], 32)
+        self.assertFalse(mask[5])
+        self.assertEqual(int(np.sum(~mask)), 1)
+
 
 class TestCleanFlatlinesNoOpPath(DebuggableTestCase):
     """No-operation path test cases for clean_flatlines function."""

--- a/tests/test_cli_bids_migrate_commands.py
+++ b/tests/test_cli_bids_migrate_commands.py
@@ -52,6 +52,20 @@ def test_bids_export_validate_import_roundtrip(tmp_path, capsys):
     assert captured.err == ""
 
 
+def test_bids_validate_reports_error_when_no_eeg_files(tmp_path):
+    from eegprep.cli.commands import bids as bids_cli
+
+    empty_root = tmp_path / "empty_bids"
+    empty_root.mkdir()
+    (empty_root / "dataset_description.json").write_text("{}", encoding="utf-8")
+
+    payload = bids_cli.validate_dataset(empty_root)
+
+    assert payload["status"] == "error"
+    assert payload["can_continue"] is False
+    assert [issue["code"] for issue in payload["errors"]] == ["BIDS_EEG_FILES_MISSING"]
+
+
 def test_bids_validate_missing_path_returns_structured_error(tmp_path, capsys):
     from eegprep.cli.commands import bids as bids_cli
 
@@ -64,6 +78,29 @@ def test_bids_validate_missing_path_returns_structured_error(tmp_path, capsys):
     assert payload["error"]["code"] == "INPUT_FILE_NOT_FOUND"
     assert payload["error"]["path"] == str(tmp_path / "missing")
     assert captured.err == ""
+
+
+def test_bids_import_set_file_uses_eeglab_loader_without_error_sniffing(tmp_path, monkeypatch):
+    from eegprep.cli.commands import bids as bids_cli
+
+    input_set = tmp_path / "input.set"
+    imported_set = tmp_path / "imported.set"
+    pop_saveset(_eeg(), input_set)
+
+    # A .set file must dispatch to the EEGLAB loader without ever invoking the BIDS sidecar
+    # importer; the previous fallback only recovered when the IndexError message matched a
+    # specific string, so any other wording silently re-raised as an opaque crash.
+    def _fail(*_args, **_kwargs):
+        raise IndexError("array index out of range")
+
+    monkeypatch.setattr(bids_cli, "pop_importbids", _fail)
+
+    payload = bids_cli.import_dataset(input_set, output=imported_set)
+
+    assert payload["status"] == "ok"
+    assert payload["dataset"]["nbchan"] == 2
+    assert imported_set.exists()
+    assert [warning["code"] for warning in payload["warnings"]] == ["BIDS_SIDECARS_SKIPPED"]
 
 
 def test_bids_import_refuses_existing_manifest_without_overwrite(tmp_path):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -8,6 +8,7 @@ import sys
 
 import yaml
 
+from eegprep.cli.core import EEGPrepCLIError, command_error, emit_command_result
 from tests.fixtures import SAMPLE_DATASET_PATH
 
 
@@ -59,6 +60,18 @@ def test_capabilities_schema_examples_and_skill_are_json_readable():
     assert any("pipeline run" in item for item in _json_stdout(examples)["examples"])
     assert skill.returncode == 0
     assert "Agent Rules" in _json_stdout(skill)["content"]
+
+
+def test_transform_command_schemas_define_every_required_property():
+    for command in ("resample", "rereference", "filter", "clean", "epoch", "ica"):
+        schema = _json_stdout(_run_cli("schema", "command", command, "--json"))["schema"]
+        properties = set(schema["properties"])
+        missing = [name for name in schema["required"] if name not in properties]
+        assert not missing, f"{command} required params absent from properties: {missing}"
+        # --output is conditionally required (allowed to be omitted with --overwrite), so it must
+        # not appear in the unconditional required list and the alternative must be advertised.
+        assert "output" not in schema["required"], command
+        assert schema["anyOf"] == [{"required": ["output"]}, {"required": ["overwrite"]}], command
 
 
 def test_every_advertised_capability_has_schema_and_examples():
@@ -190,3 +203,52 @@ def test_missing_input_returns_stable_error_code():
     payload = _json_stdout(result)
     assert payload["status"] == "error"
     assert payload["code"] == "INPUT_FILE_NOT_FOUND"
+
+
+def test_structured_command_error_preserves_non_default_exit_code(capsys):
+    error = EEGPrepCLIError("CONFIG_SCHEMA_ERROR", "bad config", exit_code=2)
+
+    result = command_error("pipeline run", error)
+    exit_code = emit_command_result(result, json_output=True)
+
+    # A structured-result usage error (exit_code=2) must not be silently downgraded to 1, so the
+    # structured path matches the exception path for the same error class.
+    assert result["exit_code"] == 2
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["exit_code"] == 2
+    assert payload["error"]["code"] == "CONFIG_SCHEMA_ERROR"
+
+
+def _write_run_config(tmp_path, name):
+    config = tmp_path / name
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "eegprep.pipeline.v1",
+                "input": {"path": str(SAMPLE_DATASET_PATH), "format": "eeglab"},
+                "output": {"directory": str(tmp_path / f"out_{name}")},
+                "steps": [{"name": "resample", "freq": 128}, {"name": "qc"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_pipeline_run_verbose_and_quiet_flags_take_effect(tmp_path):
+    verbose = _run_cli("pipeline", "run", str(_write_run_config(tmp_path, "verbose.yaml")), "--json", "--verbose")
+    quiet = _run_cli("pipeline", "run", str(_write_run_config(tmp_path, "quiet.yaml")), "--json", "--quiet")
+
+    assert verbose.returncode == 0, verbose.stderr
+    assert quiet.returncode == 0, quiet.stderr
+    # The flags must actually drive logging: --verbose emits progress chatter, --quiet suppresses it.
+    verbose_stderr = [line for line in verbose.stderr.splitlines() if line.strip()]
+    quiet_stderr = [line for line in quiet.stderr.splitlines() if line.strip()]
+    assert verbose_stderr, "expected --verbose to emit progress logging on stderr"
+    assert len(quiet_stderr) < len(verbose_stderr)
+    # In both modes the single JSON line agents parse must stay clean on stdout.
+    assert len([line for line in verbose.stdout.splitlines() if line.strip()]) == 1
+    assert len([line for line in quiet.stdout.splitlines() if line.strip()]) == 1
+    assert _json_stdout(verbose)["status"] == "ok"
+    assert _json_stdout(quiet)["status"] == "ok"

--- a/tests/test_cli_pipeline_qc_report.py
+++ b/tests/test_cli_pipeline_qc_report.py
@@ -138,6 +138,20 @@ def test_pipeline_filter_history_uses_modern_eegfiltnew(monkeypatch, tmp_path):
     assert "pop_eegfiltnew" in result["history"][0]
 
 
+def test_pipeline_filter_rejects_negative_notch_lower_edge(tmp_path):
+    config_path = _write_pipeline_config(
+        tmp_path,
+        steps=[{"name": "filter", "notch": 1, "notch_width": 4}],
+    )
+
+    result = run_pipeline_config(config_path)
+
+    assert result["status"] == "error"
+    assert result["code"] == "CONFIG_SCHEMA_ERROR"
+    assert "notch minus half notch_width must be positive" in result["message"]
+    assert not (tmp_path / "out").exists()
+
+
 def test_pipeline_invalid_config_returns_structured_error(tmp_path):
     config_path = _write_pipeline_config(
         tmp_path,

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -219,6 +219,26 @@ def test_storedisk_session_retrieve_and_console_pop_call_stay_synchronized(tmp_p
         EEG_OPTIONS.update(old_options)
 
 
+def test_console_currentset_reassignment_preserves_both_datasets():
+    session = EEGPrepSession()
+    session.store_current(_demo_eeg("first"), new=True)
+    session.store_current(_demo_eeg("second"), new=True)
+    workspace = EEGPrepConsoleWorkspace(session, exports={})
+    session.retrieve(1)
+
+    assert workspace.namespace["EEG"]["setname"] == "first"
+    assert session.CURRENTSET == [1]
+
+    workspace.namespace["CURRENTSET"] = 2
+    workspace.after_execute("CURRENTSET = 2")
+
+    assert session.CURRENTSET == [2]
+    assert session.EEG["setname"] == "second"
+    assert session.ALLEEG[0]["setname"] == "first"
+    assert session.ALLEEG[1]["setname"] == "second"
+    assert workspace.namespace["EEG"]["setname"] == "second"
+
+
 def test_console_pop_study_result_updates_shared_study_workspace():
     session = EEGPrepSession()
     session.store_current(_demo_eeg(), new=True)
@@ -1534,7 +1554,7 @@ def test_console_python_command_converts_common_eeglab_history_syntax():
     assert converted == [
         "ALLEEG, EEG, CURRENTSET = pop_newset(ALLEEG, EEG, CURRENTSET, retrieve=1)",
         "CURRENTSTUDY = 0; ALLEEG, EEG, CURRENTSET = pop_newset(ALLEEG, EEG, CURRENTSET, retrieve=2)",
-        "EEG = pop_select(EEG, channel=[1, 2], chantype=['EEG', 'EOG'])",
+        "EEG = pop_select(EEG, channel=[0, 1], chantype=['EEG', 'EOG'])",
         'LASTCOM = pop_export(EEG, filename="/tmp/demo\'s data.tsv")',
         "EEG = pop_resample(EEG, freq=64)",
         "EEG = pop_comments(EEG, plottitle='', newcomments='sample notes')",
@@ -1546,6 +1566,22 @@ def test_console_python_command_converts_common_eeglab_history_syntax():
         "ALLEEG, EEG, CURRENTSET = pop_newset(ALLEEG, EEG, CURRENTSET, retrieve=3)",
     ]
     for command in converted:
+        ast.parse(command)
+
+
+def test_console_pop_select_numeric_channels_zero_based_on_replay():
+    # GUI/history is 1-based (EEGLAB parity); the 0-based Python API requires the
+    # console to zero-base numeric channel selections so replayed history selects
+    # the same channels. Channel-by-name and chantype selections must pass through.
+    numeric = console_module._console_python_command(
+        "EEG = pop_select(EEG, 'channel', [1 3], 'rmchannel', [5]);"
+    )
+    assert numeric == "EEG = pop_select(EEG, channel=[0, 2], rmchannel=[4])"
+    by_name = console_module._console_python_command(
+        "EEG = pop_select(EEG, 'channel', {'Fz' 'Cz'}, 'chantype', {'EEG'});"
+    )
+    assert by_name == "EEG = pop_select(EEG, channel=['Fz', 'Cz'], chantype=['EEG'])"
+    for command in (numeric, by_name):
         ast.parse(command)
 
 

--- a/tests/test_eeg_compare.py
+++ b/tests/test_eeg_compare.py
@@ -5,19 +5,60 @@ This module tests the eeg_compare function which compares two EEG datasets
 and reports differences in structure and data.
 """
 
+import logging
 import os
 import unittest
 import sys
-import io
 import numpy as np
 import math
-from contextlib import redirect_stderr, redirect_stdout
 
 # Add src to path for imports
 sys.path.insert(0, 'src')
 from eegprep.functions.popfunc.eeg_compare import eeg_compare
 from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
 from eegprep.utils.testing import DebuggableTestCase
+
+EEG_COMPARE_LOGGER = 'eegprep.functions.popfunc.eeg_compare'
+
+
+def run_compare(*args, **kwargs):
+    """Call eeg_compare while capturing its log output.
+
+    eeg_compare emits informational lines (section headers and "OK" results) at INFO and
+    differences at WARNING. Return the result plus the WARNING-level text as ``stderr`` and the
+    full text as ``stdout`` so callers can assert on either, mirroring the previous stream split.
+    """
+    logger = logging.getLogger(EEG_COMPARE_LOGGER)
+    with _LogCapture(logger) as capture:
+        result = eeg_compare(*args, **kwargs)
+    return result, capture.text(logging.INFO), capture.text(logging.WARNING)
+
+
+class _LogCapture(logging.Handler):
+    def __init__(self, logger):
+        super().__init__(level=logging.DEBUG)
+        self._logger = logger
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def __enter__(self):
+        self._prev_level = self._logger.level
+        self._prev_propagate = self._logger.propagate
+        self._logger.setLevel(logging.DEBUG)
+        self._logger.propagate = False
+        self._logger.addHandler(self)
+        return self
+
+    def __exit__(self, *exc):
+        self._logger.removeHandler(self)
+        self._logger.setLevel(self._prev_level)
+        self._logger.propagate = self._prev_propagate
+        return False
+
+    def text(self, min_level):
+        return '\n'.join(self.format(r) for r in self.records if r.levelno >= min_level)
 
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")
@@ -107,18 +148,10 @@ class TestEegCompare(DebuggableTestCase):
 
     def test_identical_datasets(self):
         """Test comparison of identical datasets."""
-        # Capture output
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
+        result, stdout_output, _stderr_output = run_compare(self.basic_eeg1, self.basic_eeg1)
 
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, self.basic_eeg1)
-
-        # Should return True for identical datasets
+        # Should return a truthy summary for identical datasets
         self.assertTrue(result)
-
-        # Check output indicates no differences
-        stdout_output = stdout_capture.getvalue()
 
         # Should have minimal output for identical datasets
         self.assertIn('Field analysis:', stdout_output)
@@ -131,15 +164,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['setname'] = 'different_dataset'
         eeg2['subject'] = 'S02'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        self.assertTrue(result)  # Function should still return a summary
 
-        self.assertTrue(result)  # Function should still return True
-
-        stderr_output = stderr_capture.getvalue()
         # Should report differences in subject field
         self.assertIn('subject differs', stderr_output)
 
@@ -149,15 +177,10 @@ class TestEegCompare(DebuggableTestCase):
         del eeg2['subject']
         del eeg2['condition']
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('subject missing in second dataset', stderr_output)
         self.assertIn('condition missing in second dataset', stderr_output)
 
@@ -167,15 +190,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['filename'] = 'different.set'
         eeg2['datfile'] = 'different.dat'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, stdout_output, _stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stdout_output = stdout_capture.getvalue()
         # Should indicate filename differences are OK
         self.assertIn('(ok, supposed to differ)', stdout_output)
 
@@ -185,15 +203,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['xmin'] = -0.1  # Different from -0.2
         eeg2['xmax'] = 4.0  # Different from original
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Difference between xmin', stderr_output)
         self.assertIn('Difference between xmax', stderr_output)
 
@@ -205,15 +218,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['chanlocs'][1]['Y'] = 999.0
         eeg2['chanlocs'][2]['Z'] = 999.0
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('channel coordinates differ', stderr_output)
 
     def test_channel_label_differences(self):
@@ -222,15 +230,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['chanlocs'][0]['labels'] = 'DifferentLabel'
         eeg2['chanlocs'][1]['labels'] = 'AnotherLabel'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('channel label(s) differ', stderr_output)
 
     def test_verbose_channel_labels(self):
@@ -238,30 +241,20 @@ class TestEegCompare(DebuggableTestCase):
         eeg2 = self.create_test_eeg()
         eeg2['chanlocs'][0]['labels'] = 'DifferentLabel'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2, verbose_level=1)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2, verbose_level=1)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Ch1 differs from DifferentLabel', stderr_output)
 
     def test_different_channel_numbers(self):
         """Test comparison with different numbers of channels."""
         eeg2 = self.create_test_eeg(nbchan=16)  # Different number of channels
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Different numbers of channels', stderr_output)
 
     def test_different_event_numbers(self):
@@ -269,15 +262,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2 = self.create_test_eeg()
         eeg2['event'] = eeg2['event'][:2]  # Remove one event
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Different numbers of events', stderr_output)
 
     def test_verbose_event_output(self):
@@ -285,15 +273,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2 = self.create_test_eeg()
         eeg2['event'] = []  # No events
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2, verbose_level=1)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2, verbose_level=1)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Different numbers of events', stderr_output)
         self.assertIn('First event of first dataset:', stderr_output)
 
@@ -304,15 +287,10 @@ class TestEegCompare(DebuggableTestCase):
         for event in eeg2['event']:
             event['extra_field'] = 'test'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Not the same number of event fields', stderr_output)
 
     def test_event_latency_differences(self):
@@ -321,15 +299,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['event'][0]['latency'] = 300  # Different from 250
         eeg2['event'][1]['latency'] = 600  # Different from 500
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         self.assertIn('Event latency', stderr_output)
         self.assertIn('not OK', stderr_output)
 
@@ -338,15 +311,10 @@ class TestEegCompare(DebuggableTestCase):
         eeg2 = self.create_test_eeg()
         eeg2['event'][0]['type'] = 'different_stimulus'
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
         # The function should detect differences in event fields
         self.assertTrue(len(stderr_output) > 0)  # Should have some error output
 
@@ -361,11 +329,7 @@ class TestEegCompare(DebuggableTestCase):
         eeg_obj1 = EegObject(self.basic_eeg1)
         eeg_obj2 = EegObject(self.basic_eeg2)
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(eeg_obj1, eeg_obj2)
+        result, _stdout_output, _stderr_output = run_compare(eeg_obj1, eeg_obj2)
 
         self.assertTrue(result)
 
@@ -374,35 +338,23 @@ class TestEegCompare(DebuggableTestCase):
         eeg2 = self.create_test_eeg()
         eeg2['eventdescription'] = ['stimulus', 'response']  # Different length
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, stdout_output, stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
-        stderr_output = stderr_capture.getvalue()
-        stdout_output = stdout_capture.getvalue()
         # The function should report eventdescription differences
-        # It might be in stderr or stdout depending on the logic
+        # It might be at info or warning level depending on the logic
         output_combined = stderr_output + stdout_output
         self.assertTrue('eventdescription' in output_combined or len(stderr_output) > 0)
 
     def test_isequaln_function_coverage(self):
         """Test the internal isequaln function with various data types."""
-        from eegprep.functions.popfunc.eeg_compare import eeg_compare
-
         # Test with None values
         eeg2 = self.create_test_eeg()
         eeg2['subject'] = None
         self.basic_eeg1['subject'] = None
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, _stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
@@ -412,11 +364,7 @@ class TestEegCompare(DebuggableTestCase):
         eeg2['xmin'] = float('nan')
         self.basic_eeg1['xmin'] = float('nan')
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, _stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
@@ -426,11 +374,7 @@ class TestEegCompare(DebuggableTestCase):
         # Make arrays identical
         eeg2['data'] = self.basic_eeg1['data'].copy()
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, _stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
@@ -440,11 +384,7 @@ class TestEegCompare(DebuggableTestCase):
         # Test scalar vs array comparison edge cases
         eeg2['trials'] = np.array([1])  # Array instead of scalar
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(self.basic_eeg1, eeg2)
+        result, _stdout_output, _stderr_output = run_compare(self.basic_eeg1, eeg2)
 
         self.assertTrue(result)
 
@@ -455,11 +395,7 @@ class TestEegCompare(DebuggableTestCase):
         eeg1['event'] = []
         eeg2['event'] = []
 
-        stderr_capture = io.StringIO()
-        stdout_capture = io.StringIO()
-
-        with redirect_stderr(stderr_capture), redirect_stdout(stdout_capture):
-            result = eeg_compare(eeg1, eeg2)
+        result, _stdout_output, _stderr_output = run_compare(eeg1, eeg2)
 
         self.assertTrue(result)
 
@@ -590,6 +526,46 @@ class TestIsequaln(unittest.TestCase):
         arr1 = np.array([[1, 2], [3, 4]])
         arr2 = np.array([[1, 2], [3, 4]])
         self.assertTrue(self.isequaln(arr1, arr2))
+
+
+class TestEegCompareReturnContract(unittest.TestCase):
+    """Pin the documented return contract: eeg_compare returns a summary string."""
+
+    def _eeg(self):
+        return {
+            'setname': 'ds',
+            'subject': 'S01',
+            'xmin': 0.0,
+            'xmax': 1.0,
+            'chanlocs': [],
+            'event': [],
+        }
+
+    def test_identical_returns_match_summary_string(self):
+        result, stdout_output, stderr_output = run_compare(self._eeg(), self._eeg())
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, "All fields match (no differences found)")
+        self.assertEqual(stderr_output, "")
+
+    def test_differences_returned_as_string_not_bool(self):
+        eeg2 = self._eeg()
+        eeg2['subject'] = 'S02'
+        result, _stdout_output, stderr_output = run_compare(self._eeg(), eeg2)
+        self.assertIsInstance(result, str)
+        self.assertNotIsInstance(result, bool)
+        self.assertIn('differences', result.lower())
+        self.assertIn('subject differs', stderr_output)
+
+    def test_array_mismatch_returns_summary_string(self):
+        result, _stdout_output, _stderr_output = run_compare(np.zeros((2, 3)), np.zeros((3, 2)))
+        self.assertIsInstance(result, str)
+        self.assertIn('Array shape mismatch', result)
+
+    def test_trigger_error_raises_on_difference(self):
+        eeg2 = self._eeg()
+        eeg2['subject'] = 'S02'
+        with self.assertRaises(ValueError):
+            eeg_compare(self._eeg(), eeg2, trigger_error=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_eeg_eegrej.py
+++ b/tests/test_eeg_eegrej.py
@@ -385,6 +385,25 @@ class TestEEGEegrejExtended(unittest.TestCase):
         self.assertNotIn(0.0, latencies)
         self.assertNotIn(float(result['pnts']), latencies)
 
+    def test_eeg_eegrej_keeps_nonboundary_events_at_edges(self):
+        """Genuine (non-boundary) events at the first/last sample must not be dropped."""
+        EEG = self.base_eeg.copy()
+        # stim at the first sample (latency 0) and a stim that lands on the
+        # final sample after rejection (latency 20 -> 17 once 3 samples removed)
+        EEG['event'] = [
+            {"type": "stim", "latency": 0.0},
+            {"type": "stim", "latency": 20.0},
+        ]
+
+        regions = np.array([[3, 5]])
+        result = eeg_eegrej(EEG, regions)
+
+        self.assertEqual(result['pnts'], 17)
+        stim_events = [e for e in result['event'] if e.get('type') == 'stim']
+        stim_latencies = sorted(e['latency'] for e in stim_events)
+        # both stim events survive: one at the first sample, one at the last sample
+        self.assertEqual(stim_latencies, [0.0, 17.0])
+
     def test_eeg_eegrej_duplicate_event_cleanup(self):
         """Test eeg_eegrej duplicate event cleanup."""
         EEG = self.base_eeg.copy()

--- a/tests/test_eegobj.py
+++ b/tests/test_eegobj.py
@@ -144,6 +144,29 @@ class TestEEGobj(unittest.TestCase):
         with self.assertRaises(AttributeError):
             obj.nonexistent_function()
 
+    def test_getattr_unknown_name_raises_on_access(self):
+        """Accessing an unknown name (e.g. a field typo) raises AttributeError immediately.
+
+        A typo like obj.icawnv (for icaweights) must fail fast instead of
+        silently returning a no-op callable that only errors when called.
+        """
+        eeg = create_test_eeg()
+        obj = EEGobj(eeg)
+
+        with self.assertRaises(AttributeError):
+            obj.icawnv  # misspelled field name, not an eegprep function
+
+        # hasattr reflects the same contract.
+        self.assertFalse(hasattr(obj, 'not_a_real_field'))
+
+    def test_getattr_known_function_still_dispatches(self):
+        """A name that resolves to an eegprep function is still returned as a wrapper."""
+        eeg = create_test_eeg(n_channels=4, n_samples=50, srate=100.0, n_trials=3)
+        obj = EEGobj(eeg)
+        self.assertTrue(callable(obj.pop_select))
+        out = obj.pop_select(channel=[0, 1])
+        self.assertEqual(out['nbchan'], 2)
+
     def test_forward_function_returning_tuple(self):
         """Test method forwarding with function returning tuple."""
         eeg = create_test_eeg()

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -162,28 +162,27 @@ class TestEpochFunctional(unittest.TestCase):
         # Put a distinctive ramp in epoch 2 so we can detect correct slicing
         data[0, :, 1] = np.linspace(0, 1, 100)
 
-        # Event at 1.2 s relative to concatenated stream:
-        # global sample for event center = floor(1.2 * 100) = 120
-        # Epoch boundaries every 100 points
-        events = np.array([1.2], dtype=float)
+        # Event at 1.5 s relative to the concatenated stream:
+        # global sample for event center = floor(1.5 * 100) = 150
+        # Epoch boundaries every 100 points, so the window stays inside epoch 2.
+        events = np.array([1.5], dtype=float)
         lim = np.array([-0.2, 0.3], dtype=float)  # [-20, +29] samples window inside epoch 2
 
         ep, newtime, idx, _, _, _ = epoch(data, events, lim, srate=srate, verbose='off')
 
         # Expect one accepted epoch
         self.assertTrue(np.array_equal(idx, np.array([0])))
-        # The extracted data should match the correct slice from linearized data
-        # With MATLAB-compatible indexing: event at 1.2s (sample 120) with window [-0.2, 0.3]
-        # becomes MATLAB indices [101, 149] (1-based), which in Python becomes [99:149] (0-based)
-        pos0 = int(np.floor(events[0] * srate))  # 120 (0-based)
+        # The extracted data should match the correct slice from linearized data.
+        # MATLAB epoch.m uses data(:,posinit:posend) (1-based); Python slices [posinit-1:posend].
+        pos0 = int(np.floor(events[0] * srate))  # 150
         reallim0 = int(np.round(lim[0] * srate))  # -20
         reallim1 = int(np.round(lim[1] * srate - 1))  # 29
-        posinit = pos0 + reallim0  # 100 (0-based)
-        posend = pos0 + reallim1  # 149 (0-based)
+        posinit = pos0 + reallim0  # 130 (MATLAB 1-based column)
+        posend = pos0 + reallim1  # 179 (MATLAB 1-based column)
 
         # MATLAB slicing: posinit:posend (1-based) becomes [posinit-1:posend] (0-based)
-        start_global = posinit - 1  # 99 (Python 0-based)
-        end_global = posend  # 149 (Python 0-based exclusive)
+        start_global = posinit - 1  # 129 (Python 0-based)
+        end_global = posend  # 179 (Python 0-based exclusive)
 
         # Extract the expected slice from linearized data (Fortran order)
         data_linearized = data.reshape(1, -1, order='F')
@@ -191,6 +190,12 @@ class TestEpochFunctional(unittest.TestCase):
         self.assertTrue(np.allclose(ep[0, :, 0], expected, atol=1e-12))
         # newtime should reflect limits divided by srate with the -1 sample convention
         self.assertTrue(np.allclose(newtime, np.array([lim[0], np.round(lim[1] * srate - 1) / srate]), atol=1e-12))
+
+        # A window that straddles the boundary between two source epochs (event at
+        # 1.2 s spans columns 99..148, crossing the 100-sample epoch boundary) must
+        # be rejected, matching EEGLAB's floor((posinit-1)/dataframes) test.
+        _, _, idx_cross, _, _, _ = epoch(data, np.array([1.2]), lim, srate=srate, verbose='off')
+        self.assertEqual(idx_cross.size, 0)
 
     def test_functional_valuelim_pass_all(self):
         srate = 200.0
@@ -212,6 +217,29 @@ class TestEpochFunctional(unittest.TestCase):
         _, _, _, alleventout, alllatencyout, _ = epoch(data, events, lim, srate=srate, verbose='off')
         self.assertEqual(len(alleventout), 0)
         self.assertEqual(len(alllatencyout), 0)
+
+    def test_boundary_first_last_sample(self):
+        # data values equal their 0-based column index so we can verify exact slices
+        srate = 100.0
+        data = np.arange(500, dtype=float).reshape(1, 500)
+        lim = np.array([-0.2, 0.5], dtype=float)  # reallim = [-20, 49] samples
+
+        # Event whose window would start one sample before the data (posinit==0,
+        # 0-based) must be rejected like EEGLAB, not produce a negative-index slice.
+        _, _, idx_before, _, _, _ = epoch(data, np.array([0.2]), lim, srate=srate, verbose='off')
+        self.assertEqual(idx_before.size, 0)
+
+        # Event whose window starts exactly at the first sample (posinit==1, 1-based)
+        # must be accepted and yield the true leading samples.
+        ep_first, _, idx_first, _, _, _ = epoch(data, np.array([0.21]), lim, srate=srate, verbose='off')
+        self.assertTrue(np.array_equal(idx_first, np.array([0])))
+        self.assertTrue(np.allclose(ep_first[0, :3, 0], np.array([0.0, 1.0, 2.0])))
+
+        # Event whose window ends exactly at the last sample (posend==datawidth)
+        # must be accepted; the previous off-by-one rejected it.
+        ep_last, _, idx_last, _, _, _ = epoch(data, np.array([4.51]), lim, srate=srate, verbose='off')
+        self.assertTrue(np.array_equal(idx_last, np.array([0])))
+        self.assertTrue(np.allclose(ep_last[0, -3:, 0], np.array([497.0, 498.0, 499.0])))
 
 
 if __name__ == '__main__':

--- a/tests/test_file_menu_pop_functions.py
+++ b/tests/test_file_menu_pop_functions.py
@@ -78,6 +78,46 @@ def test_pop_fileio_uses_importdata_for_text_arrays(tmp_path):
     assert command == f"EEG = pop_fileio({_matlab_string(data_file)});"
 
 
+def test_pop_fileio_imports_plain_mat_data_array(tmp_path):
+    import scipy.io
+
+    data_file = tmp_path / "raw.mat"
+    scipy.io.savemat(data_file, {"data": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])})
+
+    eeg = pop_fileio(data_file)
+
+    assert eeg["nbchan"] == 2
+    assert eeg["pnts"] == 3
+
+
+def test_pop_fileio_does_not_silently_fall_back_for_eeglab_mat(tmp_path):
+    import scipy.io
+
+    # An EEGLAB dataset .mat whose data sidecar is missing must surface the load
+    # failure, not be silently re-imported as a raw MATLAB data array.
+    dataset = tmp_path / "broken.mat"
+    scipy.io.savemat(
+        dataset,
+        {
+            "data": "missing.fdt",
+            "datfile": "missing.fdt",
+            "nbchan": 4,
+            "srate": 100,
+            "pnts": 100,
+            "trials": 1,
+            "xmin": 0.0,
+            "xmax": 1.0,
+            "setname": "x",
+            "chanlocs": np.array([]),
+            "event": np.array([]),
+            "icachansind": np.array([]),
+        },
+    )
+
+    with pytest.raises(FileNotFoundError):
+        pop_fileio(dataset)
+
+
 def test_pop_importevent_replaces_and_appends_events(tmp_path):
     events_file = tmp_path / "events.tsv"
     events_file.write_text("type\tlatency\tduration\nstim\t1\t0\nresp\t4\t1\n", encoding="utf-8")

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -1,6 +1,9 @@
+import ast
+import inspect
 import os
 import logging
 import sys
+import textwrap
 import unittest
 from unittest import mock
 
@@ -9,6 +12,7 @@ import pytest
 
 from eegprep.functions.guifunc.eeglab_menu import eeglab_menus, menu_actions
 from eegprep.functions.guifunc.menu_actions import (
+    IMPLEMENTED_ACTIONS,
     MenuActionDispatcher,
     action_kind,
 )
@@ -329,6 +333,52 @@ class MainMenuSpecTests(unittest.TestCase):
             [],
         )
         self.assertEqual(action_kind("pop_fileio_brainvision_mat"), "implemented")
+
+    def test_implemented_actions_registry_matches_dispatch_routing(self):
+        # IMPLEMENTED_ACTIONS gates whether a menu item is shown enabled. An entry
+        # with no dispatch arm would render enabled yet fall through to the
+        # show_coming_soon catch-all; a dispatch arm missing from the set would be
+        # classified "unknown"/placeholder. Keep the two in lockstep.
+        routed = _dispatch_routed_actions()
+        self.assertEqual(
+            sorted(IMPLEMENTED_ACTIONS - routed),
+            [],
+            "IMPLEMENTED_ACTIONS entries with no dispatch handler (enabled menu items that no-op)",
+        )
+        self.assertEqual(
+            sorted(routed - IMPLEMENTED_ACTIONS),
+            [],
+            "dispatch handlers missing from IMPLEMENTED_ACTIONS (classified unknown/placeholder)",
+        )
+
+
+def _dispatch_routed_actions():
+    """Base action names routed to a real handler by ``MenuActionDispatcher.dispatch``."""
+    import eegprep.functions.guifunc.menu_actions as menu_actions_module
+
+    source = textwrap.dedent(inspect.getsource(MenuActionDispatcher.dispatch))
+    module_sets = {name: value for name, value in vars(menu_actions_module).items() if isinstance(value, set)}
+    routed: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        left = node.left
+        if not (isinstance(left, ast.Name) and left.id in ("base", "action")):
+            continue
+        operator = node.ops[0]
+        comparator = node.comparators[0]
+        if isinstance(operator, ast.Eq) and isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+            routed.add(comparator.value)
+        elif isinstance(operator, ast.In):
+            if isinstance(comparator, (ast.Set, ast.List, ast.Tuple)):
+                routed.update(
+                    element.value
+                    for element in comparator.elts
+                    if isinstance(element, ast.Constant) and isinstance(element.value, str)
+                )
+            elif isinstance(comparator, ast.Name) and comparator.id in module_sets:
+                routed.update(module_sets[comparator.id])
+    return routed
 
 
 class EEGPrepSessionTests(unittest.TestCase):
@@ -782,6 +832,73 @@ class MenuActionDispatcherTests(unittest.TestCase):
         self.assertEqual(session.CURRENTSET, [1, 2])
         self.assertEqual([item["ref"] for item in session.EEG], ["average", "average"])
         self.assertEqual([item["ref"] for item in session.ALLEEG], ["average", "average"])
+
+    def test_cancelled_newset_commit_does_not_pollute_dataset_history(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(), new=True)
+        original_history = session.EEG.get("history", "")
+        original_allcom = list(session.ALLCOM)
+        dispatcher = MenuActionDispatcher(session)
+        select_command = "EEG = pop_select(EEG, 'point', [1 20]);"
+
+        with (
+            mock.patch(
+                "eegprep.functions.popfunc.pop_select.pop_select",
+                return_value=(session.EEG, select_command),
+            ),
+            # User cancels the pop_newset dialog, so no dataset is committed.
+            mock.patch(
+                "eegprep.functions.guifunc.menu_actions.pop_newset",
+                return_value=(session.ALLEEG, session.EEG, [1], ""),
+            ),
+        ):
+            dispatcher.dispatch("pop_select", parent=object())
+
+        self.assertEqual(session.EEG.get("history", ""), original_history)
+        self.assertNotIn(select_command, str(session.EEG.get("history", "")))
+        self.assertEqual(session.ALLCOM, original_allcom)
+
+    def test_committed_newset_records_processing_history_on_stored_dataset(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(), new=True)
+        dispatcher = MenuActionDispatcher(session)
+        processed = dict(session.EEG, setname="selected")
+        select_command = "EEG = pop_select(EEG, 'point', [1 20]);"
+
+        with mock.patch(
+            "eegprep.functions.popfunc.pop_select.pop_select",
+            return_value=(processed, select_command),
+        ):
+            dispatcher.dispatch("pop_select")
+
+        self.assertEqual(session.EEG["setname"], "selected")
+        self.assertEqual(session.ALLEEG[0]["setname"], "selected")
+        self.assertIn(select_command, str(session.EEG["history"]))
+        self.assertIn(select_command, str(session.ALLEEG[0]["history"]))
+
+    def test_headplot_menu_action_commits_spline_file_through_session(self):
+        session = EEGPrepSession()
+        session.store_current(_demo_eeg(), new=True)
+        events = []
+        session.add_change_listener(lambda _session: events.append("changed"))
+        dispatcher = MenuActionDispatcher(session)
+        headplot_command = "pop_headplot(EEG, 1, [0], '', [1 1]);"
+
+        def fake_pop_headplot(eeg, *, typeplot, return_com):
+            eeg["splinefile"] = "/tmp/demo.spl"
+            return (["figure"], headplot_command)
+
+        with mock.patch("eegprep.functions.popfunc.pop_headplot.pop_headplot", side_effect=fake_pop_headplot):
+            dispatcher.dispatch("pop_headplot")
+
+        self.assertEqual(session.EEG["splinefile"], "/tmp/demo.spl")
+        self.assertEqual(session.ALLEEG[0]["splinefile"], "/tmp/demo.spl")
+        self.assertEqual(session.ALLCOM[-1], headplot_command)
+        self.assertTrue(events, "headplot commit must notify session listeners")
+        # Committing through store_current records the edit in the dataset
+        # history; a history-only path would leave the dataset .history untouched.
+        self.assertIn(headplot_command, str(session.EEG["history"]))
+        self.assertIn(headplot_command, str(session.ALLEEG[0]["history"]))
 
     def test_resave_updates_single_dataset_metadata_and_saved_state(self):
         session = EEGPrepSession()

--- a/tests/test_pac_time_frequency_helpers.py
+++ b/tests/test_pac_time_frequency_helpers.py
@@ -79,6 +79,21 @@ def test_pac_reports_explicit_unsupported_statistics_and_latphase():
     assert "not silently emulated" in PAC_UNSUPPORTED_MESSAGE
 
 
+def test_pac_rejects_unimplemented_plotting_options():
+    amp, phase, srate = _coupled_trials()
+
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        pac(amp, phase, srate, title="my coupling")
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        pac(amp, phase, srate, vert=[100.0])
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        pac(amp, phase, srate, newfig="off")
+
+    # Default plotting values still compute PAC without plotting.
+    result = pac(amp, phase, srate, title="", vert=None, newfig="on", ntimesout=4)
+    assert isinstance(result, PacResult)
+
+
 def test_std_pac_computes_study_cache_and_std_pacplot_reads_it():
     study, alleeg = _study_pair()
 

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -84,6 +84,31 @@ def test_pop_spectopo_plots_sample_data_headlessly(sample_eeg):
     plt.close(result["figure"])
 
 
+def test_pop_spectopo_component_default_controls_succeed(ica_epoch):
+    result, command = pop_spectopo(
+        ica_epoch, dataflag=0, freqs=[10], plotchan=0, icamode=True, icacomps=[1, 2], nicamaps=2, return_com=True
+    )
+
+    assert result["spectra"].shape[0] == 2
+    assert "pop_spectopo(EEG" in command
+    plt.close(result["figure"])
+
+
+def test_pop_spectopo_rejects_nondefault_plotchan(ica_epoch):
+    with pytest.raises(ValueError, match="whole-scalp component spectra"):
+        pop_spectopo(ica_epoch, dataflag=0, freqs=[10], plotchan=3, icacomps=[1, 2])
+
+
+def test_pop_spectopo_rejects_max_power_plotchan(ica_epoch):
+    with pytest.raises(ValueError, match="whole-scalp component spectra"):
+        pop_spectopo(ica_epoch, dataflag=0, freqs=[10], plotchan=[], icacomps=[1, 2])
+
+
+def test_pop_spectopo_rejects_datacomp_icamode(ica_epoch):
+    with pytest.raises(ValueError, match="component spectra"):
+        pop_spectopo(ica_epoch, dataflag=0, freqs=[10], icamode=False, icacomps=[1, 2])
+
+
 def test_pop_prop_plots_sample_channel_properties(sample_eeg):
     figure, command = pop_prop(sample_eeg, typecomp=1, chanorcomp=1, return_com=True)
 

--- a/tests/test_phase4_timefreq_statistics.py
+++ b/tests/test_phase4_timefreq_statistics.py
@@ -40,7 +40,8 @@ from eegprep.functions.timefreqfunc.dftfilt import dftfilt
 from eegprep.functions.timefreqfunc.dftfilt2 import dftfilt2
 from eegprep.functions.timefreqfunc.dftfilt3 import dftfilt3
 from eegprep.functions.timefreqfunc.newcrossf import newcrossf
-from eegprep.functions.timefreqfunc.newtimef import newtimef
+from eegprep.functions.timefreqfunc.newtimef import _is_on as newtimef_is_on
+from eegprep.functions.timefreqfunc.newtimef import compute_time_frequency, newtimef
 from eegprep.functions.timefreqfunc.newtimefbaseln import newtimefbaseln
 from eegprep.functions.timefreqfunc.newtimefpowerunit import newtimefpowerunit
 from eegprep.functions.timefreqfunc.rsadjust import rsadjust
@@ -89,6 +90,31 @@ def test_newtimef_rejects_unknown_options():
 
     with pytest.raises(TypeError, match="unexpected keyword"):
         newtimef(signal, 128, [0, 1000], 128, 0, unsupported_option=1)
+
+
+def test_newtimef_is_on_uses_whitelist_semantics():
+    assert newtimef_is_on("on") is True
+    assert newtimef_is_on("yes") is True
+    assert newtimef_is_on(1) is True
+    # Unrecognized values are treated as OFF, matching the canonical is_on.
+    assert newtimef_is_on("yes-please") is False
+    assert newtimef_is_on("display") is False
+    assert newtimef_is_on("off") is False
+
+
+def test_newtimef_fails_loudly_on_unimplemented_overlap_and_plotphase():
+    signal = np.sin(2 * np.pi * 10 * np.arange(128) / 128)
+
+    with pytest.raises(NotImplementedError, match="overlap"):
+        newtimef(signal, 128, [0, 1000], 128, 0, plot="off", overlap=2)
+    with pytest.raises(NotImplementedError, match="plotphase"):
+        newtimef(signal, 128, [0, 1000], 128, 0, plot="off", plotphase="on")
+    with pytest.raises(NotImplementedError, match="overlap"):
+        compute_time_frequency(signal, 128, [0, 1000], 128, 0, overlap=2)
+
+    # Default values still compute without raising.
+    result = newtimef(signal, 128, [0, 1000], 128, 0, plot="off", overlap=None, plotphase="off")
+    assert result.ersp.shape == result.itc.shape
 
 
 def test_newtimef_nonzero_cycles_use_wavelet_time_grid(sample_epoch):

--- a/tests/test_pop_editeventvals.py
+++ b/tests/test_pop_editeventvals.py
@@ -1,0 +1,73 @@
+"""Tests for pop_editeventvals latency display/edit symmetry."""
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from eegprep.functions.popfunc.pop_editeventvals import (
+    pop_editeventvals,
+    pop_editeventvals_dialog_spec,
+    _display_event_value,
+    _display_field_label,
+)
+
+
+def _epoched_eeg():
+    """Epoched dataset: 2 trials, 50 points/epoch, srate 100, xmin -0.1 s."""
+    return {
+        "data": np.zeros((2, 50, 2), dtype=float),
+        "nbchan": 2,
+        "pnts": 50,
+        "trials": 2,
+        "srate": 100.0,
+        "xmin": -0.1,
+        "xmax": 0.39,
+        "times": np.arange(50, dtype=float),
+        "chanlocs": [{"labels": "Cz"}, {"labels": "Pz"}],
+        "chaninfo": {},
+        # latencies stored in points across concatenated epochs (1-based)
+        "event": [
+            {"type": "stim", "latency": 15.0, "duration": 0.0, "epoch": 1},
+            {"type": "resp", "latency": 70.0, "duration": 0.0, "epoch": 2},
+        ],
+        "urevent": [],
+        "epoch": [{}, {}],
+        "reject": {},
+        "stats": {},
+        "icaweights": np.array([]),
+        "icasphere": np.array([]),
+        "icawinv": np.array([]),
+        "icaact": np.array([]),
+        "icachansind": np.array([], dtype=int),
+        "history": "",
+        "saved": "no",
+    }
+
+
+def test_epoched_latency_display_matches_ms_label():
+    """The epoched latency dialog label says ms, so the displayed value must be ms."""
+    eeg = _epoched_eeg()
+    assert _display_field_label(eeg, "latency") == "Latency (ms)"
+    # point 15 in epoch 1 with xmin -0.1 s -> (15-1)/100 - 0.1 = 0.04 s = 40 ms
+    assert _display_event_value(eeg, eeg["event"][0], "latency") == 40.0
+    # the dialog spec exposes the same ms value, not the raw stored point count
+    spec = pop_editeventvals_dialog_spec(eeg)
+    latency_edit = next(control for control in spec.controls if control.tag == "field_latency")
+    assert latency_edit.value == 40.0
+
+
+def test_epoched_latency_edit_is_symmetric_with_display():
+    """Editing an epoched latency to its displayed ms value leaves the stored point unchanged."""
+    eeg = _epoched_eeg()
+    displayed = _display_event_value(eeg, eeg["event"][0], "latency")
+    out = pop_editeventvals(deepcopy(eeg), "changefield", [1, "latency", displayed])
+    assert out["event"][0]["latency"] == pytest.approx(eeg["event"][0]["latency"])
+
+
+def test_epoched_latency_edit_round_trips_through_display():
+    """Writing a new ms latency then reading it back yields the same ms value."""
+    eeg = _epoched_eeg()
+    new_ms = 60.0
+    out = pop_editeventvals(deepcopy(eeg), "changefield", [1, "latency", new_ms])
+    assert _display_event_value(out, out["event"][0], "latency") == new_ms

--- a/tests/test_pop_loadset.py
+++ b/tests/test_pop_loadset.py
@@ -1,6 +1,9 @@
+import h5py
 import numpy as np
+import pytest
 
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
+from eegprep.functions.popfunc.pop_loadset_h5 import pop_loadset_h5
 
 
 def test_pop_loadset_marks_loaded_dataset_justloaded():
@@ -35,3 +38,57 @@ def test_pop_loadset_hdf5_fallback_does_not_subtract_icachansind_twice():
 
     assert np.issubdtype(eeg["icachansind"].dtype, np.integer)
     assert eeg["icachansind"][0] == 0
+
+
+def test_pop_loadset_corrupt_v7_set_surfaces_real_error_not_h5py(tmp_path):
+    # A corrupt non-HDF5 .set must surface the real scipy parse error, not be silently
+    # rerouted to the HDF5 loader where h5py raises a cryptic "file signature not found".
+    corrupt = tmp_path / "corrupt.set"
+    corrupt.write_bytes(b"MATLAB 5.0 MAT-file, corrupt" + b"\x00" * 100 + b"\xff" * 50)
+
+    with pytest.raises(Exception) as excinfo:
+        pop_loadset(str(corrupt))
+
+    message = str(excinfo.value).lower()
+    assert "file signature not found" not in message
+    assert "mat file" in message or "unknown mat file" in message
+
+
+def test_pop_loadset_routes_hdf5_file_to_h5_loader(tmp_path):
+    # A genuine HDF5 .set is detected by its signature and loaded by the HDF5 path.
+    filepath = tmp_path / "hdf5.set"
+    with h5py.File(filepath, "w") as f:
+        eeg_group = f.create_group("EEG")
+        eeg_group.create_dataset("srate", data=np.array([[500.0]]))
+        eeg_group.create_dataset("nbchan", data=np.array([[4]]))
+        eeg_group.create_dataset("pnts", data=np.array([[100]]))
+        eeg_group.create_dataset("trials", data=np.array([[1]]))
+        eeg_group.create_dataset("xmin", data=np.array([[-1.0]]))
+        eeg_group.create_dataset("xmax", data=np.array([[1.0]]))
+        eeg_group.create_dataset("data", data=np.zeros((4, 100), dtype=np.float32))
+
+    eeg = pop_loadset(str(filepath))
+
+    assert eeg["nbchan"] == 4
+    assert eeg["data"].shape == (4, 100)
+
+
+def test_pop_loadset_h5_unicode_decodes_via_general_path(tmp_path):
+    # The general uint16 -> UTF-8 decode (no hard-coded emoji branch) returns the
+    # correct character. The bytes below are UTF-8 for U+1F496 (sparkling heart).
+    filepath = tmp_path / "unicode.set"
+    with h5py.File(filepath, "w") as f:
+        eeg_group = f.create_group("EEG")
+        unicode_bytes = np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150], dtype=np.uint16)
+        eeg_group.create_dataset("unicode_string", data=unicode_bytes)
+        eeg_group.create_dataset("srate", data=np.array([[500.0]]))
+        eeg_group.create_dataset("nbchan", data=np.array([[4]]))
+        eeg_group.create_dataset("pnts", data=np.array([[100]]))
+        eeg_group.create_dataset("trials", data=np.array([[1]]))
+        eeg_group.create_dataset("xmin", data=np.array([[-1.0]]))
+        eeg_group.create_dataset("xmax", data=np.array([[1.0]]))
+        eeg_group.create_dataset("data", data=np.zeros((4, 100), dtype=np.float32))
+
+    eeg = pop_loadset_h5(str(filepath))
+
+    assert eeg["unicode_string"] == "hello \U0001f496"

--- a/tests/test_pop_loadset_h5.py
+++ b/tests/test_pop_loadset_h5.py
@@ -357,8 +357,8 @@ class TestPopLoadsetH5(DebuggableTestCase):
 
         with h5py.File(filepath, 'w') as f:
             eeg_group = f.create_group('EEG')
-            # Create Unicode string data (special case handled in pop_loadset_h5)
-            unicode_ascii = np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150], dtype=np.uint16)  # "hello 👖"
+            # Create Unicode string data: UTF-8 bytes for "hello 💖" stored one byte per uint16
+            unicode_ascii = np.array([104, 101, 108, 108, 111, 32, 240, 159, 146, 150], dtype=np.uint16)  # "hello 💖"
             eeg_group.create_dataset('unicode_string', data=unicode_ascii)
 
             # Add minimal required data to prevent eeg_checkset from failing
@@ -372,8 +372,8 @@ class TestPopLoadsetH5(DebuggableTestCase):
 
         EEG = pop_loadset_h5(filepath)
 
-        # Should handle Unicode strings (special case in the code)
-        self.assertEqual(EEG['unicode_string'], 'hello 👖')
+        # The general uint16 -> UTF-8 decode path returns the correct emoji.
+        self.assertEqual(EEG['unicode_string'], 'hello \U0001f496')
 
 
 @unittest.skipIf(os.getenv('EEGPREP_SKIP_MATLAB') == '1', "MATLAB not available")

--- a/tests/test_pop_select.py
+++ b/tests/test_pop_select.py
@@ -358,6 +358,30 @@ class TestPopSelectEdgeCases(unittest.TestCase):
         self.assertEqual(EEG_out['nbchan'], 2)
         self.assertEqual(EEG_out['data'].shape[0], 2)
 
+    def test_channel_selection_by_type(self):
+        """Selecting by chantype keeps only channels whose type matches (no unpack crash)."""
+        EEG = copy.deepcopy(self.EEG)
+        types = ['EEG', 'EEG', 'EOG', 'EOG']
+        for chan, ctype in zip(EEG['chanlocs'], types):
+            chan['type'] = ctype
+
+        EEG_out = pop_select(EEG, chantype=['EEG'])
+
+        self.assertEqual(EEG_out['nbchan'], 2)
+        self.assertEqual([chan['labels'] for chan in EEG_out['chanlocs']], ['Fz', 'Cz'])
+
+    def test_channel_removal_by_type(self):
+        """Removing by rmchantype drops channels whose type matches (no unpack crash)."""
+        EEG = copy.deepcopy(self.EEG)
+        types = ['EEG', 'EEG', 'EOG', 'EOG']
+        for chan, ctype in zip(EEG['chanlocs'], types):
+            chan['type'] = ctype
+
+        EEG_out = pop_select(EEG, rmchantype=['EOG'])
+
+        self.assertEqual(EEG_out['nbchan'], 2)
+        self.assertEqual([chan['labels'] for chan in EEG_out['chanlocs']], ['Fz', 'Cz'])
+
     def test_negative_indices_error(self):
         """Test that negative channel indices raise appropriate errors."""
         EEG = copy.deepcopy(self.EEG)

--- a/tests/test_runamica.py
+++ b/tests/test_runamica.py
@@ -271,6 +271,32 @@ class TestFindAmicaBinary(unittest.TestCase):
                 _find_amica_binary()
 
 
+class TestRunamicaTempCleanup(unittest.TestCase):
+    """A failed run must not leak the auto-created temp directory."""
+
+    def _amica_temp_dirs(self):
+        root = tempfile.gettempdir()
+        return {name for name in os.listdir(root) if name.startswith('amica_')}
+
+    def test_failed_run_removes_temp_dir(self):
+        data = np.random.RandomState(0).randn(4, 500)
+        before = self._amica_temp_dirs()
+
+        def _boom(binary, param_file):
+            raise RuntimeError("amica binary failed")
+
+        with mock.patch(
+            'eegprep.functions.sigprocfunc.runamica._find_amica_binary',
+            return_value='/dummy/amica',
+        ):
+            with mock.patch('eegprep.functions.sigprocfunc.runamica._run_amica', side_effect=_boom):
+                with self.assertRaises(RuntimeError):
+                    runamica(data, num_models=1, max_iter=10, max_threads=1)
+
+        # No new amica_* temp directory should survive the failure.
+        self.assertEqual(self._amica_temp_dirs() - before, set())
+
+
 @unittest.skipUnless(is_amica_available(), "AMICA binary not functional on this platform")
 class TestRunamicaIntegration(unittest.TestCase):
     """Integration test: run AMICA binary on small synthetic data."""

--- a/tests/test_sigproc_eegrej.py
+++ b/tests/test_sigproc_eegrej.py
@@ -1,0 +1,56 @@
+"""Tests for the low-level signal-processing eegrej (sigprocfunc.eegrej)."""
+
+import unittest
+
+import numpy as np
+
+from eegprep.functions.sigprocfunc.eegrej import eegrej
+
+
+class TestSigprocEegrej(unittest.TestCase):
+    def setUp(self):
+        # 1 channel, 30 samples with values equal to their 1-based sample index
+        self.data = np.arange(1, 31, dtype=float).reshape(1, 30)
+        self.timelength = 30.0
+
+    def test_boundary_shift_uses_base_span_not_nested_duration(self):
+        # The first removed region already contains a boundary event with a large
+        # duration. EEGLAB shifts later boundary latencies by the prior regions'
+        # base spans only; the nested duration must NOT pull later boundaries left.
+        events = [
+            {"type": "boundary", "latency": 7.0, "duration": 100.0},  # inside [5, 10]
+            {"type": "stim", "latency": 25.0},
+        ]
+        _, _, newevents, boundevents = eegrej(self.data, [[5, 10], [20, 22]], self.timelength, events)
+
+        # Region1 boundary at start-1 = 4 -> 4.5.
+        # Region2 boundary at start-1 = 19, shifted by region1 base span (6) -> 13 -> 13.5.
+        # The augmented duration (106) must not be used for the shift.
+        np.testing.assert_array_equal(boundevents, [4.5, 13.5])
+
+        bnd = {ev["latency"]: ev["duration"] for ev in newevents if ev.get("type") == "boundary"}
+        # The first boundary's .duration carries the nested duration (base 6 + 100).
+        self.assertEqual(bnd[4.5], 106.0)
+        # The second boundary's .duration is region2's base span (22 - 20 + 1 = 3).
+        self.assertEqual(bnd[13.5], 3.0)
+
+    def test_multiple_regions_without_nested_boundaries(self):
+        # With no nested boundary durations, base span == duration, so the shift is
+        # unchanged: region2 boundary at 11 shifted by region1 base span 4 -> 7.5.
+        _, _, _, boundevents = eegrej(self.data, [[5, 8], [12, 14]], self.timelength)
+        np.testing.assert_array_equal(boundevents, [4.5, 7.5])
+
+    def test_adjacent_regions_merge_to_single_boundary(self):
+        # Adjacent regions excise a contiguous block; the two boundaries collapse
+        # to one latency after the base-span shift.
+        _, _, _, boundevents = eegrej(self.data, [[5, 8], [9, 12]], self.timelength)
+        np.testing.assert_array_equal(boundevents, [4.5])
+
+    def test_overlapping_regions_merge_to_single_boundary(self):
+        # Overlapping regions are de-overlapped then excised as one contiguous block.
+        _, _, _, boundevents = eegrej(self.data, [[5, 10], [8, 12]], self.timelength)
+        np.testing.assert_array_equal(boundevents, [4.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_study_measures.py
+++ b/tests/test_study_measures.py
@@ -97,6 +97,24 @@ def test_std_precomp_channel_measures_store_eeglab_named_fields():
         std_readerp(collapsed, alleeg, channels=[1], subject="S01")
 
 
+def test_std_precomp_recompute_off_preserves_cached_channel_measures():
+    study, alleeg = _study_pair()
+
+    study, alleeg = std_precomp(study, alleeg, [1], erp="on", spec="on")
+    original_erp = deepcopy(study["changrp"][0]["erpdata"])
+    # Overwrite the cached value with a sentinel the recompute path would never produce.
+    sentinel = (np.asarray(original_erp) + 1000.0).tolist()
+    study["changrp"][0]["erpdata"] = sentinel
+
+    # recompute='off' must keep the cached measure rather than recomputing it.
+    study, alleeg = std_precomp(study, alleeg, [1], erp="on", spec="on", recompute="off")
+    np.testing.assert_allclose(np.asarray(study["changrp"][0]["erpdata"]), np.asarray(sentinel))
+
+    # recompute='on' must overwrite the sentinel with a freshly computed measure.
+    study, alleeg = std_precomp(study, alleeg, [1], erp="on", spec="on", recompute="on")
+    np.testing.assert_allclose(np.asarray(study["changrp"][0]["erpdata"]), np.asarray(original_erp))
+
+
 def test_std_precomp_baseline_and_design_contract(caplog):
     study, alleeg = _study_pair()
     alleeg[0]["times"] = np.asarray([-100.0, 0.0, 100.0, 200.0])

--- a/tests/test_study_metadata.py
+++ b/tests/test_study_metadata.py
@@ -111,6 +111,31 @@ def test_std_makedesign_selects_1_based_design_and_validates_variables():
         std_selectdesign(study, alleeg, 3)
 
 
+def test_std_makedesign_delfiles_off_preserves_cached_measures():
+    study, alleeg = pop_study(
+        None,
+        [
+            _eeg("one", subject="S01", condition="target", group="control"),
+            _eeg("two", subject="S02", condition="standard", group="patient"),
+        ],
+    )
+    erpdata = [[1.0, 2.0, 3.0]]
+    study["changrp"] = [{"name": "Ch1", "channels": ["Ch1"], "erpdata": erpdata, "erptimes": [0.0, 1.0, 2.0]}]
+
+    kept, _command = std_makedesign(
+        study, alleeg, 2, variable1="group", values1=["control"], delfiles="off", return_com=True
+    )
+    assert kept["changrp"][0]["erpdata"] == erpdata
+    assert kept["changrp"][0]["erptimes"] == [0.0, 1.0, 2.0]
+
+    study["changrp"] = [{"name": "Ch1", "channels": ["Ch1"], "erpdata": erpdata, "erptimes": [0.0, 1.0, 2.0]}]
+    cleared, _command = std_makedesign(
+        study, alleeg, 2, variable1="group", values1=["control"], delfiles="on", return_com=True
+    )
+    assert "erpdata" not in cleared["changrp"][0]
+    assert "erptimes" not in cleared["changrp"][0]
+
+
 def test_pop_studydesign_selects_and_updates_design():
     study, alleeg = pop_study(
         None,

--- a/tests/test_utils_asr.py
+++ b/tests/test_utils_asr.py
@@ -69,20 +69,31 @@ class TestAsrCalibrate(unittest.TestCase):
                 self.assertTrue(len(state['B']) > 1)
                 self.assertTrue(len(state['A']) > 0)
 
-    def test_unsupported_sampling_rate(self):
-        """Test calibration with unsupported sampling rate (triggers warning)."""
-        unsupported_srate = 999.0
+    def test_unsupported_sampling_rate_raises(self):
+        """Unsupported sampling rates must fail loudly, not silently degrade.
+
+        Common rates like 999/1000/1024 Hz have no pre-computed spectral filter.
+        Substituting a trivial difference filter would silently miscalibrate ASR
+        thresholds, so asr_calibrate must raise rather than warn-and-continue.
+        """
         data = np.random.randn(4, 1000) * 0.3
 
-        with self.assertLogs('eegprep.plugins.clean_rawdata.asr_calibrate', level='WARNING') as log:
-            state = asr_calibrate(data, unsupported_srate)
+        for unsupported_srate in (999.0, 1000.0, 1024.0):
+            with self.subTest(srate=unsupported_srate):
+                with self.assertRaises(ValueError) as cm:
+                    asr_calibrate(data, unsupported_srate)
+                self.assertIn('No pre-computed ASR spectral filter', str(cm.exception))
 
-        # Check that warning was logged
-        self.assertTrue(any('No pre-computed spectral filter' in msg for msg in log.output))
+    def test_unsupported_sampling_rate_allows_explicit_filter(self):
+        """An explicit B/A bypasses the precomputed-filter lookup for any srate."""
+        data = np.random.randn(4, 1000) * 0.3
+        B = np.array([1.0, -0.5])
+        A = np.array([1.0])
 
-        # Check that fallback filter was used
-        self.assertEqual(len(state['B']), 2)  # Simple fallback filter
-        self.assertEqual(len(state['A']), 1)
+        state = asr_calibrate(data, 999.0, B=B, A=A)
+        self.assertIn('M', state)
+        np.testing.assert_array_equal(state['B'], B)
+        np.testing.assert_array_equal(state['A'], A)
 
     def test_parameter_validation(self):
         """Test parameter validation and edge cases."""
@@ -361,6 +372,18 @@ class TestAsrProcess(unittest.TestCase):
             self.assertTrue(any('Failed to calculate inverse' in msg for msg in log.output))
             self.assertEqual(cleaned_data.shape, self.test_data.shape)
 
+    def test_component_selection_shape_error_propagates(self):
+        """A shape/contract bug during component selection must surface, not be
+        silently swallowed into a no-op (keep-all) for the affected window.
+        """
+        bad_state = dict(self.state)
+        # T is C x C in a valid state; an incompatible threshold matrix makes
+        # finite_matmul(T, V) fail. This must raise rather than disable cleaning.
+        bad_state['T'] = np.ones((self.n_channels + 1, self.n_channels + 1))
+
+        with self.assertRaises(ValueError):
+            asr_process(self.test_data, self.srate, bad_state)
+
     def test_state_persistence_across_calls(self):
         """Test that state is properly maintained across multiple processing calls."""
         # First call
@@ -396,15 +419,16 @@ class TestAsrProcess(unittest.TestCase):
         self.assertTrue(np.all(np.isfinite(cleaned_data)))
 
     def test_component_selection_error_handling(self):
-        """Test error handling in component selection logic."""
-        # Mock numpy.sum to raise an error during threshold calculation
-        with patch('numpy.sum', side_effect=Exception("Threshold error")):
-            with self.assertLogs('eegprep.plugins.clean_rawdata.asr_process', level='ERROR') as log:
-                cleaned_data, new_state = asr_process(self.test_data, self.srate, self.state)
+        """An unexpected error during threshold computation must propagate.
 
-            # Should log error and use fallback (keep all components)
-            self.assertTrue(any('Error in component selection' in msg for msg in log.output))
-            self.assertEqual(cleaned_data.shape, self.test_data.shape)
+        Previously such errors were swallowed and the window silently kept all
+        components (no artifact removal). They must now surface so genuine bugs are
+        visible rather than producing quietly under-cleaned data.
+        """
+        with patch('numpy.sum', side_effect=Exception("Threshold error")):
+            with self.assertRaises(Exception) as cm:
+                asr_process(self.test_data, self.srate, self.state)
+            self.assertIn('Threshold error', str(cm.exception))
 
 
 class TestAsrIntegration(unittest.TestCase):
@@ -603,25 +627,27 @@ class TestAsrEdgeCases(unittest.TestCase):
         self.assertEqual(cleaned_data.shape, test_data.shape)
 
     def test_very_high_sampling_rate(self):
-        """Test ASR with very high sampling rate."""
-        n_channels = 4
-        srate = 2000.0  # High sampling rate
+        """Very high (unsupported) sampling rate must fail loudly in calibration.
 
-        # Create appropriate amount of data
+        2000 Hz has no pre-computed spectral filter; calibration must raise rather
+        than silently substitute a degenerate difference filter.
+        """
+        n_channels = 4
+        srate = 2000.0  # High, unsupported sampling rate
+
         n_samples = int(srate * 2)  # 2 seconds
         calib_data = np.random.randn(n_channels, n_samples) * 0.3
 
-        # Should use fallback filter for unsupported sampling rate
-        with self.assertLogs('eegprep.plugins.clean_rawdata.asr_calibrate', level='WARNING'):
-            state = asr_calibrate(calib_data, srate)
+        with self.assertRaises(ValueError) as cm:
+            asr_calibrate(calib_data, srate)
+        self.assertIn('No pre-computed ASR spectral filter', str(cm.exception))
 
-        # Should still work
-        self.assertIsInstance(state, dict)
-
-        # Test processing
+        # With explicit filter coefficients the high rate is processable end-to-end.
+        B = np.array([1.0, -0.5])
+        A = np.array([1.0])
+        state = asr_calibrate(calib_data, srate, B=B, A=A)
         test_data = np.random.randn(n_channels, 200) * 0.4
         cleaned_data, _ = asr_process(test_data, srate, state)
-
         self.assertEqual(cleaned_data.shape, test_data.shape)
 
     def test_zero_variance_data(self):


### PR DESCRIPTION
Replace silent fallbacks with real dispatch, make validated-but-ignored options take effect or fail loudly, and fix index/boundary errors across loading, event/channel selection, sigproc, the GUI/console session, the CLI, and the ASR/clean pipeline. Each fix lands with a test that reproduces the bug first. Notable: pop_loadset/pop_fileio stop swallowing load errors, the console now zero-bases pop_select numeric channels so 1-based history replays correctly, epoch()/eegrej() boundary math is corrected, asr_calibrate/clean_artifacts/asr_process stop silently degrading, and CLI schema/exit-code contracts match behavior.

Fixes #196