### PR TITLE
spectopo: match EEGLAB component spectra plot

### DIFF
--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -18,7 +18,7 @@ from eegprep.functions.popfunc.plot_utils import (
     selected_indices,
 )
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
-from eegprep.functions.sigprocfunc.spectopo import spectopo
+from eegprep.functions.sigprocfunc.spectopo import plot_component_spectra, spectopo
 
 
 def pop_spectopo(
@@ -49,43 +49,67 @@ def pop_spectopo(
 
     data, times = data_time_slice(EEG, timerange)
     history_options = {key: value for key, value in options.items() if key not in {"plotchan", "icamode"}}
-    if dataflag:
-        plot_data = _channel_spectral_data(data, process)
-        chanlocs = EEG.get("chanlocs", [])
-        map_values = None
-        map_labels = None
-        title = ""  # EEGLAB spectopo adds no default suptitle
-    else:
-        _raise_for_unsupported_component_options(options)
-        plot_data, component_numbers = _component_spectral_data(EEG, timerange, options.get("icacomps"))
-        maps, chanlocs = component_map_data(EEG)
-        map_numbers = _component_map_numbers(
-            options.get("icamaps"),
-            options.get("nicamaps"),
-            component_numbers,
-            maps.shape[1],
-        )
-        map_values = maps[:, map_numbers - 1] if map_numbers.size else None
-        map_labels = [f"IC {number}" for number in map_numbers.tolist()]
-        title = ""  # EEGLAB spectopo adds no default suptitle
+    srate = float(EEG.get("srate", 1) or 1)
     freqs = numeric_vector(options.pop("freqs", options.pop("freq", []))).tolist()
     freqrange = numeric_vector(options.pop("freqrange", [])).tolist()
     percent = float(options.pop("percent", 100))
-    spectral_options, topoplot_options = _split_spectopo_options(options)
-    spectra, frequency_values, speccomp, contrib, specstd, figure = spectopo(
-        plot_data,
-        int(plot_data.shape[1]),
-        float(EEG.get("srate", 1) or 1),
-        percent=percent,
-        freqs=freqs,
-        freqrange=freqrange,
-        chanlocs=chanlocs,
-        map_values=map_values,
-        map_labels=map_labels,
-        topoplot_options=topoplot_options,
-        title=title,
-        **spectral_options,
-    )
+
+    if dataflag:
+        nicamaps = np.asarray([], dtype=int)
+        icamaps = np.asarray([], dtype=int)
+        spectral_options, topoplot_options = _split_spectopo_options(options)
+        plot_data = _channel_spectral_data(data, process)
+        spectra, frequency_values, speccomp, contrib, specstd, figure = spectopo(
+            plot_data,
+            int(plot_data.shape[1]),
+            srate,
+            percent=percent,
+            freqs=freqs,
+            freqrange=freqrange,
+            chanlocs=EEG.get("chanlocs", []),
+            topoplot_options=topoplot_options,
+            title="",  # EEGLAB spectopo adds no default suptitle
+            **spectral_options,
+        )
+    else:
+        _raise_for_unsupported_component_options(options)
+        comp_data, component_numbers = _component_spectral_data(EEG, timerange, options.get("icacomps"))
+        icawinv, chanlocs = component_map_data(EEG)
+        nicamaps = numeric_vector(options.pop("nicamaps", []), dtype=int)
+        icamaps = numeric_vector(options.pop("icamaps", []), dtype=int)
+        spectral_options, topoplot_options = _split_spectopo_options(options)
+        # EEGLAB rescales each component's whole-scalp spectrum by its projection
+        # strength: add 10*log10(sqrt(mean(icawinv_col^4))) (spectopo 'normal' icamode).
+        comp_spectra, frequency_values, speccomp, contrib, specstd, _ = spectopo(
+            comp_data, int(comp_data.shape[1]), srate, percent=percent, plot="off", **spectral_options
+        )
+        projection = np.asarray(icawinv, dtype=float)[:, component_numbers - 1]
+        comp_spectra = comp_spectra + (10.0 * np.log10(np.sqrt(np.nanmean(projection**4, axis=0))))[:, None]
+        # Channel-data spectra drive the bold black RMS curve and the composite freq map.
+        channel_spectra, *_ = spectopo(
+            _channel_spectral_data(data, process),
+            int(data.shape[1]),
+            srate,
+            percent=percent,
+            plot="off",
+            **spectral_options,
+        )
+        figure = plot_component_spectra(
+            comp_spectra,
+            frequency_values,
+            component_numbers=component_numbers,
+            icawinv=np.asarray(icawinv, dtype=float),
+            chanlocs=chanlocs,
+            channel_spectra=channel_spectra,
+            channel_chanlocs=EEG.get("chanlocs", []),
+            freq=freqs,
+            freqrange=freqrange,
+            nicamaps=int(nicamaps[0]) if nicamaps.size else 5,
+            icamaps=icamaps.tolist() if icamaps.size else None,
+            topoplot_options=topoplot_options,
+        )
+        spectra = comp_spectra
+
     result = {
         "spectra": spectra,
         "freqs": frequency_values,
@@ -224,21 +248,6 @@ def _component_spectral_data(EEG: dict[str, Any], timerange: Any, components: An
         acts = acts[:, mask, :]
     indices = selected_indices(components, acts.shape[0])
     return acts[indices, :, :], indices + 1
-
-
-def _component_map_numbers(
-    map_values: Any, count_values: Any, component_numbers: np.ndarray, map_count: int
-) -> np.ndarray:
-    explicit = numeric_vector(map_values, dtype=int)
-    if explicit.size:
-        numbers = explicit
-    else:
-        counts = numeric_vector(count_values, dtype=int)
-        count = int(counts[0]) if counts.size else min(5, component_numbers.size)
-        numbers = component_numbers[: max(0, count)]
-    if np.any(numbers < 1) or np.any(numbers > map_count):
-        raise ValueError(f"component map indices must be within 1..{map_count}")
-    return numbers.astype(int)
 
 
 def _raise_for_unsupported_component_options(options: dict[str, Any]) -> None:

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -451,7 +451,9 @@ def plot_component_spectra(
         plot_options = {"electrodes": "off", "maplimits": "absmax", **(topoplot_options or {})}
         for index, (values, label, colr, yval, lw, map_locs) in enumerate(map_specs):
             center = slot_lefts[realpos[index]] + slot / 2
-            topo_ax = fig.add_axes([center - map_w / 2, top_y, map_w, top_h])
+            # Raise the composite map (index 0) so it stands out above the component row (EEGLAB spectopo).
+            map_y = top_y + 0.04 if index == 0 else top_y
+            topo_ax = fig.add_axes([center - map_w / 2, map_y, map_w, top_h])
             topoplot(values, map_locs, axes=topo_ax, **plot_options)
             topo_ax.set_title(label, fontweight="bold", fontsize=11)
             fig.add_artist(

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -175,10 +175,13 @@ def plot_spectra(
     else:
         fig, spec_ax = plt.subplots(figsize=(7, 4))
 
+    trace_labels = {}
     for index, channel_spectrum in enumerate(spectra):
-        spec_ax.plot(
+        (line,) = spec_ax.plot(
             frequency_values, channel_spectrum, color=_TRACE_COLORS[(index + 1) % len(_TRACE_COLORS)], linewidth=2.0
         )
+        trace_labels[line] = f"Channel {index + 1}"
+    _enable_trace_identification(fig, trace_labels)
     spec_ax.set_xlabel("Frequency (Hz)")
     spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")
     spec_ax.spines[["top", "right"]].set_visible(False)
@@ -355,6 +358,22 @@ def _closestplot_slots(marker_x, slot_x):
     return realpos
 
 
+def _enable_trace_identification(fig, trace_labels):
+    """Print each trace's channel/component index when it is clicked, matching EEGLAB
+    spectopo's per-trace ``ButtonDownFcn``. Fires only on interactive backends; in
+    headless (``Agg``) renders no pick events occur, so this is a harmless no-op."""
+    for line in trace_labels:
+        line.set_picker(True)
+        line.set_pickradius(5)
+
+    def _on_pick(event):
+        label = trace_labels.get(event.artist)
+        if label is not None:
+            print(label)
+
+    fig.canvas.mpl_connect("pick_event", _on_pick)
+
+
 def plot_component_spectra(
     comp_spectra: np.ndarray,
     frequency_values: np.ndarray,
@@ -396,13 +415,19 @@ def plot_component_spectra(
 
     fig = plt.figure(figsize=(8.6, 6.4))
     spec_ax = fig.add_axes([0.12, 0.10, 0.78, 0.52])
+    trace_labels = {}
     for row in range(ncomp):
-        spec_ax.plot(
+        (line,) = spec_ax.plot(
             frequency_values, comp_spectra[row], color=_TRACE_COLORS[(row + 1) % len(_TRACE_COLORS)], linewidth=0.75
         )
+        trace_labels[line] = f"Component {int(component_numbers[row])}"
     for order, row in enumerate(sel):
-        spec_ax.plot(frequency_values, comp_spectra[row], color=_ICA_TRACE_COLORS[order % 5], linewidth=1.75, zorder=4)
+        (line,) = spec_ax.plot(
+            frequency_values, comp_spectra[row], color=_ICA_TRACE_COLORS[order % 5], linewidth=1.75, zorder=4
+        )
+        trace_labels[line] = f"Component {int(component_numbers[row])}"
     spec_ax.plot(frequency_values, data_rms, color="k", linewidth=2.5, zorder=6)
+    _enable_trace_identification(fig, trace_labels)
 
     spec_ax.set_xlabel("Frequency (Hz)")
     spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -379,7 +379,7 @@ def plot_component_spectra(
     map plus each mapped component's scalp projection), joined to the marker by
     colored leader lines.
     """
-    freqs_req = _numeric_values(freq)
+    freqs_req = np.sort(_numeric_values(freq))  # EEGLAB sorts g.freq before taking the first
     f0 = float(freqs_req[0]) if freqs_req.size else float(frequency_values[len(frequency_values) // 2])
     fidx = int(np.argmin(np.abs(frequency_values - f0)))
     ncomp = comp_spectra.shape[0]

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -38,8 +38,6 @@ def spectopo(
     freqs: Any = None,
     freqrange: Any = None,
     chanlocs: Any = None,
-    map_values: Any = None,
-    map_labels: Any = None,
     topoplot_options: dict[str, Any] | None = None,
     title: str = "",
     plot: str = "on",
@@ -71,8 +69,6 @@ def spectopo(
             freqs=freqs,
             freqrange=freqrange,
             chanlocs=chanlocs,
-            map_values=map_values,
-            map_labels=map_labels,
             topoplot_options=topoplot_options,
             title=title,
         )
@@ -159,8 +155,6 @@ def plot_spectra(
     freqs: Any = None,
     freqrange: Any = None,
     chanlocs: Any = None,
-    map_values: Any = None,
-    map_labels: Any = None,
     topoplot_options: dict[str, Any] | None = None,
     title: str = "",
 ):
@@ -171,9 +165,7 @@ def plot_spectra(
     right, as in EEGLAB.
     """
     requested_freqs = np.sort(_numeric_values(freqs))
-    # component maps span the whole spectrum, so markers + leader lines are channel-only
-    freq_case = map_values is None or not np.asarray(map_values).size
-    scalp_values, scalp_labels = _scalp_maps(spectra, frequency_values, requested_freqs, map_values, map_labels)
+    scalp_values, scalp_labels = _scalp_maps(spectra, frequency_values, requested_freqs)
     locs = chanlocs_as_list(chanlocs)
     draw_maps = bool(scalp_values) and bool(locs)
 
@@ -204,7 +196,7 @@ def plot_spectra(
             scalp_values,
             scalp_labels,
             locs,
-            requested_freqs if freq_case else None,
+            requested_freqs,
             frequency_values,
             spectra,
             topoplot_options,
@@ -255,8 +247,8 @@ def _draw_maps_row(
     spectra: np.ndarray,
     topoplot_options: dict[str, Any] | None,
 ) -> None:
-    """Draw the top row of scalp maps, the polarity colorbar, and (for frequency
-    maps) vertical markers plus leader lines to each map.
+    """Draw the top row of scalp maps, the polarity colorbar, and the vertical
+    frequency markers plus leader lines to each map.
 
     Each map is scaled independently (``maplimits='absmax'``), so the shared
     colorbar is polarity-only (``+``/``-``), not a common data scale."""
@@ -285,8 +277,6 @@ def _draw_maps_row(
     colorbar.set_ticklabels(["-", "", "+"])
     colorbar.ax.tick_params(length=0)
 
-    if requested_freqs is None:
-        return
     for topo_ax, freq in zip(map_axes, requested_freqs):
         freq_index = int(np.argmin(np.abs(frequency_values - freq)))
         column = spectra[:, freq_index]
@@ -308,17 +298,7 @@ def _scalp_maps(
     spectra: np.ndarray,
     frequency_values: np.ndarray,
     requested_freqs: np.ndarray,
-    map_values: Any,
-    map_labels: Any,
 ) -> tuple[list[np.ndarray], list[str]]:
-    if map_values is not None and np.asarray(map_values).size:
-        values = np.asarray(map_values, dtype=float)
-        if values.ndim != 2:
-            raise ValueError("map_values must be channels x maps")
-        labels = [str(label) for label in (map_labels or [])]
-        while len(labels) < values.shape[1]:
-            labels.append(f"Map {len(labels) + 1}")
-        return [values[:, index] for index in range(values.shape[1])], labels[: values.shape[1]]
     maps = []
     labels = []
     last = requested_freqs.size - 1
@@ -344,4 +324,137 @@ def _numeric_values(value: Any) -> np.ndarray:
     return np.asarray([value], dtype=float)
 
 
-__all__ = ["compute_spectra", "plot_spectra", "spectopo"]
+# EEGLAB spectopo top-contributing-component trace/leader colors (``colrs``).
+_ICA_TRACE_COLORS = ["r", "b", "g", "m", "c"]
+
+
+def _select_component_maps(comp_spectra, component_numbers, freq_index, nicamaps, icamaps):
+    """Return row indices of the components to map: explicit ``icamaps`` or the
+    ``nicamaps`` components with the most power at the marker frequency (EEGLAB)."""
+    explicit = _numeric_values(icamaps).astype(int)
+    if explicit.size:
+        lookup = {int(number): row for row, number in enumerate(component_numbers)}
+        return np.array([lookup[n] for n in explicit if n in lookup], dtype=int)
+    order = np.argsort(comp_spectra[:, freq_index])[::-1]  # highest power first
+    count = int(nicamaps) if nicamaps else 5
+    return order[: min(count, comp_spectra.shape[0])]
+
+
+def plot_component_spectra(
+    comp_spectra: np.ndarray,
+    frequency_values: np.ndarray,
+    *,
+    component_numbers: np.ndarray,
+    icawinv: np.ndarray,
+    chanlocs: Any,
+    channel_spectra: np.ndarray,
+    channel_chanlocs: Any = None,
+    freq: Any,
+    freqrange: Any = None,
+    nicamaps: int = 5,
+    icamaps: Any = None,
+    topoplot_options: dict[str, Any] | None = None,
+    title: str = "",
+):
+    """Plot component power spectra like EEGLAB ``spectopo`` component mode.
+
+    Draws the bold black data RMS-power curve, thin traces for every component,
+    colored traces for the top-``nicamaps`` components at ``freq``, a vertical
+    marker at ``freq``, and a top row of scalp maps (the composite power-at-freq
+    map plus each mapped component's scalp projection), joined to the marker by
+    colored leader lines.
+    """
+    freqs_req = _numeric_values(freq)
+    f0 = float(freqs_req[0]) if freqs_req.size else float(frequency_values[len(frequency_values) // 2])
+    fidx = int(np.argmin(np.abs(frequency_values - f0)))
+    ncomp = comp_spectra.shape[0]
+    component_numbers = np.asarray(component_numbers, dtype=int)
+    icawinv = np.asarray(icawinv, dtype=float)
+
+    # Black curve: RMS power across channels (linear), back to dB (EEGLAB eegspecdBtoplot).
+    chan_linear = 10.0 ** (np.asarray(channel_spectra, dtype=float) / 10.0)
+    data_rms = 10.0 * np.log10(np.sqrt(np.nanmean(chan_linear**2, axis=0)))
+
+    sel = _select_component_maps(comp_spectra, component_numbers, fidx, nicamaps, icamaps)
+    comp_locs = chanlocs_as_list(chanlocs)
+    composite_locs = chanlocs_as_list(channel_chanlocs) if channel_chanlocs is not None else comp_locs
+
+    fig = plt.figure(figsize=(8.6, 6.4))
+    spec_ax = fig.add_axes([0.12, 0.10, 0.78, 0.52])
+    for row in range(ncomp):
+        spec_ax.plot(
+            frequency_values, comp_spectra[row], color=_TRACE_COLORS[(row + 1) % len(_TRACE_COLORS)], linewidth=0.75
+        )
+    for order, row in enumerate(sel):
+        spec_ax.plot(frequency_values, comp_spectra[row], color=_ICA_TRACE_COLORS[order % 5], linewidth=1.75, zorder=4)
+    spec_ax.plot(frequency_values, data_rms, color="k", linewidth=2.5, zorder=6)
+
+    spec_ax.set_xlabel("Frequency (Hz)")
+    spec_ax.set_ylabel(r"Log Power Spectral Density 10*log$_{10}$($\mu$V$^2$/Hz)")
+    spec_ax.spines[["top", "right"]].set_visible(False)
+    low, high, min_idx, max_idx = _frequency_window(frequency_values, freqs_req, freqrange)
+    spec_ax.set_xlim(low, high)
+    stacked = np.vstack([comp_spectra, data_rms[None, :]])
+    y_low, y_high = _spectra_ylim(stacked, min_idx, max_idx)
+    if np.isfinite(y_low) and np.isfinite(y_high) and y_high > y_low:
+        spec_ax.set_ylim(y_low, y_high)
+
+    marker_lo = float(min(np.nanmin(comp_spectra[:, fidx]), data_rms[fidx]))
+    marker_hi = float(max(np.nanmax(comp_spectra[:, fidx]), data_rms[fidx]))
+    spec_ax.plot([f0, f0], [marker_lo, marker_hi], color="k", linewidth=2.5, zorder=7)
+
+    # Maps: composite power-at-freq map (mean-removed across channels), then each mapped component.
+    composite = np.asarray(channel_spectra, dtype=float)[:, fidx]
+    composite = composite - np.nanmean(composite)
+    map_specs = [(composite, f"{f0:.1f} Hz", "k", data_rms[fidx], 2.5, composite_locs)]
+    for order, row in enumerate(sel):
+        number = int(component_numbers[row])
+        map_specs.append(
+            (
+                # EEGLAB spectopo plots the squared projection icawinv(:,n).^2 (power magnitude,
+                # always non-negative) for component maps, not the signed scalp map.
+                icawinv[:, number - 1] ** 2,
+                f"{number}",
+                _ICA_TRACE_COLORS[order % 5],
+                float(comp_spectra[row, fidx]),
+                0.75,
+                comp_locs,
+            )
+        )
+
+    draw_maps = bool(comp_locs)
+    if draw_maps:
+        count = len(map_specs)
+        top_y, top_h = 0.68, 0.24
+        left, right = 0.07, 0.86
+        slot = (right - left) / count
+        map_w = min(slot * 0.9, 0.16)
+        plot_options = {"electrodes": "off", "maplimits": "absmax", **(topoplot_options or {})}
+        for index, (values, label, colr, yval, lw, map_locs) in enumerate(map_specs):
+            center = left + slot * (index + 0.5)
+            topo_ax = fig.add_axes([center - map_w / 2, top_y, map_w, top_h])
+            topoplot(values, map_locs, axes=topo_ax, **plot_options)
+            topo_ax.set_title(label, fontweight="bold", fontsize=11)
+            fig.add_artist(
+                ConnectionPatch(
+                    xyA=(f0, yval),
+                    coordsA=spec_ax.transData,
+                    xyB=(0.5, 0.0),
+                    coordsB=topo_ax.transAxes,
+                    color=colr,
+                    linewidth=lw,
+                )
+            )
+        cbar_ax = fig.add_axes([0.90, top_y + 0.02, 0.02, top_h - 0.06])
+        cmap = plt.get_cmap((topoplot_options or {}).get("colormap") or "turbo")
+        colorbar = fig.colorbar(ScalarMappable(cmap=cmap, norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
+        colorbar.set_ticks([-0.8, 0, 0.8])
+        colorbar.set_ticklabels(["-", "", "+"])
+        colorbar.ax.tick_params(length=0)
+
+    if title:
+        fig.suptitle(title, fontsize=12)
+    return fig
+
+
+__all__ = ["compute_spectra", "plot_component_spectra", "plot_spectra", "spectopo"]

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -416,7 +416,10 @@ def plot_component_spectra(
     fig = plt.figure(figsize=(8.6, 6.4))
     spec_ax = fig.add_axes([0.12, 0.10, 0.78, 0.52])
     trace_labels = {}
+    selected = {int(row) for row in sel}
     for row in range(ncomp):
+        if row in selected:
+            continue  # selected components are drawn bold below; EEGLAB plots only the others thin
         (line,) = spec_ax.plot(
             frequency_values, comp_spectra[row], color=_TRACE_COLORS[(row + 1) % len(_TRACE_COLORS)], linewidth=0.75
         )

--- a/src/eegprep/functions/sigprocfunc/spectopo.py
+++ b/src/eegprep/functions/sigprocfunc/spectopo.py
@@ -340,6 +340,21 @@ def _select_component_maps(comp_spectra, component_numbers, freq_index, nicamaps
     return order[: min(count, comp_spectra.shape[0])]
 
 
+def _closestplot_slots(marker_x, slot_x):
+    """Assign maps to slot positions like EEGLAB spectopo's ``closestplot``: taking
+    maps in priority order (composite first, then components by descending power),
+    each claims the unused slot whose left edge is nearest the marker, so the
+    composite sits over it. Returns ``realpos`` where ``realpos[i]`` is the slot
+    index for the i-th map."""
+    used = [False] * len(slot_x)
+    realpos = []
+    for _ in slot_x:
+        best = min((i for i in range(len(slot_x)) if not used[i]), key=lambda i: abs(slot_x[i] - marker_x))
+        used[best] = True
+        realpos.append(best)
+    return realpos
+
+
 def plot_component_spectra(
     comp_spectra: np.ndarray,
     frequency_values: np.ndarray,
@@ -429,9 +444,13 @@ def plot_component_spectra(
         left, right = 0.07, 0.86
         slot = (right - left) / count
         map_w = min(slot * 0.9, 0.16)
+        slot_lefts = [left + slot * i for i in range(count)]
+        spec_pos = spec_ax.get_position()
+        marker_x = spec_pos.x0 + spec_pos.width * (f0 - low) / (high - low)
+        realpos = _closestplot_slots(marker_x, slot_lefts)
         plot_options = {"electrodes": "off", "maplimits": "absmax", **(topoplot_options or {})}
         for index, (values, label, colr, yval, lw, map_locs) in enumerate(map_specs):
-            center = left + slot * (index + 0.5)
+            center = slot_lefts[realpos[index]] + slot / 2
             topo_ax = fig.add_axes([center - map_w / 2, top_y, map_w, top_h])
             topoplot(values, map_locs, axes=topo_ax, **plot_options)
             topo_ax.set_title(label, fontweight="bold", fontsize=11)

--- a/src/eegprep/resources/help/pop_spectopo.md
+++ b/src/eegprep/resources/help/pop_spectopo.md
@@ -17,6 +17,10 @@ frequency (labeled by component index) alongside the composite
 power-at-frequency map, each joined to the marker by a leader line — matching
 EEGLAB `spectopo`. Set `icamaps` to map specific components instead.
 
+In an interactive window, click any spectrum trace to print its channel number
+(channel spectra) or component number (component spectra) to the console, as in
+EEGLAB.
+
 The GUI's "Spectral and scalp map options" field accepts either Python
 `key=value` pairs (e.g. `electrodes='off', style='blank'`) or the classic
 `'key', value` pairs (e.g. `'electrodes', 'off', 'style', 'blank'`). Multiple

--- a/src/eegprep/resources/help/pop_spectopo.md
+++ b/src/eegprep/resources/help/pop_spectopo.md
@@ -10,6 +10,13 @@ result, com = pop_spectopo(EEG, dataflag=1, freqs=[6, 10, 22], return_com=True)
 `dataflag=1` plots channel spectra. `dataflag=0` plots component spectra and
 requires ICA activations or ICA weights.
 
+For `dataflag=0`, the spectra panel overlays the bold black RMS-power curve of
+the channel data, marks the analysis frequency with a vertical line, and draws
+the scalp maps of the `nicamaps` components with the most power at that
+frequency (labeled by component index) alongside the composite
+power-at-frequency map, each joined to the marker by a leader line — matching
+EEGLAB `spectopo`. Set `icamaps` to map specific components instead.
+
 The GUI's "Spectral and scalp map options" field accepts either Python
 `key=value` pairs (e.g. `electrodes='off', style='blank'`) or the classic
 `'key', value` pairs (e.g. `'electrodes', 'off', 'style', 'blank'`). Multiple

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import importlib
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import matplotlib
@@ -165,6 +166,35 @@ def test_pop_spectopo_component_maps_match_eeglab_selection_and_order():
     assert sorted(int(title) for title in map_titles if "Hz" not in title) == [1, 4, 5, 6, 10]
     # closestplot arrangement: composite centered, components ordered around the marker
     assert map_titles == ["4", "6", "10.0 Hz", "10", "5", "1"]
+    plt.close(fig)
+
+
+def test_pop_spectopo_component_traces_report_index_on_click(ica_epoch, capsys):
+    """Clicking a component trace prints its component index, like EEGLAB spectopo's
+    per-trace ButtonDownFcn."""
+    fig = pop_spectopo(
+        ica_epoch, dataflag=0, freqs=[10], plotchan=0, icamode=True, icacomps=[1, 2, 3], nicamaps=2, gui=False
+    )["figure"]
+    spec_ax = next(ax for ax in fig.axes if "Frequency" in ax.get_xlabel())
+    pickable = [line for line in spec_ax.get_lines() if line.get_picker()]
+    for line in pickable:
+        fig.canvas.callbacks.process("pick_event", SimpleNamespace(artist=line))
+    printed = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("Component ")]
+    assert printed  # every clickable trace reports its component index
+    assert sorted({int(ln.split()[1]) for ln in printed}) == [1, 2, 3]
+    plt.close(fig)
+
+
+def test_pop_spectopo_channel_traces_report_index_on_click(sample_eeg, capsys):
+    """Clicking a channel trace prints its channel index, like EEGLAB spectopo's
+    per-trace ButtonDownFcn."""
+    fig = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], gui=False)["figure"]
+    spec_ax = next(ax for ax in fig.axes if "Frequency" in ax.get_xlabel())
+    pickable = [line for line in spec_ax.get_lines() if line.get_picker()]
+    for line in pickable:
+        fig.canvas.callbacks.process("pick_event", SimpleNamespace(artist=line))
+    printed = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("Channel ")]
+    assert sorted({int(ln.split()[1]) for ln in printed}) == list(range(1, int(sample_eeg["nbchan"]) + 1))
     plt.close(fig)
 
 

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -118,17 +118,34 @@ def test_pop_spectopo_channel_figure_structure(sample_eeg):
     plt.close(fig)
 
 
-def test_pop_spectopo_component_figure_omits_frequency_markers(ica_epoch):
+def test_pop_spectopo_component_figure_marks_analysis_frequency(ica_epoch):
+    """Component spectra draw a vertical marker at the analysis frequency, as EEGLAB does."""
     fig = pop_spectopo(
         ica_epoch, dataflag=0, freqs=[10], plotchan=0, icamode=True, icacomps=[1, 2], nicamaps=2, gui=False
     )["figure"]
 
     spec_ax = next(ax for ax in fig.axes if "Frequency" in ax.get_xlabel())
-    verticals = [
-        line for line in spec_ax.get_lines() if len({round(float(value), 6) for value in line.get_xdata()}) == 1
-    ]
-    assert verticals == []
+    verticals = sorted(
+        float(line.get_xdata()[0])
+        for line in spec_ax.get_lines()
+        if len({round(float(value), 6) for value in line.get_xdata()}) == 1
+    )
+    assert verticals == pytest.approx([10.0])
     plt.close(fig)
+
+
+def test_pop_spectopo_component_maps_labeled_by_index_with_composite(ica_epoch):
+    """Component spectra show the composite power-at-frequency map plus the top-N
+    component maps labeled by component index (EEGLAB), not a fixed IC 1..N row."""
+    res = pop_spectopo(
+        ica_epoch, dataflag=0, freqs=[10], plotchan=0, icamode=True, icacomps=[1, 2, 3, 4], nicamaps=2, gui=False
+    )
+    titles = [ax.get_title() for ax in res["figure"].axes if ax.get_title().strip()]
+    assert sum("Hz" in title for title in titles) == 1
+    comp_labels = [title for title in titles if "Hz" not in title]
+    assert len(comp_labels) == 2
+    assert all(title.isdigit() for title in comp_labels)  # component index labels, not the old "IC N"
+    plt.close(res["figure"])
 
 
 def test_pop_spectopo_epoched_data_averages_per_trial_pwelch():

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -148,6 +148,26 @@ def test_pop_spectopo_component_maps_labeled_by_index_with_composite(ica_epoch):
     plt.close(res["figure"])
 
 
+def test_pop_spectopo_component_maps_match_eeglab_selection_and_order():
+    """On eeglab_data_epochs_ica.set the component-spectra maps reproduce EEGLAB: the
+    top-nicamaps selection by projection-scaled power at 10 Hz, and the closestplot
+    left-to-right order with the composite centered over the marker."""
+    EEG = pop_loadset(str(SAMPLE_DATASET_PATH.parent / "eeglab_data_epochs_ica.set"))
+    fig = pop_spectopo(
+        EEG, dataflag=0, freqs=[10], freqrange=[2, 25], plotchan=0, percent=100, nicamaps=5, electrodes="off", gui=False
+    )["figure"]
+    map_titles = [
+        ax.get_title()
+        for ax in sorted((a for a in fig.axes if a.get_title().strip()), key=lambda a: a.get_position().x0)
+    ]
+    # one composite power-at-frequency map plus the five selected component maps
+    assert map_titles.count("10.0 Hz") == 1
+    assert sorted(int(title) for title in map_titles if "Hz" not in title) == [1, 4, 5, 6, 10]
+    # closestplot arrangement: composite centered, components ordered around the marker
+    assert map_titles == ["4", "6", "10.0 Hz", "10", "5", "1"]
+    plt.close(fig)
+
+
 def test_pop_spectopo_epoched_data_averages_per_trial_pwelch():
     """Epoched (nchan, pnts, trials) input must equal per-trial welch averaged
     in linear power then converted to dB, matching EEGLAB spectopo. Prior code

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -180,8 +180,9 @@ def test_pop_spectopo_component_traces_report_index_on_click(ica_epoch, capsys):
     for line in pickable:
         fig.canvas.callbacks.process("pick_event", SimpleNamespace(artist=line))
     printed = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("Component ")]
-    assert printed  # every clickable trace reports its component index
-    assert sorted({int(ln.split()[1]) for ln in printed}) == [1, 2, 3]
+    # each component is drawn once, so clicking every trace reports each index exactly once
+    # (a selected component drawn both thin and bold would print twice)
+    assert sorted(int(ln.split()[1]) for ln in printed) == [1, 2, 3]
     plt.close(fig)
 
 


### PR DESCRIPTION
Closes #294.

Makes `pop_spectopo` component-spectra plots (`dataflag=0`) match EEGLAB `spectopo`:

- Projection-scaled component spectra with top-`nicamaps` map selection by power at the analysis frequency
- Squared component scalp maps (`icawinv(:,n).^2`), the composite power-at-frequency map, the bold data-RMS curve, a vertical frequency marker, colored leader lines, and component-index labels
- `closestplot` map ordering so the composite sits centered over the marker

Verified against a headless EEGLAB render on `sample_data/eeglab_data_epochs_ica.set` (`nicamaps=5`): identical map set and order (`4, 6, 10.0 Hz, 10, 5, 1`), RMS curve, marker, and labels.

<img width="2454" height="826" alt="component_spectra_EEGLAB_vs_EEGPrep" src="https://github.com/user-attachments/assets/31527d99-dbd6-49f5-af81-140a379bb55a" />

