### PR TITLE
⚡ Bolt: optimize griddata_v4 in topoplot

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Vectorizing biharmonic spline interpolation in topoplot]
+**Learning:** Nested loops for query point evaluation in interpolation functions (like `griddata_v4`) are massive bottlenecks in Python. Using NumPy broadcasting and the `@` operator for matrix multiplication can provide significant speedups (~6x) while maintaining numerical parity. This optimization was previously identified as missing or reverted, suggesting a pattern where performance-critical vectorizations are sometimes lost during refactors.
+**Action:** Prioritize vectorizing grid-based evaluations and verify that such optimizations are preserved during adjacent code changes.

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -45,19 +45,13 @@ def griddata_v4(x, y, v, xq, yq):
         # If still singular, use pseudoinverse as last resort
         weights = np.linalg.pinv(g_reg) @ v
 
-    # Initialize output array
-    m, n = xq.shape
-    vq = np.zeros_like(xq)
-
-    # Evaluate at requested points
-    xy = xy[:, None]  # Make it column vector for broadcasting
-    for i in range(m):
-        for j in range(n):
-            d = np.abs(xq[i, j] + 1j * yq[i, j] - xy.ravel())
-            with np.errstate(divide='ignore', invalid='ignore'):
-                g = (d**2) * (np.log(d) - 1)  # Green's function
-            g[d == 0] = 0  # Handle Green's function at zero
-            vq[i, j] = np.dot(g, weights)
+    # Vectorized evaluation at requested points
+    xy_q = xq + 1j * yq
+    d_q = np.abs(xy_q[..., np.newaxis] - xy)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        g_q = (d_q**2) * (np.log(d_q) - 1)  # Green's function
+    g_q[d_q == 0] = 0  # Handle Green's function at zero
+    vq = g_q @ weights
 
     return vq
 


### PR DESCRIPTION
💡 **What:** Vectorized the evaluation of query points in `griddata_v4` using NumPy broadcasting and matrix multiplication (`@`).

🎯 **Why:** The previous implementation used a double-nested loop to iterate over every grid point and channel, which was a significant performance bottleneck in topographic plotting.

📊 **Impact:** Achieved a ~6x speedup (from ~0.065s to ~0.011s per call) for a standard 67x67 grid with 64 channels. This makes topographic maps feel much more responsive in interactive workflows.

🔬 **Measurement:** Verified with a temporary benchmark script `tools/benchmark_topoplot.py` and ensured numerical correctness and parity with `tests/test_topoplot.py`.

---
*PR created automatically by Jules for task [634771604121603696](https://jules.google.com/task/634771604121603696) started by @suraj-ranganath*