### PR TITLE
Display figures from GUI/console and add a plot on/off flag

### DIFF
--- a/docs/source/user_guide/gui_tutorials.rst
+++ b/docs/source/user_guide/gui_tutorials.rst
@@ -27,6 +27,15 @@ The console workflow is recommended because it shows ``LASTCOM`` and ``ALLCOM``
 after each menu action. See :ref:`gui_console_session` for the shared-session
 model and implementation details.
 
+.. note::
+
+   Plotting commands such as ``Plot > Channel spectra and maps`` and
+   ``Plot > Channel ERPs > With scalp maps`` open a figure window on any
+   interactive backend, whether you trigger them from a Plot menu or call the
+   matching ``pop_*`` function in ``eegprep-console``. On non-interactive
+   backends (for example ``Agg`` in headless runs) the figure is built and
+   returned without opening a window.
+
 Load, Inspect, and Save a Dataset
 =================================
 

--- a/docs/source/user_guide/gui_tutorials.rst
+++ b/docs/source/user_guide/gui_tutorials.rst
@@ -36,6 +36,11 @@ model and implementation details.
    backends (for example ``Agg`` in headless runs) the figure is built and
    returned without opening a window.
 
+   When scripting, pass ``plot='off'`` to any plotting ``pop_*`` function to
+   build and return the figure without popping a window, for example
+   ``fig = pop_spectopo(EEG, 1, [], freqs=[10], plot='off')['figure']`` to save
+   or embed it. The default ``plot='on'`` displays it.
+
 Load, Inspect, and Save a Dataset
 =================================
 

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -655,15 +655,11 @@ class _IPythonShellAdapter:
         _make_shell_prompt_dynamic(self.shell)
         restore_logging = _install_prompt_safe_logging()
         restore_progress_logging = _install_console_progress_logging()
-        # Enable the Qt event loop *and* point matplotlib at the matching qtagg
-        # backend, so figures from pop_* plot functions actually pop up and stay
-        # responsive; a bare enable_gui("qt") leaves matplotlib on its default
-        # backend, whose windows the Qt loop never drives.
+        # qtagg so figures are driven by the Qt loop; a bare enable_gui("qt")
+        # leaves the default backend, which the loop can't drive.
         self.shell.enable_matplotlib("qt")
-        # Keep interactive mode OFF so figures never auto-display on creation:
-        # pop_* functions show them explicitly via show_figures(). Otherwise an
-        # interactive figure window pops on every plt.subplots() and steals GUI
-        # focus even when plot='off' suppresses the plot itself.
+        # Interactive mode off: pop_* functions display via show_figures(), so
+        # plot='off' opens no window and does not steal GUI focus.
         plt.ioff()
 
         def post_run_cell(result: Any) -> None:

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -653,7 +653,11 @@ class _IPythonShellAdapter:
         _make_shell_prompt_dynamic(self.shell)
         restore_logging = _install_prompt_safe_logging()
         restore_progress_logging = _install_console_progress_logging()
-        self.shell.enable_gui("qt")
+        # Enable the Qt event loop *and* point matplotlib at the matching qtagg
+        # backend, so figures from pop_* plot functions actually pop up and stay
+        # responsive; a bare enable_gui("qt") leaves matplotlib on its default
+        # backend, whose windows the Qt loop never drives.
+        self.shell.enable_matplotlib("qt")
 
         def post_run_cell(result: Any) -> None:
             raw_cell = getattr(getattr(result, "info", None), "raw_cell", "")

--- a/src/eegprep/functions/adminfunc/console.py
+++ b/src/eegprep/functions/adminfunc/console.py
@@ -15,6 +15,8 @@ import warnings
 from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
+import matplotlib.pyplot as plt
+
 import eegprep
 from eegprep.functions.adminfunc.eegh import eegh, eegh_find
 from eegprep.extension_runtime import ExtensionRuntime
@@ -658,6 +660,11 @@ class _IPythonShellAdapter:
         # responsive; a bare enable_gui("qt") leaves matplotlib on its default
         # backend, whose windows the Qt loop never drives.
         self.shell.enable_matplotlib("qt")
+        # Keep interactive mode OFF so figures never auto-display on creation:
+        # pop_* functions show them explicitly via show_figures(). Otherwise an
+        # interactive figure window pops on every plt.subplots() and steals GUI
+        # focus even when plot='off' suppresses the plot itself.
+        plt.ioff()
 
         def post_run_cell(result: Any) -> None:
             raw_cell = getattr(getattr(result, "info", None), "raw_cell", "")

--- a/src/eegprep/functions/popfunc/plot_utils.py
+++ b/src/eegprep/functions/popfunc/plot_utils.py
@@ -21,22 +21,14 @@ def backend_can_display() -> bool:
 
 
 def show_figures(figures: Any, *, plot: str = "on") -> None:
-    """Pop up figure windows on an interactive backend, like EEGLAB plots.
+    """Display figures (a single figure, a list, or ``None``) on an interactive backend.
 
-    Accepts a single figure, a list/tuple of figures, or ``None``. It is a no-op
-    on file-output backends (Agg, PDF, ...) so headless rendering and tests stay
-    silent. Displaying here, rather than in the noninteractive sigproc cores,
-    keeps those cores test-safe while every plotting ``pop_*`` wrapper shows its
-    figure from both the GUI and the console.
-
-    Pass ``plot="off"`` to suppress the window entirely; callers still receive
-    the built figure so they can save or embed it without a pop-up.
+    No-op on file-output backends (Agg, PDF, ...) so headless runs stay silent.
+    ``plot="off"`` suppresses the window but still returns the built figure.
     """
     if str(plot).lower() == "off":
-        # Interactive sessions (e.g. IPython's ``%matplotlib qt``) auto-display
-        # every pyplot-managed figure, so suppressing the window means removing
-        # the figure from pyplot's registry, not just skipping ``show()``. The
-        # returned Figure object stays usable for ``savefig``/embedding.
+        # Close, not just skip show(): an interactive session auto-displays any
+        # pyplot-managed figure, so the window is suppressed only by unregistering it.
         for figure in _as_figure_list(figures):
             plt.close(figure)
         return

--- a/src/eegprep/functions/popfunc/plot_utils.py
+++ b/src/eegprep/functions/popfunc/plot_utils.py
@@ -33,6 +33,12 @@ def show_figures(figures: Any, *, plot: str = "on") -> None:
     the built figure so they can save or embed it without a pop-up.
     """
     if str(plot).lower() == "off":
+        # Interactive sessions (e.g. IPython's ``%matplotlib qt``) auto-display
+        # every pyplot-managed figure, so suppressing the window means removing
+        # the figure from pyplot's registry, not just skipping ``show()``. The
+        # returned Figure object stays usable for ``savefig``/embedding.
+        for figure in _as_figure_list(figures):
+            plt.close(figure)
         return
     if not backend_can_display():
         return

--- a/src/eegprep/functions/popfunc/plot_utils.py
+++ b/src/eegprep/functions/popfunc/plot_utils.py
@@ -20,7 +20,7 @@ def backend_can_display() -> bool:
     return plt.get_backend().lower() not in _NONINTERACTIVE_BACKENDS
 
 
-def show_figures(figures: Any) -> None:
+def show_figures(figures: Any, *, plot: str = "on") -> None:
     """Pop up figure windows on an interactive backend, like EEGLAB plots.
 
     Accepts a single figure, a list/tuple of figures, or ``None``. It is a no-op
@@ -28,7 +28,12 @@ def show_figures(figures: Any) -> None:
     silent. Displaying here, rather than in the noninteractive sigproc cores,
     keeps those cores test-safe while every plotting ``pop_*`` wrapper shows its
     figure from both the GUI and the console.
+
+    Pass ``plot="off"`` to suppress the window entirely; callers still receive
+    the built figure so they can save or embed it without a pop-up.
     """
+    if str(plot).lower() == "off":
+        return
     if not backend_can_display():
         return
     for figure in _as_figure_list(figures):

--- a/src/eegprep/functions/popfunc/plot_utils.py
+++ b/src/eegprep/functions/popfunc/plot_utils.py
@@ -20,15 +20,15 @@ def backend_can_display() -> bool:
     return plt.get_backend().lower() not in _NONINTERACTIVE_BACKENDS
 
 
-def show_figures(figures: Any, *, plot: str = "on") -> None:
+def show_figures(figures: Any, *, plot: str | bool = "on") -> None:
     """Display figures (a single figure, a list, or ``None``) on an interactive backend.
 
     No-op on file-output backends (Agg, PDF, ...) so headless runs stay silent.
-    ``plot="off"`` suppresses the window but still returns the built figure.
+    ``plot`` accepts ``'on'/'off'`` or ``True/False``. With it off, the figures are
+    closed (unregistered from pyplot) so an interactive session cannot auto-display
+    them; the caller keeps the returned Figure, which stays usable for ``savefig``.
     """
-    if str(plot).lower() == "off":
-        # Close, not just skip show(): an interactive session auto-displays any
-        # pyplot-managed figure, so the window is suppressed only by unregistering it.
+    if not _plot_enabled(plot):
         for figure in _as_figure_list(figures):
             plt.close(figure)
         return
@@ -261,6 +261,15 @@ def history_command(function_name: str, *args: Any, eeg_name: str = "EEG", **kwa
         f"{key}={python_literal(value)}" for key, value in kwargs.items() if not _is_empty_history_value(value)
     )
     return f"{function_name}({', '.join(pieces)})"
+
+
+def _plot_enabled(plot: str | bool) -> bool:
+    """Whether the ``plot`` flag requests a window: ``'on'/'off'`` or ``True/False``."""
+    if isinstance(plot, bool):
+        return plot
+    if isinstance(plot, str) and plot.strip().lower() in {"on", "off"}:
+        return plot.strip().lower() == "on"
+    raise ValueError(f"plot must be 'on'/'off' or True/False, got {plot!r}")
 
 
 def _as_figure_list(figures: Any) -> list[Any]:

--- a/src/eegprep/functions/popfunc/plot_utils.py
+++ b/src/eegprep/functions/popfunc/plot_utils.py
@@ -4,11 +4,35 @@ from __future__ import annotations
 
 from typing import Any
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from eegprep.functions.miscfunc.misc import finite_matmul
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
 from eegprep.functions.popfunc._pop_utils import is_empty_value, parse_numeric_sequence
+
+# matplotlib's file-output backends cannot open a figure window.
+_NONINTERACTIVE_BACKENDS = frozenset({"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"})
+
+
+def backend_can_display() -> bool:
+    """Return True when the active matplotlib backend can show a figure window."""
+    return plt.get_backend().lower() not in _NONINTERACTIVE_BACKENDS
+
+
+def show_figures(figures: Any) -> None:
+    """Pop up figure windows on an interactive backend, like EEGLAB plots.
+
+    Accepts a single figure, a list/tuple of figures, or ``None``. It is a no-op
+    on file-output backends (Agg, PDF, ...) so headless rendering and tests stay
+    silent. Displaying here, rather than in the noninteractive sigproc cores,
+    keeps those cores test-safe while every plotting ``pop_*`` wrapper shows its
+    figure from both the GUI and the console.
+    """
+    if not backend_can_display():
+        return
+    for figure in _as_figure_list(figures):
+        figure.show()
 
 
 def as_eeg_list(value: Any) -> list[dict[str, Any]]:
@@ -234,6 +258,14 @@ def history_command(function_name: str, *args: Any, eeg_name: str = "EEG", **kwa
         f"{key}={python_literal(value)}" for key, value in kwargs.items() if not _is_empty_history_value(value)
     )
     return f"{function_name}({', '.join(pieces)})"
+
+
+def _as_figure_list(figures: Any) -> list[Any]:
+    if figures is None:
+        return []
+    if isinstance(figures, (list, tuple)):
+        return [figure for figure in figures if figure is not None]
+    return [figures]
 
 
 def _is_empty_sequence(value: Any) -> bool:

--- a/src/eegprep/functions/popfunc/pop_comperp.py
+++ b/src/eegprep/functions/popfunc/pop_comperp.py
@@ -31,7 +31,7 @@ def pop_comperp(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_comperp.py
+++ b/src/eegprep/functions/popfunc/pop_comperp.py
@@ -31,10 +31,14 @@ def pop_comperp(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Compute and plot grand-average ERPs across loaded datasets."""
+    """Compute and plot grand-average ERPs across loaded datasets.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     datasets = as_eeg_list(ALLEEG)
     if gui is None:
         gui = datadd is None
@@ -91,7 +95,7 @@ def pop_comperp(
         options=options,
     )
     result = {"erp1": erp1, "erp2": erp2, "erpsub": erpsub, "times": times, "pvalues": pvalues, "figure": figure}
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     command = history_command(
         "pop_comperp", int(flag), (add_indices + 1).tolist(), (sub_indices + 1).tolist(), eeg_name="ALLEEG", **kwargs
     )

--- a/src/eegprep/functions/popfunc/pop_comperp.py
+++ b/src/eegprep/functions/popfunc/pop_comperp.py
@@ -18,6 +18,7 @@ from eegprep.functions.popfunc.plot_utils import (
     eeg_times_ms,
     history_command,
     numeric_vector,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import is_on
 
@@ -90,6 +91,7 @@ def pop_comperp(
         options=options,
     )
     result = {"erp1": erp1, "erp2": erp2, "erpsub": erpsub, "times": times, "pvalues": pvalues, "figure": figure}
+    show_figures(figure)
     command = history_command(
         "pop_comperp", int(flag), (add_indices + 1).tolist(), (sub_indices + 1).tolist(), eeg_name="ALLEEG", **kwargs
     )

--- a/src/eegprep/functions/popfunc/pop_envtopo.py
+++ b/src/eegprep/functions/popfunc/pop_envtopo.py
@@ -17,6 +17,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.sigprocfunc.envtopo import envtopo
 
@@ -81,6 +82,7 @@ def pop_envtopo(
         title=title,
     )
     command = history_command("pop_envtopo", timerange, **command_kwargs)
+    show_figures(figure)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_envtopo.py
+++ b/src/eegprep/functions/popfunc/pop_envtopo.py
@@ -28,10 +28,14 @@ def pop_envtopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot largest component ERP envelopes and component maps."""
+    """Plot largest component ERP envelopes and component maps.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     if isinstance(EEG, list):
@@ -82,7 +86,7 @@ def pop_envtopo(
         title=title,
     )
     command = history_command("pop_envtopo", timerange, **command_kwargs)
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_envtopo.py
+++ b/src/eegprep/functions/popfunc/pop_envtopo.py
@@ -28,7 +28,7 @@ def pop_envtopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_erpimage.py
+++ b/src/eegprep/functions/popfunc/pop_erpimage.py
@@ -30,7 +30,7 @@ def pop_erpimage(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_erpimage.py
+++ b/src/eegprep/functions/popfunc/pop_erpimage.py
@@ -17,6 +17,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import is_on
 from eegprep.functions.sigprocfunc.erpimage import erpimage
@@ -84,6 +85,7 @@ def pop_erpimage(
         vert=kwargs.pop("vert", None),
     )
     command = history_command("pop_erpimage", typeplot, int(index), **command_kwargs)
+    show_figures(figure)
     return ({"figure": figure, "image": image}, command) if return_com else {"figure": figure, "image": image}
 
 

--- a/src/eegprep/functions/popfunc/pop_erpimage.py
+++ b/src/eegprep/functions/popfunc/pop_erpimage.py
@@ -30,10 +30,14 @@ def pop_erpimage(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot an ERP image for one channel or component."""
+    """Plot an ERP image for one channel or component.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     typeplot = int(typeplot)
@@ -85,7 +89,7 @@ def pop_erpimage(
         vert=kwargs.pop("vert", None),
     )
     command = history_command("pop_erpimage", typeplot, int(index), **command_kwargs)
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return ({"figure": figure, "image": image}, command) if return_com else {"figure": figure, "image": image}
 
 

--- a/src/eegprep/functions/popfunc/pop_eventstat.py
+++ b/src/eegprep/functions/popfunc/pop_eventstat.py
@@ -23,7 +23,7 @@ def pop_eventstat(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
 ):
     """Compute and plot statistics for numeric EEG event fields.

--- a/src/eegprep/functions/popfunc/pop_eventstat.py
+++ b/src/eegprep/functions/popfunc/pop_eventstat.py
@@ -23,9 +23,13 @@ def pop_eventstat(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
 ):
-    """Compute and plot statistics for numeric EEG event fields."""
+    """Compute and plot statistics for numeric EEG event fields.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     if gui is None:
@@ -50,7 +54,7 @@ def pop_eventstat(
     )
     result = signalstat(values, 1, label, float(percent), title)
     command = history_command("pop_eventstat", eventfield, type, latrange, percent)
-    show_figures(result.figure)
+    show_figures(result.figure, plot=plot)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_eventstat.py
+++ b/src/eegprep/functions/popfunc/pop_eventstat.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
-from eegprep.functions.popfunc.plot_utils import history_command, numeric_vector
+from eegprep.functions.popfunc.plot_utils import history_command, numeric_vector, show_figures
 from eegprep.functions.popfunc._pop_utils import is_empty_value as _is_empty
 from eegprep.functions.popfunc.eeg_point2lat import eeg_point2lat
 from eegprep.functions.sigprocfunc.signalstat import signalstat
@@ -50,6 +50,7 @@ def pop_eventstat(
     )
     result = signalstat(values, 1, label, float(percent), title)
     command = history_command("pop_eventstat", eventfield, type, latrange, percent)
+    show_figures(result.figure)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_headplot.py
+++ b/src/eegprep/functions/popfunc/pop_headplot.py
@@ -46,6 +46,7 @@ def pop_headplot(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
@@ -54,6 +55,8 @@ def pop_headplot(
     Like EEGLAB, ``pop_headplot`` requires a ``.spl`` spline setup file. Use
     ``setup={...}`` to create one, ``load=...`` to reuse one, or launch the GUI
     to select/create it interactively.
+
+    Pass ``plot='off'`` to build and return the figures without opening a window.
     """
     if EEG is None:
         return ([], "") if return_com else []
@@ -111,7 +114,7 @@ def pop_headplot(
     command = _history_command(
         typeplot, items_array, topotitle, [rows, columns], colorbar, setup, load, command_options
     )
-    show_figures(figures)
+    show_figures(figures, plot=plot)
     return (figures, command) if return_com else figures
 
 

--- a/src/eegprep/functions/popfunc/pop_headplot.py
+++ b/src/eegprep/functions/popfunc/pop_headplot.py
@@ -20,6 +20,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import is_empty_value as _is_empty
 from eegprep.functions.popfunc._pop_utils import is_on as _is_on
@@ -110,6 +111,7 @@ def pop_headplot(
     command = _history_command(
         typeplot, items_array, topotitle, [rows, columns], colorbar, setup, load, command_options
     )
+    show_figures(figures)
     return (figures, command) if return_com else figures
 
 

--- a/src/eegprep/functions/popfunc/pop_headplot.py
+++ b/src/eegprep/functions/popfunc/pop_headplot.py
@@ -46,7 +46,7 @@ def pop_headplot(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_newcrossf.py
+++ b/src/eegprep/functions/popfunc/pop_newcrossf.py
@@ -30,7 +30,7 @@ def pop_newcrossf(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_newcrossf.py
+++ b/src/eegprep/functions/popfunc/pop_newcrossf.py
@@ -30,10 +30,14 @@ def pop_newcrossf(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot event-related channel/component cross-coherence."""
+    """Plot event-related channel/component cross-coherence.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     typeproc = int(typeproc)
@@ -64,7 +68,7 @@ def pop_newcrossf(
     command = history_command(
         "pop_newcrossf", typeproc, _first_index(num1), _first_index(num2), tlimits, cycles, **options
     )
-    show_figures(result.figure)
+    show_figures(result.figure, plot=plot)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_newcrossf.py
+++ b/src/eegprep/functions/popfunc/pop_newcrossf.py
@@ -14,6 +14,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.timefreqfunc.newcrossf import newcrossf
@@ -63,6 +64,7 @@ def pop_newcrossf(
     command = history_command(
         "pop_newcrossf", typeproc, _first_index(num1), _first_index(num2), tlimits, cycles, **options
     )
+    show_figures(result.figure)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_newtimef.py
+++ b/src/eegprep/functions/popfunc/pop_newtimef.py
@@ -30,7 +30,7 @@ def pop_newtimef(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_newtimef.py
+++ b/src/eegprep/functions/popfunc/pop_newtimef.py
@@ -30,10 +30,14 @@ def pop_newtimef(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot a channel or component ERSP/ITC decomposition."""
+    """Plot a channel or component ERSP/ITC decomposition.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     typeproc = int(typeproc)
@@ -57,7 +61,7 @@ def pop_newtimef(
     data, times = _selected_signal(EEG, typeproc, num, tlimits)
     result = newtimef(data, data.shape[0], [times[0], times[-1]], float(EEG.get("srate", 1) or 1), cycles, **options)
     command = history_command("pop_newtimef", typeproc, _first_index(num), tlimits, cycles, **options)
-    show_figures(result.figure)
+    show_figures(result.figure, plot=plot)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_newtimef.py
+++ b/src/eegprep/functions/popfunc/pop_newtimef.py
@@ -15,6 +15,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.timefreqfunc.newtimef import newtimef
@@ -56,6 +57,7 @@ def pop_newtimef(
     data, times = _selected_signal(EEG, typeproc, num, tlimits)
     result = newtimef(data, data.shape[0], [times[0], times[-1]], float(EEG.get("srate", 1) or 1), cycles, **options)
     command = history_command("pop_newtimef", typeproc, _first_index(num), tlimits, cycles, **options)
+    show_figures(result.figure)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_plotdata.py
+++ b/src/eegprep/functions/popfunc/pop_plotdata.py
@@ -24,7 +24,7 @@ def pop_plotdata(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_plotdata.py
+++ b/src/eegprep/functions/popfunc/pop_plotdata.py
@@ -24,10 +24,14 @@ def pop_plotdata(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot component ERP activations in a rectangular array."""
+    """Plot component ERP activations in a rectangular array.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     if gui is None:
@@ -51,7 +55,7 @@ def pop_plotdata(
         ylimits=ylimits,
     )
     command = history_command("pop_plotdata", components, **command_kwargs)
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_plotdata.py
+++ b/src/eegprep/functions/popfunc/pop_plotdata.py
@@ -8,7 +8,13 @@ import numpy as np
 
 from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
-from eegprep.functions.popfunc.plot_utils import component_activations, eeg_times_ms, history_command, numeric_vector
+from eegprep.functions.popfunc.plot_utils import (
+    component_activations,
+    eeg_times_ms,
+    history_command,
+    numeric_vector,
+    show_figures,
+)
 from eegprep.functions.sigprocfunc.plottopo import plottopo
 
 
@@ -45,6 +51,7 @@ def pop_plotdata(
         ylimits=ylimits,
     )
     command = history_command("pop_plotdata", components, **command_kwargs)
+    show_figures(figure)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_plottopo.py
+++ b/src/eegprep/functions/popfunc/pop_plottopo.py
@@ -14,6 +14,7 @@ from eegprep.functions.popfunc.plot_utils import (
     numeric_vector,
     parse_plot_options_text,
     selected_indices,
+    show_figures,
 )
 from eegprep.functions.sigprocfunc.plottopo import plottopo
 
@@ -63,6 +64,7 @@ def pop_plottopo(
         rect=rect,
     )
     command = history_command("pop_plottopo", chans, **command_kwargs)
+    show_figures(figure)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_plottopo.py
+++ b/src/eegprep/functions/popfunc/pop_plottopo.py
@@ -25,10 +25,14 @@ def pop_plottopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot channel ERP traces in a rectangular/scalp-like array."""
+    """Plot channel ERP traces in a rectangular/scalp-like array.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     if gui is None:
@@ -64,7 +68,7 @@ def pop_plottopo(
         rect=rect,
     )
     command = history_command("pop_plottopo", chans, **command_kwargs)
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_plottopo.py
+++ b/src/eegprep/functions/popfunc/pop_plottopo.py
@@ -25,7 +25,7 @@ def pop_plottopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -34,11 +34,15 @@ def pop_prop(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     scroll_event: int | bool = 1,
     show_activity: bool = False,
     return_com: bool = False,
 ):
-    """Plot properties of one channel or independent component."""
+    """Plot properties of one channel or independent component.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     typecomp = int(typecomp)
@@ -61,7 +65,7 @@ def pop_prop(
             show=show_activity,
         )
     command = history_command("pop_prop", typecomp, indices.astype(int).tolist(), winhandle, spec_opt)
-    show_figures(figures)
+    show_figures(figures, plot=plot)
     return (
         (figures[0] if len(figures) == 1 else figures, command)
         if return_com

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -34,7 +34,7 @@ def pop_prop(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     scroll_event: int | bool = 1,
     show_activity: bool = False,
     return_com: bool = False,

--- a/src/eegprep/functions/popfunc/pop_prop.py
+++ b/src/eegprep/functions/popfunc/pop_prop.py
@@ -19,6 +19,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.sigprocfunc.spectopo import compute_spectra
 from eegprep.functions.sigprocfunc.topoplot import topoplot
@@ -60,6 +61,7 @@ def pop_prop(
             show=show_activity,
         )
     command = history_command("pop_prop", typecomp, indices.astype(int).tolist(), winhandle, spec_opt)
+    show_figures(figures)
     return (
         (figures[0] if len(figures) == 1 else figures, command)
         if return_com

--- a/src/eegprep/functions/popfunc/pop_signalstat.py
+++ b/src/eegprep/functions/popfunc/pop_signalstat.py
@@ -13,6 +13,7 @@ from eegprep.functions.popfunc.plot_utils import (
     component_map_data,
     history_command,
     numeric_vector,
+    show_figures,
 )
 from eegprep.functions.sigprocfunc.signalstat import signalstat
 
@@ -64,6 +65,7 @@ def pop_signalstat(
         map_value = maps[:, index - 1]
     result = signalstat(values, 1, dlabel, float(percent), dlabel2, map_value, stat_chanlocs)
     command = history_command("pop_signalstat", typeproc, index, percent)
+    show_figures(result.figure)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_signalstat.py
+++ b/src/eegprep/functions/popfunc/pop_signalstat.py
@@ -26,9 +26,13 @@ def pop_signalstat(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
 ):
-    """Compute and plot statistics for one channel or component."""
+    """Compute and plot statistics for one channel or component.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     typeproc = int(typeproc)
@@ -65,7 +69,7 @@ def pop_signalstat(
         map_value = maps[:, index - 1]
     result = signalstat(values, 1, dlabel, float(percent), dlabel2, map_value, stat_chanlocs)
     command = history_command("pop_signalstat", typeproc, index, percent)
-    show_figures(result.figure)
+    show_figures(result.figure, plot=plot)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_signalstat.py
+++ b/src/eegprep/functions/popfunc/pop_signalstat.py
@@ -26,7 +26,7 @@ def pop_signalstat(
     *,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
 ):
     """Compute and plot statistics for one channel or component.

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -30,10 +30,14 @@ def pop_spectopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot channel or component spectra and scalp maps."""
+    """Plot channel or component spectra and scalp maps.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     options = parse_key_value_args(args, kwargs, lowercase_kwargs=True)
@@ -47,6 +51,10 @@ def pop_spectopo(
         timerange = result["timerange"]
         process = result["process"]
         options.update(result["options"])
+
+    # "plot" governs whether the window pops up; keep it out of the core spectopo
+    # options so a stray EEGLAB-style 'plot','off' can't suppress figure drawing.
+    plot = str(options.pop("plot", plot))
 
     data, times = data_time_slice(EEG, timerange)
     history_options = {key: value for key, value in options.items() if key not in {"plotchan", "icamode"}}
@@ -128,7 +136,7 @@ def pop_spectopo(
         process=None if process == "EEG" else process,
         **history_options,
     )
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -16,6 +16,7 @@ from eegprep.functions.popfunc.plot_utils import (
     numeric_vector,
     parse_plot_options_text,
     selected_indices,
+    show_figures,
 )
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args
 from eegprep.functions.sigprocfunc.spectopo import plot_component_spectra, spectopo
@@ -127,8 +128,7 @@ def pop_spectopo(
         process=None if process == "EEG" else process,
         **history_options,
     )
-    if gui and figure is not None:
-        figure.show()
+    show_figures(figure)
     return (result, command) if return_com else result
 
 

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -52,9 +52,10 @@ def pop_spectopo(
         process = result["process"]
         options.update(result["options"])
 
-    # "plot" gates the window here; keep it out of the core options so it can't
-    # also suppress figure drawing.
-    plot = options.pop("plot", plot)
+    # Guard only: drop a stray EEGLAB-style ('plot', ...) pair so it can't reach
+    # the core spectopo(plot=...) and skip drawing. The display flag is the
+    # keyword-only "plot" parameter, consistent with the other wrappers.
+    options.pop("plot", None)
 
     data, times = data_time_slice(EEG, timerange)
     history_options = {key: value for key, value in options.items() if key not in {"plotchan", "icamode"}}
@@ -280,7 +281,7 @@ def _raise_for_unsupported_component_options(options: dict[str, Any]) -> None:
 
 
 def _split_spectopo_options(options: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
-    spectral_keys = {"plot", "winsize", "overlap", "nfft"}
+    spectral_keys = {"winsize", "overlap", "nfft"}
     spectral = {key: options[key] for key in spectral_keys if key in options}
     if "winsize" in spectral:
         spectral["winsize"] = int(numeric_vector(spectral["winsize"])[0])

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -30,7 +30,7 @@ def pop_spectopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
@@ -54,7 +54,7 @@ def pop_spectopo(
 
     # "plot" gates the window here; keep it out of the core options so it can't
     # also suppress figure drawing.
-    plot = str(options.pop("plot", plot))
+    plot = options.pop("plot", plot)
 
     data, times = data_time_slice(EEG, timerange)
     history_options = {key: value for key, value in options.items() if key not in {"plotchan", "icamode"}}

--- a/src/eegprep/functions/popfunc/pop_spectopo.py
+++ b/src/eegprep/functions/popfunc/pop_spectopo.py
@@ -52,8 +52,8 @@ def pop_spectopo(
         process = result["process"]
         options.update(result["options"])
 
-    # "plot" governs whether the window pops up; keep it out of the core spectopo
-    # options so a stray EEGLAB-style 'plot','off' can't suppress figure drawing.
+    # "plot" gates the window here; keep it out of the core options so it can't
+    # also suppress figure drawing.
     plot = str(options.pop("plot", plot))
 
     data, times = data_time_slice(EEG, timerange)

--- a/src/eegprep/functions/popfunc/pop_timtopo.py
+++ b/src/eegprep/functions/popfunc/pop_timtopo.py
@@ -24,10 +24,14 @@ def pop_timtopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
-    """Plot channel ERP traces and scalp maps at selected latencies."""
+    """Plot channel ERP traces and scalp maps at selected latencies.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if EEG is None:
         return (None, "") if return_com else None
     if gui is None:
@@ -53,7 +57,7 @@ def pop_timtopo(
         topoplot_options=topoplot_options,
     )
     command = history_command("pop_timtopo", plottimes, **command_kwargs)
-    show_figures(figure)
+    show_figures(figure, plot=plot)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_timtopo.py
+++ b/src/eegprep/functions/popfunc/pop_timtopo.py
@@ -24,7 +24,7 @@ def pop_timtopo(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/popfunc/pop_timtopo.py
+++ b/src/eegprep/functions/popfunc/pop_timtopo.py
@@ -13,6 +13,7 @@ from eegprep.functions.popfunc.plot_utils import (
     history_command,
     numeric_vector,
     parse_plot_options_text,
+    show_figures,
 )
 from eegprep.functions.sigprocfunc.timtopo import timtopo
 
@@ -52,6 +53,7 @@ def pop_timtopo(
         topoplot_options=topoplot_options,
     )
     command = history_command("pop_timtopo", plottimes, **command_kwargs)
+    show_figures(figure)
     return (figure, command) if return_com else figure
 
 

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -13,7 +13,7 @@ from eegprep.functions.guifunc.inputgui import inputgui
 from eegprep.functions.guifunc.spec import ControlSpec, DialogSpec
 from eegprep.functions.miscfunc.misc import round_mat
 from eegprep.functions.popfunc._chanutils import chanlocs_as_list
-from eegprep.functions.popfunc.plot_utils import component_map_data
+from eegprep.functions.popfunc.plot_utils import component_map_data, show_figures
 from eegprep.functions.popfunc.plot_utils import history_command as plot_history_command
 from eegprep.functions.popfunc._pop_utils import is_on as _is_on
 from eegprep.functions.popfunc._pop_utils import parse_key_value_args, parse_numeric_sequence, parse_text_tokens
@@ -108,9 +108,7 @@ def pop_topoplot(
     command = _history_command(typeplot, items_array, topotitle, rowcols_array, int(bool(plotdip)), options)
 
     # EEGLAB displays the figure whether called from the GUI or the command line.
-    if _backend_can_display():
-        for figure in figures:
-            figure.show()
+    show_figures(figures)
     return (figures, command) if return_com else figures
 
 
@@ -206,8 +204,7 @@ def plot_channel_locations(EEG: dict[str, Any], *, mode: str = "labels", return_
     fig, *_ = topoplot([], chanlocs, style="blank", electrodes=electrodes, title="Channel locations")
     command = f"topoplot([], EEG['chanlocs'], style='blank', electrodes={electrodes!r})"
 
-    if _backend_can_display():
-        fig.show()
+    show_figures(fig)
     return (fig, command) if return_com else fig
 
 
@@ -428,15 +425,6 @@ def _validate_topoplot_inputs(EEG: dict[str, Any], typeplot: int) -> None:
     _require_chanlocs(EEG)
     if typeplot == 0:
         _require_ica(EEG)
-
-
-# matplotlib's file-output backends (Agg, PDF, SVG, ...) cannot open a window.
-_NONINTERACTIVE_BACKENDS = frozenset({"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"})
-
-
-def _backend_can_display() -> bool:
-    """True when the active matplotlib backend can show a figure window."""
-    return plt.get_backend().lower() not in _NONINTERACTIVE_BACKENDS
 
 
 def _is_plotdip_value(value: Any) -> bool:

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -30,6 +30,7 @@ def pop_topoplot(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):
@@ -48,6 +49,7 @@ def pop_topoplot(
             are deferred to the Phase 4 headplot/DIPFIT integration.
         gui: Force or suppress the EEGLAB-like input dialog.
         renderer: Optional dialog renderer for tests.
+        plot: ``'off'`` builds and returns the figures without opening a window.
         return_com: Return ``(figures, command)`` when true.
         **kwargs: Additional ``topoplot`` options such as ``electrodes``,
             ``colorbar`` and ``maplimits``.
@@ -108,7 +110,7 @@ def pop_topoplot(
     command = _history_command(typeplot, items_array, topotitle, rowcols_array, int(bool(plotdip)), options)
 
     # EEGLAB displays the figure whether called from the GUI or the command line.
-    show_figures(figures)
+    show_figures(figures, plot=plot)
     return (figures, command) if return_com else figures
 
 

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -204,7 +204,7 @@ def plot_channel_locations(EEG: dict[str, Any], *, mode: str = "labels", return_
     fig, *_ = topoplot([], chanlocs, style="blank", electrodes=electrodes, title="Channel locations")
     command = f"topoplot([], EEG['chanlocs'], style='blank', electrodes={electrodes!r})"
 
-    show_figures(fig)
+    # topoplot() owns and displays this standalone figure; no extra show here.
     return (fig, command) if return_com else fig
 
 

--- a/src/eegprep/functions/popfunc/pop_topoplot.py
+++ b/src/eegprep/functions/popfunc/pop_topoplot.py
@@ -30,7 +30,7 @@ def pop_topoplot(
     *args: Any,
     gui: bool | None = None,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
     **kwargs: Any,
 ):

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -315,8 +315,7 @@ def topoplot(datavector, chan_locs, **kwargs):
 
         if own_figure:
             ax.set_title('Topoplot')
-            # Standalone topoplot() owns its figure, so it displays it, matching a
-            # bare EEGLAB topoplot() call; embedded (axes=) calls stay silent.
+            # Display only when we own the figure, like a bare EEGLAB topoplot() call.
             show_figures(fig)
 
         handle = fig

--- a/src/eegprep/functions/sigprocfunc/topoplot.py
+++ b/src/eegprep/functions/sigprocfunc/topoplot.py
@@ -4,6 +4,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import griddata
 
+from eegprep.functions.popfunc.plot_utils import show_figures
+
 
 def griddata_v4(x, y, v, xq, yq):
     """Python version of MATLAB's GDATAV4 interpolation based on David T. Sandwell's biharmonic spline interpolation.
@@ -313,7 +315,9 @@ def topoplot(datavector, chan_locs, **kwargs):
 
         if own_figure:
             ax.set_title('Topoplot')
-            _show_if_interactive()
+            # Standalone topoplot() owns its figure, so it displays it, matching a
+            # bare EEGLAB topoplot() call; embedded (axes=) calls stay silent.
+            show_figures(fig)
 
         handle = fig
 
@@ -351,7 +355,7 @@ def _blank_topoplot(chan_locs, *, noplot='off', electrodes='on', gridscale=67, *
     ax.axis('off')
     ax.set_title(kwargs.get('title', 'Channel locations'))
     if own_figure:
-        _show_if_interactive()
+        show_figures(fig)
     return fig, Zi, 0.5, xi, yi
 
 
@@ -409,11 +413,6 @@ def _draw_electrode_labels(ax, x, y, labels, electrodes, *, showlabels=False):
         return
     for x_pos, y_pos, text in zip(x, y, text_labels):
         ax.annotate(text, (x_pos, y_pos), fontsize=7, ha='center', va='center')
-
-
-def _show_if_interactive():
-    if 'agg' not in plt.get_backend().lower():
-        plt.show()
 
 
 def _maplimits_kwargs(maplimits, data):

--- a/src/eegprep/functions/studyfunc/pop_chanplot.py
+++ b/src/eegprep/functions/studyfunc/pop_chanplot.py
@@ -37,9 +37,13 @@ def pop_chanplot(
     mode: str = "channels",
     gui: bool = False,
     renderer: Any | None = None,
+    plot: str = "on",
     return_com: bool = False,
 ):
-    """Plot precomputed STUDY channel or component measures."""
+    """Plot precomputed STUDY channel or component measures.
+
+    Pass ``plot='off'`` to build and return the figure without opening a window.
+    """
     if STUDY is None:
         raise ValueError("pop_chanplot requires a STUDY structure")
     datasets = as_eeg_list(ALLEEG)
@@ -65,7 +69,7 @@ def pop_chanplot(
     etc = study.get("etc") if isinstance(study.get("etc"), dict) else {}
     study["etc"] = {**etc, "last_chanplot": last_selection}
     command = _history_command(channels=channels, components=components, measure=measure, mode=mode)
-    show_figures(fig)
+    show_figures(fig, plot=plot)
     return (study, command, fig) if return_com else study
 
 

--- a/src/eegprep/functions/studyfunc/pop_chanplot.py
+++ b/src/eegprep/functions/studyfunc/pop_chanplot.py
@@ -17,6 +17,7 @@ from eegprep.functions.popfunc.plot_utils import (
     eeg_times_ms,
     numeric_vector,
     python_literal,
+    show_figures,
 )
 from eegprep.functions.studyfunc._std_measureplot import plot_measure_data
 from eegprep.functions.studyfunc._study_utils import MEASURE_DATA_FIELDS
@@ -64,6 +65,7 @@ def pop_chanplot(
     etc = study.get("etc") if isinstance(study.get("etc"), dict) else {}
     study["etc"] = {**etc, "last_chanplot": last_selection}
     command = _history_command(channels=channels, components=components, measure=measure, mode=mode)
+    show_figures(fig)
     return (study, command, fig) if return_com else study
 
 

--- a/src/eegprep/functions/studyfunc/pop_chanplot.py
+++ b/src/eegprep/functions/studyfunc/pop_chanplot.py
@@ -37,7 +37,7 @@ def pop_chanplot(
     mode: str = "channels",
     gui: bool = False,
     renderer: Any | None = None,
-    plot: str = "on",
+    plot: str | bool = "on",
     return_com: bool = False,
 ):
     """Plot precomputed STUDY channel or component measures.

--- a/src/eegprep/resources/help/pop_chanplot.md
+++ b/src/eegprep/resources/help/pop_chanplot.md
@@ -25,3 +25,5 @@ editing.
 
 Use `std_erpplot`, `std_specplot`, `std_erspplot`, and `std_itcplot` for direct
 script-level access to the same cached measure plotting helpers.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_comperp.md
+++ b/src/eegprep/resources/help/pop_comperp.md
@@ -27,3 +27,5 @@ testing.
 Unsupported option names now raise `ValueError` with the unsupported keys
 listed. STUDY-level ERP statistics and EEGLAB plot callbacks that depend on
 MATLAB workspace state remain outside this standalone wrapper.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_envtopo.md
+++ b/src/eegprep/resources/help/pop_envtopo.md
@@ -12,3 +12,5 @@ EEGPrep's standalone wrapper accepts one dataset. Multi-dataset envelope
 comparison is not implemented because component maps, ICA channel subsets, and
 dataset-level envelopes need a dedicated group workflow rather than a silent
 merge.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_erpimage.md
+++ b/src/eegprep/resources/help/pop_erpimage.md
@@ -35,3 +35,5 @@ EEGPrep does not implement EEGLAB's phase-sorting, coherence, spectrum inset,
 amplitude-image, or event-alignment workflows in this standalone ERP-image
 wrapper. Those options raise clear `ValueError` messages instead of falling
 through to MATLAB-only behavior.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_eventstat.md
+++ b/src/eegprep/resources/help/pop_eventstat.md
@@ -13,3 +13,5 @@ stats = pop_eventstat(EEG, "duration", ["square"], [0, 300], 5)
 
 String-valued event fields are ignored because the statistical workflow requires
 numeric values.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_headplot.md
+++ b/src/eegprep/resources/help/pop_headplot.md
@@ -40,3 +40,5 @@ The Manual coreg. window shows user electrodes in green and reference electrodes
 in brown. `Align montages` fits a shared-scale transform to common labels;
 `Warp montage` fits the EEGLAB-style 9-parameter transform. The transform field
 is then written back to the `pop_headplot` setup dialog.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_newcrossf.md
+++ b/src/eegprep/resources/help/pop_newcrossf.md
@@ -15,3 +15,5 @@ Supported deterministic coherence modes are `phasecoher`, `phasecoher2`,
 continuous inputs use EEGLAB's cross-spectrum mode. Bootstrap, shuffle,
 `subitc`, and supplied `rboot` significance paths are supported in standalone
 Python.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_newtimef.md
+++ b/src/eegprep/resources/help/pop_newtimef.md
@@ -24,3 +24,5 @@ of each event column, matching EEGLAB's standalone workflow.
 The `tf cycle calc` button opens the Morlet wavelet cycle calculator. It writes
 the calculated frequency and cycle vectors back to the parent `pop_newtimef`
 dialog.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_plotdata.md
+++ b/src/eegprep/resources/help/pop_plotdata.md
@@ -7,3 +7,5 @@ fig, com = pop_plotdata(EEG, components=[1, 2, 3], return_com=True)
 ```
 
 This requires ICA activations or ICA weights.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_plottopo.md
+++ b/src/eegprep/resources/help/pop_plottopo.md
@@ -8,3 +8,5 @@ fig, com = pop_plottopo(EEG, chans=[1, 2, 3], rect=False, return_com=True)
 ```
 
 Channel indices are EEGLAB-facing and 1-based.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_prop.md
+++ b/src/eegprep/resources/help/pop_prop.md
@@ -8,3 +8,5 @@ fig, com = pop_prop(EEG, typecomp=1, chanorcomp=1, return_com=True)
 ```
 
 Use `typecomp=1` for channels and `typecomp=0` for ICA components.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_signalstat.md
+++ b/src/eegprep/resources/help/pop_signalstat.md
@@ -15,3 +15,5 @@ stats = pop_signalstat(EEG, 0, 2, 10)
 The GUI asks for the channel/component number and trim percentage, then renders
 a histogram, boxplot, QQ plot, topographic context when channel locations are
 available, and statistics panel.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_spectopo.md
+++ b/src/eegprep/resources/help/pop_spectopo.md
@@ -25,3 +25,6 @@ The GUI's "Spectral and scalp map options" field accepts either Python
 `key=value` pairs (e.g. `electrodes='off', style='blank'`) or the classic
 `'key', value` pairs (e.g. `'electrodes', 'off', 'style', 'blank'`). Multiple
 entries in either style are separated by commas.
+
+When scripting, pass `plot='off'` to build and return the figure without
+opening a window (`result['figure']`); the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_timtopo.md
+++ b/src/eegprep/resources/help/pop_timtopo.md
@@ -8,3 +8,5 @@ fig, com = pop_timtopo(EEG, plottimes=[100, 200], return_com=True)
 
 If no latency is supplied, EEGPrep maps the latency of maximum field strength
 (peak RMS across channels), matching the EEGLAB default.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/src/eegprep/resources/help/pop_topoplot.md
+++ b/src/eegprep/resources/help/pop_topoplot.md
@@ -21,3 +21,5 @@ Additional `topoplot` options can be passed as keyword arguments, for example
 `electrodes="on"`, `colorbar="off"`, or `maplimits=[-5, 5]`.
 
 DIPFIT dipole overlays and 3-D head plots are handled by later Phase 4 work.
+
+When scripting, pass `plot='off'` to build the figure without opening a window; the default `plot='on'` displays it.

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -1499,8 +1499,7 @@ def test_run_console_forwards_cli_options_to_gui_launcher():
     assert captured["gui_kwargs"]["native_file_dialogs"] is False
     assert "EEGPrep interactive console" in captured["banner"]
     assert shell.enabled_gui == "qt"
-    # Console keeps matplotlib non-interactive: figures display only via
-    # show_figures(), so plot='off' never pops a window or steals GUI focus.
+    # Non-interactive: pop_* display via show_figures(), so plot='off' pops nothing.
     assert not plt.isinteractive()
     assert shell.called is True
     assert "EEG" in captured["namespace"]

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -12,6 +12,7 @@ import warnings
 from types import SimpleNamespace
 from unittest import mock
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -1498,6 +1499,9 @@ def test_run_console_forwards_cli_options_to_gui_launcher():
     assert captured["gui_kwargs"]["native_file_dialogs"] is False
     assert "EEGPrep interactive console" in captured["banner"]
     assert shell.enabled_gui == "qt"
+    # Console keeps matplotlib non-interactive: figures display only via
+    # show_figures(), so plot='off' never pops a window or steals GUI focus.
+    assert not plt.isinteractive()
     assert shell.called is True
     assert "EEG" in captured["namespace"]
 

--- a/tests/test_console_workspace.py
+++ b/tests/test_console_workspace.py
@@ -1452,7 +1452,7 @@ class _FakeShell:
         self.enabled_gui = None
         self.called = False
 
-    def enable_gui(self, gui):
+    def enable_matplotlib(self, gui):
         self.enabled_gui = gui
 
     def __call__(self):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -14,6 +14,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 from matplotlib.backend_bases import MouseEvent
+from matplotlib.figure import Figure
 import numpy as np
 import pytest
 import scipy.io
@@ -31,7 +32,13 @@ from eegprep.functions.popfunc.pop_headplot import (
 )
 from eegprep.functions.popfunc.pop_loadset import pop_loadset
 from eegprep.functions.popfunc.pop_epoch import pop_epoch
-from eegprep.functions.popfunc.plot_utils import component_activations, data_time_slice, parse_plot_options_text
+from eegprep.functions.popfunc.plot_utils import (
+    backend_can_display,
+    component_activations,
+    data_time_slice,
+    parse_plot_options_text,
+    show_figures,
+)
 from eegprep.functions.popfunc.pop_plotdata import pop_plotdata
 from eegprep.functions.popfunc.pop_plottopo import pop_plottopo, pop_plottopo_dialog_spec
 from eegprep.functions.popfunc.pop_prop import pop_prop, pop_prop_dialog_spec
@@ -848,6 +855,64 @@ def test_component_plot_wrappers_work_when_ica_fields_exist(ica_epoch):
     plt.close(plotdata_fig)
     plt.close(envtopo_fig)
     plt.close(erpimage_result["figure"])
+
+
+def test_show_figures_is_noop_on_noninteractive_backend(monkeypatch):
+    """On file-output backends (Agg, the test default) show_figures opens nothing."""
+    figure = plt.figure()
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+
+    assert not backend_can_display()
+    show_figures(figure)
+
+    assert shown == []
+    plt.close(figure)
+
+
+def test_show_figures_displays_each_figure_on_interactive_backend(monkeypatch):
+    """On an interactive backend show_figures pops each figure and skips None entries."""
+    first, second = plt.figure(), plt.figure()
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    show_figures([first, None, second])
+
+    assert shown == [first, second]
+    plt.close(first)
+    plt.close(second)
+
+
+def test_plot_wrappers_display_figures_on_interactive_backend(sample_epoch, ica_epoch, monkeypatch):
+    """Every plotting pop_* wrapper pops up its figure on an interactive backend,
+    like EEGLAB. The GUI relies on this to make graphs appear; on Agg it stays silent."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    timtopo_fig, _ = pop_timtopo(sample_epoch, plottimes=[0], return_com=True)
+    plottopo_fig, _ = pop_plottopo(sample_epoch, chans=[1, 2], return_com=True)
+    erpimage_result, _ = pop_erpimage(sample_epoch, typeplot=1, index=1, return_com=True)
+    prop_fig, _ = pop_prop(ica_epoch, typecomp=0, chanorcomp=1, return_com=True)
+    topoplot_figs, _ = pop_topoplot(ica_epoch, typeplot=0, items=[1], colorbar="off", return_com=True)
+    spectopo_result, _ = pop_spectopo(ica_epoch, dataflag=0, freqs=[10], return_com=True)
+    plotdata_fig, _ = pop_plotdata(ica_epoch, components=[1, 2], return_com=True)
+    envtopo_fig, _ = pop_envtopo(ica_epoch, components=[1, 2], return_com=True)
+
+    expected = [
+        timtopo_fig,
+        plottopo_fig,
+        erpimage_result["figure"],
+        prop_fig,
+        *topoplot_figs,
+        spectopo_result["figure"],
+        plotdata_fig,
+        envtopo_fig,
+    ]
+    for figure in expected:
+        assert figure in shown
+        plt.close(figure)
 
 
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -1034,11 +1034,28 @@ def test_plot_off_figure_still_savable(sample_eeg):
     """A figure returned with plot='off' is closed but still usable for savefig."""
     figure = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="off")["figure"]
 
+    assert not plt.fignum_exists(figure.number)  # closed / unregistered from pyplot
+
     buffer = io.BytesIO()
     figure.savefig(buffer, format="png")
 
     assert buffer.getvalue()
     plt.close(figure)
+
+
+def test_pop_spectopo_plot_pair_is_ignored_not_leaked(sample_eeg, monkeypatch):
+    """A stray EEGLAB-style ('plot','off') pair is dropped before the spectopo core
+    (figure still built) and does not act as the keyword-only display flag."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+    plt.close("all")
+
+    result = pop_spectopo(sample_eeg, 1, [], "EEG", "plot", "off", freqs=[10])
+
+    assert result["figure"] is not None  # guard held: core still drew
+    assert shown == [result["figure"]]  # keyword-only: the pair did not suppress
+    plt.close("all")
 
 
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -949,39 +949,42 @@ def test_plot_channel_locations_displays_figure_exactly_once(sample_eeg, monkeyp
     plt.close(fig)
 
 
-def test_show_figures_plot_off_suppresses_window(monkeypatch):
-    """show_figures(plot='off') opens no window even on an interactive backend."""
-    figure = plt.figure()
+def test_show_figures_plot_off_closes_figure(monkeypatch):
+    """plot='off' never calls show() and removes the figure from pyplot's registry
+    so an interactive session (IPython %matplotlib qt) cannot auto-display it."""
     shown = []
     monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
     monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
 
-    show_figures(figure, plot="off")
+    fig_off = plt.figure()
+    num = fig_off.number
+    show_figures(fig_off, plot="off")
     assert shown == []
-    show_figures(figure, plot="on")
-    assert shown == [figure]
-    plt.close(figure)
+    assert not plt.fignum_exists(num)  # closed -> interactive mode won't show it
+
+    fig_on = plt.figure()
+    show_figures(fig_on, plot="on")
+    assert shown == [fig_on]
+    plt.close(fig_on)
 
 
 def test_plot_off_builds_figure_without_a_window(sample_eeg, sample_epoch, monkeypatch):
-    """plot='off' still builds and returns the figure but pops no window; the
-    default displays it. Covered for both return shapes (dict and bare figure)."""
+    """plot='off' still returns a usable figure but leaves nothing in pyplot's
+    registry to auto-display; the default plot='on' shows it."""
     shown = []
     monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
     monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+    plt.close("all")
 
     spec = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="off")
     timtopo_fig = pop_timtopo(sample_epoch, plottimes=[0], plot="off")
-    assert spec["figure"] is not None
-    assert timtopo_fig is not None
-    assert shown == []  # nothing displayed with plot='off'
+    assert spec["figure"] is not None and timtopo_fig is not None  # built and returned
+    assert shown == []  # never shown
+    assert plt.get_fignums() == []  # nothing left for an interactive session to pop up
 
     displayed = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="on")
     assert shown == [displayed["figure"]]
-
-    plt.close(spec["figure"])
-    plt.close(timtopo_fig)
-    plt.close(displayed["figure"])
+    plt.close("all")
 
 
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -949,6 +949,41 @@ def test_plot_channel_locations_displays_figure_exactly_once(sample_eeg, monkeyp
     plt.close(fig)
 
 
+def test_show_figures_plot_off_suppresses_window(monkeypatch):
+    """show_figures(plot='off') opens no window even on an interactive backend."""
+    figure = plt.figure()
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    show_figures(figure, plot="off")
+    assert shown == []
+    show_figures(figure, plot="on")
+    assert shown == [figure]
+    plt.close(figure)
+
+
+def test_plot_off_builds_figure_without_a_window(sample_eeg, sample_epoch, monkeypatch):
+    """plot='off' still builds and returns the figure but pops no window; the
+    default displays it. Covered for both return shapes (dict and bare figure)."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    spec = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="off")
+    timtopo_fig = pop_timtopo(sample_epoch, plottimes=[0], plot="off")
+    assert spec["figure"] is not None
+    assert timtopo_fig is not None
+    assert shown == []  # nothing displayed with plot='off'
+
+    displayed = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="on")
+    assert shown == [displayed["figure"]]
+
+    plt.close(spec["figure"])
+    plt.close(timtopo_fig)
+    plt.close(displayed["figure"])
+
+
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):
     figure, command = pop_prop(ica_epoch, typecomp=0, chanorcomp=1, return_com=True)
 

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -45,7 +45,9 @@ from eegprep.functions.popfunc.pop_prop import pop_prop, pop_prop_dialog_spec
 from eegprep.functions.popfunc.pop_signalstat import pop_signalstat
 from eegprep.functions.popfunc.pop_spectopo import pop_spectopo
 from eegprep.functions.popfunc.pop_timtopo import pop_timtopo
-from eegprep.functions.popfunc.pop_topoplot import pop_topoplot
+from eegprep.functions.popfunc.pop_topoplot import plot_channel_locations, pop_topoplot
+from eegprep.functions.popfunc._chanutils import chanlocs_as_list
+from eegprep.functions.sigprocfunc.topoplot import topoplot
 from eegprep.functions.studyfunc.pop_chanplot import pop_chanplot, pop_chanplot_dialog_spec
 from eegprep.functions.sigprocfunc.coregister import (
     ElectrodeSet,
@@ -913,6 +915,38 @@ def test_plot_wrappers_display_figures_on_interactive_backend(sample_epoch, ica_
     for figure in expected:
         assert figure in shown
         plt.close(figure)
+
+
+def test_topoplot_core_displays_only_when_it_owns_the_figure(sample_eeg, monkeypatch):
+    """Match EEGLAB: a standalone topoplot() call pops a window, but a call that
+    draws into a caller's axes (axes=) adds no window of its own."""
+    chanlocs = chanlocs_as_list(sample_eeg["chanlocs"])
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    standalone, *_ = topoplot([], chanlocs, style="blank")
+    assert shown == [standalone]
+
+    fig, ax = plt.subplots()
+    topoplot([], chanlocs, style="blank", axes=ax)
+    assert shown == [standalone]  # the embedded call opened no new window
+
+    plt.close(standalone)
+    plt.close(fig)
+
+
+def test_plot_channel_locations_displays_figure_exactly_once(sample_eeg, monkeypatch):
+    """The channel-locations view shows its figure once, via the topoplot core that
+    owns it, with no duplicate wrapper show."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    fig, _ = plot_channel_locations(sample_eeg, mode="labels", return_com=True)
+
+    assert shown == [fig]
+    plt.close(fig)
 
 
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -987,6 +987,48 @@ def test_plot_off_builds_figure_without_a_window(sample_eeg, sample_epoch, monke
     plt.close("all")
 
 
+def test_show_figures_plot_accepts_bool(monkeypatch):
+    """The plot flag also accepts booleans: False suppresses, True displays."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+
+    fig_off = plt.figure()
+    num = fig_off.number
+    show_figures(fig_off, plot=False)
+    assert shown == []
+    assert not plt.fignum_exists(num)
+
+    fig_on = plt.figure()
+    show_figures(fig_on, plot=True)
+    assert shown == [fig_on]
+    plt.close(fig_on)
+
+
+def test_show_figures_plot_rejects_unknown_value(monkeypatch):
+    """An unrecognized plot value fails loudly rather than silently showing a window."""
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+    fig = plt.figure()
+    with pytest.raises(ValueError):
+        show_figures(fig, plot="maybe")
+    plt.close(fig)
+
+
+def test_wrapper_plot_flag_accepts_bool(sample_eeg, monkeypatch):
+    """A wrapper honors plot=False like plot='off': figure built, no window."""
+    shown = []
+    monkeypatch.setattr(Figure, "show", lambda self: shown.append(self))
+    monkeypatch.setattr(plt, "get_backend", lambda: "QtAgg")
+    plt.close("all")
+
+    result = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot=False)
+
+    assert result["figure"] is not None
+    assert shown == []
+    assert plt.get_fignums() == []
+    plt.close("all")
+
+
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):
     figure, command = pop_prop(ica_epoch, typecomp=0, chanorcomp=1, return_com=True)
 

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -930,7 +930,7 @@ def test_topoplot_core_displays_only_when_it_owns_the_figure(sample_eeg, monkeyp
 
     fig, ax = plt.subplots()
     topoplot([], chanlocs, style="blank", axes=ax)
-    assert shown == [standalone]  # the embedded call opened no new window
+    assert shown == [standalone]
 
     plt.close(standalone)
     plt.close(fig)
@@ -960,7 +960,7 @@ def test_show_figures_plot_off_closes_figure(monkeypatch):
     num = fig_off.number
     show_figures(fig_off, plot="off")
     assert shown == []
-    assert not plt.fignum_exists(num)  # closed -> interactive mode won't show it
+    assert not plt.fignum_exists(num)
 
     fig_on = plt.figure()
     show_figures(fig_on, plot="on")
@@ -978,9 +978,9 @@ def test_plot_off_builds_figure_without_a_window(sample_eeg, sample_epoch, monke
 
     spec = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="off")
     timtopo_fig = pop_timtopo(sample_epoch, plottimes=[0], plot="off")
-    assert spec["figure"] is not None and timtopo_fig is not None  # built and returned
-    assert shown == []  # never shown
-    assert plt.get_fignums() == []  # nothing left for an interactive session to pop up
+    assert spec["figure"] is not None and timtopo_fig is not None
+    assert shown == []
+    assert plt.get_fignums() == []
 
     displayed = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="on")
     assert shown == [displayed["figure"]]

--- a/tests/test_phase4_plot_wrappers.py
+++ b/tests/test_phase4_plot_wrappers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 from copy import deepcopy
 import importlib
+import io
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -1027,6 +1028,17 @@ def test_wrapper_plot_flag_accepts_bool(sample_eeg, monkeypatch):
     assert shown == []
     assert plt.get_fignums() == []
     plt.close("all")
+
+
+def test_plot_off_figure_still_savable(sample_eeg):
+    """A figure returned with plot='off' is closed but still usable for savefig."""
+    figure = pop_spectopo(sample_eeg, dataflag=1, freqs=[10], plot="off")["figure"]
+
+    buffer = io.BytesIO()
+    figure.savefig(buffer, format="png")
+
+    assert buffer.getvalue()
+    plt.close(figure)
 
 
 def test_pop_prop_attaches_component_activity_browser_model(ica_epoch):


### PR DESCRIPTION
Plotting pop_* functions built a figure but never displayed it from the GUI or eegprep-console. Route every plot wrapper and the topoplot core through a shared show_figures helper, and keep the console's matplotlib non-interactive so display is explicit. Adds a keyword-only plot flag on the plot wrappers: plot='on', plot=True, or omitting it shows the window; plot='off' or plot=False builds and returns the figure without a window; any other value raises ValueError. Updates docstrings and GUI help.