### PR TITLE
Converge rejection ICA clean helpers

### DIFF
--- a/src/eegprep/functions/popfunc/_eegplot_rejection.py
+++ b/src/eegprep/functions/popfunc/_eegplot_rejection.py
@@ -15,16 +15,20 @@ from eegprep.functions.popfunc._rejection import (
     rejection_data,
     update_reject_fields,
 )
-from eegprep.functions.popfunc.pop_eegplot import (
-    DEFAULT_REJECTION_COLORS,
-    MANUAL_REJECTION_COLOR,
-    REJECTION_FAMILIES,
-    pad_rejection_rows,
-    rejection_row_count,
-)
 from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 from eegprep.functions.sigprocfunc.eegplot import eegplot, eegplot2trial, trial2eegplot
 
+
+MANUAL_REJECTION_COLOR = (1.0, 0.9, 0.9)
+DEFAULT_REJECTION_COLORS = {
+    "manual": (1.0000, 1.0000, 0.7830),
+    "thresh": (0.8487, 1.0000, 0.5008),
+    "const": (0.6940, 1.0000, 0.7008),
+    "jp": (1.0000, 0.6991, 0.7537),
+    "kurt": (0.6880, 0.7042, 1.0000),
+    "freq": (0.9596, 0.7193, 1.0000),
+}
+REJECTION_FAMILIES = ("manual", "thresh", "const", "jp", "kurt", "freq")
 
 # Autorej shares manual-color browser marks and is not superposed as a separate EEGLAB family.
 _AUTO_REJECTION_COLOR = MANUAL_REJECTION_COLOR
@@ -98,6 +102,49 @@ def run_epoched_rejection(
         rejected,
         command,
     )
+
+
+def run_epoched_mark_rejection(
+    EEG: dict[str, Any],
+    icacomp: int | bool,
+    elecrange: Any,
+    superpose: int | bool,
+    reject: int | bool,
+    *,
+    marks_fn: Callable[[dict[str, Any], np.ndarray, list[int]], tuple[np.ndarray, np.ndarray, Any]],
+    kind: str,
+    error_message: str,
+    command_fn: Callable[[list[int], Any], str],
+    display: bool = False,
+    command_callback: Any | None = None,
+    show: bool = True,
+) -> tuple[dict[str, Any], list[int], str, Any]:
+    """Run an epoched rejection method that already computes trial/row marks."""
+    out = copy_eeg(EEG)
+    data, row_count = rejection_data(out, icacomp)
+    if int(out.get("trials", data.shape[2]) or data.shape[2]) <= 1:
+        raise ValueError(error_message)
+    elecrange = one_based_indices(elecrange, limit=row_count, default_all=True)
+    marks, marks_e, payload = marks_fn(out, data, elecrange)
+    update_reject_fields(out, icacomp=icacomp, kind=kind, reject=marks, reject_e=marks_e)
+    rejected = (np.flatnonzero(marks) + 1).tolist()
+    command = command_fn(elecrange, payload)
+    if display:
+        open_epoched_rejection_browser(
+            out,
+            data=data,
+            icacomp=icacomp,
+            elecrange=elecrange,
+            kind=kind,
+            superpose=superpose,
+            reject=reject,
+            command=command,
+            command_callback=command_callback,
+            show=show,
+        )
+    elif int(bool(reject)) and rejected:
+        out = pop_rejepoch(out, rejected, 0)
+    return out, rejected, command, payload
 
 
 def vistype_from_gui(value: Any) -> int:
@@ -290,6 +337,58 @@ def ensure_rejection_defaults(EEG: dict[str, Any]) -> None:
         reject.setdefault(f"rej{family}col", np.asarray(color, dtype=float))
 
 
+def pad_rejection_rows(values: Any, row_count: int, trials: int) -> np.ndarray:
+    """Zero-pad/crop a row-mask array to ``(row_count, trials)``."""
+    out = np.zeros((row_count, trials), dtype=bool)
+    arr = np.asarray(values, dtype=bool)
+    if arr.ndim == 1 and arr.size:
+        arr = arr.reshape(1, -1)
+    if arr.ndim == 2:
+        rows = min(row_count, arr.shape[0])
+        cols = min(trials, arr.shape[1])
+        out[:rows, :cols] = arr[:rows, :cols]
+    return out
+
+
+def rejection_row_count(EEG: dict[str, Any], icacomp: int | bool) -> int:
+    """Return the number of channel or component rows for rejection marks."""
+    if int(bool(icacomp)):
+        return int(EEG.get("nbchan", np.asarray(EEG.get("data")).shape[0]) or 0)
+    weights = np.asarray(EEG.get("icaweights", []))
+    return int(weights.shape[0]) if weights.ndim == 2 else 0
+
+
+def manual_rejection_color(EEG: dict[str, Any]) -> tuple[float, float, float]:
+    """Return the EEG manual rejection color."""
+    return rejection_family_color(EEG.get("reject") or {}, "manual", MANUAL_REJECTION_COLOR)
+
+
+def displayed_rejection_families(reject: dict[str, Any]) -> tuple[str, ...]:
+    """Return the EEGLAB rejection families currently displayed in a browser."""
+    disprej = reject.get("disprej")
+    if disprej is not None and np.asarray(disprej, dtype=object).size:
+        return tuple(str(item) for item in np.asarray(disprej, dtype=object).ravel() if str(item) in REJECTION_FAMILIES)
+    return tuple(family for family in REJECTION_FAMILIES if has_rejection_family(reject, family))
+
+
+def has_rejection_family(reject: dict[str, Any], family: str) -> bool:
+    """Return whether data or component marks exist for a rejection family."""
+    return any(np.asarray(reject.get(field, [])).size for field in (f"rej{family}", f"icarej{family}"))
+
+
+def rejection_family_color(
+    reject: dict[str, Any],
+    family: str,
+    default: tuple[float, float, float] | None = None,
+) -> tuple[float, float, float]:
+    """Return a normalized RGB color for a rejection family."""
+    fallback = default if default is not None else DEFAULT_REJECTION_COLORS.get(family, MANUAL_REJECTION_COLOR)
+    values = np.asarray(reject.get(f"rej{family}col", fallback), dtype=float).ravel()
+    if values.size < 3:
+        return fallback
+    return tuple(float(item) for item in values[:3])
+
+
 def _apply_superposed_family_rows(
     EEG: dict[str, Any],
     rows: np.ndarray,
@@ -302,7 +401,7 @@ def _apply_superposed_family_rows(
     pnts: int,
 ) -> None:
     reject = EEG.setdefault("reject", {})
-    families = set(_displayed_families(reject))
+    families = set(displayed_rejection_families(reject))
     families.add(_family_from_kind(kind))
     for family in sorted(families):
         family_kind = f"rej{family}"
@@ -390,14 +489,7 @@ def _trial_marks(value: Any, trials: int) -> np.ndarray:
 
 
 def _displayed_families(reject: dict[str, Any]) -> tuple[str, ...]:
-    disprej = reject.get("disprej")
-    if disprej is not None and np.asarray(disprej, dtype=object).size:
-        return tuple(str(item) for item in np.asarray(disprej, dtype=object).ravel() if str(item) in REJECTION_FAMILIES)
-    return tuple(family for family in REJECTION_FAMILIES if _has_family_marks(reject, family))
-
-
-def _has_family_marks(reject: dict[str, Any], family: str) -> bool:
-    return any(np.asarray(reject.get(field, [])).size for field in (f"rej{family}", f"icarej{family}"))
+    return displayed_rejection_families(reject)
 
 
 def _kind_color(EEG: dict[str, Any], kind: str) -> tuple[float, float, float]:
@@ -409,11 +501,7 @@ def _kind_color(EEG: dict[str, Any], kind: str) -> tuple[float, float, float]:
 
 
 def _family_color(reject: dict[str, Any], family: str) -> tuple[float, float, float]:
-    default = DEFAULT_REJECTION_COLORS.get(family, MANUAL_REJECTION_COLOR)
-    values = np.asarray(reject.get(f"rej{family}col", default), dtype=float).ravel()
-    if values.size < 3:
-        return default
-    return tuple(float(item) for item in values[:3])
+    return rejection_family_color(reject, family)
 
 
 def _family_from_kind(kind: str) -> str:

--- a/src/eegprep/functions/popfunc/_ica_utils.py
+++ b/src/eegprep/functions/popfunc/_ica_utils.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from eegprep.functions.miscfunc.misc import finite_matmul, finite_pinv
+from eegprep.functions.miscfunc.pinv import pinv
+
 
 def flatten_ica_data(data):
     """Flatten channel-major EEG data using EEGLAB/MATLAB epoch ordering."""
@@ -20,6 +23,8 @@ def finalize_ica_fields(EEG, *, sortcomps='off', posact='off'):
     ``EEG['icawinv']`` and returns ``EEG``. Shared by the runica, AMICA, and
     Picard backends so the post-decomposition behavior stays identical.
     """
+    EEG['icawinv'] = finite_pinv(finite_matmul(EEG['icaweights'], EEG['icasphere']), solver=pinv)
+
     # Optionally sort components by mean descending activation variance
     if sortcomps in ('on', True):
         # Flatten icaact to 2D for variance computation
@@ -52,4 +57,5 @@ def finalize_ica_fields(EEG, *, sortcomps='off', posact='off'):
                 EEG['icawinv'][:, r] = -EEG['icawinv'][:, r]
                 EEG['icaweights'][r, :] = -EEG['icaweights'][r, :]
 
+    EEG['icawinv'] = finite_pinv(finite_matmul(EEG['icaweights'], EEG['icasphere']), solver=pinv)
     return EEG

--- a/src/eegprep/functions/popfunc/eeg_amica.py
+++ b/src/eegprep/functions/popfunc/eeg_amica.py
@@ -140,4 +140,4 @@ def load_amica_model(EEG, mods, model_num=0):
     EEG['icaact'] = (EEG['icaweights'] @ EEG['icasphere']) @ data
     EEG['icaact'] = reshape_ica_activations(EEG['icaact'], EEG['pnts'], EEG['trials'])
 
-    return EEG
+    return finalize_ica_fields(EEG)

--- a/src/eegprep/functions/popfunc/pop_eegplot.py
+++ b/src/eegprep/functions/popfunc/pop_eegplot.py
@@ -7,11 +7,19 @@ from typing import Any
 from eegprep.functions.popfunc._plot_utils import history_command
 import numpy as np
 
+from eegprep.functions.popfunc._eegplot_rejection import (
+    DEFAULT_REJECTION_COLORS,
+    MANUAL_REJECTION_COLOR,
+    displayed_rejection_families,
+    manual_rejection_color,
+    pad_rejection_rows,
+    rejection_family_color,
+    rejection_row_count,
+)
 from eegprep.functions.popfunc._rejection import copy_eeg
 from eegprep.functions.popfunc.eeg_eegrej import eeg_eegrej
 from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 from eegprep.functions.sigprocfunc.eegplot import (
-    DEFAULT_WINREJ_COLOR,
     eegplot,
     eegplot2event,
     eegplot2trial,
@@ -21,16 +29,6 @@ from eegprep.functions.sigprocfunc.eegplot import (
 )
 
 
-MANUAL_REJECTION_COLOR = (1.0, 0.9, 0.9)
-DEFAULT_REJECTION_COLORS = {
-    "manual": (1.0000, 1.0000, 0.7830),
-    "thresh": (0.8487, 1.0000, 0.5008),
-    "const": (0.6940, 1.0000, 0.7008),
-    "jp": (1.0000, 0.6991, 0.7537),
-    "kurt": (0.6880, 0.7042, 1.0000),
-    "freq": (0.9596, 0.7193, 1.0000),
-}
-REJECTION_FAMILIES = ("manual", "thresh", "const", "jp", "kurt", "freq")
 CONTINUOUS_MANUAL_WINREJ = "rejmanualwinrej"
 CONTINUOUS_ICA_MANUAL_WINREJ = "icarejmanualwinrej"
 
@@ -65,7 +63,7 @@ def pop_eegplot(
     )
     options.setdefault("events", EEG.get("event", []))
     accept_callback = options.pop("command_callback", None)
-    options.setdefault("wincolor", _manual_color(EEG))
+    options.setdefault("wincolor", manual_rejection_color(EEG))
     options.setdefault("butlabel", "Reject" if int(bool(reject)) else "Update Marks")
     trials = int(EEG.get("trials", 1) or 1)
     if trials > 1:
@@ -149,7 +147,7 @@ def apply_eegplot_rejections(
 
     pnts = int(out.get("pnts", np.asarray(out.get("data")).shape[1]))
     if rows.size:
-        trial_marks, row_marks = eegplot2trial(rows, pnts, trials, _manual_color(out), None)
+        trial_marks, row_marks = eegplot2trial(rows, pnts, trials, manual_rejection_color(out), None)
         store_superpose = superpose
     else:
         trial_marks = np.zeros(trials, dtype=bool)
@@ -168,16 +166,16 @@ def _initial_epoch_winrej(EEG: dict[str, Any], icacomp: int, superpose: int) -> 
     row_count = rejection_row_count(EEG, icacomp)
     manual, manual_e = _reject_arrays(reject, "rejmanual", trials, row_count, icacomp=icacomp)
     if int(superpose) == 0:
-        return trial2eegplot(manual, manual_e, pnts, _manual_color(EEG))
+        return trial2eegplot(manual, manual_e, pnts, manual_rejection_color(EEG))
     if int(superpose) == 2:
         return _superposed_epoch_winrej(EEG, reject, icacomp, trials, row_count, pnts, manual, manual_e)
     rows = []
-    old_color = tuple(min(component + 0.15, 1.0) for component in _manual_color(EEG))
+    old_color = tuple(min(component + 0.15, 1.0) for component in manual_rejection_color(EEG))
     old, old_e = _reject_arrays(reject, "rejglobal", trials, row_count, icacomp=1)
     old_rows = trial2eegplot(old, old_e, pnts, old_color)
     if old_rows.size:
         rows.append(old_rows)
-    manual_rows = trial2eegplot(manual, manual_e, pnts, _manual_color(EEG))
+    manual_rows = trial2eegplot(manual, manual_e, pnts, manual_rejection_color(EEG))
     if manual_rows.size:
         rows.append(manual_rows)
     return np.vstack(rows) if rows else np.zeros((0, 5 + row_count), dtype=float)
@@ -207,9 +205,9 @@ def _superposed_epoch_winrej(
     manual_e: np.ndarray,
 ) -> np.ndarray:
     rows = []
-    manual_color = _manual_color(EEG)
-    for family in _displayed_rejection_families(reject):
-        color = _reject_color(reject, family, DEFAULT_REJECTION_COLORS.get(family, manual_color))
+    manual_color = manual_rejection_color(EEG)
+    for family in displayed_rejection_families(reject):
+        color = rejection_family_color(reject, family, DEFAULT_REJECTION_COLORS.get(family, manual_color))
         if tuple(color) == tuple(manual_color):
             continue
         marks, marks_e = _reject_arrays(reject, f"rej{family}", trials, row_count, icacomp=icacomp)
@@ -296,27 +294,6 @@ def _reject_arrays(
     return out, row_marks
 
 
-def pad_rejection_rows(values: np.ndarray, row_count: int, trials: int) -> np.ndarray:
-    """Zero-pad/crop a row-mask array to ``(row_count, trials)``."""
-    out = np.zeros((row_count, trials), dtype=bool)
-    arr = np.asarray(values, dtype=bool)
-    if arr.ndim == 1 and arr.size:
-        arr = arr.reshape(1, -1)
-    if arr.ndim == 2:
-        rows = min(row_count, arr.shape[0])
-        cols = min(trials, arr.shape[1])
-        out[:rows, :cols] = arr[:rows, :cols]
-    return out
-
-
-def rejection_row_count(EEG: dict[str, Any], icacomp: int) -> int:
-    """Return the number of channel or component rows for rejection marks."""
-    if int(bool(icacomp)):
-        return int(EEG.get("nbchan", np.asarray(EEG.get("data")).shape[0]) or 0)
-    weights = np.asarray(EEG.get("icaweights", []))
-    return int(weights.shape[0]) if weights.ndim == 2 else 0
-
-
 def _require_ica(EEG: dict[str, Any]) -> None:
     if _nonempty_array(EEG.get("icaact")):
         return
@@ -336,37 +313,6 @@ def _dataset_pnts(EEG: dict[str, Any]) -> int:
     if data.ndim >= 2:
         return int(data.shape[1])
     return 0
-
-
-def _displayed_rejection_families(reject: dict[str, Any]) -> tuple[str, ...]:
-    disprej = reject.get("disprej")
-    if disprej is None or np.asarray(disprej, dtype=object).size == 0:
-        return tuple(family for family in REJECTION_FAMILIES if _has_rejection_family(reject, family))
-    values = np.asarray(disprej, dtype=object).ravel().tolist()
-    return tuple(str(value) for value in values if str(value) in REJECTION_FAMILIES)
-
-
-def _has_rejection_family(reject: dict[str, Any], family: str) -> bool:
-    data_marks = reject.get(f"rej{family}")
-    component_marks = reject.get(f"icarej{family}")
-    return (data_marks is not None and np.asarray(data_marks).size > 0) or (
-        component_marks is not None and np.asarray(component_marks).size > 0
-    )
-
-
-def _manual_color(EEG: dict[str, Any]) -> tuple[float, float, float]:
-    reject = EEG.get("reject") or {}
-    return _reject_color(reject, "manual", MANUAL_REJECTION_COLOR)
-
-
-def _reject_color(
-    reject: dict[str, Any], family: str, default: tuple[float, float, float]
-) -> tuple[float, float, float]:
-    color = reject.get(f"rej{family}col", default)
-    values = np.asarray(color if color is not None else DEFAULT_WINREJ_COLOR, dtype=float).ravel()
-    if values.size < 3:
-        return default
-    return tuple(float(item) for item in values[:3])
 
 
 __all__ = ["apply_eegplot_rejections", "eegplot_accept_creates_dataset", "pop_eegplot"]

--- a/src/eegprep/functions/popfunc/pop_eegthresh.py
+++ b/src/eegprep/functions/popfunc/pop_eegthresh.py
@@ -8,17 +8,9 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
-from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
+from eegprep.functions.popfunc._eegplot_rejection import run_epoched_mark_rejection
 from eegprep.functions.popfunc._pop_utils import format_history_value
-from eegprep.functions.popfunc._rejection import (
-    copy_eeg,
-    eegthresh_marks,
-    one_based_indices,
-    parse_numeric_sequence,
-    rejection_data,
-    update_reject_fields,
-)
-from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
+from eegprep.functions.popfunc._rejection import eegthresh_marks, parse_numeric_sequence
 
 
 def pop_eegthresh(
@@ -166,45 +158,50 @@ def _apply_one(
     command_callback: Any | None = None,
     show: bool = True,
 ) -> tuple[dict[str, Any], list[int], str]:
-    out = copy_eeg(EEG)
-    data, row_count = rejection_data(out, icacomp)
-    trials = int(out.get("trials", data.shape[2]) or data.shape[2])
-    if trials <= 1:
-        raise ValueError("pop_eegthresh requires epoched data")
-    elecrange = one_based_indices(elecrange, limit=row_count, default_all=True)
-    negthresh = [-10.0] if negthresh is None else negthresh
-    posthresh = [10.0] if posthresh is None else posthresh
-    starttime = [float(out.get("xmin", 0.0))] if starttime is None else starttime
-    endtime = [float(out.get("xmax", 0.0))] if endtime is None else endtime
-    marks, marks_e = eegthresh_marks(
-        data,
-        elecrange,
-        negthresh,
-        posthresh,
-        (float(out.get("xmin", 0.0)), float(out.get("xmax", 0.0))),
-        starttime,
-        endtime,
-    )
-    update_reject_fields(out, icacomp=icacomp, kind="rejthresh", reject=marks, reject_e=marks_e)
-    rejected = (np.flatnonzero(marks) + 1).tolist()
-    command = _history_command(
-        icacomp, elecrange, negthresh, posthresh, starttime, endtime, superpose, int(bool(reject))
-    )
-    if display:
-        open_epoched_rejection_browser(
-            out,
-            data=data,
-            icacomp=icacomp,
-            elecrange=elecrange,
-            kind="rejthresh",
-            superpose=superpose,
-            reject=reject,
-            command=command,
-            command_callback=command_callback,
-            show=show,
+    def _marks(out: dict[str, Any], data: np.ndarray, normalized_elecrange: list[int]):
+        normalized = {
+            "negthresh": [-10.0] if negthresh is None else negthresh,
+            "posthresh": [10.0] if posthresh is None else posthresh,
+            "starttime": [float(out.get("xmin", 0.0))] if starttime is None else starttime,
+            "endtime": [float(out.get("xmax", 0.0))] if endtime is None else endtime,
+        }
+        marks, marks_e = eegthresh_marks(
+            data,
+            normalized_elecrange,
+            normalized["negthresh"],
+            normalized["posthresh"],
+            (float(out.get("xmin", 0.0)), float(out.get("xmax", 0.0))),
+            normalized["starttime"],
+            normalized["endtime"],
         )
-    elif int(bool(reject)) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
+        return marks, marks_e, normalized
+
+    def _command(normalized_elecrange: list[int], normalized: dict[str, Any]) -> str:
+        return _history_command(
+            icacomp,
+            normalized_elecrange,
+            normalized["negthresh"],
+            normalized["posthresh"],
+            normalized["starttime"],
+            normalized["endtime"],
+            superpose,
+            int(bool(reject)),
+        )
+
+    out, rejected, command, _normalized = run_epoched_mark_rejection(
+        EEG,
+        icacomp,
+        elecrange,
+        superpose,
+        reject,
+        marks_fn=_marks,
+        kind="rejthresh",
+        error_message="pop_eegthresh requires epoched data",
+        command_fn=_command,
+        display=display,
+        command_callback=command_callback,
+        show=show,
+    )
     return out, rejected, command
 
 

--- a/src/eegprep/functions/popfunc/pop_rejspec.py
+++ b/src/eegprep/functions/popfunc/pop_rejspec.py
@@ -8,17 +8,12 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
-from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
+from eegprep.functions.popfunc._eegplot_rejection import run_epoched_mark_rejection
 from eegprep.functions.popfunc._pop_utils import format_history_value, parse_key_value_args
 from eegprep.functions.popfunc._rejection import (
-    copy_eeg,
-    one_based_indices,
     parse_numeric_sequence,
-    rejection_data,
     spectrum_marks,
-    update_reject_fields,
 )
-from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 
 
 def pop_rejspec(
@@ -169,46 +164,44 @@ def _apply_one(
     command_callback: Any | None = None,
     show: bool = True,
 ) -> tuple[dict[str, Any], list[int], str]:
-    out = copy_eeg(EEG)
-    data, row_count = rejection_data(out, icacomp)
-    if int(out.get("trials", data.shape[2]) or data.shape[2]) <= 1:
-        raise ValueError("pop_rejspec requires epoched data")
-    elecrange = one_based_indices(options.get("elecrange"), limit=row_count, default_all=True)
-    threshold = options.get("threshold", [-30, 30])
-    freqlimits = options.get("freqlimits", [15, 30])
-    method = str(options.get("method", "multitaper")).lower()
-    marks, marks_e, spectra = spectrum_marks(
-        data, elecrange, float(out.get("srate", 1.0)), threshold, freqlimits, method
-    )
-    if int(bool(icacomp)):
-        out["specdata"] = spectra
-    else:
-        out["specicaact"] = spectra
-    update_reject_fields(out, icacomp=icacomp, kind="rejfreq", reject=marks, reject_e=marks_e)
-    rejected = (np.flatnonzero(marks) + 1).tolist()
-    normalized_options = dict(options)
-    normalized_options["elecrange"] = elecrange
-    normalized_options["method"] = method
-    normalized_options.setdefault("threshold", threshold)
-    normalized_options.setdefault("freqlimits", freqlimits)
-    normalized_options.setdefault("eegplotplotallrej", 0)
-    normalized_options.setdefault("eegplotreject", 0)
-    command = _history_command(icacomp, normalized_options)
-    if display:
-        open_epoched_rejection_browser(
-            out,
-            data=data,
-            icacomp=icacomp,
-            elecrange=elecrange,
-            kind="rejfreq",
-            superpose=_int_option(normalized_options.get("eegplotplotallrej", 0)),
-            reject=int(bool(_int_option(normalized_options.get("eegplotreject", 0)))),
-            command=command,
-            command_callback=command_callback,
-            show=show,
+    def _marks(out: dict[str, Any], data: np.ndarray, elecrange: list[int]):
+        threshold = options.get("threshold", [-30, 30])
+        freqlimits = options.get("freqlimits", [15, 30])
+        method = str(options.get("method", "multitaper")).lower()
+        marks, marks_e, spectra = spectrum_marks(
+            data, elecrange, float(out.get("srate", 1.0)), threshold, freqlimits, method
         )
-    elif int(bool(options.get("eegplotreject", 0))) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
+        if int(bool(icacomp)):
+            out["specdata"] = spectra
+        else:
+            out["specicaact"] = spectra
+        normalized_options = dict(options)
+        normalized_options["elecrange"] = elecrange
+        normalized_options["method"] = method
+        normalized_options.setdefault("threshold", threshold)
+        normalized_options.setdefault("freqlimits", freqlimits)
+        normalized_options.setdefault("eegplotplotallrej", 0)
+        normalized_options.setdefault("eegplotreject", 0)
+        return marks, marks_e, normalized_options
+
+    def _command(_elecrange: list[int], normalized_options: dict[str, Any]) -> str:
+        return _history_command(icacomp, normalized_options)
+
+    normalized_reject = int(bool(_int_option(options.get("eegplotreject", 0))))
+    out, rejected, command, _normalized_options = run_epoched_mark_rejection(
+        EEG,
+        icacomp,
+        options.get("elecrange"),
+        _int_option(options.get("eegplotplotallrej", 0)),
+        normalized_reject,
+        marks_fn=_marks,
+        kind="rejfreq",
+        error_message="pop_rejspec requires epoched data",
+        command_fn=_command,
+        display=display,
+        command_callback=command_callback,
+        show=show,
+    )
     return out, rejected, command
 
 

--- a/src/eegprep/functions/popfunc/pop_rejtrend.py
+++ b/src/eegprep/functions/popfunc/pop_rejtrend.py
@@ -8,17 +8,12 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
-from eegprep.functions.popfunc._eegplot_rejection import open_epoched_rejection_browser
+from eegprep.functions.popfunc._eegplot_rejection import run_epoched_mark_rejection
 from eegprep.functions.popfunc._pop_utils import format_history_value
 from eegprep.functions.popfunc._rejection import (
-    copy_eeg,
-    one_based_indices,
     parse_numeric_sequence,
-    rejection_data,
     trend_marks,
-    update_reject_fields,
 )
-from eegprep.functions.popfunc.pop_rejepoch import pop_rejepoch
 
 
 def pop_rejtrend(
@@ -151,33 +146,46 @@ def _apply_one(
     command_callback: Any | None = None,
     show: bool = True,
 ) -> tuple[dict[str, Any], str]:
-    out = copy_eeg(EEG)
-    data, row_count = rejection_data(out, icacomp)
-    if int(out.get("trials", data.shape[2]) or data.shape[2]) <= 1:
-        raise ValueError("pop_rejtrend requires epoched data")
-    elecrange = one_based_indices(elecrange, limit=row_count, default_all=True)
-    winsize = int(parse_numeric_sequence(winsize if winsize is not None else [data.shape[1]], dtype=float)[0])
-    minslope = float(parse_numeric_sequence(minslope, dtype=float)[0])
-    minstd = float(parse_numeric_sequence(minstd, dtype=float)[0])
-    marks, marks_e = trend_marks(data, elecrange, winsize, minslope, minstd)
-    update_reject_fields(out, icacomp=icacomp, kind="rejconst", reject=marks, reject_e=marks_e)
-    rejected = (np.flatnonzero(marks) + 1).tolist()
-    command = _history_command(icacomp, elecrange, winsize, minslope, minstd, superpose, reject)
-    if display:
-        open_epoched_rejection_browser(
-            out,
-            data=data,
-            icacomp=icacomp,
-            elecrange=elecrange,
-            kind="rejconst",
-            superpose=superpose,
-            reject=reject,
-            command=command,
-            command_callback=command_callback,
-            show=show,
+    def _marks(_out: dict[str, Any], data: np.ndarray, normalized_elecrange: list[int]):
+        normalized = {
+            "winsize": int(parse_numeric_sequence(winsize if winsize is not None else [data.shape[1]], dtype=float)[0]),
+            "minslope": float(parse_numeric_sequence(minslope, dtype=float)[0]),
+            "minstd": float(parse_numeric_sequence(minstd, dtype=float)[0]),
+        }
+        marks, marks_e = trend_marks(
+            data,
+            normalized_elecrange,
+            normalized["winsize"],
+            normalized["minslope"],
+            normalized["minstd"],
         )
-    elif int(bool(reject)) and rejected:
-        out = pop_rejepoch(out, rejected, 0)
+        return marks, marks_e, normalized
+
+    def _command(normalized_elecrange: list[int], normalized: dict[str, Any]) -> str:
+        return _history_command(
+            icacomp,
+            normalized_elecrange,
+            normalized["winsize"],
+            normalized["minslope"],
+            normalized["minstd"],
+            superpose,
+            reject,
+        )
+
+    out, _rejected, command, _normalized = run_epoched_mark_rejection(
+        EEG,
+        icacomp,
+        elecrange,
+        superpose,
+        reject,
+        marks_fn=_marks,
+        kind="rejconst",
+        error_message="pop_rejtrend requires epoched data",
+        command_fn=_command,
+        display=display,
+        command_callback=command_callback,
+        show=show,
+    )
     return out, command
 
 

--- a/src/eegprep/plugins/clean_rawdata/clean_channels.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_channels.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import numpy as np
 
 from ...functions.miscfunc.misc import finite_matmul, round_mat
+from .private.channel_removal import remove_channels_without_pop_select, update_clean_channel_mask
 from .private.ransac import calc_projector
 from .private.sigproc import design_fir, filtfilt_fast
 from .private.stats import mad
@@ -158,24 +159,7 @@ def clean_channels(
                 logger.debug("Exception traceback:", exc_info=True)
 
             logger.info(f'Removing {np.sum(removed_channels)} channels and dropping signal meta-data.')
-            if len(EEG['chanlocs']) == EEG['data'].shape[0]:
-                EEG['chanlocs'] = np.asarray([ch for i, ch in enumerate(EEG['chanlocs']) if not removed_channels[i]])
-            # pop_select() by default truncates the data to float32, so we need to do the same
-            EEG['data'] = np.asarray(EEG['data'], dtype=np.float32)
-            EEG['data'] = EEG['data'][~removed_channels, :]
-            EEG['nbchan'] = EEG['data'].shape[0]
-
-            # Clear other fields
-            for field in ['icawinv', 'icasphere', 'icaweights', 'icaact', 'stats', 'specdata', 'specicaact']:
-                if field in EEG:
-                    EEG[field] = np.array([])
-
-        # Update clean_channel_mask
-        if 'etc' in EEG and 'clean_channel_mask' in EEG['etc']:
-            EEG['etc']['clean_channel_mask'][EEG['etc']['clean_channel_mask']] = ~removed_channels
-        else:
-            if 'etc' not in EEG:
-                EEG['etc'] = {}
-            EEG['etc']['clean_channel_mask'] = ~removed_channels
+            EEG = remove_channels_without_pop_select(EEG, removed_channels)
+        update_clean_channel_mask(EEG, removed_channels)
 
     return EEG

--- a/src/eegprep/plugins/clean_rawdata/clean_channels_nolocs.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_channels_nolocs.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 
+from .private.channel_removal import remove_channels_without_pop_select, update_clean_channel_mask
 from .private.sigproc import design_fir, design_kaiser, filtfilt_fast
 
 logger = logging.getLogger(__name__)
@@ -116,30 +117,7 @@ def clean_channels_nolocs(
                 logger.debug('Exception traceback:', exc_info=True)
 
             logger.info('Falling back to a basic substitute and dropping signal meta-data.')
-            # Manual channel removal
-            if len(EEG['chanlocs']) == EEG['data'].shape[0]:
-                EEG['chanlocs'] = np.asarray([ch for i, ch in enumerate(EEG['chanlocs']) if not removed_channels[i]])
-            # pop_select() by default truncates the data to float32, so we need to do the same
-            EEG['data'] = np.asarray(EEG['data'], dtype=np.float32)
-            EEG['data'] = EEG['data'][~removed_channels, :]
-            EEG['nbchan'] = EEG['data'].shape[0]
-
-            # Clear other fields
-            for field in ['icawinv', 'icasphere', 'icaweights', 'icaact', 'stats', 'specdata', 'specicaact']:
-                if field in EEG:
-                    EEG[field] = np.array([])
-
-        # Update clean_channel_mask
-        if (
-            'etc' in EEG
-            and 'clean_channel_mask' in EEG['etc']
-            and sum(EEG['etc']['clean_channel_mask']) == len(removed_channels)
-        ):
-            mask = EEG['etc']['clean_channel_mask']
-            EEG['etc']['clean_channel_mask'] = np.logical_and(mask, ~removed_channels[mask])
-        else:
-            if 'etc' not in EEG:
-                EEG['etc'] = {}
-            EEG['etc']['clean_channel_mask'] = ~removed_channels
+            EEG = remove_channels_without_pop_select(EEG, removed_channels)
+        update_clean_channel_mask(EEG, removed_channels)
 
     return EEG, removed_channels

--- a/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
+++ b/src/eegprep/plugins/clean_rawdata/clean_flatlines.py
@@ -5,6 +5,8 @@ import logging
 
 import numpy as np
 
+from .private.channel_removal import remove_channels_without_pop_select, update_clean_channel_mask
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,18 +61,7 @@ def clean_flatlines(EEG: Dict[str, Any], max_flatline_duration: float = 5.0, max
                 logger.error('Could not select channels using EEGLAB\'s pop_select(); details: %s', str(e))
                 logger.debug('Exception traceback:', exc_info=True)
             logger.info('Falling back to a basic substitute and dropping signal meta-data.')
-            # pop_select() by default truncates the data to float32, so we need to do the same
-            EEG['data'] = np.asarray(EEG['data'], dtype=np.float32)
-            EEG['data'] = EEG['data'][np.logical_not(removed_channels), :]
-            if len(EEG['chanlocs']) == len(removed_channels):
-                EEG['chanlocs'] = EEG['chanlocs'][np.logical_not(removed_channels)]
-            EEG['nbchan'] = EEG['data'].shape[0]
-            for fn in EEG.keys() & {'icawinv', 'icasphere', 'icaweights', 'icaact', 'stats', 'specdata', 'specicaact'}:
-                EEG[fn] = np.array([])
-            CCM = EEG['etc'].get('clean_channel_mask')
-            if CCM is not None:
-                CCM[CCM] = ~removed_channels
-            else:
-                EEG['etc']['clean_channel_mask'] = ~removed_channels
+            EEG = remove_channels_without_pop_select(EEG, removed_channels)
+        update_clean_channel_mask(EEG, removed_channels)
 
     return EEG

--- a/src/eegprep/plugins/clean_rawdata/private/channel_removal.py
+++ b/src/eegprep/plugins/clean_rawdata/private/channel_removal.py
@@ -1,0 +1,42 @@
+"""Shared clean_rawdata channel-removal helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+CHANNEL_DEPENDENT_FIELDS = ("icawinv", "icasphere", "icaweights", "icaact", "stats", "specdata", "specicaact")
+
+
+def remove_channels_without_pop_select(EEG: dict[str, Any], removed_channels: np.ndarray) -> dict[str, Any]:
+    """Remove channels when ``pop_select`` is unavailable."""
+    removed = np.asarray(removed_channels, dtype=bool).ravel()
+    data = np.asarray(EEG["data"], dtype=np.float32)
+    chanlocs = EEG.get("chanlocs", [])
+    if len(chanlocs) == data.shape[0]:
+        if isinstance(chanlocs, np.ndarray):
+            EEG["chanlocs"] = chanlocs[~removed]
+        else:
+            EEG["chanlocs"] = np.asarray([chanloc for index, chanloc in enumerate(chanlocs) if not removed[index]])
+    EEG["data"] = data[~removed, ...]
+    EEG["nbchan"] = EEG["data"].shape[0]
+    for field in CHANNEL_DEPENDENT_FIELDS:
+        if field in EEG:
+            EEG[field] = np.array([])
+    return EEG
+
+
+def update_clean_channel_mask(EEG: dict[str, Any], removed_channels: np.ndarray) -> None:
+    """Update ``EEG.etc.clean_channel_mask`` after current-channel removal."""
+    removed = np.asarray(removed_channels, dtype=bool).ravel()
+    etc = EEG.setdefault("etc", {})
+    mask = etc.get("clean_channel_mask")
+    if mask is not None:
+        existing = np.asarray(mask, dtype=bool).ravel()
+        if int(np.sum(existing)) == removed.size:
+            updated = np.array(existing, dtype=bool, copy=True)
+            updated[updated] = ~removed
+            etc["clean_channel_mask"] = updated
+            return
+    etc["clean_channel_mask"] = ~removed

--- a/tests/test_clean_rawdata_channel_removal.py
+++ b/tests/test_clean_rawdata_channel_removal.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+
+from eegprep.plugins.clean_rawdata.private.channel_removal import update_clean_channel_mask
+
+
+def test_update_clean_channel_mask_composites_original_channel_mask():
+    eeg = {"etc": {"clean_channel_mask": np.array([True, False, True, True])}}
+    removed_channels = np.array([False, True, False])
+
+    update_clean_channel_mask(eeg, removed_channels)
+
+    np.testing.assert_array_equal(eeg["etc"]["clean_channel_mask"], [True, False, False, True])
+
+
+def test_update_clean_channel_mask_resets_mismatched_existing_mask():
+    eeg = {"etc": {"clean_channel_mask": np.array([True, False, True, True])}}
+    removed_channels = np.array([False, True])
+
+    update_clean_channel_mask(eeg, removed_channels)
+
+    np.testing.assert_array_equal(eeg["etc"]["clean_channel_mask"], [True, False])
+
+
+def test_update_clean_channel_mask_creates_zero_and_all_removal_masks():
+    no_removal = {"etc": {}}
+    all_removed = {}
+
+    update_clean_channel_mask(no_removal, np.zeros(3, dtype=bool))
+    update_clean_channel_mask(all_removed, np.ones(3, dtype=bool))
+
+    np.testing.assert_array_equal(no_removal["etc"]["clean_channel_mask"], [True, True, True])
+    np.testing.assert_array_equal(all_removed["etc"]["clean_channel_mask"], [False, False, False])

--- a/tests/test_eeg_runica.py
+++ b/tests/test_eeg_runica.py
@@ -143,6 +143,28 @@ def test_finalize_ica_fields_shared_sort_and_sign_normalization():
     np.testing.assert_allclose(out["icawinv"], pinv(out["icaweights"] @ out["icasphere"]))
 
 
+def test_finalize_ica_fields_recomputes_stale_backend_inverse_after_sorting():
+    """Final ICA fields must be invariant even if a backend reports stale maps."""
+    from eegprep.functions.popfunc._ica_utils import finalize_ica_fields
+
+    rng = np.random.default_rng(17)
+    nbchan, pnts, trials = 3, 5, 2
+    sphere = np.array([[1.0, 0.2, 0.0], [0.0, 1.5, 0.1], [0.3, 0.0, 2.0]])
+    weights = np.array([[2.0, 0.0, 0.5], [0.1, 1.0, 0.0], [0.0, -0.4, 1.5]])
+    data = rng.standard_normal((nbchan, pnts * trials))
+    icaact = (weights @ sphere) @ data
+    eeg = {
+        "icaweights": weights.copy(),
+        "icasphere": sphere.copy(),
+        "icawinv": np.full((nbchan, nbchan), 99.0),
+        "icaact": icaact.reshape(nbchan, pnts, trials, order="F"),
+    }
+
+    out = finalize_ica_fields(eeg, sortcomps=True, posact=False)
+
+    np.testing.assert_allclose(out["icawinv"], pinv(out["icaweights"] @ out["icasphere"]))
+
+
 def test_pop_runica_concatenates_epoched_datasets_in_eeglab_order(monkeypatch):
     first = _epoched_eeg()
     second = _epoched_eeg(offset=100)

--- a/tests/test_rejection_workflows.py
+++ b/tests/test_rejection_workflows.py
@@ -672,6 +672,18 @@ def test_channel_and_continuous_rejection_work_on_sample_data_without_ica():
         pop_eegthresh(sample, 0, [1], -10, 10, 0, 1)
 
 
+def test_rejection_component_threshold_recomputes_stale_stored_icaact():
+    eeg = _epoched_eeg()
+    eeg["icaweights"] = 2.0 * np.eye(4)
+    eeg["icasphere"] = np.eye(4)
+    eeg["icaact"] = np.zeros((4, eeg["pnts"], eeg["trials"]))
+
+    out, rejected = pop_eegthresh(eeg, 0, [1], -40, 40, 0, 0.79, 0, 0)
+
+    assert rejected == [2]
+    assert out["reject"]["icarejthresh"].tolist() == [False, True, False, False, False]
+
+
 def test_pop_rejchan_default_threshold_matches_gui_zscore_default():
     eeg = create_test_eeg(n_channels=2, n_samples=20, n_trials=1, srate=100)
     eeg["data"] = np.zeros((2, 20))


### PR DESCRIPTION
🤖 Converges epoched rejection browser handling, ICA final field invariants, and clean_rawdata channel-mask updates behind shared helpers. Adds focused regression coverage for stale component activations, stale ICA inverse matrices, and clean_channel_mask edge cases.

Fixes #209
Part of #207