### PR TITLE
⚡ Bolt: vectorize griddata_v4 in topoplot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Vectorized griddata_v4 in topoplot
+**Learning:** Evaluating biharmonic spline interpolants on a 2D grid using nested Python loops is a major bottleneck. Vectorizing the distance calculation and Green's function evaluation with NumPy broadcasting leads to a ~5.3x speedup for a standard 67x67 grid.
+**Action:** Always look for nested loops over coordinate grids when performing spatial interpolation or plotting, and replace them with broadcasting and matrix multiplication.

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -45,19 +45,14 @@ def griddata_v4(x, y, v, xq, yq):
         # If still singular, use pseudoinverse as last resort
         weights = np.linalg.pinv(g_reg) @ v
 
-    # Initialize output array
-    m, n = xq.shape
-    vq = np.zeros_like(xq)
-
-    # Evaluate at requested points
-    xy = xy[:, None]  # Make it column vector for broadcasting
-    for i in range(m):
-        for j in range(n):
-            d = np.abs(xq[i, j] + 1j * yq[i, j] - xy.ravel())
-            with np.errstate(divide='ignore', invalid='ignore'):
-                g = (d**2) * (np.log(d) - 1)  # Green's function
-            g[d == 0] = 0  # Handle Green's function at zero
-            vq[i, j] = np.dot(g, weights)
+    # Evaluate at requested points (vectorized)
+    # xq, yq: (grid, grid), xy: (channels,)
+    # d: (grid, grid, channels)
+    d = np.abs((xq + 1j * yq)[..., None] - xy[None, None, :])
+    with np.errstate(divide='ignore', invalid='ignore'):
+        g = (d**2) * (np.log(d) - 1)  # Green's function
+    g[d == 0] = 0  # Handle Green's function at zero
+    vq = g @ weights
 
     return vq
 


### PR DESCRIPTION
### 💡 What:
Vectorized the `griddata_v4` function in `src/eegprep/functions/sigprocfunc/topoplot.py`.

### 🎯 Why:
The previous implementation used a double-nested Python loop to evaluate the biharmonic spline at each query point on the grid. This is a classic NumPy anti-pattern that causes significant overhead for high-resolution topographic maps.

### 📊 Impact:
- **Speedup:** ~5.3x faster for a standard 67x67 grid.
- **Baseline:** 0.0694s
- **Optimized:** 0.0132s
- **Memory:** Introduces a small intermediate 3D array (grid x grid x channels), which is negligible for typical EEG data sizes (e.g., < 20MB for 128x128 grid and 128 channels).

### 🔬 Measurement:
Verified using a temporary benchmark script `tools/benchmark_topoplot.py` that measures the execution time of `griddata_v4` on a 67x67 grid with 128 channels. Correctness was verified by running `tests/test_topoplot.py`.

---
*PR created automatically by Jules for task [14043069869634748481](https://jules.google.com/task/14043069869634748481) started by @suraj-ranganath*