### PR TITLE
Fix dark-mode dialog contrast

### DIFF
--- a/src/eegprep/functions/guifunc/coregister.py
+++ b/src/eegprep/functions/guifunc/coregister.py
@@ -10,6 +10,7 @@ from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
 from eegprep.functions.guifunc.pophelp import pophelp
+from eegprep.functions.guifunc.theme import EEGLAB_BACKGROUND, EEGLAB_TEXT
 from eegprep.functions.popfunc.pop_chansel import pop_chansel
 from eegprep.functions.sigprocfunc.coregister import (
     ElectrodeSet,
@@ -33,8 +34,8 @@ except ImportError:  # pragma: no cover - optional GUI dependency
     FigureCanvas = None
 
 _BaseDialog = QDialog if QDialog is not None else object
-_EEGLAB_BLUE = "#000066"
-_EEGLAB_BG = "#a8c2ff"
+_EEGLAB_BLUE = EEGLAB_TEXT
+_EEGLAB_BG = EEGLAB_BACKGROUND
 _PLOT_BG = "#edf5ff"
 _SOURCE_COLOR = "#00a000"
 _REFERENCE_COLOR = "#cc9985"

--- a/src/eegprep/functions/guifunc/listdlg2.py
+++ b/src/eegprep/functions/guifunc/listdlg2.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+from eegprep.functions.guifunc.theme import (
+    EEGLAB_BACKGROUND,
+    EEGLAB_BUTTON_BACKGROUND,
+    EEGLAB_CONTROL_BACKGROUND,
+    EEGLAB_CONTROL_BORDER,
+    EEGLAB_TEXT,
+)
+
 try:  # pragma: no cover - depends on optional GUI dependency
     from PySide6 import QtCore, QtWidgets
 except ImportError:  # pragma: no cover - depends on optional GUI dependency
@@ -159,33 +167,33 @@ def _normalise_initial(
 
 def _apply_listdlg_style(dialog: Any) -> None:
     dialog.setStyleSheet(
-        """
-        QDialog {
-            background: #a8c2ff;
-            color: #000066;
+        f"""
+        QDialog {{
+            background: {EEGLAB_BACKGROUND};
+            color: {EEGLAB_TEXT};
             font-size: 16px;
-        }
-        QLabel {
-            color: #000066;
+        }}
+        QLabel {{
+            color: {EEGLAB_TEXT};
             background: transparent;
             font-size: 16px;
-        }
-        QListWidget {
-            background: white;
+        }}
+        QListWidget {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
             color: black;
-            border: 1px solid #7f7f7f;
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             font-size: 16px;
-        }
-        QPushButton {
-            background: #eeeeee;
-            border: 1px solid #7f7f7f;
+        }}
+        QPushButton {{
+            background: {EEGLAB_BUTTON_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             min-width: 62px;
             max-width: 62px;
             min-height: 18px;
             max-height: 18px;
             padding: 0;
-            color: #000066;
+            color: {EEGLAB_TEXT};
             font-size: 16px;
-        }
+        }}
         """
     )

--- a/src/eegprep/functions/guifunc/long_task.py
+++ b/src/eegprep/functions/guifunc/long_task.py
@@ -8,6 +8,8 @@ import logging
 import threading
 from typing import Any
 
+from eegprep.functions.guifunc.theme import append_eeglab_floating_dialog_style
+
 try:  # pragma: no cover - depends on optional GUI dependency
     from PySide6 import QtCore, QtWidgets
 except ImportError:  # pragma: no cover - depends on optional GUI dependency
@@ -50,6 +52,7 @@ def run_long_task(
     progress.setAutoReset(False)
     progress.setMinimumDuration(0)
     progress.setWindowModality(qt_core.Qt.WindowModal)
+    append_eeglab_floating_dialog_style(progress)
 
     class Worker(qt_core.QObject):
         succeeded = qt_core.Signal(object)

--- a/src/eegprep/functions/guifunc/main_window.py
+++ b/src/eegprep/functions/guifunc/main_window.py
@@ -16,7 +16,7 @@ from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.menu_placeholders import is_placeholder_action
 from eegprep.functions.guifunc.menu_spec import MenuItemSpec, menu_enabled
 from eegprep.functions.guifunc.session import EEGPrepSession
-from eegprep.functions.guifunc.theme import eeglab_floating_dialog_stylesheet
+from eegprep.functions.guifunc.theme import EEGLAB_BACKGROUND, EEGLAB_TEXT, eeglab_floating_dialog_stylesheet
 
 try:  # pragma: no cover - optional GUI dependency
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -26,8 +26,8 @@ except ImportError:  # pragma: no cover - optional GUI dependency
     QtWidgets = None
 
 
-BACKEEGLABCOLOR = "#a8c2ff"
-GUITEXTCOLOR = "#000066"
+BACKEEGLABCOLOR = EEGLAB_BACKGROUND
+GUITEXTCOLOR = EEGLAB_TEXT
 PLUGINMENUCOLOR = "#800080"
 APP_NAME = "EEGPrep"
 _MACOS_MENU_BRANDING_RETRY_MS = 100

--- a/src/eegprep/functions/guifunc/main_window.py
+++ b/src/eegprep/functions/guifunc/main_window.py
@@ -16,6 +16,7 @@ from eegprep.functions.guifunc.menu_actions import MenuActionDispatcher
 from eegprep.functions.guifunc.menu_placeholders import is_placeholder_action
 from eegprep.functions.guifunc.menu_spec import MenuItemSpec, menu_enabled
 from eegprep.functions.guifunc.session import EEGPrepSession
+from eegprep.functions.guifunc.theme import eeglab_floating_dialog_stylesheet
 
 try:  # pragma: no cover - optional GUI dependency
     from PySide6 import QtCore, QtGui, QtWidgets
@@ -476,7 +477,7 @@ def _main_window_stylesheet() -> str:
         border: 1px solid #777777;
         background: {BACKEEGLABCOLOR};
     }}
-    """
+    """ + eeglab_floating_dialog_stylesheet()
 
 
 def _configure_eeglab_label(label: Any, qt_widgets: Any) -> None:

--- a/src/eegprep/functions/guifunc/qt.py
+++ b/src/eegprep/functions/guifunc/qt.py
@@ -10,7 +10,16 @@ from typing import Any
 import numpy as np
 
 from eegprep.functions.guifunc.pophelp import pophelp
-from eegprep.functions.guifunc.theme import eeglab_floating_dialog_stylesheet
+from eegprep.functions.guifunc.theme import (
+    EEGLAB_BACKGROUND,
+    EEGLAB_BUTTON_BACKGROUND,
+    EEGLAB_CONTROL_BACKGROUND,
+    EEGLAB_CONTROL_BORDER,
+    EEGLAB_CONTROL_DISABLED_BACKGROUND,
+    EEGLAB_DISABLED_TEXT,
+    EEGLAB_TEXT,
+    eeglab_floating_dialog_stylesheet,
+)
 from eegprep.functions.guifunc.tf_cycle_calc_dialog import tf_cycle_calc_dialog_spec
 from eegprep.functions.popfunc.pop_chansel import pop_chansel
 from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
@@ -394,122 +403,122 @@ def _QDialog() -> Any:
 
 
 def _apply_eeglab_style(dialog: Any, spec: DialogSpec) -> None:
-    base_stylesheet = """
-        QDialog {
-            background: #a8c2ff;
-            color: #000066;
+    base_stylesheet = f"""
+        QDialog {{
+            background: {EEGLAB_BACKGROUND};
+            color: {EEGLAB_TEXT};
             font-size: 16px;
-        }
-        QLabel, QCheckBox, QPushButton, QLineEdit, QTextEdit, QComboBox, QListWidget {
+        }}
+        QLabel, QCheckBox, QPushButton, QLineEdit, QTextEdit, QComboBox, QListWidget {{
             font-size: 16px;
-        }
-        QLabel, QCheckBox {
-            color: #000066;
+        }}
+        QLabel, QCheckBox {{
+            color: {EEGLAB_TEXT};
             background: transparent;
-        }
-        QLabel:disabled, QCheckBox:disabled {
-            color: #7c86a8;
-        }
-        QLineEdit {
-            background: white;
-            border: 1px solid #7f7f7f;
+        }}
+        QLabel:disabled, QCheckBox:disabled {{
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QLineEdit {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             min-height: 18px;
             max-height: 18px;
             margin-left: 1px;
             padding: 0 3px;
-            color: #000066;
-        }
-        QLineEdit:disabled {
-            background: #dce6ff;
-            color: #7c86a8;
-        }
-        QTextEdit {
-            background: white;
-            border: 1px solid #7f7f7f;
-            color: #000066;
-        }
-        QComboBox {
-            background: white;
-            border: 1px solid #7f7f7f;
+            color: {EEGLAB_TEXT};
+        }}
+        QLineEdit:disabled {{
+            background: {EEGLAB_CONTROL_DISABLED_BACKGROUND};
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QTextEdit {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
+            color: {EEGLAB_TEXT};
+        }}
+        QComboBox {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             min-height: 20px;
             max-height: 20px;
-            color: #000066;
-        }
-        QComboBox:disabled {
-            background: #dce6ff;
-            color: #7c86a8;
-        }
-        QListWidget {
-            background: white;
-            border: 1px solid #7f7f7f;
+            color: {EEGLAB_TEXT};
+        }}
+        QComboBox:disabled {{
+            background: {EEGLAB_CONTROL_DISABLED_BACKGROUND};
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QListWidget {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             min-height: 74px;
             max-height: 74px;
-            color: #000066;
-        }
-        QPushButton {
-            background: #eeeeee;
-            border: 1px solid #7f7f7f;
+            color: {EEGLAB_TEXT};
+        }}
+        QPushButton {{
+            background: {EEGLAB_BUTTON_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
             min-height: 18px;
             max-height: 18px;
             padding: 0 10px;
-            color: #000066;
-        }
-        QPushButton:disabled {
+            color: {EEGLAB_TEXT};
+        }}
+        QPushButton:disabled {{
             color: #b0b0b0;
-        }
-        QPushButton#double_dip_help {
+        }}
+        QPushButton#double_dip_help {{
             min-width: 150px;
             max-width: 150px;
-        }
-        QPushButton#events_button {
+        }}
+        QPushButton#events_button {{
             min-width: 130px;
             max-width: 130px;
-        }
-        QPushButton#scroll {
+        }}
+        QPushButton#scroll {{
             min-width: 159px;
             max-width: 159px;
-        }
-        QPushButton#refbr, QPushButton#exclude_button, QPushButton#refloc_button {
+        }}
+        QPushButton#refbr, QPushButton#exclude_button, QPushButton#refloc_button {{
             min-width: 33px;
             max-width: 33px;
             padding: 0;
-        }
+        }}
         QPushButton#interp_nondatchan,
         QPushButton#interp_removedchans,
         QPushButton#interp_datchan,
         QPushButton#interp_selectchan,
-        QPushButton#interp_uselist {
+        QPushButton#interp_uselist {{
             min-width: 434px;
             max-width: 434px;
             padding: 0;
-        }
-        QDialog#pop_interp QPushButton {
+        }}
+        QDialog#pop_interp QPushButton {{
             padding: 0;
-        }
+        }}
         QDialog#pop_interp QLineEdit,
-        QDialog#pop_interp QComboBox {
+        QDialog#pop_interp QComboBox {{
             min-width: 198px;
             max-width: 198px;
-        }
-        QDialog#pop_reref QLineEdit {
+        }}
+        QDialog#pop_reref QLineEdit {{
             min-width: 163px;
             max-width: 163px;
-        }
-        QDialog#pop_runica QListWidget {
+        }}
+        QDialog#pop_runica QListWidget {{
             min-height: 102px;
             max-height: 102px;
-        }
-        QCheckBox {
+        }}
+        QCheckBox {{
             spacing: 4px;
-        }
-        QCheckBox::indicator {
+        }}
+        QCheckBox::indicator {{
             width: 13px;
             height: 13px;
-        }
-        QCheckBox::indicator:unchecked {
-            background: white;
-            border: 1px solid #7f7f7f;
-        }
+        }}
+        QCheckBox::indicator:unchecked {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
+        }}
         """
     dialog.setStyleSheet(base_stylesheet + eeglab_floating_dialog_stylesheet() + (spec.extra_stylesheet or ""))
 

--- a/src/eegprep/functions/guifunc/qt.py
+++ b/src/eegprep/functions/guifunc/qt.py
@@ -10,6 +10,7 @@ from typing import Any
 import numpy as np
 
 from eegprep.functions.guifunc.pophelp import pophelp
+from eegprep.functions.guifunc.theme import eeglab_floating_dialog_stylesheet
 from eegprep.functions.guifunc.tf_cycle_calc_dialog import tf_cycle_calc_dialog_spec
 from eegprep.functions.popfunc.pop_chansel import pop_chansel
 from eegprep.functions.popfunc.pop_eegplot import pop_eegplot
@@ -510,7 +511,7 @@ def _apply_eeglab_style(dialog: Any, spec: DialogSpec) -> None:
             border: 1px solid #7f7f7f;
         }
         """
-    dialog.setStyleSheet(base_stylesheet + (spec.extra_stylesheet or ""))
+    dialog.setStyleSheet(base_stylesheet + eeglab_floating_dialog_stylesheet() + (spec.extra_stylesheet or ""))
 
 
 def _row_weights(row_geometry: Any) -> list[float]:

--- a/src/eegprep/functions/guifunc/theme.py
+++ b/src/eegprep/functions/guifunc/theme.py
@@ -71,14 +71,14 @@ def eeglab_floating_dialog_stylesheet() -> str:
         QProgressDialog QPushButton:disabled {{
             color: {EEGLAB_DISABLED_TEXT};
         }}
-        QProgressBar {{
+        QProgressDialog QProgressBar {{
             background: {EEGLAB_CONTROL_DISABLED_BACKGROUND};
             border: 1px solid {EEGLAB_CONTROL_BORDER};
             color: {EEGLAB_TEXT};
             min-height: 12px;
             text-align: center;
         }}
-        QProgressBar::chunk {{
+        QProgressDialog QProgressBar::chunk {{
             background: {EEGLAB_PROGRESS_CHUNK};
         }}
         """

--- a/src/eegprep/functions/guifunc/theme.py
+++ b/src/eegprep/functions/guifunc/theme.py
@@ -1,0 +1,90 @@
+"""Shared EEGPrep Qt style fragments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+EEGLAB_BACKGROUND = "#a8c2ff"
+EEGLAB_TEXT = "#000066"
+EEGLAB_DISABLED_TEXT = "#7c86a8"
+EEGLAB_CONTROL_BACKGROUND = "#ffffff"
+EEGLAB_CONTROL_DISABLED_BACKGROUND = "#dce6ff"
+EEGLAB_CONTROL_BORDER = "#7f7f7f"
+EEGLAB_BUTTON_BACKGROUND = "#eeeeee"
+EEGLAB_SELECTION_BACKGROUND = "#c6d9ff"
+EEGLAB_PROGRESS_CHUNK = "#0078d7"
+
+
+def eeglab_floating_dialog_stylesheet() -> str:
+    """Return styles for child dialogs that must stay legible in dark mode."""
+    return f"""
+        QFileDialog, QProgressDialog {{
+            background: {EEGLAB_BACKGROUND};
+            color: {EEGLAB_TEXT};
+        }}
+        QFileDialog QLabel,
+        QFileDialog QCheckBox,
+        QFileDialog QRadioButton,
+        QProgressDialog QLabel {{
+            background: transparent;
+            color: {EEGLAB_TEXT};
+        }}
+        QFileDialog QLabel:disabled,
+        QFileDialog QCheckBox:disabled,
+        QFileDialog QRadioButton:disabled,
+        QProgressDialog QLabel:disabled {{
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QFileDialog QLineEdit,
+        QFileDialog QTextEdit,
+        QFileDialog QPlainTextEdit,
+        QFileDialog QComboBox,
+        QFileDialog QListView,
+        QFileDialog QTreeView,
+        QFileDialog QTableView,
+        QFileDialog QHeaderView::section {{
+            background: {EEGLAB_CONTROL_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
+            color: {EEGLAB_TEXT};
+            selection-background-color: {EEGLAB_SELECTION_BACKGROUND};
+            selection-color: {EEGLAB_TEXT};
+        }}
+        QFileDialog QLineEdit:disabled,
+        QFileDialog QTextEdit:disabled,
+        QFileDialog QPlainTextEdit:disabled,
+        QFileDialog QComboBox:disabled,
+        QFileDialog QListView:disabled,
+        QFileDialog QTreeView:disabled,
+        QFileDialog QTableView:disabled {{
+            background: {EEGLAB_CONTROL_DISABLED_BACKGROUND};
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QFileDialog QPushButton,
+        QProgressDialog QPushButton {{
+            background: {EEGLAB_BUTTON_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
+            color: {EEGLAB_TEXT};
+            padding: 2px 10px;
+        }}
+        QFileDialog QPushButton:disabled,
+        QProgressDialog QPushButton:disabled {{
+            color: {EEGLAB_DISABLED_TEXT};
+        }}
+        QProgressBar {{
+            background: {EEGLAB_CONTROL_DISABLED_BACKGROUND};
+            border: 1px solid {EEGLAB_CONTROL_BORDER};
+            color: {EEGLAB_TEXT};
+            min-height: 12px;
+            text-align: center;
+        }}
+        QProgressBar::chunk {{
+            background: {EEGLAB_PROGRESS_CHUNK};
+        }}
+        """
+
+
+def append_eeglab_floating_dialog_style(widget: Any) -> None:
+    """Append floating-dialog styles to a Qt widget without replacing local rules."""
+    stylesheet = widget.styleSheet()
+    widget.setStyleSheet(stylesheet + "\n" + eeglab_floating_dialog_stylesheet())

--- a/tests/test_gui_long_task.py
+++ b/tests/test_gui_long_task.py
@@ -46,6 +46,10 @@ def test_run_long_task_returns_result_and_forwards_progress(qapp):
     assert errors == []
     assert finished == [handle]
     assert "worker progress" in handle.dialog.labelText()
+    assert "QProgressDialog" in handle.dialog.styleSheet()
+    assert "QProgressBar::chunk" in handle.dialog.styleSheet()
+    assert "#a8c2ff" in handle.dialog.styleSheet()
+    assert "#000066" in handle.dialog.styleSheet()
 
 
 def test_run_long_task_restores_eegprep_logger_level_after_forwarding_progress(qapp):

--- a/tests/test_gui_long_task.py
+++ b/tests/test_gui_long_task.py
@@ -47,7 +47,7 @@ def test_run_long_task_returns_result_and_forwards_progress(qapp):
     assert finished == [handle]
     assert "worker progress" in handle.dialog.labelText()
     assert "QProgressDialog" in handle.dialog.styleSheet()
-    assert "QProgressBar::chunk" in handle.dialog.styleSheet()
+    assert "QProgressDialog QProgressBar::chunk" in handle.dialog.styleSheet()
     assert "#a8c2ff" in handle.dialog.styleSheet()
     assert "#000066" in handle.dialog.styleSheet()
 

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -294,6 +294,10 @@ class MainMenuSpecTests(unittest.TestCase):
         self.assertIn("QMenuBar::item:disabled", stylesheet)
         self.assertIn("color: #64708f", stylesheet)
         self.assertIn("background: transparent", stylesheet)
+        self.assertIn("QFileDialog", stylesheet)
+        self.assertIn("QProgressDialog", stylesheet)
+        self.assertIn("QProgressBar::chunk", stylesheet)
+        self.assertIn("selection-background-color: #c6d9ff", stylesheet)
 
     def test_all_menu_actions_are_classified(self):
         actions = menu_actions(eeglab_menus(all_menus=True))

--- a/tests/test_gui_main_window.py
+++ b/tests/test_gui_main_window.py
@@ -296,7 +296,8 @@ class MainMenuSpecTests(unittest.TestCase):
         self.assertIn("background: transparent", stylesheet)
         self.assertIn("QFileDialog", stylesheet)
         self.assertIn("QProgressDialog", stylesheet)
-        self.assertIn("QProgressBar::chunk", stylesheet)
+        self.assertIn("QProgressDialog QProgressBar::chunk", stylesheet)
+        self.assertNotIn("\n        QProgressBar {", stylesheet)
         self.assertIn("selection-background-color: #c6d9ff", stylesheet)
 
     def test_all_menu_actions_are_classified(self):


### PR DESCRIPTION
Apply EEGPrep’s light EEGLAB-style palette to progress dialogs and non-native Qt file pickers so dark-mode system palettes do not make navy labels unreadable. Adds focused GUI tests for the shared stylesheet and long-task progress dialog.