### PR TITLE
timtopo conversion 

### DIFF
--- a/src/eegprep/functions/sigprocfunc/timtopo.py
+++ b/src/eegprep/functions/sigprocfunc/timtopo.py
@@ -156,6 +156,9 @@ def _draw_maps_row(
     cbar_ax = fig.add_axes([0.925, top_y + 0.07, 0.018, top_h - 0.14])
     cmap = plt.get_cmap((topoplot_options or {}).get("colormap") or "turbo")
     colorbar = fig.colorbar(ScalarMappable(cmap=cmap, norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
+    # Inset the +/- labels from the bar ends (EEGLAB places them at the outermost ticks,
+    # not flush with the extremes). Purely cosmetic; the bar spans the full gradient and
+    # does not drive the per-map scalp colors.
     colorbar.set_ticks([-0.8, 0, 0.8])
     colorbar.set_ticklabels(["-", "", "+"])
     colorbar.ax.tick_params(length=0)
@@ -196,15 +199,17 @@ def _enable_click_maps(
 
 
 def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.ndarray:
-    if plottimes is not None and len(np.asarray(plottimes).ravel()):
-        requested = np.asarray(plottimes, dtype=float).ravel()
-        requested = requested[np.isfinite(requested)]
-        if requested.size:
-            return requested
-    # Default frame is the peak global power (sum of squares across channels), matching
-    # EEGLAB timtopo's ``max(sum(data.*data))`` -- not the mean-removed variance.
-    power = np.nansum(values**2, axis=0)
-    return np.asarray([x_values[int(np.nanargmax(power))]], dtype=float)
+    # Empty/NaN slots use the peak global power latency (sum of squares across channels),
+    # matching EEGLAB timtopo's ``max(sum(data.*data))`` -- not the mean-removed variance.
+    auto = float(x_values[int(np.nanargmax(np.nansum(values**2, axis=0)))])
+    requested = np.asarray(plottimes, dtype=float).ravel() if plottimes is not None else np.asarray([], dtype=float)
+    if requested.size == 0:
+        return np.asarray([auto], dtype=float)
+    # EEGLAB replaces each NaN entry with the peak-power latency, keeping the finite
+    # entries and the slot count, rather than dropping the NaN slot.
+    requested = requested.copy()
+    requested[np.isnan(requested)] = auto
+    return requested
 
 
 def _latency_values(values: np.ndarray, x_values: np.ndarray, latency: float, winsize: float) -> np.ndarray:

--- a/src/eegprep/functions/sigprocfunc/timtopo.py
+++ b/src/eegprep/functions/sigprocfunc/timtopo.py
@@ -1,4 +1,4 @@
-"""ERP trace plus scalp map helper matching EEGLAB ``timtopo`` basics."""
+"""ERP trace plus scalp map helper matching EEGLAB ``timtopo``."""
 
 from __future__ import annotations
 
@@ -6,9 +6,24 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+from matplotlib.patches import ConnectionPatch
 
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.sigprocfunc.topoplot import topoplot
+
+# MATLAB's default axes color order, cycled across the oblique leader lines as
+# EEGLAB ``timtopo`` does when it draws each leader with no explicit color.
+_LEADER_COLORS = [
+    (0.000, 0.447, 0.741),
+    (0.850, 0.325, 0.098),
+    (0.929, 0.694, 0.125),
+    (0.494, 0.184, 0.556),
+    (0.466, 0.674, 0.188),
+    (0.301, 0.745, 0.933),
+    (0.635, 0.078, 0.184),
+]
 
 
 def timtopo(
@@ -21,7 +36,12 @@ def timtopo(
     title: str = "",
     topoplot_options: dict[str, Any] | None = None,
 ):
-    """Plot all channel traces and scalp maps at selected latencies."""
+    """Plot all channel traces and scalp maps at selected latencies.
+
+    The layout mirrors EEGLAB ``timtopo``: a row of scalp maps sits above an ERP
+    trace panel, each map joined to a blue latency marker on the traces by an
+    oblique leader line, with a ``+``/``-`` polarity colorbar on the right.
+    """
     values = np.asarray(data, dtype=float)
     if values.ndim == 3:
         values = np.nanmean(values, axis=2)
@@ -36,22 +56,97 @@ def timtopo(
     if x_values.size != points:
         raise ValueError("times must match the number of data points")
     map_times = _plot_times(values, x_values, plottimes)
-    fig = plt.figure(figsize=(8, 4 + 1.7 * max(1, int(np.ceil(len(map_times) / 4)))))
-    trace_ax = fig.add_subplot(2, 1, 1)
+    locs = chanlocs_as_list(chanlocs)
+    draw_maps = bool(locs)
+
+    if draw_maps:
+        fig = plt.figure(figsize=(8, 6))
+        trace_ax = fig.add_axes([0.13, 0.10, 0.80, 0.50])
+    else:
+        fig, trace_ax = plt.subplots(figsize=(8, 4))
+
     trace_ax.plot(x_values, values.T, linewidth=0.7)
-    trace_ax.axhline(0, color="0.7", linewidth=0.6)
-    for latency in map_times:
-        trace_ax.axvline(latency, color="black", linestyle=":", linewidth=0.8)
-    trace_ax.set_xlabel("Time (ms)")
-    trace_ax.set_ylabel("uV")
-    trace_ax.set_title(title or "Channel ERPs with scalp maps")
-    for index, latency in enumerate(map_times, start=1):
-        ax = fig.add_subplot(2, max(len(map_times), 1), max(len(map_times), 1) + index)
-        map_values = _latency_values(values, x_values, latency, winsize)
-        topoplot(map_values, chanlocs_as_list(chanlocs), axes=ax, electrodes="off", **(topoplot_options or {}))
-        ax.set_title(f"{latency:g} ms")
-    fig.tight_layout()
+    trace_ax.set_xlabel("Latency (ms)")
+    trace_ax.set_ylabel("Potential (µV)")
+    trace_ax.grid(True, axis="y", linestyle=":")
+    trace_ax.set_xlim(float(x_values[0]), float(x_values[-1]))
+    y_low, y_high = float(np.nanmin(values)), float(np.nanmax(values))
+    if y_high > y_low:
+        trace_ax.set_ylim(y_low, y_high)
+    if x_values[0] < 0 < x_values[-1]:
+        trace_ax.axvline(0, color="k", linestyle=":", linewidth=1.5)
+
+    if draw_maps:
+        _draw_maps_row(fig, trace_ax, values, x_values, map_times, locs, winsize, topoplot_options)
+    else:
+        for latency in map_times:
+            trace_ax.axvline(latency, color="b", linewidth=1.0)
+
+    if title:
+        # EEGLAB places the timtopo title between the trace panel and the maps, left-aligned.
+        fig.text(0.03, 0.62, title, ha="left", fontsize=12)
     return fig
+
+
+def _draw_maps_row(
+    fig: Any,
+    trace_ax: Any,
+    values: np.ndarray,
+    x_values: np.ndarray,
+    map_times: np.ndarray,
+    locs: list,
+    winsize: float,
+    topoplot_options: dict[str, Any] | None,
+) -> None:
+    """Draw the top row of scalp maps, the blue latency markers with oblique leader
+    lines down to the traces, and the ``+``/``-`` polarity colorbar.
+
+    Each map is scaled independently (``maplimits='absmax'``, EEGLAB's default), so
+    the shared colorbar is polarity-only, not a common data scale."""
+    count = len(map_times)
+    top_y, top_h = 0.66, 0.26
+    left, right = 0.10, 0.88
+    slot = (right - left) / count
+    map_w = min(slot * 0.92, 0.24)
+    # EEGLAB shows electrode markers unless the maps get tiny (topowidth < 0.12).
+    plot_options = {"electrodes": "on", "maplimits": "absmax", **(topoplot_options or {})}
+    if map_w < 0.12:
+        plot_options["electrodes"] = "off"
+
+    for index, latency in enumerate(map_times):
+        frame = int(np.argmin(np.abs(x_values - latency)))
+        map_values = _latency_values(values, x_values, latency, winsize)
+        center = left + slot * (index + 0.5)
+        topo_ax = fig.add_axes([center - map_w / 2, top_y, map_w, top_h])
+        topoplot(map_values, locs, axes=topo_ax, **plot_options)
+        topo_ax.set_title(f"{latency:.0f}", fontweight="bold", fontsize=10)
+
+        # Blue vertical line through the data range at this latency, over a white
+        # underlay so it reads clearly against the multicolored traces (EEGLAB).
+        column = values[:, frame]
+        v_low, v_high = float(np.nanmin(column)), float(np.nanmax(column))
+        trace_ax.plot([latency, latency], [v_low, v_high], color="w", linewidth=2.0, zorder=3)
+        trace_ax.plot([latency, latency], [v_low, v_high], color="b", linewidth=1.5, zorder=4)
+
+        # Oblique leader line from the marker's top to the bottom-center of the map,
+        # cycling MATLAB's default color order the way EEGLAB does.
+        fig.add_artist(
+            ConnectionPatch(
+                xyA=(latency, v_high),
+                coordsA=trace_ax.transData,
+                xyB=(0.5, 0.0),
+                coordsB=topo_ax.transAxes,
+                color=_LEADER_COLORS[index % len(_LEADER_COLORS)],
+                linewidth=1.0,
+            )
+        )
+
+    cbar_ax = fig.add_axes([0.925, top_y + 0.07, 0.018, top_h - 0.14])
+    cmap = plt.get_cmap((topoplot_options or {}).get("colormap") or "turbo")
+    colorbar = fig.colorbar(ScalarMappable(cmap=cmap, norm=Normalize(vmin=-1, vmax=1)), cax=cbar_ax)
+    colorbar.set_ticks([-0.8, 0, 0.8])
+    colorbar.set_ticklabels(["-", "", "+"])
+    colorbar.ax.tick_params(length=0)
 
 
 def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.ndarray:

--- a/src/eegprep/functions/sigprocfunc/timtopo.py
+++ b/src/eegprep/functions/sigprocfunc/timtopo.py
@@ -155,8 +155,10 @@ def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.
         requested = requested[np.isfinite(requested)]
         if requested.size:
             return requested
-    variance = np.nanvar(values, axis=0)
-    return np.asarray([x_values[int(np.nanargmax(variance))]], dtype=float)
+    # Default frame is the peak global power (sum of squares across channels), matching
+    # EEGLAB timtopo's ``max(sum(data.*data))`` -- not the mean-removed variance.
+    power = np.nansum(values**2, axis=0)
+    return np.asarray([x_values[int(np.nanargmax(power))]], dtype=float)
 
 
 def _latency_values(values: np.ndarray, x_values: np.ndarray, latency: float, winsize: float) -> np.ndarray:

--- a/src/eegprep/functions/sigprocfunc/timtopo.py
+++ b/src/eegprep/functions/sigprocfunc/timtopo.py
@@ -40,7 +40,9 @@ def timtopo(
 
     The layout mirrors EEGLAB ``timtopo``: a row of scalp maps sits above an ERP
     trace panel, each map joined to a blue latency marker on the traces by an
-    oblique leader line, with a ``+``/``-`` polarity colorbar on the right.
+    oblique leader line, with a ``+``/``-`` polarity colorbar on the right. Clicking
+    a trace redraws the rightmost scalp map at the clicked latency (interactive
+    backends only).
     """
     values = np.asarray(data, dtype=float)
     if values.ndim == 3:
@@ -77,7 +79,10 @@ def timtopo(
         trace_ax.axvline(0, color="k", linestyle=":", linewidth=1.5)
 
     if draw_maps:
-        _draw_maps_row(fig, trace_ax, values, x_values, map_times, locs, winsize, topoplot_options)
+        target_ax, plot_options, target_leader = _draw_maps_row(
+            fig, trace_ax, values, x_values, map_times, locs, winsize, topoplot_options
+        )
+        _enable_click_maps(fig, trace_ax, target_ax, target_leader, values, x_values, locs, winsize, plot_options)
     else:
         for latency in map_times:
             trace_ax.axvline(latency, color="b", linewidth=1.0)
@@ -97,12 +102,14 @@ def _draw_maps_row(
     locs: list,
     winsize: float,
     topoplot_options: dict[str, Any] | None,
-) -> None:
+) -> tuple[Any, dict[str, Any], Any]:
     """Draw the top row of scalp maps, the blue latency markers with oblique leader
     lines down to the traces, and the ``+``/``-`` polarity colorbar.
 
     Each map is scaled independently (``maplimits='absmax'``, EEGLAB's default), so
-    the shared colorbar is polarity-only, not a common data scale."""
+    the shared colorbar is polarity-only, not a common data scale. Returns the
+    rightmost map axes, the topoplot options, and that map's leader line, which the
+    click callback reuses."""
     count = len(map_times)
     top_y, top_h = 0.66, 0.26
     left, right = 0.10, 0.88
@@ -130,7 +137,7 @@ def _draw_maps_row(
 
         # Oblique leader line from the marker's top to the bottom-center of the map,
         # cycling MATLAB's default color order the way EEGLAB does.
-        fig.add_artist(
+        leader = fig.add_artist(
             ConnectionPatch(
                 xyA=(latency, v_high),
                 coordsA=trace_ax.transData,
@@ -147,6 +154,53 @@ def _draw_maps_row(
     colorbar.set_ticks([-0.8, 0, 0.8])
     colorbar.set_ticklabels(["-", "", "+"])
     colorbar.ax.tick_params(length=0)
+    return topo_ax, plot_options, leader
+
+
+def _enable_click_maps(
+    fig: Any,
+    trace_ax: Any,
+    target_ax: Any,
+    target_leader: Any,
+    values: np.ndarray,
+    x_values: np.ndarray,
+    locs: list,
+    winsize: float,
+    plot_options: dict[str, Any],
+) -> None:
+    """Redraw the rightmost scalp map at the clicked ERP latency, matching EEGLAB
+    timtopo's click callback. Fires only on interactive backends; headless renders
+    receive no click events, so this is a harmless no-op."""
+    srate = (values.shape[1] - 1) / (float(x_values[-1]) - float(x_values[0])) * 1000.0
+
+    def _on_click(event: Any) -> None:
+        if event.inaxes is not trace_ax or event.xdata is None:
+            return
+        latency = float(event.xdata)
+        # Hide the rightmost map's static leader; it no longer points at the redrawn map.
+        target_leader.set_visible(False)
+        target_ax.clear()
+        topoplot(_click_latency_values(values, x_values, srate, latency, winsize), locs, axes=target_ax, **plot_options)
+        if winsize and winsize > 0:
+            label = f"{latency - winsize:.0f} to {latency + winsize:.0f} ms"
+        else:
+            label = f"{latency:.0f} ms"
+        target_ax.set_title(label, fontweight="bold", fontsize=10)
+        event.canvas.draw_idle()
+
+    fig.canvas.mpl_connect("button_press_event", _on_click)
+
+
+def _click_latency_values(
+    values: np.ndarray, x_values: np.ndarray, srate: float, latency: float, winsize: float
+) -> np.ndarray:
+    """ERP averaged over +/- winsize ms around a clicked latency (single frame when
+    winsize == 0), matching EEGLAB timtopo's click callback."""
+    center = int(round((latency - float(x_values[0])) / 1000.0 * srate))
+    winpts = int(round(winsize / 1000.0 * srate))
+    lo = max(0, center - winpts)
+    hi = min(values.shape[1] - 1, center + winpts)
+    return np.nanmean(values[:, lo : hi + 1], axis=1)
 
 
 def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.ndarray:

--- a/src/eegprep/functions/sigprocfunc/timtopo.py
+++ b/src/eegprep/functions/sigprocfunc/timtopo.py
@@ -88,8 +88,13 @@ def timtopo(
             trace_ax.axvline(latency, color="b", linewidth=1.0)
 
     if title:
-        # EEGLAB places the timtopo title between the trace panel and the maps, left-aligned.
-        fig.text(0.03, 0.62, title, ha="left", fontsize=12)
+        if draw_maps:
+            # EEGLAB places the timtopo title between the trace panel and the maps, left-aligned.
+            fig.text(0.03, 0.62, title, ha="left", fontsize=12)
+        else:
+            # No maps row to sit under; keep the title on the trace panel instead of at y=0.62,
+            # which would land inside the full-height axes.
+            trace_ax.set_title(title)
     return fig
 
 
@@ -171,7 +176,6 @@ def _enable_click_maps(
     """Redraw the rightmost scalp map at the clicked ERP latency, matching EEGLAB
     timtopo's click callback. Fires only on interactive backends; headless renders
     receive no click events, so this is a harmless no-op."""
-    srate = (values.shape[1] - 1) / (float(x_values[-1]) - float(x_values[0])) * 1000.0
 
     def _on_click(event: Any) -> None:
         if event.inaxes is not trace_ax or event.xdata is None:
@@ -180,7 +184,7 @@ def _enable_click_maps(
         # Hide the rightmost map's static leader; it no longer points at the redrawn map.
         target_leader.set_visible(False)
         target_ax.clear()
-        topoplot(_click_latency_values(values, x_values, srate, latency, winsize), locs, axes=target_ax, **plot_options)
+        topoplot(_latency_values(values, x_values, latency, winsize), locs, axes=target_ax, **plot_options)
         if winsize and winsize > 0:
             label = f"{latency - winsize:.0f} to {latency + winsize:.0f} ms"
         else:
@@ -189,18 +193,6 @@ def _enable_click_maps(
         event.canvas.draw_idle()
 
     fig.canvas.mpl_connect("button_press_event", _on_click)
-
-
-def _click_latency_values(
-    values: np.ndarray, x_values: np.ndarray, srate: float, latency: float, winsize: float
-) -> np.ndarray:
-    """ERP averaged over +/- winsize ms around a clicked latency (single frame when
-    winsize == 0), matching EEGLAB timtopo's click callback."""
-    center = int(round((latency - float(x_values[0])) / 1000.0 * srate))
-    winpts = int(round(winsize / 1000.0 * srate))
-    lo = max(0, center - winpts)
-    hi = min(values.shape[1] - 1, center + winpts)
-    return np.nanmean(values[:, lo : hi + 1], axis=1)
 
 
 def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.ndarray:
@@ -216,11 +208,13 @@ def _plot_times(values: np.ndarray, x_values: np.ndarray, plottimes: Any) -> np.
 
 
 def _latency_values(values: np.ndarray, x_values: np.ndarray, latency: float, winsize: float) -> np.ndarray:
+    """ERP at ``latency``: a single frame when ``winsize == 0``, otherwise averaged over
+    ``latency +/- winsize`` ms. This is EEGLAB timtopo's half-width convention, shared by
+    the static map row and the click callback so both use one window for a given input."""
     if winsize <= 0:
         frame = int(np.argmin(np.abs(x_values - latency)))
         return values[:, frame]
-    half_window = winsize / 2.0
-    mask = (x_values >= latency - half_window) & (x_values <= latency + half_window)
+    mask = (x_values >= latency - winsize) & (x_values <= latency + winsize)
     if not np.any(mask):
         raise ValueError("winsize does not include any samples around requested latency")
     return np.nanmean(values[:, mask], axis=1)

--- a/src/eegprep/resources/help/pop_timtopo.md
+++ b/src/eegprep/resources/help/pop_timtopo.md
@@ -6,5 +6,5 @@ Plots channel ERP traces together with scalp maps at selected latencies.
 fig, com = pop_timtopo(EEG, plottimes=[100, 200], return_com=True)
 ```
 
-If no latency is supplied, EEGPrep uses the latency with largest channel
-variance, matching the common EEGLAB default.
+If no latency is supplied, EEGPrep maps the latency of maximum field strength
+(peak RMS across channels), matching the EEGLAB default.

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -13,6 +13,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
+from matplotlib.backend_bases import MouseEvent
 import numpy as np
 import pytest
 import scipy.io
@@ -1434,6 +1435,21 @@ def test_timtopo_auto_latency_uses_peak_global_power(sample_epoch):
     map_titles = [ax.get_title().strip() for ax in fig.axes if ax.get_title().strip()]
     assert len(map_titles) == 1
     assert float(map_titles[0]) == pytest.approx(global_power_latency, abs=1)
+    plt.close(fig)
+
+
+def test_timtopo_click_redraws_rightmost_scalp_map(sample_epoch):
+    """Clicking a trace redraws the rightmost scalp map (and titles it) at the clicked
+    latency, matching EEGLAB timtopo's ButtonDownFcn."""
+    fig, _ = pop_timtopo(sample_epoch, plottimes=[-50, 0, 100, 180], return_com=True)
+    fig.canvas.draw()
+    trace_ax = fig.axes[0]
+    click_latency = 50.0
+    px, py = trace_ax.transData.transform((click_latency, 0.0))
+    event = MouseEvent("button_press_event", fig.canvas, px, py)
+    fig.canvas.callbacks.process("button_press_event", event)
+    map_titles = [ax.get_title() for ax in fig.axes if ax.get_title().strip()]
+    assert f"{click_latency:.0f} ms" in map_titles
     plt.close(fig)
 
 

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -30,7 +30,7 @@ from eegprep.functions.popfunc.pop_headplot import (
 )
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_epoch import pop_epoch
-from eegprep.functions.popfunc.plot_utils import component_activations, parse_plot_options_text
+from eegprep.functions.popfunc.plot_utils import component_activations, data_time_slice, parse_plot_options_text
 from eegprep.functions.popfunc.pop_plotdata import pop_plotdata
 from eegprep.functions.popfunc.pop_plottopo import pop_plottopo, pop_plottopo_dialog_spec
 from eegprep.functions.popfunc.pop_prop import pop_prop, pop_prop_dialog_spec
@@ -1417,6 +1417,24 @@ def test_plot_history_preserves_effective_options(sample_epoch, ica_epoch):
     plt.close(timtopo_fig)
     plt.close(plottopo_fig)
     plt.close(envtopo_fig)
+
+
+def test_timtopo_auto_latency_uses_peak_global_power(sample_epoch):
+    """Default (NaN) latency is the frame of peak global power (sum of squares across
+    channels), as EEGLAB timtopo picks it -- not the max mean-removed variance frame."""
+    data, _ = data_time_slice(sample_epoch, None)
+    erp = np.nanmean(data, axis=2)
+    x = np.linspace(float(sample_epoch["xmin"]) * 1000.0, float(sample_epoch["xmax"]) * 1000.0, erp.shape[1])
+    global_power_latency = x[int(np.argmax(np.sum(erp**2, axis=0)))]
+    variance_latency = x[int(np.argmax(np.nanvar(erp, axis=0)))]
+    # Guard: the two metrics must disagree here or the test could not catch the bug.
+    assert round(global_power_latency) != round(variance_latency)
+
+    fig, _ = pop_timtopo(sample_epoch, plottimes=[float("nan")], return_com=True)
+    map_titles = [ax.get_title().strip() for ax in fig.axes if ax.get_title().strip()]
+    assert len(map_titles) == 1
+    assert float(map_titles[0]) == pytest.approx(global_power_latency, abs=1)
+    plt.close(fig)
 
 
 def test_pop_spectopo_component_path_plots_component_maps(ica_epoch):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -1453,6 +1453,19 @@ def test_timtopo_click_redraws_rightmost_scalp_map(sample_epoch):
     plt.close(fig)
 
 
+def test_timtopo_mixed_nan_plottimes_fills_slot_with_auto_latency(sample_epoch):
+    """A NaN entry in plottimes is filled with the peak-power latency (EEGLAB), keeping the
+    other requested latencies and the slot count -- not silently dropped."""
+    data, _ = data_time_slice(sample_epoch, None)
+    erp = np.nanmean(data, axis=2)
+    x = np.linspace(float(sample_epoch["xmin"]) * 1000.0, float(sample_epoch["xmax"]) * 1000.0, erp.shape[1])
+    auto = x[int(np.argmax(np.sum(erp**2, axis=0)))]
+    fig, _ = pop_timtopo(sample_epoch, plottimes=[float("nan"), 100.0], return_com=True)
+    latencies = sorted(float(ax.get_title().split()[0]) for ax in fig.axes if ax.get_title().strip())
+    assert latencies == [pytest.approx(min(auto, 100.0), abs=1), pytest.approx(max(auto, 100.0), abs=1)]
+    plt.close(fig)
+
+
 def test_timtopo_click_matches_static_map_for_same_winsize(sample_epoch):
     """The click callback reuses the static row's window helper, so clicking a map's own
     latency reproduces its scalp map -- guarding a single winsize window in both paths."""

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -1453,6 +1453,22 @@ def test_timtopo_click_redraws_rightmost_scalp_map(sample_epoch):
     plt.close(fig)
 
 
+def test_timtopo_click_matches_static_map_for_same_winsize(sample_epoch):
+    """The click callback reuses the static row's window helper, so clicking a map's own
+    latency reproduces its scalp map -- guarding a single winsize window in both paths."""
+    latency, winsize = 60.0, 20.0
+    fig, _ = pop_timtopo(sample_epoch, plottimes=[latency], winsize=[winsize], return_com=True)
+    fig.canvas.draw()
+    map_ax = [ax for ax in fig.axes if ax.get_title().strip()][-1]
+    static_map = np.ma.filled(map_ax.images[0].get_array().astype(float), np.nan)
+    trace_ax = fig.axes[0]
+    px, py = trace_ax.transData.transform((latency, 0.0))
+    fig.canvas.callbacks.process("button_press_event", MouseEvent("button_press_event", fig.canvas, px, py))
+    clicked_map = np.ma.filled(map_ax.images[0].get_array().astype(float), np.nan)
+    np.testing.assert_allclose(clicked_map, static_map, equal_nan=True)
+    plt.close(fig)
+
+
 def test_pop_spectopo_component_path_plots_component_maps(ica_epoch):
     result, command = pop_spectopo(
         ica_epoch,


### PR DESCRIPTION
**Bring timtopo to EEGLAB parity**
   
Ports EEGLAB's timtopo scalp-map-over-ERP plot to EEGPrep, matching its layout, default behavior, and interactivity.

**Changes**
- Layout parity — scalp-map row on top, ERP trace panel below, colored oblique leaders, blue latency markers, zero-time line, +/- polarity colorbar, electrode dots, and EEGLAB axis labels.
- Correct default latency — the auto (NaN) map now uses peak field strength (RMS / global power across channels, max(sum(data.²))), matching EEGLAB; previously it used mean-removed variance and picked the wrong frame.
- Click interactivity — clicking an ERP trace redraws the rightmost scalp map at that latency (averaging ±winsize ms), mirroring EEGLAB's ButtonDownFcn; no-op on headless backends.
- Help text corrected to describe the peak-RMS default.

**Testing**
- New integration tests: auto-latency selection (with a guard that it differs from the old variance metric) and click-driven map redraw.
- Full plot-wrapper + visual-parity suites pass; ruff/ty clean.
- Verified side-by-side against live EEGLAB R2025a (default and 4-map cases render identically).

**EEGLAB Visual Comparison**
<img width="1819" height="746" alt="timtopo_parity_default" src="https://github.com/user-attachments/assets/75eb8f84-98df-42bb-a5c1-e85d2020097a" />
<img width="1819" height="746" alt="timtopo_parity_4maps" src="https://github.com/user-attachments/assets/674f11d6-fd4e-4268-bc19-3418aab14bd5" />
