### PR TITLE
[Console] Fix background ICA logging

### DIFF
--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import re
 import sys
+import threading
 import warnings
 from collections.abc import Callable, Iterator, Mapping
 from typing import Any
@@ -1255,15 +1256,15 @@ def _terminal_write(message: str, *, stream: Any | None = None, sync: bool = Fal
         return
     if sync:
         # GUI previews have to appear before warnings raised by the same Qt callback.
-        prefix = ANSI_CLEAR_LINE if _is_tty(output) else "\n"
-        output.write(f"{prefix}{message}")
-        output.flush()
+        _write_terminal_direct(message, output)
+        return
+    if threading.current_thread() is not threading.main_thread():
+        _write_terminal_direct(message, output)
         return
     try:
         run_module = importlib.import_module("prompt_toolkit.application.run_in_terminal")
     except ImportError:
-        output.write(f"\n{message}")
-        output.flush()
+        _write_terminal_direct(message, output)
         return
 
     def write_message() -> None:
@@ -1271,6 +1272,12 @@ def _terminal_write(message: str, *, stream: Any | None = None, sync: bool = Fal
         output.flush()
 
     run_module.run_in_terminal(write_message)
+
+
+def _write_terminal_direct(message: str, output: Any) -> None:
+    prefix = ANSI_CLEAR_LINE if _is_tty(output) else "\n"
+    output.write(f"{prefix}{message}")
+    output.flush()
 
 
 def _is_tty(stream: Any) -> bool:

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import ast
+from contextlib import redirect_stderr
 import io
 import importlib
 import logging
 import sys
+import threading
 import textwrap
 import warnings
 from types import SimpleNamespace
@@ -1724,6 +1726,38 @@ def test_prompt_safe_logging_install_restores_stream_handlers():
         assert handler.stream is stream
     finally:
         root_logger.removeHandler(handler)
+
+
+def test_prompt_safe_logging_handles_background_thread_records_without_traceback():
+    logger = logging.getLogger("eegprep.tests.console_background")
+    original_level = logger.level
+    original_propagate = logger.propagate
+    original_raise_exceptions = logging.raiseExceptions
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logging.raiseExceptions = True
+    output = io.StringIO()
+    errors = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(levelname)s (%(name)s) %(message)s"))
+    logger.addHandler(handler)
+    restore = console_module._install_prompt_safe_logging()
+
+    try:
+        with redirect_stderr(errors):
+            thread = threading.Thread(target=lambda: logger.info("worker progress"))
+            thread.start()
+            thread.join()
+    finally:
+        restore()
+        logger.removeHandler(handler)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+        logging.raiseExceptions = original_raise_exceptions
+
+    assert "INFO (eegprep.tests.console_background) worker progress" in output.getvalue()
+    assert "Logging error" not in errors.getvalue()
+    assert "RuntimeError" not in errors.getvalue()
 
 
 def test_terminal_write_prints_above_active_prompt():


### PR DESCRIPTION
Route prompt-safe console writes from worker threads through the direct terminal fallback instead of prompt-toolkit's main-thread path. This keeps ICA progress visible during GUI background tasks without logging tracebacks and adds a regression test for background-thread log records.

Fixes #222