### PR TITLE
Match MATLAB column-major average reference (float32 parity)

### DIFF
--- a/src/eegprep/functions/sigprocfunc/reref.py
+++ b/src/eegprep/functions/sigprocfunc/reref.py
@@ -80,15 +80,18 @@ def reref(
     else:
         # Average reference via matrix multiplication, matching MATLAB's
         # reref.m: refmatrix = eye(n) - ones(n)/n; data = refmatrix * data.
-        # This produces results numerically closer to MATLAB than the
-        # algebraically equivalent data - mean(data) because the float32
-        # accumulation order in BLAS matrix multiplication matches MATLAB, while
-        # np.mean uses pairwise summation which can diverge enough to
-        # cascade through nonlinear downstream operations (e.g. ASR).
+        # MATLAB accumulates this product column-major; replicate that float32
+        # accumulation order in NumPy (row-major) by transposing the operands
+        # (refmatrix is symmetric, so (data.T @ refmatrix).T == refmatrix @ data
+        # algebraically). The plain np.dot(refmatrix, data) form is ~0.06 uV off
+        # MATLAB in float32, which cascades through nonlinear downstream steps
+        # (ICA convergence) for borderline subjects; the transposed form is
+        # bit-exact to MATLAB on x86 BLAS.
         n = len(chansin)
         dt = original_dtype
         refmatrix = np.eye(n, dtype=dt) - np.ones((n, n), dtype=dt) / dt.type(n)
-        work[chansin_array, :] = np.dot(refmatrix, work[chansin_array, :].astype(dt))
+        block = np.ascontiguousarray(work[chansin_array, :].astype(dt).T)
+        work[chansin_array, :] = (block @ refmatrix).T
         mean_data = None
 
     if locs is not None:


### PR DESCRIPTION
🤖 Average re-referencing was computed as `np.dot(refmatrix, data)` (NumPy row-major), which differs from MATLAB `reref.m`'s column-major `refmatrix * data` by up to ~0.06 µV in float32. For borderline subjects, ICA (Picard) convergence amplifies this tiny input difference into a *different* decomposition, cascading to ~2–3 µV differences at ICLabel and epoching.

## Fix
Transpose the operands — `(data.T @ refmatrix).T` (refmatrix is symmetric, so algebraically identical) — to replicate MATLAB's column-major float32 accumulation order. Bit-exact to MATLAB on x86 BLAS. Single-line change; only the average-reference branch is touched (specific-channel/huber paths unchanged). `pop_reref` routes both the data and the ICA `icawinv` through `reref()`, so both are covered.

## Validation (13 P300 subjects, Python 3.10 + MATLAB R2022b)
- **Step-2 re-reference: 0.03–0.16 µV → 0.000000 µV** for all 13 subjects.
- Steps 1–4 bit-exact; **ICA AMARI ~0 / corr 1.0** for all subjects, including sub-005/008/013 (previously 0.029 / 0.042 / 0.026).
- **Step-5 ICLabel max across subjects: 3.34 µV → 0.0002 µV**; the sub-005/008/013 ICLabel divergence (2.76 / 3.34 / 1.87 µV) is eliminated, and the same components are rejected on both sides.
