### PR TITLE
Spectopo plot converison

### DIFF
--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -103,6 +103,8 @@ def pop_spectopo(
         process=None if process == "EEG" else process,
         **history_options,
     )
+    if gui and figure is not None:
+        figure.show()
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -54,7 +54,7 @@ def pop_spectopo(
         chanlocs = EEG.get("chanlocs", [])
         map_values = None
         map_labels = None
-        title = ""
+        title = ""  # EEGLAB spectopo adds no default suptitle
     else:
         _raise_for_unsupported_component_options(options)
         plot_data, component_numbers = _component_spectral_data(EEG, timerange, options.get("icacomps"))
@@ -67,7 +67,7 @@ def pop_spectopo(
         )
         map_values = maps[:, map_numbers - 1] if map_numbers.size else None
         map_labels = [f"IC {number}" for number in map_numbers.tolist()]
-        title = ""
+        title = ""  # EEGLAB spectopo adds no default suptitle
     freqs = numeric_vector(options.pop("freqs", options.pop("freq", []))).tolist()
     freqrange = numeric_vector(options.pop("freqrange", [])).tolist()
     percent = float(options.pop("percent", 100))

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -54,7 +54,7 @@ def pop_spectopo(
         chanlocs = EEG.get("chanlocs", [])
         map_values = None
         map_labels = None
-        title = "Channel spectra and maps"
+        title = ""
     else:
         _raise_for_unsupported_component_options(options)
         plot_data, component_numbers = _component_spectral_data(EEG, timerange, options.get("icacomps"))
@@ -67,7 +67,7 @@ def pop_spectopo(
         )
         map_values = maps[:, map_numbers - 1] if map_numbers.size else None
         map_labels = [f"IC {number}" for number in map_numbers.tolist()]
-        title = "Component spectra and maps"
+        title = ""
     freqs = numeric_vector(options.pop("freqs", options.pop("freq", []))).tolist()
     freqrange = numeric_vector(options.pop("freqrange", [])).tolist()
     percent = float(options.pop("percent", 100))

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -6,10 +6,27 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+from matplotlib.patches import ConnectionPatch
 from scipy.signal import welch
 
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.sigprocfunc.topoplot import topoplot
+
+# Lowest frequency plotted on the spectra axis, matching EEGLAB ``spectopo`` LOPLOTHZ.
+LOPLOTHZ = 1.0
+# Per-channel trace colors, mirroring EEGLAB ``spectopo`` ``allcolors``. Channel
+# ``k`` (1-based) uses ``_TRACE_COLORS[k % len]``, as EEGLAB does with ``mod(k, 7) + 1``.
+_TRACE_COLORS = [
+    (0.0, 0.75, 0.75),
+    (1.0, 0.0, 0.0),
+    (0.0, 0.5, 0.0),
+    (0.0, 0.0, 1.0),
+    (0.25, 0.25, 0.25),
+    (0.75, 0.75, 0.0),
+    (0.75, 0.0, 0.75),
+]
 
 
 def spectopo(
@@ -117,41 +134,136 @@ def plot_spectra(
     topoplot_options: dict[str, Any] | None = None,
     title: str = "",
 ):
-    """Plot spectra and optional scalp maps at selected frequencies."""
-    requested_freqs = _numeric_values(freqs)
+    """Plot spectra and optional scalp maps, mirroring EEGLAB ``spectopo``.
+
+    Scalp maps sit in a top row above the spectra axis, connected to vertical
+    frequency markers by leader lines, with a ``+``/``-`` polarity colorbar on the
+    right, as in EEGLAB.
+    """
+    requested_freqs = np.sort(_numeric_values(freqs))
+    freq_case = map_values is None or not np.asarray(map_values).size
     scalp_values, scalp_labels = _scalp_maps(spectra, frequency_values, requested_freqs, map_values, map_labels)
-    if scalp_values and chanlocs_as_list(chanlocs):
-        rows = 1 + int(np.ceil(len(scalp_values) / 3))
-        fig = plt.figure(figsize=(8, 2.8 + rows * 1.7))
-        ax = fig.add_subplot(rows, 1, 1)
-        topo_axes = [
-            fig.add_subplot(rows, min(3, len(scalp_values)), index + 1 + min(3, len(scalp_values)))
-            for index in range(len(scalp_values))
-        ]
+    locs = chanlocs_as_list(chanlocs)
+    draw_maps = bool(scalp_values) and bool(locs)
+
+    if draw_maps:
+        fig = plt.figure(figsize=(7.6, 6.2))
+        spec_ax = fig.add_axes([0.13, 0.10, 0.80, 0.52])
     else:
-        fig, ax = plt.subplots(figsize=(7, 4))
-        topo_axes = []
-    for channel_spectrum in spectra:
-        ax.plot(frequency_values, channel_spectrum, linewidth=0.8)
-    mean_spectrum = np.nanmean(spectra, axis=0)
-    ax.plot(frequency_values, mean_spectrum, color="black", linewidth=2.0, label="mean")
-    ax.set_xlabel("Frequency (Hz)")
-    ax.set_ylabel("Log Power Spectral Density 10*log10(uV^2/Hz)")
-    ax.set_title(title or "Channel spectra and maps")
-    if freqrange is not None and len(_numeric_values(freqrange)) == 2:
-        bounds = _numeric_values(freqrange)
-        ax.set_xlim(float(bounds[0]), float(bounds[1]))
-    elif requested_freqs.size:
-        ax.set_xlim(0, max(float(np.nanmax(requested_freqs)) * 1.15, 1.0))
-    ax.grid(True, alpha=0.25)
-    for topo_ax, values, label in zip(topo_axes, scalp_values, scalp_labels):
-        plot_options = {"electrodes": "off", **(topoplot_options or {})}
-        topoplot(values, chanlocs_as_list(chanlocs), axes=topo_ax, **plot_options)
-        topo_ax.set_title(label)
-    fig.tight_layout()
+        fig, spec_ax = plt.subplots(figsize=(7, 4))
+
+    for index, channel_spectrum in enumerate(spectra):
+        spec_ax.plot(
+            frequency_values, channel_spectrum, color=_TRACE_COLORS[(index + 1) % len(_TRACE_COLORS)], linewidth=0.8
+        )
+    spec_ax.set_xlabel("Frequency (Hz)")
+    spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")
+    spec_ax.spines[["top", "right"]].set_visible(False)
+
+    low, high, min_idx, max_idx = _frequency_window(frequency_values, requested_freqs, freqrange)
+    spec_ax.set_xlim(low, high)
+    y_low, y_high = _spectra_ylim(spectra, min_idx, max_idx)
+    if np.isfinite(y_low) and np.isfinite(y_high) and y_high > y_low:
+        spec_ax.set_ylim(y_low, y_high)
+
+    if draw_maps:
+        _draw_maps_row(
+            fig,
+            spec_ax,
+            scalp_values,
+            scalp_labels,
+            locs,
+            requested_freqs if freq_case else None,
+            frequency_values,
+            spectra,
+            topoplot_options,
+        )
+
+    if title:
+        fig.suptitle(title, fontsize=12)
     if plt.get_backend().lower() != "agg":
         plt.show()
     return fig
+
+
+def _frequency_window(
+    frequency_values: np.ndarray, requested_freqs: np.ndarray, freqrange: Any
+) -> tuple[float, float, int, int]:
+    """Return the (low, high) x-limits and their frequency indices, as EEGLAB does."""
+    bounds = _numeric_values(freqrange)
+    if bounds.size >= 2:
+        low, high = float(bounds[0]), float(bounds[1])
+    else:
+        low = LOPLOTHZ
+        maxfreq = float(np.nanmax(requested_freqs)) if requested_freqs.size else float(np.nanmax(frequency_values))
+        high = 5.0 * np.ceil(maxfreq / 5.0) if maxfreq % 5 != 0 else maxfreq * 1.1
+    min_idx = int(np.argmin(np.abs(frequency_values - low)))
+    max_idx = int(np.argmin(np.abs(frequency_values - high)))
+    return float(frequency_values[min_idx]), float(frequency_values[max_idx]), min_idx, max_idx
+
+
+def _spectra_ylim(spectra: np.ndarray, min_idx: int, max_idx: int) -> tuple[float, float]:
+    """Data range over the plotted band, expanded by 1/7 each side (EEGLAB convention)."""
+    low_i, high_i = sorted((min_idx, max_idx))
+    window = spectra[:, low_i : high_i + 1]
+    if window.size == 0:
+        return np.nan, np.nan
+    y_low, y_high = float(np.nanmin(window)), float(np.nanmax(window))
+    span = y_high - y_low
+    return y_low - span / 7.0, y_high + span / 7.0
+
+
+def _draw_maps_row(
+    fig: Any,
+    spec_ax: Any,
+    scalp_values: list[np.ndarray],
+    scalp_labels: list[str],
+    locs: list,
+    requested_freqs: np.ndarray | None,
+    frequency_values: np.ndarray,
+    spectra: np.ndarray,
+    topoplot_options: dict[str, Any] | None,
+) -> None:
+    """Draw the top row of scalp maps, the polarity colorbar, and (for frequency
+    maps) vertical markers plus leader lines to each map."""
+    count = len(scalp_values)
+    top_y, top_h = 0.66, 0.26
+    left, right = 0.10, 0.88
+    slot = (right - left) / count
+    map_w = min(slot * 0.92, 0.24)
+    plot_options = {"electrodes": "off", "maplimits": "absmax", **(topoplot_options or {})}
+
+    map_axes = []
+    for index, (values, label) in enumerate(zip(scalp_values, scalp_labels)):
+        center = left + slot * (index + 0.5)
+        topo_ax = fig.add_axes([center - map_w / 2, top_y, map_w, top_h])
+        topoplot(values, locs, axes=topo_ax, **plot_options)
+        topo_ax.set_title(label, fontweight="bold", fontsize=11)
+        map_axes.append(topo_ax)
+
+    cbar_ax = fig.add_axes([0.92, top_y + 0.02, 0.02, top_h - 0.06])
+    colorbar = fig.colorbar(ScalarMappable(cmap=plt.get_cmap("jet"), norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
+    colorbar.set_ticks([-1, 0, 1])
+    colorbar.set_ticklabels(["-", "", "+"])
+    colorbar.ax.tick_params(length=0)
+
+    if requested_freqs is None:
+        return
+    for topo_ax, freq in zip(map_axes, requested_freqs):
+        freq_index = int(np.argmin(np.abs(frequency_values - freq)))
+        column = spectra[:, freq_index]
+        y_low, y_high = float(np.nanmin(column)), float(np.nanmax(column))
+        spec_ax.plot([freq, freq], [y_low, y_high], color="k", linewidth=2.0, zorder=5)
+        fig.add_artist(
+            ConnectionPatch(
+                xyA=(freq, y_high),
+                coordsA=spec_ax.transData,
+                xyB=(0.5, 0.05),
+                coordsB=topo_ax.transAxes,
+                color="k",
+                linewidth=0.5,
+            )
+        )
 
 
 def _scalp_maps(
@@ -171,10 +283,14 @@ def _scalp_maps(
         return [values[:, index] for index in range(values.shape[1])], labels[: values.shape[1]]
     maps = []
     labels = []
-    for freq in requested_freqs:
+    last = requested_freqs.size - 1
+    for index, freq in enumerate(requested_freqs):
         freq_index = int(np.argmin(np.abs(frequency_values - freq)))
-        maps.append(spectra[:, freq_index])
-        labels.append(f"{freq:g} Hz")
+        # EEGLAB maps the mean-removed power across channels so the map shows
+        # spatial deviation rather than the overall level.
+        column = spectra[:, freq_index]
+        maps.append(column - np.nanmean(column))
+        labels.append(f"{freq:.1f} Hz" if index == last else f"{freq:.1f}")
     return maps, labels
 
 

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -154,7 +154,7 @@ def plot_spectra(
 
     for index, channel_spectrum in enumerate(spectra):
         spec_ax.plot(
-            frequency_values, channel_spectrum, color=_TRACE_COLORS[(index + 1) % len(_TRACE_COLORS)], linewidth=0.8
+            frequency_values, channel_spectrum, color=_TRACE_COLORS[(index + 1) % len(_TRACE_COLORS)], linewidth=2.0
         )
     spec_ax.set_xlabel("Frequency (Hz)")
     spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -244,7 +244,8 @@ def _draw_maps_row(
         map_axes.append(topo_ax)
 
     cbar_ax = fig.add_axes([0.92, top_y + 0.02, 0.02, top_h - 0.06])
-    colorbar = fig.colorbar(ScalarMappable(cmap=plt.get_cmap("jet"), norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
+    cmap = plt.get_cmap((topoplot_options or {}).get("colormap") or "jet")
+    colorbar = fig.colorbar(ScalarMappable(cmap=cmap, norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
     # Inset the +/- labels from the bar ends (EEGLAB places them at the outermost
     # ticks, not flush with the extremes). Purely cosmetic; the bar still spans the
     # full gradient and does not drive the per-map scalp colors.

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -9,7 +9,7 @@ import numpy as np
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
 from matplotlib.patches import ConnectionPatch
-from scipy.signal import welch
+from scipy.signal import get_window, welch
 
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.sigprocfunc.topoplot import topoplot
@@ -107,15 +107,17 @@ def compute_spectra(
     nperseg = int(winsize or min(round(srate), sample_count))
     nperseg = max(1, min(nperseg, sample_count))
     noverlap = max(0, min(int(overlap), nperseg - 1))
+    # symmetric Hamming + no detrend to match MATLAB pwelch
+    window = get_window("hamming", nperseg, fftbins=False)
     freqs, power = welch(
         values,
         fs=float(srate),
-        window="hamming",
+        window=window,
         nperseg=nperseg,
         noverlap=noverlap,
         nfft=nfft,
         axis=1,
-        detrend="constant",
+        detrend=False,
         scaling="density",
     )
     spectra = 10.0 * np.log10(np.maximum(power, np.finfo(float).tiny))

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -149,6 +149,8 @@ def plot_spectra(
         topoplot(values, chanlocs_as_list(chanlocs), axes=topo_ax, **plot_options)
         topo_ax.set_title(label)
     fig.tight_layout()
+    if plt.get_backend().lower() != "agg":
+        plt.show()
     return fig
 
 

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -243,7 +243,10 @@ def _draw_maps_row(
 
     cbar_ax = fig.add_axes([0.92, top_y + 0.02, 0.02, top_h - 0.06])
     colorbar = fig.colorbar(ScalarMappable(cmap=plt.get_cmap("jet"), norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
-    colorbar.set_ticks([-1, 0, 1])
+    # Inset the +/- labels from the bar ends (EEGLAB places them at the outermost
+    # ticks, not flush with the extremes). Purely cosmetic; the bar still spans the
+    # full gradient and does not drive the per-map scalp colors.
+    colorbar.set_ticks([-0.8, 0, 0.8])
     colorbar.set_ticklabels(["-", "", "+"])
     colorbar.ax.tick_params(length=0)
 

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -143,6 +143,7 @@ def plot_spectra(
     right, as in EEGLAB.
     """
     requested_freqs = np.sort(_numeric_values(freqs))
+    # component maps span the whole spectrum, so markers + leader lines are channel-only
     freq_case = map_values is None or not np.asarray(map_values).size
     scalp_values, scalp_labels = _scalp_maps(spectra, frequency_values, requested_freqs, map_values, map_labels)
     locs = chanlocs_as_list(chanlocs)
@@ -201,7 +202,7 @@ def _frequency_window(
         high = 5.0 * np.ceil(maxfreq / 5.0) if maxfreq % 5 != 0 else maxfreq * 1.1
     min_idx = int(np.argmin(np.abs(frequency_values - low)))
     max_idx = int(np.argmin(np.abs(frequency_values - high)))
-    return float(frequency_values[min_idx]), float(frequency_values[max_idx]), min_idx, max_idx
+    return low, high, min_idx, max_idx
 
 
 def _spectra_ylim(spectra: np.ndarray, min_idx: int, max_idx: int) -> tuple[float, float]:
@@ -227,7 +228,10 @@ def _draw_maps_row(
     topoplot_options: dict[str, Any] | None,
 ) -> None:
     """Draw the top row of scalp maps, the polarity colorbar, and (for frequency
-    maps) vertical markers plus leader lines to each map."""
+    maps) vertical markers plus leader lines to each map.
+
+    Each map is scaled independently (``maplimits='absmax'``), so the shared
+    colorbar is polarity-only (``+``/``-``), not a common data scale."""
     count = len(scalp_values)
     top_y, top_h = 0.66, 0.26
     left, right = 0.10, 0.88

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -183,8 +183,8 @@ def plot_spectra(
 
     if title:
         fig.suptitle(title, fontsize=12)
-    if plt.get_backend().lower() != "agg":
-        plt.show()
+    if not draw_maps:
+        fig.tight_layout()
     return fig
 
 

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -279,17 +279,23 @@ def topoplot(datavector, chan_locs, **kwargs):
         markersize = kwargs.get('markersize', 6)
         if str(ELECTRODES).lower() == 'on':
             ax.scatter(x_rotated, y_rotated, c='k', s=markersize, zorder=5)
-        # Head circles: a thick white ring at slightly smaller radius fills the
-        # gap between the interpolated image edge and the head outline.
         theta_c = np.linspace(0, 2 * np.pi, 100)
+        # white ring hides the jagged color edge at rmax
         ax.plot(
             np.cos(theta_c) * (rmax * 0.99), np.sin(theta_c) * (rmax * 0.99), color='white', linewidth=2.5, zorder=3
         )
-        ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=1.5, zorder=4)
-        # Nose marker
-        nose_w = 0.08
-        ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
-        _draw_ears(ax)
+        # head drawn at squeezefac*rmax, so it sits inside the color skirt (EEGLAB)
+        headrad = squeezefac * rmax
+        ax.plot(np.cos(theta_c) * headrad, np.sin(theta_c) * headrad, 'k', linewidth=_HEAD_LINEWIDTH, zorder=4)
+        nose_w = 0.08 * squeezefac
+        ax.plot(
+            [nose_w, 0, -nose_w],
+            [headrad, headrad + 0.06 * squeezefac, headrad],
+            'k',
+            linewidth=_HEAD_LINEWIDTH,
+            zorder=4,
+        )
+        _draw_ears(ax, scale=squeezefac)
 
         _draw_electrode_labels(ax, x_rotated, y_rotated, labels, ELECTRODES, showlabels=kwargs.get('showlabels', False))
 
@@ -364,24 +370,24 @@ def _channel_location_points(chan_locs):
     return np.asarray(labels), np.asarray(xs), np.asarray(ys)
 
 
-# Ear outline from EEGLAB topoplot (rmax = 0.5, scale factor 1); the left ear is
-# the mirror of these x-coordinates.
+# EEGLAB topoplot ear outline (rmax = 0.5); the left ear mirrors these x-coords.
 _EAR_X = np.array([0.492, 0.510, 0.518, 0.5299, 0.5419, 0.540, 0.547, 0.532, 0.510, 0.484])
 _EAR_Y = np.array([0.0955, 0.1175, 0.1183, 0.1146, 0.0955, -0.0055, -0.0932, -0.1313, -0.1384, -0.1199])
+_HEAD_LINEWIDTH = 2.5
 
 
-def _draw_ears(ax):
-    """Draw the left and right ear outlines, matching EEGLAB topoplot."""
-    ax.plot(_EAR_X, _EAR_Y, 'k', linewidth=1.5, zorder=4)
-    ax.plot(-_EAR_X, _EAR_Y, 'k', linewidth=1.5, zorder=4)
+def _draw_ears(ax, scale=1.0):
+    """Draw both ear outlines; ``scale`` shrinks them with the head (EEGLAB ``sf``)."""
+    ax.plot(_EAR_X * scale, _EAR_Y * scale, 'k', linewidth=_HEAD_LINEWIDTH, zorder=4)
+    ax.plot(-_EAR_X * scale, _EAR_Y * scale, 'k', linewidth=_HEAD_LINEWIDTH, zorder=4)
 
 
 def _draw_head(ax):
     theta_c = np.linspace(0, 2 * np.pi, 100)
     rmax = 0.5
-    ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=1.5, zorder=4)
+    ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=_HEAD_LINEWIDTH, zorder=4)
     nose_w = 0.08
-    ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
+    ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=_HEAD_LINEWIDTH, zorder=4)
     _draw_ears(ax)
 
 

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -271,7 +271,14 @@ def topoplot(datavector, chan_locs, **kwargs):
             )
             levels = np.linspace(np.nanmin(Zi), np.nanmax(Zi), 8)[1:-1]
             ax.contour(
-                grid_x, grid_y, Zi, levels=levels, colors=[(0.2, 0.2, 0.2)], linewidths=0.5, linestyles='solid', zorder=2
+                grid_x,
+                grid_y,
+                Zi,
+                levels=levels,
+                colors=[(0.2, 0.2, 0.2)],
+                linewidths=0.5,
+                linestyles='solid',
+                zorder=2,
             )
         if kwargs.get('colorbar', own_figure):
             fig.colorbar(im, ax=ax, shrink=0.7)

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -263,6 +263,16 @@ def topoplot(datavector, chan_locs, **kwargs):
         im = ax.imshow(
             Zi, extent=extent_rotated, origin='lower', cmap=cmap, **_maplimits_kwargs(kwargs.get('maplimits'), Zi)
         )
+        # Contour lines 
+        if np.count_nonzero(np.isfinite(Zi)) > 1 and np.nanmin(Zi) < np.nanmax(Zi):
+            grid_x, grid_y = np.meshgrid(
+                np.linspace(extent_rotated[0], extent_rotated[1], Zi.shape[1]),
+                np.linspace(extent_rotated[2], extent_rotated[3], Zi.shape[0]),
+            )
+            levels = np.linspace(np.nanmin(Zi), np.nanmax(Zi), 8)[1:-1]
+            ax.contour(
+                grid_x, grid_y, Zi, levels=levels, colors=[(0.2, 0.2, 0.2)], linewidths=0.5, linestyles='solid', zorder=2
+            )
         if kwargs.get('colorbar', own_figure):
             fig.colorbar(im, ax=ax, shrink=0.7)
 

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -124,7 +124,7 @@ def topoplot(datavector, chan_locs, **kwargs):
                 noplot = 'on'
 
     # Set colormap
-    cmap = plt.get_cmap('jet')
+    cmap = plt.get_cmap(kwargs.get('colormap') or 'jet')
     GRID_SCALE = gridscale
 
     datavector = np.array([] if datavector is None else datavector).flatten()

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -263,7 +263,7 @@ def topoplot(datavector, chan_locs, **kwargs):
         im = ax.imshow(
             Zi, extent=extent_rotated, origin='lower', cmap=cmap, **_maplimits_kwargs(kwargs.get('maplimits'), Zi)
         )
-        # Contour lines 
+        # Contour lines
         if np.count_nonzero(np.isfinite(Zi)) > 1 and np.nanmin(Zi) < np.nanmax(Zi):
             grid_x, grid_y = np.meshgrid(
                 np.linspace(extent_rotated[0], extent_rotated[1], Zi.shape[1]),
@@ -289,6 +289,7 @@ def topoplot(datavector, chan_locs, **kwargs):
         # Nose marker
         nose_w = 0.08
         ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
+        _draw_ears(ax)
 
         _draw_electrode_labels(ax, x_rotated, y_rotated, labels, ELECTRODES, showlabels=kwargs.get('showlabels', False))
 
@@ -363,12 +364,25 @@ def _channel_location_points(chan_locs):
     return np.asarray(labels), np.asarray(xs), np.asarray(ys)
 
 
+# Ear outline from EEGLAB topoplot (rmax = 0.5, scale factor 1); the left ear is
+# the mirror of these x-coordinates.
+_EAR_X = np.array([0.492, 0.510, 0.518, 0.5299, 0.5419, 0.540, 0.547, 0.532, 0.510, 0.484])
+_EAR_Y = np.array([0.0955, 0.1175, 0.1183, 0.1146, 0.0955, -0.0055, -0.0932, -0.1313, -0.1384, -0.1199])
+
+
+def _draw_ears(ax):
+    """Draw the left and right ear outlines, matching EEGLAB topoplot."""
+    ax.plot(_EAR_X, _EAR_Y, 'k', linewidth=1.5, zorder=4)
+    ax.plot(-_EAR_X, _EAR_Y, 'k', linewidth=1.5, zorder=4)
+
+
 def _draw_head(ax):
     theta_c = np.linspace(0, 2 * np.pi, 100)
     rmax = 0.5
     ax.plot(np.cos(theta_c) * rmax, np.sin(theta_c) * rmax, 'k', linewidth=1.5, zorder=4)
     nose_w = 0.08
     ax.plot([nose_w, 0, -nose_w], [rmax, rmax + 0.06, rmax], 'k', linewidth=1.5, zorder=4)
+    _draw_ears(ax)
 
 
 def _draw_electrode_labels(ax, x, y, labels, electrodes, *, showlabels=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ MATLAB_FILE_SUFFIXES = (
     "tests/test_pop_epoch.py",
     "tests/test_pop_loadset_h5.py",
     "tests/test_pop_resample.py",
+    "tests/test_spectopo_parity.py",
 )
 
 MATLAB_NODEID_PARTS = (

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -99,6 +99,38 @@ def test_pop_spectopo_component_default_controls_succeed(ica_epoch):
     plt.close(result["figure"])
 
 
+def test_pop_spectopo_channel_figure_structure(sample_eeg):
+    freqs = [6, 10, 22]
+    fig = pop_spectopo(sample_eeg, dataflag=1, freqs=freqs, gui=False)["figure"]
+
+    spec_ax = next(ax for ax in fig.axes if "Frequency" in ax.get_xlabel())
+    map_axes = [ax for ax in fig.axes if ax.images]
+    assert len(map_axes) == len(freqs)
+    assert any(ax.get_position().x0 > 0.9 for ax in fig.axes)
+
+    marker_x = sorted(
+        float(line.get_xdata()[0])
+        for line in spec_ax.get_lines()
+        if len({round(float(value), 6) for value in line.get_xdata()}) == 1
+    )
+    assert marker_x == pytest.approx([float(freq) for freq in freqs])
+    assert fig.get_suptitle() == ""
+    plt.close(fig)
+
+
+def test_pop_spectopo_component_figure_omits_frequency_markers(ica_epoch):
+    fig = pop_spectopo(
+        ica_epoch, dataflag=0, freqs=[10], plotchan=0, icamode=True, icacomps=[1, 2], nicamaps=2, gui=False
+    )["figure"]
+
+    spec_ax = next(ax for ax in fig.axes if "Frequency" in ax.get_xlabel())
+    verticals = [
+        line for line in spec_ax.get_lines() if len({round(float(value), 6) for value in line.get_xdata()}) == 1
+    ]
+    assert verticals == []
+    plt.close(fig)
+
+
 def test_pop_spectopo_rejects_nondefault_plotchan(ica_epoch):
     with pytest.raises(ValueError, match="whole-scalp component spectra"):
         pop_spectopo(ica_epoch, dataflag=0, freqs=[10], plotchan=3, icacomps=[1, 2])

--- a/tests/test_spectopo_parity.py
+++ b/tests/test_spectopo_parity.py
@@ -1,0 +1,88 @@
+"""Numerical parity between EEGPrep and MATLAB/EEGLAB ``spectopo``.
+
+Runs EEGLAB's ``spectopo`` through the MATLAB engine and compares the returned
+channel log-power spectra (dB) against EEGPrep's ``spectopo`` on the identical
+dataset. Requires the MATLAB engine plus an EEGLAB checkout (via
+``eeglabcompat.get_eeglab``) and is skipped when either is unavailable, e.g. in
+CI. No MATLAB output is committed; the reference is regenerated live, mirroring
+``test_eeg_rpsd_parity``.
+"""
+
+# Force single-threaded BLAS for deterministic numerics (mirrors
+# test_eeg_rpsd_parity); must be set before numpy imports.
+import os
+
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+
+import tempfile
+import unittest
+
+import numpy as np
+import scipy.io
+
+from eegprep import pop_loadset, pop_saveset
+from eegprep.functions.adminfunc.eeglabcompat import get_eeglab
+from eegprep.functions.sigprocfunc.spectopo import spectopo
+
+local_url = os.path.join(os.path.dirname(__file__), "../sample_data/")
+
+# Absolute dB tolerance. Observed max |Δ| < 1e-5 dB vs MATLAB pwelch on the sample
+# data; 1e-2 guards against real regressions (miscalibration) without float flakiness.
+SPECTRA_ATOL_DB = 1e-2
+
+
+class TestSpectopoParity(unittest.TestCase):
+    """Parity between Python and MATLAB spectopo channel spectra."""
+
+    def setUp(self):
+        try:
+            self.eeglab = get_eeglab("MAT", auto_file_roundtrip=False)
+        except Exception as e:
+            self.skipTest(f"MATLAB/EEGLAB not available: {e}")
+        self.EEG = pop_loadset(os.path.join(local_url, "eeglab_data.set"))
+
+    def test_channel_spectra_match_matlab(self):
+        """EEGPrep spectopo channel spectra match EEGLAB spectopo (pwelch), in dB."""
+        # Python spectra (dB), no plotting.
+        py_spectra, py_freqs = spectopo(self.EEG["data"], self.EEG["pnts"], float(self.EEG["srate"]), plot="off")[:2]
+        py_freqs = np.asarray(py_freqs, dtype=float).ravel()
+
+        # MATLAB spectra on the identical dataset via a .set roundtrip.
+        temp_file = tempfile.mktemp(suffix=".set")
+        pop_saveset(self.EEG, temp_file)
+        matlab_code = f"""
+        set(0, 'DefaultFigureVisible', 'off');
+        EEG = pop_loadset('{temp_file}');
+        [spectra, freqs] = spectopo(EEG.data, EEG.pnts, EEG.srate);
+        close all; set(0, 'DefaultFigureVisible', 'on');
+        save('{temp_file}.mat', 'spectra', 'freqs');
+        """
+        self.eeglab.eval(matlab_code, nargout=0)
+
+        mat_data = scipy.io.loadmat(temp_file + ".mat")
+        ml_spectra = np.asarray(mat_data["spectra"], dtype=float)
+        ml_freqs = np.asarray(mat_data["freqs"], dtype=float).ravel()
+
+        # Clean up temp files.
+        os.remove(temp_file)
+        os.remove(temp_file + ".mat")
+        if os.path.exists(temp_file.replace(".set", ".fdt")):
+            os.remove(temp_file.replace(".set", ".fdt"))
+
+        self.assertEqual(py_spectra.shape, ml_spectra.shape)
+        np.testing.assert_allclose(py_freqs, ml_freqs, rtol=0, atol=1e-9, err_msg="frequency grids differ")
+        np.testing.assert_allclose(
+            py_spectra,
+            ml_spectra,
+            rtol=0,
+            atol=SPECTRA_ATOL_DB,
+            err_msg="EEGPrep spectopo channel spectra differ from EEGLAB (pwelch) beyond tolerance",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement spectopo plot rendering and tune the figure to match EEGLAB's spectopo output.

### Final state: 
<img width="763" height="694" alt="Screenshot 2026-07-13 at 1 07 06 PM" src="https://github.com/user-attachments/assets/18931d92-0c9b-493c-bf46-f731e4a85fc2" />

### What this does
Renders pop_spectopo / spectopo channel & component spectra with scalp maps, matching EEGLAB's figure:
  - scalp-map row above the spectra axis, a vertical marker at each requested frequency with a leader line to its map, a +/− polarity colorbar, and EEGLAB's per-channel color order;
  - scalp maps styled like EEGLAB topoplot: nose + ears, contour lines, head drawn inside the interpolation "skirt" (squeezefac), and a heavier head outline.

### Numerical parity
spectopo computes the PSD with a symmetric Hamming window and no detrending, matching EEGLAB's pwelch path — verified equal to MATLAB spectopo (pwelch) to |Δ| < 1e-5 dB across all frequency bins on eeglab_data.set.

### Colormap & display
  - topoplot and the colorbar honor topoplot_options["colormap"] (default jet), so maps and bar stay consistent.
  - The plotting functions build and return the figure without calling plt.show(); pop_spectopo displays it on the interactive path via figure.show() (no blocking, no double-render, no backend heuristic).

### Tests
  - tests/test_spectopo_parity.py — MATLAB parity test: EEGPrep channel spectra vs live EEGLAB spectopo (pwelch) within 1e-2 dB (observed < 1e-5); regenerates the reference through the MATLAB engine and skips when MATLAB/EEGLAB is unavailable (e.g. CI).
  - tests/test_phase4_plot_wrappers.py — headless smoke tests for the plot structure: scalp-map count, colorbar presence, per-frequency markers (channels) / none (components), and no default title.

### Notes
  - No default title: like EEGLAB, spectopo no longer adds a suptitle by default (previously "Channel/Component spectra and maps") — minor user-visible change.
  - The shared colorbar is polarity-only (+/−): with maplimits='absmax' each map is scaled independently.
  - Frequency markers/leader lines are drawn only for channel/frequency maps (components have no single frequency).