### PR TITLE
Revamp project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,317 @@
-<img src="https://github.com/user-attachments/assets/d7230b12-7fb8-4abb-94a0-33c47286b019" width="300">
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/d7230b12-7fb8-4abb-94a0-33c47286b019" width="300" alt="EEGPrep logo">
+</p>
 
-# What is EEGPrep?
+# EEGPrep
 
+[![Tests](https://github.com/sccn/eegprep/actions/workflows/test.yml/badge.svg)](https://github.com/sccn/eegprep/actions/workflows/test.yml)
 [![Documentation Status](https://github.com/sccn/eegprep/actions/workflows/docs.yml/badge.svg)](https://github.com/sccn/eegprep/actions/workflows/docs.yml)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
 
-EEGPrep is a Python package that reproduces the EEGLAB default preprocessing pipeline with numerical accuracy down to 1e-5 uV, including clean_rawdata and ICLabel, enabling MATLAB-to-Python equivalence for EEG analysis. It takes BIDS data as input and produces BIDS derivative dataset as output, which can then be reimported into other packages as needed (EEGLAB, Fieldtrip, Brainstorm, MNE). It does produce plots. The package will be fully documented for conversion, packaging, and testing workflows, with installation available via PyPI.
+EEGPrep is an EEGLAB-compatible, Python-native toolkit for loading, cleaning,
+visualizing, scripting, and validating EEG preprocessing workflows. It keeps the
+EEGLAB concepts researchers already know, including `EEG`, `ALLEEG`,
+`CURRENTSET`, `pop_*` functions, command history, ICA fields, channel locations,
+events, epochs, STUDY workflows, and EEGBrowser-style review, while providing a
+standalone Python package with GUI, interactive console, CLI, tests, and Sphinx
+documentation.
 
-**📚 [View Full Documentation](https://sccn.github.io/eegprep/)** | **🔧 [GitHub Pages Setup Guide](docs/GITHUB_PAGES_SETUP.md)**
+EEGPrep is built for EEG researchers who want EEGLAB-style workflows, Python
+reproducibility, and agent-friendly automation without requiring MATLAB or an
+EEGLAB checkout at runtime.
 
-## Pre-Release
+**Documentation:** [sccn.github.io/eegprep](https://sccn.github.io/eegprep/) |
+**Issue tracker:** [github.com/sccn/eegprep/issues](https://github.com/sccn/eegprep/issues)
 
-EEGPrep is currently in a pre-release phase. It functions end-to-end (bids branch) but has not yet been tested with multiple BIDS datasets. The documentation is incomplete, and use is at your own risk. The planned release is scheduled for the end of 2025.
+## Why EEGPrep?
 
+- **Familiar to EEGLAB users.** Function names, data structures, menus, history
+  commands, and GUI workflows follow EEGLAB where that helps users move between
+  tools.
+- **Python-native and standalone.** Runtime code lives in the `eegprep` package
+  and works without calling MATLAB or reading the vendored EEGLAB reference tree.
+- **GUI and console share one workspace.** Launch `eegprep-console` and switch
+  between the Qt GUI and Python commands while `EEG`, `ALLEEG`, `CURRENTSET`,
+  `LASTCOM`, `ALLCOM`, `STUDY`, and `CURRENTSTUDY` stay synchronized.
+- **Scriptable from day one.** The same `pop_*` workflows can be used from the
+  GUI, Python scripts, and the command-line interface.
+- **Designed for reproducible research.** CLI commands support structured JSON,
+  manifests, pipeline validation, stable error codes, and bundled agent guidance.
+- **Validated against EEGLAB.** Numerical parity tests and visual parity checks
+  compare EEGPrep behavior with EEGLAB for deterministic workflows.
 
 ## Install
 
-EEGPrep uses `uv` as the default package manager for development and CI.
+EEGPrep uses `uv` for development and CI. For a published release, install the
+lean package with:
 
-To add the complete EEGPrep package to a uv-managed project, including the
-ICLabel classifier (which can pull in ~7GB of binaries on Linux), use:
-```
-uv add "eegprep[all]"
-```
-
-To add the lean version:
-```
+```bash
 uv add eegprep
 ```
 
-If you are installing into a non-uv environment, `pip install eegprep` remains
-supported for published releases.
+To install all optional extras, including GUI, console, docs, and classifier
+dependencies, use:
 
-You can then manually install a lightweight CPU-only version of PyTorch if desired by
-your operating system.
-
-
-# Comparing MATLAB and Python implementations
-
-The MATLAB and Python implementations were compared using the first two subjects from the BIDS datasets [ds003061](https://nemar.org/dataexplorer/detail?dataset_id=ds003061) and [ds002680](https://nemar.org/dataexplorer/detail?dataset_id=ds002680) available on NEMAR. The observed differences were extremely small, with the largest (during HighpassFilter) below 0.002, indicating excellent numerical consistency between the two implementations.
-
-<img width="1744" height="1049" alt="Screenshot 2025-10-02 at 11 43 03" src="https://github.com/user-attachments/assets/79c17151-e2e3-4acc-b144-accdf34ae4c5" />
-
-# versioning
-- Change version inside the file pyproject.toml
-- Change version inside the file `tools/hpc/main.pbs` (for Singularity/Docker image references)
-- Run make_release in the script folder and tag with the version
-- Use the correct docker version when building (see below)
-
-# Docker (SCCN Power Users)
-
-```
-docker build -t eegprep:0.2.9 -f DOCKERFILE .
-docker tag eegprep:0.2.9 arnodelorme/eegprep:0.2.9
-docker push arnodelorme/eegprep:0.2.9
+```bash
+uv add "eegprep[all]"
 ```
 
-Check the project on https://hub.docker.com/
+If you are installing into a non-`uv` environment, `pip install eegprep` remains
+supported for published releases:
 
-Mounted folder in /usr/src/project
+```bash
+pip install eegprep
+```
 
-# PYPI Release Process (Maintainers Only)
+For a source checkout:
 
-## Quick Release Workflow
+```bash
+git clone https://github.com/sccn/eegprep.git
+cd eegprep
+uv sync --group dev
+```
+
+The complete install can pull in large optional binaries on some platforms,
+especially for ICLabel/PyTorch support. You can install a lightweight CPU-only
+PyTorch build manually if that better matches your system.
+
+## Quick Start
+
+The repository includes tutorial data in `sample_data/`, named after EEGLAB's
+sample-data convention.
+
+### Shared GUI and Python Console
+
+Launch EEGPrep with the main GUI and a synchronized IPython workspace:
+
+```bash
+uv run eegprep-console --full
+```
+
+Then use the GUI to load `sample_data/eeglab_data.set`, run preprocessing
+actions from the menus, and inspect the same state from the console:
+
+```python
+EEG["setname"], EEG["srate"], EEG["nbchan"], EEG["pnts"]
+CURRENTSET
+LASTCOM
+eegh()
+```
+
+You can also run `pop_*` commands directly:
+
+```python
+pop_resample(EEG, 64)
+pop_reref(EEG, [])
+```
+
+GUI actions and console commands append to the same history, so workflows can be
+replayed or moved into scripts.
+
+### GUI Only
+
+```bash
+uv run eegprep-gui --full
+```
+
+Use this when you want the EEGLAB-style menu workflow without an attached
+console.
+
+### Agent-Friendly CLI
+
+The `eegprep` command is intended for headless pipelines, batch processing, and
+AI agents that need machine-readable output.
+
+```bash
+uv run eegprep inspect sample_data/eeglab_data.set --json
+uv run eegprep validate sample_data/eeglab_data.set --json
+uv run eegprep capabilities --json
+uv run eegprep skills get eegprep-cli
+```
+
+Transform commands use the same EEGPrep processing functions as the Python API
+and write manifests for reproducibility:
+
+```bash
+uv run eegprep resample sample_data/eeglab_data.set \
+  --freq 64 \
+  --output sample_data/eeglab_data_64hz.set \
+  --manifest sample_data/eeglab_data_64hz_manifest.json \
+  --json
+```
+
+### Python API
+
+```python
+from pathlib import Path
+
+from eegprep import pop_eegfiltnew, pop_loadset, pop_resample, pop_saveset
+
+input_file = Path("sample_data") / "eeglab_data.set"
+output_file = Path("sample_data") / "eeglab_data_quickstart.set"
+
+EEG = pop_loadset(input_file)
+EEG, filter_com = pop_eegfiltnew(
+    EEG,
+    locutoff=1.0,
+    hicutoff=40.0,
+    plotfreqz=False,
+    return_com=True,
+)
+EEG, resample_com = pop_resample(EEG, 64, return_com=True)
+pop_saveset(EEG, output_file)
+
+print(filter_com)
+print(resample_com)
+```
+
+`return_com=True` returns the updated dataset and the replayable command string
+that EEGPrep records in GUI and console history.
+
+## For EEGLAB Users
+
+| EEGLAB concept | EEGPrep equivalent |
+| --- | --- |
+| `eeglab` GUI | `uv run eegprep-gui --full` or `uv run eegprep-console --full` |
+| `EEG`, `ALLEEG`, `CURRENTSET` | Shared `EEGPrepSession` state in the GUI and console |
+| MATLAB command history | `LASTCOM`, `ALLCOM`, and `eegh()` in `eegprep-console` |
+| `pop_*` wrappers | Python `eegprep.pop_*` functions with `return_com=True` |
+| EEGBrowser / scrolling review | EEGPrep EEGBrowser and `pop_eegplot` workflows |
+| clean_rawdata, ICLabel, FIRFilt, DIPFIT, EEG-BIDS | Bundled EEGPrep plugin ports and menu integrations |
+| STUDY workflows | Python STUDY structures, GUI paths, and `std_*` helpers |
+| MATLAB scripts | Python scripts, CLI pipelines, and history-derived commands |
+
+EEGPrep follows EEGLAB's one-based user-facing indices where researchers expect
+them, while using zero-based Python indices internally. Continuous data is
+channel-major, usually `(nbchan, pnts)`, and epoched data is usually
+`(nbchan, pnts, trials)`.
+
+## What Is Included
+
+- EEGLAB `.set` loading/saving, BIDS import/export, and common EEG file I/O.
+- BIDS derivative workflows intended to interoperate with EEGPrep, EEGLAB,
+  FieldTrip, Brainstorm, MNE, and other EEG analysis tools.
+- Dataset, event, channel-location, epoch, and history workflows.
+- Filtering, resampling, rereferencing, cleaning, rejection, interpolation, ICA,
+  component review, ICLabel, DIPFIT, topographies, spectra, time-frequency, and
+  statistics workflows.
+- EEGBrowser-style scrolling inspection, marking, and rejection.
+- STUDY and group-level workflow support.
+- Extension SDK, plugin discovery, extension validation, and agent-facing
+  extension authoring guidance.
+- Sphinx documentation, API reference, examples, and a structured CLI.
+
+## Documentation
+
+Start with the [online documentation](https://sccn.github.io/eegprep/):
+
+- [Quick Start](https://sccn.github.io/eegprep/user_guide/quickstart.html)
+- [GUI and Console Session](https://sccn.github.io/eegprep/user_guide/gui_console_session.html)
+- [Scripting Workflows](https://sccn.github.io/eegprep/user_guide/scripting_workflows.html)
+- [EEGBrowser](https://sccn.github.io/eegprep/user_guide/eegbrowser.html)
+- [Extensions](https://sccn.github.io/eegprep/user_guide/extensions.html)
+- [API Reference](https://sccn.github.io/eegprep/api/index.html)
+
+Repository documentation helpers are kept in [`docs/`](docs/). The docs
+workflow publishes the Sphinx site to GitHub Pages.
+
+## Project Status
+
+EEGPrep is in active pre-release development. It is intended to become a
+standalone Python counterpart for core EEGLAB preprocessing workflows. Current
+development emphasizes EEGLAB parity, GUI and console usability, BIDS support,
+extension support, and reproducible headless workflows.
+
+Use EEGPrep with the same care you would apply to any research preprocessing
+software: validate pipelines on representative data, inspect intermediate
+outputs, and record the exact version and command history used for analysis.
+
+## Numerical Parity
+
+EEGPrep is developed against EEGLAB as a parity oracle. The MATLAB and Python
+implementations are tested for close numerical agreement, including default
+preprocessing pipeline comparisons that target accuracy down to `1e-5` uV where
+the algorithms are deterministic. They have also been compared using the first
+two subjects from the BIDS datasets
+[ds003061](https://nemar.org/dataexplorer/detail?dataset_id=ds003061) and
+[ds002680](https://nemar.org/dataexplorer/detail?dataset_id=ds002680) on NEMAR.
+Observed differences were very small, with the largest reported HighpassFilter
+difference below `0.002`, indicating strong numerical consistency for the tested
+workflows.
+
+<img width="1744" height="1049" alt="MATLAB and Python implementation comparison" src="https://github.com/user-attachments/assets/79c17151-e2e3-4acc-b144-accdf34ae4c5" />
+
+## Development
+
+Run tests from the project root with:
+
+```bash
+uv run pytest tests
+```
+
+For quick local iteration:
+
+```bash
+uv run pytest -m "not slow"
+```
+
+The repo uses `ruff`, `ty`, and `pre-commit.py` for linting, formatting, and
+type-checking:
+
+```bash
+./pre-commit.py --changed-from origin/develop
+uv run --no-sync ruff check .
+uv run --no-sync ruff format --check .
+uv run --no-sync ty check
+```
+
+MATLAB parity tests require MATLAB Engine for Python. Install the engine from
+your MATLAB installation, for example on macOS:
+
+```bash
+uv pip install /Applications/MATLAB_R2025a.app/extern/engines/python
+```
+
+Check the installation:
+
+```python
+import matlab.engine
+
+engine = matlab.engine.start_matlab()
+engine.eval("disp('hello world');", nargout=0)
+```
+
+The MATLAB comparison entry point is `tests/matlab/main_compare.m`.
+
+## Cite
+
+If EEGPrep contributes to your research, please cite EEGPrep and the EEGLAB
+methods it ports. For EEGLAB, cite:
+
+Delorme, A., & Makeig, S. (2004). EEGLAB: an open source toolbox for analysis
+of single-trial EEG dynamics including independent component analysis. *Journal
+of Neuroscience Methods*, 134(1), 9-21.
+
+## Core Maintainers
+
+- Arnaud Delorme, UCSD, CA, USA
+- Suraj Ranganath, UCSD, CA, USA
+- Christian Kothe, Intheon, CA, USA
+- Bruno Aristimunha Pinto, Inria, France
+
+<details>
+<summary>Maintainer release notes</summary>
+
+### Versioning
+
+- Change the version inside `pyproject.toml`.
+- Change the version inside `tools/hpc/main.pbs` for Singularity/Docker image
+  references.
+- Run `make_release` in the script folder and tag with the version.
+- Use the correct Docker version when building.
+
+### PyPI Release Process
 
 Use the release script for streamlined releases:
 
@@ -70,54 +320,37 @@ uv run --group release python scripts/make_release.py
 ```
 
 The script will:
-1. Check prerequisites (build, twine, git status)
-2. Confirm the version from `pyproject.toml`
-3. Let you choose: test release, production release, or both
-4. Build and upload the package (automatically uses `eegprep_test` name for TestPyPI)
-5. Create and push git tags for production releases
 
-> **Note:** The script automatically handles a TestPyPI naming conflict by building a package
-> with the name `eegprep_test` for test releases.
+1. Check prerequisites: build, twine, and git status.
+2. Confirm the version from `pyproject.toml`.
+3. Let you choose a test release, production release, or both.
+4. Build and upload the package. TestPyPI builds automatically use the
+   `eegprep_test` name.
+5. Create and push git tags for production releases.
 
-## Prerequisites
+Install release tools with:
 
-Install build tools:
 ```bash
 uv sync --group release
 ```
 
-## API Tokens
-- Get API token for PyPI and TestPyPI (both maintainers should have these)
-- Twine will prompt for them during upload
-- Store them in `~/.pypirc` for convenience
+Get API tokens for PyPI and TestPyPI. Twine can prompt for them during upload,
+or you can store them in `~/.pypirc`.
 
-## Manual Release Process
-
-**Recommended:** Use `scripts/make_release.py` instead to avoid manual errors with package naming.
-
-If you need to release manually:
-
-**1. Update version in `pyproject.toml`**
-
-**2. Test release (staging):**
-
-> **Note:** A former maintainer owns the `eegprep` package name on TestPyPI, so you will not be able to post a
-> package named `eegprep` there at this time.
-> To work around this when performing the build manually (note the `make_release.py` script handles this for you), temporarily change the package name to `eegprep_test` in `pyproject.toml` before building.
-> Remember to change it back to `eegprep` after uploading!
+Manual release remains possible, but `scripts/make_release.py` is preferred to
+avoid package-name mistakes. A former maintainer owns the `eegprep` name on
+TestPyPI, so manual TestPyPI builds must temporarily change `name = "eegprep"`
+to `name = "eegprep_test"` in `pyproject.toml`, then change it back after
+uploading.
 
 ```bash
-# In pyproject.toml, temporarily change: name = "eegprep" to name = "eegprep_test"
 uv run --group release python -m build
 uv run --group release python -m twine upload --repository testpypi dist/*
-# Change name back to "eegprep" in pyproject.toml
-
-# Test the installation:
 uv pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ eegprep_test==X.Y.Z
-# (imports still work as 'import eegprep')
 ```
 
-**3. Production release:**
+Production release:
+
 ```bash
 uv run --group release python -m twine upload dist/*
 git tag -a vX.Y.Z -m "Release version X.Y.Z"
@@ -125,46 +358,22 @@ git push origin vX.Y.Z
 uv pip install eegprep==X.Y.Z
 ```
 
-## Documentation
-https://packaging.python.org/en/latest/tutorials/packaging-projects/
+Packaging follows the Python Packaging User Guide:
+<https://packaging.python.org/en/latest/tutorials/packaging-projects/>.
 
-## Install Package
-Packaging was done following the tutorial: https://packaging.python.org/en/latest/tutorials/packaging-projects/ with setuptools
+</details>
 
-To install the package with all optional dependencies, run:
-```
-uv add "eegprep[all]"
-```
+<details>
+<summary>Docker notes for SCCN power users</summary>
 
-## Running Tests
-
-Install MATLAB interface with `uv pip install /your/path/to/matlab/extern/engines/python` (for example on OSx `uv pip install /Applications/MATLAB_R2025a.app/extern/engines/python`)
-
-Check installation
-
-```python
-import matlab.engine
-engine = matlab.engine.start_matlab()
-engine.eval("disp('hello world');", nargout=0)
+```bash
+docker build -t eegprep:0.2.9 -f DOCKERFILE .
+docker tag eegprep:0.2.9 arnodelorme/eegprep:0.2.9
+docker push arnodelorme/eegprep:0.2.9
 ```
 
-Use tests/matlab/main_compare.m
+Check the project on Docker Hub: <https://hub.docker.com/>.
 
-This project uses `pytest` as the test runner. Existing tests may still use
-`unittest.TestCase`, and pytest runs them normally. Run tests from the project
-root with:
-```
-uv run pytest tests
-```
+Mounted folders are available in `/usr/src/project`.
 
-For quick local iteration, exclude slow tests with:
-```
-uv run pytest -m "not slow"
-```
-
-## Core maintainers
-
-- Arnaud Delorme, UCSD, CA, USA
-- Suraj Ranganath, UCSD, CA, USA
-- Christian Kothe, Intheon, CA, USA
-- Bruno Aristimunha Pinto, Inria, France
+</details>


### PR DESCRIPTION
Revamps the README into a polished project overview modeled after mature EEG tooling READMEs while preserving the existing install, parity, testing, Docker, release, and maintainer details. The landing page now clearly presents EEGPrep's GUI, console, CLI, Python API, EEGLAB compatibility, documentation, validation status, and development workflow, with maintainer-only operational notes moved into collapsible sections.