### PR TITLE
⚡ Bolt: optimize Fisher-Yates shuffle in RANSAC utilities

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-25 - Vectorizing Fisher-Yates shuffle RNG calls
+**Learning:** Replacing scalar random number generator calls (e.g., `stream.rand()`) in tight loops like Fisher-Yates shuffles with a single vectorized call (e.g., `stream.rand(n)`) significantly improves performance by reducing Python function call overhead. Additionally, using `math.floor(x + 0.5)` for scalar non-negative rounding is faster than general-purpose `round_mat` (which handles arrays and multiple decimal places) or `np.floor`.
+**Action:** Always pre-generate random numbers in a single vectorized call before entering a tight loop. For 0-decimal non-negative rounding in such loops, prefer `math.floor(x + 0.5)` over `round_mat` or `np.round` to maximize speed while maintaining MATLAB parity.

--- a/src/eegprep/plugins/clean_rawdata/private/ransac.py
+++ b/src/eegprep/plugins/clean_rawdata/private/ransac.py
@@ -1,11 +1,11 @@
 """RANSAC utilities for EEG data processing."""
 
+import math
 from typing import Optional
 
 import numpy as np
 
 from ....functions.adminfunc.eeglabcompat import get_eeglab
-from ....functions.miscfunc.misc import round_mat
 from .sphericalSplineInterpolate import sphericalSplineInterpolate
 
 
@@ -36,11 +36,15 @@ def rand_sample(n: int, m: int, stream: np.random.RandomState) -> np.ndarray:
     # Start with identity permutation
     pool = np.arange(n)
 
+    # Vectorized random number generation for performance
+    rands = stream.rand(m)
+
     # Fisher-Yates shuffle: only shuffle first m elements
     for k in range(m):
         # Choose from remaining elements (k to n-1)
         remaining = n - k
-        choice = int(round_mat((remaining - 1) * stream.rand()))
+        # Use math.floor(x + 0.5) for faster scalar non-negative rounding than round_mat
+        choice = int(math.floor((remaining - 1) * rands[k] + 0.5))
 
         # Swap pool[k] with pool[k + choice]
         idx = k + choice
@@ -86,10 +90,17 @@ def rand_permutation(n: int, stream: np.random.RandomState) -> np.ndarray:
     # Start with identity permutation [0, 1, 2, ..., n-1]
     result = np.arange(n)
 
+    if n <= 1:
+        return result
+
+    # Vectorized random number generation for performance
+    rands = stream.rand(n - 1)
+
     # Fisher-Yates shuffle: iterate backward from n-1 to 1
     for k in range(n - 1, 0, -1):
         # Pick random index from 0 to k (inclusive)
-        j = int(round_mat(k * stream.rand()))
+        # Use math.floor(x + 0.5) for faster scalar non-negative rounding than round_mat
+        j = int(math.floor(k * rands[(n - 1) - k] + 0.5))
 
         # Swap elements k and j
         result[k], result[j] = result[j], result[k]


### PR DESCRIPTION
### ⚡ Bolt: optimize Fisher-Yates shuffle in RANSAC utilities

#### 💡 What
This optimization targets the Fisher-Yates shuffle implementations in `rand_sample` and `rand_permutation` within `src/eegprep/plugins/clean_rawdata/private/ransac.py`. It introduces two key improvements:
1. **Vectorized Random Number Generation**: Pre-generates all required random numbers in a single `stream.rand(n)` call instead of calling `stream.rand()` in every loop iteration.
2. **Faster Scalar Rounding**: Replaces the general-purpose `round_mat` utility with `math.floor(x + 0.5)` for internal scalar index calculations, which is significantly faster for non-negative numbers in tight loops.

#### 🎯 Why
Fisher-Yates shuffles are used extensively in RANSAC and ICA. The overhead of individual Python function calls and the overhead of `round_mat` (which handles arrays and multiple decimal places) accumulates in these tight loops.

#### 📊 Impact
Expected performance improvement:
- `rand_sample`: ~50% faster.
- `rand_permutation`: ~30% faster.
Exact parity with EEGLAB/MATLAB random number generation is preserved.

#### 🔬 Measurement
Verified using a benchmark script comparing original vs. optimized implementations over 1000 iterations for `n=1000`. Parity was confirmed by comparing output arrays.

#### ✅ Verification
- All relevant tests in `tests/test_utils_ransac.py` and `tests/test_parity_rng.py` passed.
- Pre-commit lint and format checks passed.


---
*PR created automatically by Jules for task [14941794764479403253](https://jules.google.com/task/14941794764479403253) started by @suraj-ranganath*